### PR TITLE
Add GL/EGL extension loader generator

### DIFF
--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -14,6 +14,7 @@
 #include <wlr/render/gles2.h>
 #include <wlr/render.h>
 #include "backend/drm/drm.h"
+#include "render/glapi.h"
 
 bool wlr_drm_renderer_init(struct wlr_drm_backend *drm,
 		struct wlr_drm_renderer *renderer) {
@@ -191,7 +192,7 @@ static struct wlr_texture *get_tex_for_bo(struct wlr_drm_renderer *renderer, str
 		EGL_NONE,
 	};
 
-	tex->img = renderer->egl.eglCreateImageKHR(renderer->egl.display, EGL_NO_CONTEXT,
+	tex->img = eglCreateImageKHR(renderer->egl.display, EGL_NO_CONTEXT,
 		EGL_LINUX_DMA_BUF_EXT, NULL, attribs);
 	if (!tex->img) {
 		wlr_log(L_ERROR, "Failed to create EGL image: %s", egl_error());

--- a/backend/meson.build
+++ b/backend/meson.build
@@ -38,5 +38,5 @@ lib_wlr_backend = static_library(
 	'wlr_backend',
 	backend_files,
 	include_directories: wlr_inc,
-	dependencies: [wayland_server, egl, gbm, libinput, systemd, elogind, wlr_protos],
+	dependencies: [wayland_server, egl, gbm, libinput, systemd, elogind, wlr_render, wlr_protos],
 )

--- a/glgen.sh
+++ b/glgen.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+
+# Generates a simple GL/EGL extension function loader.
+#
+# The input is a .txt file, with each function to load on its own line.
+# If a line starts with a -, it is optional, and will not cause the loader
+# to fail if it can't load the function. You'll need to check if that function
+# is NULL before using it.
+
+if [ $# -ne 2 ]; then
+	exit 1
+fi
+
+SPEC=$1
+OUT=$2
+
+BASE=$(basename "$SPEC" .txt)
+INCLUDE_GUARD=$(printf %s "$SPEC" | tr -c [:alnum:] _ | tr [:lower:] [:upper:])
+
+DECL=""
+DEFN=""
+LOADER=""
+
+DECL_FMT='extern %s %s;'
+DEFN_FMT='%s %s;'
+LOADER_FMT='%s = (%s)eglGetProcAddress("%s");'
+CHECK_FMT='if (!%s) {
+	wlr_log(L_ERROR, "Unable to load %s");
+	return false;
+}'
+
+while read -r COMMAND; do
+	[ ${COMMAND::1} = "-" ]
+	OPTIONAL=$?
+
+	COMMAND=${COMMAND#-}
+	if [ ${COMMAND: -2} = "WL" ]; then
+		FUNC_PTR_FMT='PFN%s'
+	else
+		FUNC_PTR_FMT='PFN%sPROC'
+	fi
+
+	FUNC_PTR=$(printf "$FUNC_PTR_FMT" "$COMMAND" | tr [:lower:] [:upper:])
+
+	DECL="$DECL$(printf "\n$DECL_FMT" "$FUNC_PTR" "$COMMAND")"
+	DEFN="$DEFN$(printf "\n$DEFN_FMT" "$FUNC_PTR" "$COMMAND")"
+	LOADER="$LOADER$(printf "\n$LOADER_FMT" "$COMMAND" "$FUNC_PTR" "$COMMAND")"
+
+	if [ $OPTIONAL -ne 0 ]; then
+		LOADER="$LOADER$(printf "\n$CHECK_FMT" "$COMMAND" "$COMMAND")"
+	fi
+done < $SPEC
+
+if [ ${OUT: -2} = '.h' ]; then
+	cat > $OUT << EOF
+	#ifndef $INCLUDE_GUARD
+	#define $INCLUDE_GUARD
+
+	#include <stdbool.h>
+
+	#include <EGL/egl.h>
+	#include <EGL/eglext.h>
+	#include <EGL/eglmesaext.h>
+	#include <GLES2/gl2.h>
+	#include <GLES2/gl2ext.h>
+
+	bool load_$BASE(void);
+	$DECL
+
+	#endif
+EOF
+elif [ ${OUT: -2} = '.c' ]; then
+	cat > $OUT << EOF
+	#include <wlr/util/log.h>
+	#include "$BASE.h"
+	$DEFN
+
+	bool load_$BASE(void) {
+		static bool done = false;
+		if (done) {
+			return true;
+		}
+	$LOADER
+
+		done = true;
+		return true;
+	}
+EOF
+else
+	exit 1
+fi

--- a/include/wlr/egl.h
+++ b/include/wlr/egl.h
@@ -10,15 +10,6 @@ struct wlr_egl {
 	EGLConfig config;
 	EGLContext context;
 
-	PFNEGLGETPLATFORMDISPLAYEXTPROC get_platform_display;
-	PFNEGLCREATEPLATFORMWINDOWSURFACEEXTPROC create_platform_window_surface;
-
-	PFNEGLCREATEIMAGEKHRPROC eglCreateImageKHR;
-	PFNEGLDESTROYIMAGEKHRPROC eglDestroyImageKHR;
-	PFNEGLQUERYWAYLANDBUFFERWL eglQueryWaylandBufferWL;
-	PFNEGLBINDWAYLANDDISPLAYWL eglBindWaylandDisplayWL;
-	PFNEGLUNBINDWAYLANDDISPLAYWL eglUnbindWaylandDisplayWL;
-
 	const char *egl_exts;
 	const char *gl_exts;
 

--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,10 @@ add_project_arguments(
 	'-DWLR_SRC_DIR="@0@"'.format(meson.source_root()),
 	language: 'c',
 )
+add_project_arguments(
+	'-I@0@'.format(meson.build_root()),
+	language: 'c',
+)
 add_project_link_arguments(
 	'-Wl,-rpath,@0@'.format(meson.build_root()),
 	language: 'c',
@@ -69,8 +73,8 @@ if elogind.found() and get_option('enable_elogind')
 endif
 
 subdir('protocol')
-subdir('backend')
 subdir('render')
+subdir('backend')
 subdir('types')
 subdir('util')
 subdir('xcursor')

--- a/render/glapi.txt
+++ b/render/glapi.txt
@@ -1,0 +1,8 @@
+eglGetPlatformDisplayEXT
+eglCreatePlatformWindowSurfaceEXT
+-eglCreateImageKHR
+-eglDestroyImageKHR
+-eglQueryWaylandBufferWL
+-eglBindWaylandDisplayWL
+-eglUnbindWaylandDisplayWL
+-glEGLImageTargetTexture2DOES

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -12,8 +12,8 @@
 #include <wlr/render/matrix.h>
 #include <wlr/util/log.h>
 #include "render/gles2.h"
+#include "render/glapi.h"
 
-PFNGLEGLIMAGETARGETTEXTURE2DOESPROC glEGLImageTargetTexture2DOES = NULL;
 struct shaders shaders;
 
 static bool compile_shader(GLuint type, const GLchar *src, GLuint *shader) {
@@ -101,25 +101,7 @@ error:
 	wlr_log(L_ERROR, "Failed to set up default shaders!");
 }
 
-static void init_image_ext() {
-	if (glEGLImageTargetTexture2DOES) {
-		return;
-	}
-
-	const char *exts = (const char*) glGetString(GL_EXTENSIONS);
-	if (strstr(exts, "GL_OES_EGL_image_external")) {
- 		glEGLImageTargetTexture2DOES = (PFNGLEGLIMAGETARGETTEXTURE2DOESPROC)
-			eglGetProcAddress("glEGLImageTargetTexture2DOES");
-	}
-
-	if (!glEGLImageTargetTexture2DOES) {
-		wlr_log(L_INFO, "Failed to load glEGLImageTargetTexture2DOES "
-			"Will not be able to attach drm buffers");
-	}
-}
-
 static void init_globals() {
-	init_image_ext();
 	init_default_shaders();
 }
 

--- a/render/meson.build
+++ b/render/meson.build
@@ -1,3 +1,16 @@
+glgen = find_program('../glgen.sh')
+
+glapi_c = custom_target('glapi.c',
+	input: 'glapi.txt',
+	output: '@BASENAME@.c',
+	command: [glgen, '@INPUT@', '@OUTPUT@'],
+)
+glapi_h = custom_target('glapi.h',
+	input: 'glapi.txt',
+	output: '@BASENAME@.h',
+	command: [glgen, '@INPUT@', '@OUTPUT@'],
+)
+
 lib_wlr_render = static_library(
 	'wlr_render',
 	files(
@@ -11,6 +24,13 @@ lib_wlr_render = static_library(
 		'wlr_renderer.c',
 		'wlr_texture.c',
 	),
+	glapi_c,
+	glapi_h,
 	include_directories: wlr_inc,
 	dependencies: [glesv2, egl],
+)
+
+wlr_render = declare_dependency(
+	link_with: lib_wlr_render,
+	sources: glapi_h,
 )


### PR DESCRIPTION
This is trying to remove a lot of the boilerplate and inconsistency for using GL/EGL extension functions, by automatically generating code to load it and check errors for us.

I've written the shell script to be POSIX compatible, so hopefully it will be portable enough. It passes `checkbashisms`.

It takes a text file with each function we want to load on its own line. If a function begins with a -, it won't fail if it's not loaded.