### PR TITLE
Client provided cursors

### DIFF
--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -55,9 +55,15 @@ static void wlr_wl_output_transform(struct wlr_output *_output,
 static bool wlr_wl_output_set_cursor(struct wlr_output *_output,
 		const uint8_t *buf, int32_t stride, uint32_t width, uint32_t height,
 		int32_t hotspot_x, int32_t hotspot_y) {
-
 	struct wlr_wl_backend_output *output = (struct wlr_wl_backend_output *)_output;
 	struct wlr_wl_backend *backend = output->backend;
+
+	if (!buf) {
+		wl_pointer_set_cursor(output->backend->pointer, output->enter_serial,
+			NULL, 0, 0);
+		return true;
+	}
+
 	stride *= 4; // stride is given in pixels, we need it in bytes
 
 	if (!backend->shm || !backend->pointer) {

--- a/include/rootston/input.h
+++ b/include/rootston/input.h
@@ -79,7 +79,7 @@ struct roots_input {
 	struct wlr_xcursor_theme *theme;
 	struct wlr_xcursor *xcursor;
 	struct wlr_seat *wl_seat;
-	bool client_cursor;
+	struct roots_view *client_cursor_view;
 
 	enum roots_cursor_mode mode;
 	struct roots_view *active_view, *last_active_view;

--- a/include/rootston/input.h
+++ b/include/rootston/input.h
@@ -79,6 +79,7 @@ struct roots_input {
 	struct wlr_xcursor_theme *theme;
 	struct wlr_xcursor *xcursor;
 	struct wlr_seat *wl_seat;
+	bool client_cursor;
 
 	enum roots_cursor_mode mode;
 	struct roots_view *active_view, *last_active_view;

--- a/include/rootston/input.h
+++ b/include/rootston/input.h
@@ -107,6 +107,8 @@ struct roots_input {
 	struct wl_listener cursor_tool_tip;
 
 	struct wl_listener pointer_grab_end;
+
+	struct wl_listener request_set_cursor;
 };
 
 struct roots_input *input_create(struct roots_server *server,

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -49,6 +49,11 @@ struct wlr_output {
 		int32_t hotspot_x, hotspot_y;
 		struct wlr_renderer *renderer;
 		struct wlr_texture *texture;
+
+		// only when using a cursor surface
+		struct wlr_surface *surface;
+		struct wl_listener surface_commit;
+		struct wl_listener surface_destroy;
 	} cursor;
 
 	void *data;
@@ -64,7 +69,7 @@ void wlr_output_transform(struct wlr_output *output,
 bool wlr_output_set_cursor(struct wlr_output *output,
 	const uint8_t *buf, int32_t stride, uint32_t width, uint32_t height,
 	int32_t hotspot_x, int32_t hotspot_y);
-bool wlr_output_set_cursor_surface(struct wlr_output *output,
+void wlr_output_set_cursor_surface(struct wlr_output *output,
 	struct wlr_surface *surface, int32_t hotspot_x, int32_t hotspot_y);
 bool wlr_output_move_cursor(struct wlr_output *output, int x, int y);
 void wlr_output_destroy(struct wlr_output *output);

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -54,18 +54,22 @@ struct wlr_output {
 	void *data;
 };
 
+struct wlr_surface;
+
 void wlr_output_enable(struct wlr_output *output, bool enable);
 bool wlr_output_set_mode(struct wlr_output *output,
-		struct wlr_output_mode *mode);
+	struct wlr_output_mode *mode);
 void wlr_output_transform(struct wlr_output *output,
-		enum wl_output_transform transform);
+	enum wl_output_transform transform);
 bool wlr_output_set_cursor(struct wlr_output *output,
-		const uint8_t *buf, int32_t stride, uint32_t width, uint32_t height,
-		int32_t hotspot_x, int32_t hotspot_y);
+	const uint8_t *buf, int32_t stride, uint32_t width, uint32_t height,
+	int32_t hotspot_x, int32_t hotspot_y);
+bool wlr_output_set_cursor_surface(struct wlr_output *output,
+	struct wlr_surface *surface, int32_t hotspot_x, int32_t hotspot_y);
 bool wlr_output_move_cursor(struct wlr_output *output, int x, int y);
 void wlr_output_destroy(struct wlr_output *output);
 void wlr_output_effective_resolution(struct wlr_output *output,
-		int *width, int *height);
+	int *width, int *height);
 void wlr_output_make_current(struct wlr_output *output);
 void wlr_output_swap_buffers(struct wlr_output *output);
 void wlr_output_set_gamma(struct wlr_output *output,

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -125,9 +125,18 @@ struct wlr_seat {
 
 		struct wl_signal keyboard_grab_begin;
 		struct wl_signal keyboard_grab_end;
+
+		struct wl_signal request_set_cursor;
 	} events;
 
 	void *data;
+};
+
+struct wlr_seat_pointer_request_set_cursor_event {
+	struct wl_client *client;
+	struct wlr_seat_handle *seat_handle;
+	struct wlr_surface *surface;
+	int32_t hotspot_x, hotspot_y;
 };
 
 /**

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -299,6 +299,21 @@ static void handle_request_set_cursor(struct wl_listener *listener,
 		request_set_cursor);
 	struct wlr_seat_pointer_request_set_cursor_event *event = data;
 
+	struct wlr_surface *focused_surface = NULL;
+	double sx, sy;
+	view_at(input->server->desktop, input->cursor->x, input->cursor->y,
+		&focused_surface, &sx, &sy);
+	bool ok = focused_surface != NULL;
+	if (focused_surface != NULL) {
+		struct wl_client *focused_client =
+			wl_resource_get_client(focused_surface->resource);
+		ok = event->client == focused_client;
+	}
+	if (!ok) {
+		wlr_log(L_DEBUG, "Denying request to set cursor outside view");
+		return;
+	}
+
 	wlr_log(L_DEBUG, "Setting client cursor");
 
 	struct roots_output *output;

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -288,11 +288,8 @@ static void handle_request_set_cursor(struct wl_listener *listener,
 
 	struct roots_output *output;
 	wl_list_for_each(output, &input->server->desktop->outputs, link) {
-		if (!wlr_output_set_cursor_surface(output->wlr_output,
-				event->surface, event->hotspot_x, event->hotspot_y)) {
-			wlr_log(L_DEBUG, "Failed to set hardware cursor");
-			return;
-		}
+		wlr_output_set_cursor_surface(output->wlr_output, event->surface,
+			event->hotspot_x, event->hotspot_y);
 	}
 }
 

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -278,14 +278,18 @@ static void handle_request_set_cursor(struct wl_listener *listener,
 		void *data) {
 	struct roots_input *input = wl_container_of(listener, input,
 		request_set_cursor);
-	//struct wlr_seat_pointer_request_set_cursor_event *event = data;
+	struct wlr_seat_pointer_request_set_cursor_event *event = data;
+	if (event->surface == NULL) {
+		wlr_log(L_DEBUG, "handle_request_set_cursor with NULL surface");
+		return;
+	}
 
-	struct wlr_xcursor_image *image = input->xcursor->images[0];
+	wlr_log(L_DEBUG, "handle_request_set_cursor");
+
 	struct roots_output *output;
 	wl_list_for_each(output, &input->server->desktop->outputs, link) {
-		if (!wlr_output_set_cursor(output->wlr_output, image->buffer,
-				image->width, image->width, image->height,
-				image->hotspot_x, image->hotspot_y)) {
+		if (!wlr_output_set_cursor_surface(output->wlr_output,
+				event->surface, event->hotspot_x, event->hotspot_y)) {
 			wlr_log(L_DEBUG, "Failed to set hardware cursor");
 			return;
 		}

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -193,7 +193,8 @@ static void handle_cursor_surface_commit(struct wl_listener *listener,
 	int32_t stride = wl_shm_buffer_get_stride(buffer);
 	wl_shm_buffer_begin_access(buffer);
 	wlr_output_set_cursor(output, buffer_data, stride/4, width, height,
-		output->cursor.hotspot_x, output->cursor.hotspot_y);
+		output->cursor.hotspot_x - surface->current->sx,
+		output->cursor.hotspot_y - surface->current->sy);
 	wl_shm_buffer_end_access(buffer);
 }
 

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -190,8 +190,9 @@ static void handle_cursor_surface_commit(struct wl_listener *listener,
 	void *buffer_data = wl_shm_buffer_get_data(buffer);
 	int32_t width = wl_shm_buffer_get_width(buffer);
 	int32_t height = wl_shm_buffer_get_height(buffer);
+	int32_t stride = wl_shm_buffer_get_stride(buffer);
 	wl_shm_buffer_begin_access(buffer);
-	wlr_output_set_cursor(output, buffer_data, width, width, height,
+	wlr_output_set_cursor(output, buffer_data, stride/4, width, height,
 		output->cursor.hotspot_x, output->cursor.hotspot_y);
 	wl_shm_buffer_end_access(buffer);
 }

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -198,6 +198,10 @@ static void handle_cursor_surface_destroy(struct wl_listener *listener,
 
 void wlr_output_set_cursor_surface(struct wlr_output *output,
 		struct wlr_surface *surface, int32_t hotspot_x, int32_t hotspot_y) {
+	if (strcmp(surface->role, "cursor") != 0) {
+		return;
+	}
+
 	output->cursor.hotspot_x = hotspot_x;
 	output->cursor.hotspot_y = hotspot_y;
 

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -171,8 +171,12 @@ bool wlr_output_set_cursor(struct wlr_output *output,
 	return set_cursor(output, buf, stride, width, height, hotspot_x, hotspot_y);
 }
 
-static void commit_cursor_surface(struct wlr_output *output,
-		struct wlr_surface *surface) {
+static void handle_cursor_surface_commit(struct wl_listener *listener,
+		void *data) {
+	struct wlr_output *output = wl_container_of(listener, output,
+		cursor.surface_commit);
+	struct wlr_surface *surface = data;
+
 	struct wl_shm_buffer *buffer = wl_shm_buffer_get(surface->current->buffer);
 	if (buffer == NULL) {
 		return;
@@ -192,15 +196,6 @@ static void commit_cursor_surface(struct wlr_output *output,
 		output->cursor.hotspot_x - surface->current->sx,
 		output->cursor.hotspot_y - surface->current->sy);
 	wl_shm_buffer_end_access(buffer);
-}
-
-static void handle_cursor_surface_commit(struct wl_listener *listener,
-		void *data) {
-	struct wlr_output *output = wl_container_of(listener, output,
-		cursor.surface_commit);
-	struct wlr_surface *surface = data;
-
-	commit_cursor_surface(output, surface);
 }
 
 static void handle_cursor_surface_destroy(struct wl_listener *listener,
@@ -223,7 +218,6 @@ void wlr_output_set_cursor_surface(struct wlr_output *output,
 	output->cursor.hotspot_y = hotspot_y;
 
 	if (surface && output->cursor.surface == surface) {
-		commit_cursor_surface(output, surface);
 		return;
 	}
 
@@ -238,7 +232,6 @@ void wlr_output_set_cursor_surface(struct wlr_output *output,
 	if (surface != NULL) {
 		wl_signal_add(&surface->events.commit, &output->cursor.surface_commit);
 		wl_signal_add(&surface->events.destroy, &output->cursor.surface_destroy);
-		commit_cursor_surface(output, surface);
 	} else {
 		set_cursor(output, NULL, 0, 0, 0, hotspot_x, hotspot_y);
 	}

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -120,9 +120,9 @@ void wlr_output_transform(struct wlr_output *output,
 	wlr_output_update_matrix(output);
 }
 
-bool wlr_output_set_cursor(struct wlr_output *output,
-		const uint8_t *buf, int32_t stride, uint32_t width, uint32_t height,
-		int32_t hotspot_x, int32_t hotspot_y) {
+static bool set_cursor(struct wlr_output *output, const uint8_t *buf,
+		int32_t stride, uint32_t width, uint32_t height, int32_t hotspot_x,
+		int32_t hotspot_y) {
 	if (output->impl->set_cursor
 			&& output->impl->set_cursor(output, buf, stride, width, height,
 				hotspot_x, hotspot_y)) {
@@ -156,6 +156,18 @@ bool wlr_output_set_cursor(struct wlr_output *output,
 
 	return wlr_texture_upload_pixels(output->cursor.texture,
 		WL_SHM_FORMAT_ARGB8888, stride, width, height, buf);
+}
+
+bool wlr_output_set_cursor(struct wlr_output *output,
+		const uint8_t *buf, int32_t stride, uint32_t width, uint32_t height,
+		int32_t hotspot_x, int32_t hotspot_y) {
+	if (output->cursor.surface) {
+		wl_list_remove(&output->cursor.surface_commit.link);
+		wl_list_remove(&output->cursor.surface_destroy.link);
+		output->cursor.surface = NULL;
+	}
+
+	return set_cursor(output, buf, stride, width, height, hotspot_x, hotspot_y);
 }
 
 static void handle_cursor_surface_commit(struct wl_listener *listener,

--- a/types/wlr_seat.c
+++ b/types/wlr_seat.c
@@ -24,7 +24,10 @@ static void wl_pointer_set_cursor(struct wl_client *client,
 		struct wl_resource *surface_resource,
 		int32_t hotspot_x, int32_t hotspot_y) {
 	struct wlr_seat_handle *handle = wl_resource_get_user_data(resource);
-	struct wlr_surface *surface = wl_resource_get_user_data(surface_resource);
+	struct wlr_surface *surface = NULL;
+	if (surface_resource != NULL) {
+		surface = wl_resource_get_user_data(surface_resource);
+	}
 
 	struct wlr_seat_pointer_request_set_cursor_event *event =
 		calloc(1, sizeof(struct wlr_seat_pointer_request_set_cursor_event));

--- a/types/wlr_seat.c
+++ b/types/wlr_seat.c
@@ -27,6 +27,11 @@ static void wl_pointer_set_cursor(struct wl_client *client,
 	struct wlr_surface *surface = NULL;
 	if (surface_resource != NULL) {
 		surface = wl_resource_get_user_data(surface_resource);
+
+		if (wlr_surface_set_role(surface, "cursor", resource,
+				WL_POINTER_ERROR_ROLE) < 0) {
+			return;
+		}
 	}
 
 	struct wlr_seat_pointer_request_set_cursor_event *event =

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -51,6 +51,8 @@ static void surface_attach(struct wl_client *client,
 	struct wlr_surface *surface = wl_resource_get_user_data(resource);
 
 	surface->pending->invalid |= WLR_SURFACE_INVALID_BUFFER;
+	surface->pending->sx = sx;
+	surface->pending->sy = sy;
 	wlr_surface_state_reset_buffer(surface->pending);
 	wlr_surface_state_set_buffer(surface->pending, buffer);
 }


### PR DESCRIPTION
- [x] Update cursor on surface commit
- [x] Give surface the cursor role
- [x] The cursor actually changes only if the pointer focus for this device is one of the requesting client's surfaces or the surface parameter is the current pointer surface.
- [x] If surface is NULL, the pointer image is hidden.
- [x] On surface.attach requests to the pointer surface, hotspot_x and hotspot_y are decremented by the x and y parameters passed to the request. Attach must be confirmed by wl_surface.commit as usual.
- [x] The hotspot can also be updated by passing the currently set pointer surface to this request with new values for hotspot_x and hotspot_y.
- [x] Rootston: set default pointer when leaving a surface
- [x] Not working properly on xwayland

Docs: https://wayland.freedesktop.org/docs/html/apa.html#protocol-spec-wl_pointer-request-set_cursor