### PR TITLE
Use wl_surface input bounds for input handling

### DIFF
--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -62,14 +62,12 @@ struct roots_view {
 	// If not then this should follow the typical type/impl pattern we use
 	// elsewhere
 	void (*get_size)(struct roots_view *view, struct wlr_box *box);
-	void (*get_input_bounds)(struct roots_view *view, struct wlr_box *box);
 	void (*activate)(struct roots_view *view, bool active);
 	void (*resize)(struct roots_view *view, uint32_t width, uint32_t height);
 	void (*close)(struct roots_view *view);
 };
 
 void view_get_size(struct roots_view *view, struct wlr_box *box);
-void view_get_input_bounds(struct roots_view *view, struct wlr_box *box);
 void view_activate(struct roots_view *view, bool active);
 void view_resize(struct roots_view *view, uint32_t width, uint32_t height);
 void view_close(struct roots_view *view);

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -121,9 +121,6 @@ static void surface_set_input_region(struct wl_client *client,
 		struct wl_resource *resource,
 		struct wl_resource *region_resource) {
 	struct wlr_surface *surface = wl_resource_get_user_data(resource);
-	if ((surface->pending->invalid & WLR_SURFACE_INVALID_INPUT_REGION)) {
-		pixman_region32_clear(&surface->pending->input);
-	}
 	surface->pending->invalid |= WLR_SURFACE_INVALID_INPUT_REGION;
 	if (region_resource) {
 		pixman_region32_t *region = wl_resource_get_user_data(region_resource);
@@ -304,7 +301,7 @@ static void wlr_surface_move_state(struct wlr_surface *surface, struct wlr_surfa
 	}
 	if ((next->invalid & WLR_SURFACE_INVALID_INPUT_REGION)) {
 		// TODO: process buffer
-		pixman_region32_clear(&next->input);
+		pixman_region32_copy(&state->input, &next->input);
 	}
 	if ((next->invalid & WLR_SURFACE_INVALID_SUBSURFACE_POSITION)) {
 		state->subsurface_position.x = next->subsurface_position.x;
@@ -546,7 +543,9 @@ static struct wlr_surface_state *wlr_surface_state_create() {
 	pixman_region32_init(&state->surface_damage);
 	pixman_region32_init(&state->buffer_damage);
 	pixman_region32_init(&state->opaque);
-	pixman_region32_init(&state->input);
+	pixman_region32_init_rect(&state->input,
+		INT32_MIN, INT32_MIN, UINT32_MAX, UINT32_MAX);
+
 
 	return state;
 }


### PR DESCRIPTION
Removed `view_get_input_bounds()` because this is a surface concern.

According to the spec, input bounds have copy semantics, start out infinite, and pending input bounds are never cleared.

Do an additional check beyond surface bounds if the coordinate is contained within the input bounds for xdg-surfaces and subsurfaces.