### PR TITLE
Fixed include in wlr_keyboard.h

### DIFF
--- a/include/wlr/types/wlr_keyboard.h
+++ b/include/wlr/types/wlr_keyboard.h
@@ -3,6 +3,7 @@
 
 #include <wayland-server.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <wayland-server.h>
 #include <xkbcommon/xkbcommon.h>
 


### PR DESCRIPTION
The build was failing on my machine until I include these headers directly in the keyboard header file.