### PR TITLE
Reset buffer resource pointer on destroy signal.

### DIFF
--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -24,6 +24,7 @@ struct wlr_frame_callback {
 struct wlr_surface_state {
 	uint32_t invalid;
 	struct wl_resource *buffer;
+	struct wl_listener buffer_destroy_listener;
 	int32_t sx, sy;
 	pixman_region32_t surface_damage, buffer_damage;
 	pixman_region32_t opaque, input;


### PR DESCRIPTION
Move buffer resource pointer to separate structure to be able easily reset it when buffer get destroyed.

Second attempt to fix #195.

I'm not very proud of this solution, but it is minimal working code I was able to come up with.