### PR TITLE
Fix double free

### DIFF
--- a/types/wlr_seat.c
+++ b/types/wlr_seat.c
@@ -262,6 +262,8 @@ static void pointer_surface_destroy_notify(struct wl_listener *listener,
 		void *data) {
 	struct wlr_seat_pointer_state *state = wl_container_of(
 			listener, state, surface_destroy);
+	wl_list_remove(&state->surface_destroy.link);
+	wl_list_init(&state->surface_destroy.link);
 	state->focused_surface = NULL;
 	wlr_seat_pointer_clear_focus(state->wlr_seat);
 }
@@ -270,6 +272,8 @@ static void pointer_resource_destroy_notify(struct wl_listener *listener,
 		void *data) {
 	struct wlr_seat_pointer_state *state = wl_container_of(
 			listener, state, resource_destroy);
+	wl_list_remove(&state->resource_destroy.link);
+	wl_list_init(&state->resource_destroy.link);
 	state->focused_surface = NULL;
 	wlr_seat_pointer_clear_focus(state->wlr_seat);
 }
@@ -499,6 +503,8 @@ static void keyboard_surface_destroy_notify(struct wl_listener *listener,
 		void *data) {
 	struct wlr_seat_keyboard_state *state = wl_container_of(
 			listener, state, surface_destroy);
+	wl_list_remove(&state->surface_destroy.link);
+	wl_list_init(&state->surface_destroy.link);
 	state->focused_surface = NULL;
 	wlr_seat_keyboard_clear_focus(state->wlr_seat);
 }
@@ -507,6 +513,8 @@ static void keyboard_resource_destroy_notify(struct wl_listener *listener,
 		void *data) {
 	struct wlr_seat_keyboard_state *state = wl_container_of(
 			listener, state, resource_destroy);
+	wl_list_remove(&state->resource_destroy.link);
+	wl_list_init(&state->resource_destroy.link);
 	state->focused_surface = NULL;
 	wlr_seat_keyboard_clear_focus(state->wlr_seat);
 }


### PR DESCRIPTION
When surface/resource are destroyed by signal from wayland, list pointers become invalid and are freed second time in `wlr_seat_keyboard_enter()` and `wlr_seat_pointer_enter()`.

E.g.
```
==8704== Invalid write of size 8
==8704==    at 0x529A137: wl_list_remove (in /usr/lib/libwayland-server.so.0.1.0)
==8704==    by 0x506BDE6: wlr_seat_pointer_enter (wlr_seat.c:320)
==8704==    by 0x10C2B7: cursor_update_position (cursor.c:58)
==8704==    by 0x10C5F5: handle_cursor_motion (cursor.c:123)
==8704==    by 0x5069585: wl_signal_emit (wayland-server-core.h:388)
==8704==    by 0x5069FA9: handle_pointer_motion (wlr_cursor.c:269)
==8704==    by 0x505ADDA: wl_signal_emit (wayland-server-core.h:388)
==8704==    by 0x505AF9D: handle_pointer_motion (pointer.c:38)
==8704==    by 0x505A9FF: wlr_libinput_event (events.c:202)
==8704==    by 0x5059A38: wlr_libinput_readable (backend.c:34)
==8704==    by 0x52979B1: wl_event_loop_dispatch (in /usr/lib/libwayland-server.so.0.1.0)
==8704==    by 0x529614B: wl_display_run (in /usr/lib/libwayland-server.so.0.1.0)
==8704==  Address 0x103cf450 is 208 bytes inside a block of size 296 free'd
==8704==    at 0x4C2E14B: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8704==    by 0x506E41B: destroy_surface (wlr_surface.c:597)
==8704==    by 0x5295C11: ??? (in /usr/lib/libwayland-server.so.0.1.0)
==8704==    by 0x5295C61: wl_resource_destroy (in /usr/lib/libwayland-server.so.0.1.0)
==8704==    by 0x506C9FB: surface_destroy (wlr_surface.c:45)
==8704==    by 0x81311C7: ffi_call_unix64 (in /usr/lib/libffi.so.6.0.4)
==8704==    by 0x8130C29: ffi_call (in /usr/lib/libffi.so.6.0.4)
==8704==    by 0x52997FC: ??? (in /usr/lib/libwayland-server.so.0.1.0)
==8704==    by 0x5295F78: ??? (in /usr/lib/libwayland-server.so.0.1.0)
==8704==    by 0x52979B1: wl_event_loop_dispatch (in /usr/lib/libwayland-server.so.0.1.0)
==8704==    by 0x529614B: wl_display_run (in /usr/lib/libwayland-server.so.0.1.0)
==8704==    by 0x10EBEB: main (main.c:45)
==8704==  Block was alloc'd at
==8704==    at 0x4C2EF35: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8704==    by 0x506E43D: wlr_surface_create (wlr_surface.c:603)
==8704==    by 0x5071E04: wl_compositor_create_surface (wlr_compositor.c:18)
==8704==    by 0x81311C7: ffi_call_unix64 (in /usr/lib/libffi.so.6.0.4)
==8704==    by 0x8130C29: ffi_call (in /usr/lib/libffi.so.6.0.4)
==8704==    by 0x52997FC: ??? (in /usr/lib/libwayland-server.so.0.1.0)
==8704==    by 0x5295F78: ??? (in /usr/lib/libwayland-server.so.0.1.0)
==8704==    by 0x52979B1: wl_event_loop_dispatch (in /usr/lib/libwayland-server.so.0.1.0)
==8704==    by 0x529614B: wl_display_run (in /usr/lib/libwayland-server.so.0.1.0)
==8704==    by 0x10EBEB: main (main.c:45)
```