### PR TITLE
Add FreeBSD compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,5 @@ Run these commands:
 
     meson build
     ninja -C build
+
+(On FreeBSD, you need to pass an extra flag to prevent a linking error: `meson build -D b_lundef=false`)

--- a/backend/meson.build
+++ b/backend/meson.build
@@ -1,7 +1,6 @@
 backend_files = files(
 	'backend.c',
 	'session/direct-ipc.c',
-	'session/direct.c',
 	'session/session.c',
 	'drm/atomic.c',
 	'drm/backend.c',
@@ -25,6 +24,12 @@ backend_files = files(
 	'wayland/os-compatibility.c',
 	'x11/backend.c',
 )
+
+if host_machine.system().startswith('freebsd')
+	backend_files += files('session/direct-freebsd.c')
+else
+	backend_files += files('session/direct.c')
+endif
 
 if systemd.found()
 	backend_files += files('session/logind.c')

--- a/backend/session/direct-freebsd.c
+++ b/backend/session/direct-freebsd.c
@@ -1,0 +1,217 @@
+#include <errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <termios.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <dev/evdev/input.h>
+#include <sys/kbio.h>
+#include <sys/consio.h>
+#include <wayland-server.h>
+#include <wlr/backend/session/interface.h>
+#include <wlr/util/log.h>
+#include "backend/session/direct-ipc.h"
+
+const struct session_impl session_direct;
+
+struct direct_session {
+	struct wlr_session base;
+	int tty_fd;
+	int old_kbmode;
+	int sock;
+	pid_t child;
+
+	struct wl_event_source *vt_source;
+};
+
+static int direct_session_open(struct wlr_session *base, const char *path) {
+	struct direct_session *session = wl_container_of(base, session, base);
+
+	int fd = direct_ipc_open(session->sock, path);
+	if (fd < 0) {
+		wlr_log(L_ERROR, "Failed to open %s: %s%s", path, strerror(-fd),
+			fd == -EINVAL ? "; is another display server running?" : "");
+		return fd;
+	}
+
+	struct stat st;
+	if (fstat(fd, &st) < 0) {
+		close(fd);
+		return -errno;
+	}
+
+	return fd;
+}
+
+static void direct_session_close(struct wlr_session *base, int fd) {
+	struct direct_session *session = wl_container_of(base, session, base);
+
+	struct stat st;
+	if (fstat(fd, &st) < 0) {
+		wlr_log_errno(L_ERROR, "Stat failed");
+		close(fd);
+		return;
+	}
+
+	close(fd);
+}
+
+static bool direct_change_vt(struct wlr_session *base, unsigned vt) {
+	struct direct_session *session = wl_container_of(base, session, base);
+	return ioctl(session->tty_fd, VT_ACTIVATE, (int)vt) == 0;
+}
+
+static void direct_session_destroy(struct wlr_session *base) {
+	struct direct_session *session = wl_container_of(base, session, base);
+	struct vt_mode mode = {
+		.mode = VT_AUTO,
+	};
+
+	errno = 0;
+
+	ioctl(session->tty_fd, KDSKBMODE, session->old_kbmode);
+	ioctl(session->tty_fd, KDSETMODE, KD_TEXT);
+	ioctl(session->tty_fd, VT_SETMODE, &mode);
+
+	if (errno) {
+		wlr_log(L_ERROR, "Failed to restore tty");
+	}
+
+	direct_ipc_finish(session->sock, session->child);
+	close(session->sock);
+
+	wl_event_source_remove(session->vt_source);
+	close(session->tty_fd);
+	free(session);
+}
+
+static int vt_handler(int signo, void *data) {
+	struct direct_session *session = data;
+
+	if (session->base.active) {
+		session->base.active = false;
+		wl_signal_emit(&session->base.session_signal, session);
+		ioctl(session->tty_fd, VT_RELDISP, 1);
+	} else {
+		ioctl(session->tty_fd, VT_RELDISP, VT_ACKACQ);
+		session->base.active = true;
+		wl_signal_emit(&session->base.session_signal, session);
+	}
+
+	return 1;
+}
+
+static bool setup_tty(struct direct_session *session, struct wl_display *display) {
+	int fd = -1, tty = -1, tty0_fd = -1;
+	if ((tty0_fd = open("/dev/ttyv0", O_RDWR | O_CLOEXEC)) < 0) {
+		wlr_log_errno(L_ERROR, "Could not open /dev/ttyv0 to find a free vt");
+		goto error;
+	}
+	if (ioctl(tty0_fd, VT_OPENQRY, &tty) != 0) {
+		wlr_log_errno(L_ERROR, "Could not find a free vt");
+		goto error;
+	}
+	close(tty0_fd);
+	char tty_path[64];
+	snprintf(tty_path, sizeof(tty_path), "/dev/ttyv%d", tty - 1);
+	wlr_log(L_INFO, "Using tty %s", tty_path);
+	fd = open(tty_path, O_RDWR | O_NOCTTY | O_CLOEXEC);
+
+	if (fd == -1) {
+		wlr_log_errno(L_ERROR, "Cannot open tty");
+		return false;
+	}
+
+	ioctl(fd, VT_ACTIVATE, tty);
+	ioctl(fd, VT_WAITACTIVE, tty);
+
+	int old_kbmode;
+	if (ioctl(fd, KDGKBMODE, &old_kbmode)) {
+		wlr_log_errno(L_ERROR, "Failed to read tty %d keyboard mode", tty);
+		goto error;
+	}
+
+	if (ioctl(fd, KDSKBMODE, K_CODE)) {
+		wlr_log_errno(L_ERROR, "Failed to set keyboard mode K_CODE on tty %d", tty);
+		goto error;
+	}
+
+	if (ioctl(fd, KDSETMODE, KD_GRAPHICS)) {
+		wlr_log_errno(L_ERROR, "Failed to set graphics mode on tty %d", tty);
+		goto error;
+	}
+
+	struct vt_mode mode = {
+		.mode = VT_PROCESS,
+		.relsig = SIGUSR1,
+		.acqsig = SIGUSR1,
+		.frsig = SIGIO, // has to be set
+	};
+
+	if (ioctl(fd, VT_SETMODE, &mode) < 0) {
+		wlr_log(L_ERROR, "Failed to take control of tty %d", tty);
+		goto error;
+	}
+
+	struct wl_event_loop *loop = wl_display_get_event_loop(display);
+	session->vt_source = wl_event_loop_add_signal(loop, SIGUSR1,
+		vt_handler, session);
+	if (!session->vt_source) {
+		goto error;
+	}
+
+	session->base.vtnr = tty;
+	session->tty_fd = fd;
+	session->old_kbmode = old_kbmode;
+
+	return true;
+
+error:
+	// Drop back to tty 1, better than hanging in a useless blank console
+	ioctl(fd, VT_ACTIVATE, 1);
+	close(fd);
+	return false;
+}
+
+static struct wlr_session *direct_session_create(struct wl_display *disp) {
+	struct direct_session *session = calloc(1, sizeof(*session));
+	if (!session) {
+		wlr_log_errno(L_ERROR, "Allocation failed");
+		return NULL;
+	}
+
+	session->sock = direct_ipc_init(&session->child);
+	if (session->sock == -1) {
+		goto error_session;
+	}
+
+	if (!setup_tty(session, disp)) {
+		goto error_ipc;
+	}
+
+	wlr_log(L_INFO, "Successfully loaded direct session");
+
+	snprintf(session->base.seat, sizeof(session->base.seat), "seat0");
+	session->base.impl = &session_direct;
+	return &session->base;
+
+error_ipc:
+	direct_ipc_finish(session->sock, session->child);
+	close(session->sock);
+error_session:
+	free(session);
+	return NULL;
+}
+
+const struct session_impl session_direct = {
+	.create = direct_session_create,
+	.destroy = direct_session_destroy,
+	.open = direct_session_open,
+	.close = direct_session_close,
+	.change_vt = direct_change_vt,
+};

--- a/backend/session/direct-ipc.c
+++ b/backend/session/direct-ipc.c
@@ -1,4 +1,8 @@
 #define _POSIX_C_SOURCE 200809L
+#ifdef __FreeBSD__
+#define __BSD_VISIBLE 1
+#define INPUT_MAJOR 0
+#endif
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -8,10 +12,12 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <sys/sysmacros.h>
 #include <sys/wait.h>
-#include <xf86drm.h>
+#ifdef __linux__
+#include <sys/sysmacros.h>
 #include <linux/major.h>
+#endif
+#include <xf86drm.h>
 #include <wlr/util/log.h>
 #include "backend/session/direct-ipc.h"
 
@@ -35,11 +41,12 @@ static bool have_permissions(void) {
 }
 #else
 static bool have_permissions(void) {
+#ifdef __linux__
 	if (geteuid() != 0) {
 		wlr_log(L_ERROR, "Do not have root privileges; cannot become DRM master");
 		return false;
 	}
-
+#endif
 	return true;
 }
 #endif

--- a/backend/session/session.c
+++ b/backend/session/session.c
@@ -263,6 +263,11 @@ size_t wlr_session_find_gpus(struct wlr_session *session,
 		return explicit_find_gpus(session, ret_len, ret, explicit);
 	}
 
+#ifdef __FreeBSD__
+	// XXX: libudev-devd does not return any GPUs (yet?)
+	return explicit_find_gpus(session, ret_len, ret, "/dev/drm/0");
+#else
+
 	struct udev_enumerate *en = udev_enumerate_new(session->udev);
 	if (!en) {
 		wlr_log(L_ERROR, "Failed to create udev enumeration");
@@ -329,4 +334,5 @@ size_t wlr_session_find_gpus(struct wlr_session *session,
 	udev_enumerate_unref(en);
 
 	return i;
+#endif
 }

--- a/backend/wayland/os-compatibility.c
+++ b/backend/wayland/os-compatibility.c
@@ -29,7 +29,9 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
+#ifdef __linux__
 #include <sys/epoll.h>
+#endif
 #include <string.h>
 #include <stdlib.h>
 

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -1,4 +1,4 @@
-#define _POSIX_C_SOURCE 199309L
+#define _POSIX_C_SOURCE 200112L
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -8,7 +8,11 @@
 #include <xcb/xcb.h>
 #include <xcb/glx.h>
 #include <X11/Xlib-xcb.h>
+#ifdef __linux__
 #include <linux/input-event-codes.h>
+#elif __FreeBSD__
+#include <dev/evdev/input-event-codes.h>
+#endif
 #include <wlr/backend/interface.h>
 #include <wlr/backend/x11.h>
 #include <wlr/egl.h>

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -1,5 +1,5 @@
 #define _POSIX_C_SOURCE 199309L
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>

--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,9 @@ if cc.get_id() == 'clang'
 	add_project_arguments('-Wno-missing-braces', language: 'c')
 endif
 
+# Avoid wl_buffer deprecation warnings
+add_project_arguments('-DWL_HIDE_DEPRECATED', language: 'c')
+
 wayland_server = dependency('wayland-server')
 wayland_client = dependency('wayland-client')
 wayland_egl    = dependency('wayland-egl')

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -46,7 +46,8 @@ foreach p : client_protocols
 	wl_protos_headers += wayland_scanner_client.process(xml)
 endforeach
 
-lib_wl_protos = static_library('wl_protos', wl_protos_src + wl_protos_headers)
+lib_wl_protos = static_library('wl_protos', wl_protos_src + wl_protos_headers,
+	dependencies: [wayland_client]) # for the include directory
 
 wlr_protos = declare_dependency(
 	link_with: lib_wl_protos,

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -1,10 +1,13 @@
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
 #include <math.h>
-// TODO: BSD et al
+#ifdef __linux__
 #include <linux/input-event-codes.h>
+#elif __FreeBSD__
+#include <dev/evdev/input-event-codes.h>
+#endif
 #include <wayland-server.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/util/log.h>

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -1,4 +1,4 @@
-#define _POSIX_C_SOURCE 199309L
+#define _POSIX_C_SOURCE 200809L
 #include <time.h>
 #include <stdlib.h>
 #include <stdbool.h>

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -1,4 +1,4 @@
-#define _POSIX_C_SOURCE 199309L
+#define _POSIX_C_SOURCE 200809L
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>

--- a/util/log.c
+++ b/util/log.c
@@ -1,4 +1,4 @@
-#define _POSIX_C_SOURCE 1
+#define _POSIX_C_SOURCE 199506L
 #include <errno.h>
 #include <stdarg.h>
 #include <stdio.h>

--- a/xcursor/meson.build
+++ b/xcursor/meson.build
@@ -5,4 +5,5 @@ lib_wlr_xcursor = static_library(
 		'wlr_xcursor.c',
 	),
 	include_directories: wlr_inc,
+	dependencies: [egl] # header required via include/wlr/render.h
 )

--- a/xwayland/sockets.c
+++ b/xwayland/sockets.c
@@ -1,4 +1,8 @@
 #define _XOPEN_SOURCE 700
+#ifdef __FreeBSD__
+// for SOCK_CLOEXEC
+#define __BSD_VISIBLE 1
+#endif
 #include <stdlib.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -65,9 +69,12 @@ static bool open_sockets(int socks[2], int display) {
 
 	mkdir(socket_dir, 0777);
 
-	// TODO: non-linux apparently want another format
+#ifdef __linux__
 	addr.sun_path[0] = 0;
 	path_size = snprintf(addr.sun_path + 1, sizeof(addr.sun_path) - 1, socket_fmt, display);
+#else
+	path_size = snprintf(addr.sun_path, sizeof(addr.sun_path), socket_fmt, display);
+#endif
 	socks[0] = open_socket(&addr, path_size);
 	if (socks[0] < 0) {
 		return false;

--- a/xwayland/xwayland.c
+++ b/xwayland/xwayland.c
@@ -1,5 +1,9 @@
 #define _XOPEN_SOURCE 700
 #define _DEFAULT_SOURCE
+#ifdef __FreeBSD__
+// for SOCK_CLOEXEC
+#define __BSD_VISIBLE 1
+#endif
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -16,6 +20,14 @@
 #include "wlr/xwayland.h"
 #include "sockets.h"
 #include "xwm.h"
+
+#ifdef __FreeBSD__
+static inline int clearenv(void) {
+	extern char **environ;
+	environ[0] = NULL;
+	return 0;
+}
+#endif
 
 static void safe_close(int fd) {
 	if (fd >= 0) {


### PR DESCRIPTION
Hi, it's [me](https://github.com/swaywm/sway/commit/da26d69cb1b21d582a81af0cad7342fab6596eed), again :)

(Do not merge this just yet!)

So, it works on X11, can't test on DRM/KMS for now because kernel panic. (well, I could install a couple month old kernel where wlc/sway worked, but I'll look into fixing the problem instead)

- `-Wno-error=deprecated-declarations` because `warning: 'wl_buffer' is deprecated`. This comes from `EGL/eglmesaext.h`. I have Mesa 17.2.2 and Wayland 1.13.0, but seems like it was deprecated a [long long time ago](https://mail.gnome.org/archives/commits-list/2013-October/msg08157.html). You didn't encounter this on Linux? o_0
- the libinput ifdefs are for compatibility with version 1.6.0 (damn we have to catch up…)
- There's the `environ` linking issue (undefined symbol). Maybe because of some linker flag that meson uses…
- I'm not sure about the raw terminal thing (from https://github.com/Cloudef/wlc/commit/ef3c443b3ab97a3a900de386973a3d1a5ccb065c) — @johalun why did wlc both save/restore termios state and set the raw flag?
- The elephant in the room. The ugly part of the patch. **The `_POSIX_C_SOURCE` / `_XOPEN_SOURCE` stuff.** What does it do on Linux? On FreeBSD, it actually makes all the headers compliant with old POSIX specifications and nothing more (`__BSD_VISIBLE` gets disabled) — so we lose `CLOCK_MONOTONIC`, `minor`/`major`, `snprintf` and a bunch of other stuff I already forgot. Currently I have `ifdef`'d these defines to Linux where they caused problems, but that's really bad. What do you think about them? Are they actually necessary anywhere at all?