### PR TITLE
move surface finder functions to wlroots

### DIFF
--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -122,4 +122,11 @@ void wlr_surface_make_subsurface(struct wlr_surface *surface,
  */
 struct wlr_surface *wlr_surface_get_main_surface(struct wlr_surface *surface);
 
+/**
+ * Find a subsurface within this surface at the surface-local coordinates.
+ * Returns the surface and coordinates in the topmost surface coordinate system
+ * or NULL if no subsurface is found at that location.
+ */
+struct wlr_subsurface *wlr_surface_subsurface_at(struct wlr_surface *surface,
+		double sx, double sy, double *sub_x, double *sub_y);
 #endif

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -206,4 +206,12 @@ void wlr_xdg_toplevel_v6_set_resizing(struct wlr_xdg_surface_v6 *surface,
  */
 void wlr_xdg_toplevel_v6_send_close(struct wlr_xdg_surface_v6 *surface);
 
+/**
+ * Find a popup within this surface at the surface-local coordinates. Returns
+ * the popup and coordinates in the topmost surface coordinate system or NULL if
+ * no popup is found at that location.
+ */
+struct wlr_xdg_surface_v6 *wlr_xdg_surface_v6_popup_at(
+		struct wlr_xdg_surface_v6 *surface, double sx, double sy,
+		double *popup_sx, double *popup_sy);
 #endif

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -839,3 +839,35 @@ struct wlr_surface *wlr_surface_get_main_surface(struct wlr_surface *surface) {
 
 	return surface;
 }
+
+struct wlr_subsurface *wlr_surface_subsurface_at(struct wlr_surface *surface,
+		double sx, double sy, double *sub_x, double *sub_y) {
+	struct wlr_subsurface *subsurface;
+	wl_list_for_each(subsurface, &surface->subsurface_list, parent_link) {
+		double _sub_x = subsurface->surface->current->subsurface_position.x;
+		double _sub_y = subsurface->surface->current->subsurface_position.y;
+		struct wlr_subsurface *sub =
+			wlr_surface_subsurface_at(subsurface->surface, _sub_x + sx,
+				_sub_y + sy, sub_x, sub_y);
+		if (sub) {
+			// TODO: This won't work for nested subsurfaces. Convert sub_x and
+			// sub_y to the parent coordinate system
+			return sub;
+		}
+
+		int sub_width = subsurface->surface->current->buffer_width;
+		int sub_height = subsurface->surface->current->buffer_height;
+		if ((sx > _sub_x && sx < _sub_x + sub_width) &&
+				(sy > _sub_y && sy < _sub_y + sub_height)) {
+			if (pixman_region32_contains_point(
+						&subsurface->surface->current->input,
+						sx - _sub_x, sy - _sub_y, NULL)) {
+				*sub_x = _sub_x;
+				*sub_y = _sub_y;
+				return subsurface;
+			}
+		}
+	}
+
+	return NULL;
+}


### PR DESCRIPTION
No logic changes.

I think I broke subsurfaces in an earlier commit so I'm fixing that now.