### PR TITLE
x11-backend: create wlr output global

### DIFF
--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -260,6 +260,7 @@ static bool wlr_x11_backend_start(struct wlr_backend *backend) {
 
 	xcb_map_window(x11->xcb_conn, output->win);
 	xcb_flush(x11->xcb_conn);
+	wlr_output_create_global(&output->wlr_output, x11->wl_display);
 
 	wl_signal_emit(&x11->backend.events.output_add, output);
 	wl_signal_emit(&x11->backend.events.input_add, &x11->keyboard_dev);


### PR DESCRIPTION
Fixes segfault with qtcreator.