### PR TITLE
[WIP] Fix client cursors

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -470,7 +470,7 @@ static void wlr_drm_connector_transform(struct wlr_output *output,
 
 static bool wlr_drm_connector_set_cursor(struct wlr_output *output,
 		const uint8_t *buf, int32_t stride, uint32_t width, uint32_t height,
-		int32_t hotspot_x, int32_t hotspot_y) {
+		int32_t hotspot_x, int32_t hotspot_y, bool update_pixels) {
 	struct wlr_drm_connector *conn = (struct wlr_drm_connector *)output;
 	struct wlr_drm_backend *drm = conn->drm;
 	struct wlr_drm_renderer *renderer = &drm->renderer;
@@ -478,7 +478,8 @@ static bool wlr_drm_connector_set_cursor(struct wlr_output *output,
 	struct wlr_drm_crtc *crtc = conn->crtc;
 	struct wlr_drm_plane *plane = crtc->cursor;
 
-	if (!buf) {
+	if (!buf && update_pixels) {
+		// Hide the cursor
 		return drm->iface->crtc_set_cursor(drm, crtc, NULL);
 	}
 
@@ -564,6 +565,11 @@ static bool wlr_drm_connector_set_cursor(struct wlr_output *output,
 		output->cursor.hotspot_x = -plane->surf.height + hotspot_x;
 		output->cursor.hotspot_y = plane->surf.width - hotspot_y;
 		break;
+	}
+
+	if (!update_pixels) {
+		// Only update the cursor hotspot
+		return true;
 	}
 
 	struct gbm_bo *bo = plane->cursor_bo;

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -66,8 +66,12 @@ static bool wlr_wl_output_set_cursor(struct wlr_output *_output,
 	}
 	if (!buf) {
 		// Hide cursor
-		wl_pointer_set_cursor(output->backend->pointer, output->enter_serial,
-			NULL, 0, 0);
+		wl_surface_destroy(output->cursor_surface);
+		munmap(output->cursor_data, output->cursor_buf_size);
+		output->cursor_surface = NULL;
+		output->cursor_buf_size = 0;
+		wlr_wl_output_update_cursor(output, output->enter_serial, hotspot_x,
+			hotspot_y);
 		return true;
 	}
 
@@ -160,7 +164,7 @@ static void wlr_wl_output_destroy(struct wlr_output *_output) {
 
 void wlr_wl_output_update_cursor(struct wlr_wl_backend_output *output,
 			uint32_t serial, int32_t hotspot_x, int32_t hotspot_y) {
-	if (output->cursor_surface && output->backend->pointer && serial) {
+	if (output->backend->pointer && serial) {
 		wl_pointer_set_cursor(output->backend->pointer, serial,
 			output->cursor_surface, hotspot_x, hotspot_y);
 	}

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -54,11 +54,18 @@ static void wlr_wl_output_transform(struct wlr_output *_output,
 
 static bool wlr_wl_output_set_cursor(struct wlr_output *_output,
 		const uint8_t *buf, int32_t stride, uint32_t width, uint32_t height,
-		int32_t hotspot_x, int32_t hotspot_y) {
+		int32_t hotspot_x, int32_t hotspot_y, bool update_pixels) {
 	struct wlr_wl_backend_output *output = (struct wlr_wl_backend_output *)_output;
 	struct wlr_wl_backend *backend = output->backend;
 
+	if (!update_pixels) {
+		// Update hotspot without changing cursor image
+		wlr_wl_output_update_cursor(output, output->enter_serial, hotspot_x,
+			hotspot_y);
+		return true;
+	}
 	if (!buf) {
+		// Hide cursor
 		wl_pointer_set_cursor(output->backend->pointer, output->enter_serial,
 			NULL, 0, 0);
 		return true;

--- a/include/rootston/input.h
+++ b/include/rootston/input.h
@@ -79,7 +79,7 @@ struct roots_input {
 	struct wlr_xcursor_theme *theme;
 	struct wlr_xcursor *xcursor;
 	struct wlr_seat *wl_seat;
-	struct roots_view *client_cursor_view;
+	struct wl_client *cursor_client;
 
 	enum roots_cursor_mode mode;
 	struct roots_view *active_view, *last_active_view;

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -8,16 +8,16 @@ struct wlr_output_impl {
 	void (*enable)(struct wlr_output *output, bool enable);
 	bool (*set_mode)(struct wlr_output *output, struct wlr_output_mode *mode);
 	void (*transform)(struct wlr_output *output,
-			enum wl_output_transform transform);
+		enum wl_output_transform transform);
 	bool (*set_cursor)(struct wlr_output *output, const uint8_t *buf,
-			int32_t stride, uint32_t width, uint32_t height,
-			int32_t hotspot_x, int32_t hotspot_y);
+		int32_t stride, uint32_t width, uint32_t height,
+		int32_t hotspot_x, int32_t hotspot_y, bool update_pixels);
 	bool (*move_cursor)(struct wlr_output *output, int x, int y);
 	void (*destroy)(struct wlr_output *output);
 	void (*make_current)(struct wlr_output *output);
 	void (*swap_buffers)(struct wlr_output *output);
 	void (*set_gamma)(struct wlr_output *output,
-			uint16_t size, uint16_t *r, uint16_t *g, uint16_t *b);
+		uint16_t size, uint16_t *r, uint16_t *g, uint16_t *b);
 	uint16_t (*get_gamma_size)(struct wlr_output *output);
 };
 
@@ -25,6 +25,6 @@ void wlr_output_init(struct wlr_output *output, const struct wlr_output_impl *im
 void wlr_output_free(struct wlr_output *output);
 void wlr_output_update_matrix(struct wlr_output *output);
 struct wl_global *wlr_output_create_global(
-		struct wlr_output *wlr_output, struct wl_display *display);
+	struct wlr_output *wlr_output, struct wl_display *display);
 
 #endif

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -306,8 +306,8 @@ static void handle_request_set_cursor(struct wl_listener *listener,
 
 	struct wlr_surface *focused_surface =
 		event->seat_handle->wlr_seat->pointer_state.focused_surface;
-	bool ok = focused_surface != NULL;
-	if (focused_surface != NULL) {
+	bool ok = focused_surface != NULL && focused_surface->resource != NULL;
+	if (ok) {
 		struct wl_client *focused_client =
 			wl_resource_get_client(focused_surface->resource);
 		ok = event->client == focused_client;

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -80,10 +80,16 @@ void cursor_update_position(struct roots_input *input, uint32_t time) {
 	case ROOTS_CURSOR_PASSTHROUGH:
 		view = view_at(desktop, input->cursor->x, input->cursor->y, &surface,
 			&sx, &sy);
-		if (view != input->client_cursor_view) {
+		bool set_compositor_cursor = !view && input->cursor_client;
+		if (view) {
+			struct wl_client *view_client =
+				wl_resource_get_client(view->wlr_surface->resource);
+			set_compositor_cursor = view_client != input->cursor_client;
+		}
+		if (set_compositor_cursor) {
 			wlr_log(L_DEBUG, "Switching to compositor cursor");
 			cursor_set_xcursor_image(input, input->xcursor->images[0]);
-			input->client_cursor_view = NULL;
+			input->cursor_client = NULL;
 		}
 		if (view) {
 			wlr_seat_pointer_notify_enter(input->wl_seat, surface, sx, sy);
@@ -298,10 +304,8 @@ static void handle_request_set_cursor(struct wl_listener *listener,
 		request_set_cursor);
 	struct wlr_seat_pointer_request_set_cursor_event *event = data;
 
-	struct wlr_surface *focused_surface = NULL;
-	double sx, sy;
-	struct roots_view *focused_view = view_at(input->server->desktop,
-		input->cursor->x, input->cursor->y, &focused_surface, &sx, &sy);
+	struct wlr_surface *focused_surface =
+		event->seat_handle->wlr_seat->pointer_state.focused_surface;
 	bool ok = focused_surface != NULL;
 	if (focused_surface != NULL) {
 		struct wl_client *focused_client =
@@ -309,7 +313,7 @@ static void handle_request_set_cursor(struct wl_listener *listener,
 		ok = event->client == focused_client;
 	}
 	if (!ok) {
-		wlr_log(L_DEBUG, "Denying request to set cursor outside view");
+		wlr_log(L_DEBUG, "Denying request to set cursor from unfocused client");
 		return;
 	}
 
@@ -321,7 +325,7 @@ static void handle_request_set_cursor(struct wl_listener *listener,
 			event->hotspot_x, event->hotspot_y);
 	}
 
-	input->client_cursor_view = focused_view;
+	input->cursor_client = event->client;
 }
 
 void cursor_initialize(struct roots_input *input) {

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -238,10 +238,6 @@ void wlr_output_set_cursor_surface(struct wlr_output *output,
 	output->cursor.hotspot_x = hotspot_x;
 	output->cursor.hotspot_y = hotspot_y;
 
-	if (surface && output->cursor.surface == surface) {
-		return;
-	}
-
 	if (output->cursor.surface) {
 		wl_list_remove(&output->cursor.surface_commit.link);
 		wl_list_remove(&output->cursor.surface_destroy.link);
@@ -252,7 +248,9 @@ void wlr_output_set_cursor_surface(struct wlr_output *output,
 
 	if (surface != NULL) {
 		wl_signal_add(&surface->events.commit, &output->cursor.surface_commit);
-		wl_signal_add(&surface->events.destroy, &output->cursor.surface_destroy);
+		wl_signal_add(&surface->events.destroy,
+			&output->cursor.surface_destroy);
+		commit_cursor_surface(output, surface);
 	} else {
 		set_cursor(output, NULL, 0, 0, 0, hotspot_x, hotspot_y);
 	}

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -264,9 +264,7 @@ void wlr_output_set_cursor_surface(struct wlr_output *output,
 		wl_signal_add(&surface->events.commit, &output->cursor.surface_commit);
 		wl_signal_add(&surface->events.destroy,
 			&output->cursor.surface_destroy);
-		// TODO: doing it breaks GTK apps
-		// TODO: not doing it breaks weston-subsurfaces
-		//commit_cursor_surface(output, surface);
+		commit_cursor_surface(output, surface);
 	} else {
 		set_cursor(output, NULL, 0, 0, 0, hotspot_x, hotspot_y);
 	}

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -259,7 +259,9 @@ void wlr_output_set_cursor_surface(struct wlr_output *output,
 		wl_signal_add(&surface->events.commit, &output->cursor.surface_commit);
 		wl_signal_add(&surface->events.destroy,
 			&output->cursor.surface_destroy);
-		commit_cursor_surface(output, surface);
+		// TODO: doing it breaks GTK apps
+		// TODO: not doing it breaks weston-subsurfaces
+		//commit_cursor_surface(output, surface);
 	} else {
 		set_cursor(output, NULL, 0, 0, 0, hotspot_x, hotspot_y);
 	}

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -257,7 +257,15 @@ void wlr_output_set_cursor_surface(struct wlr_output *output,
 		output->cursor.surface = NULL;
 	}
 
-	output->cursor.is_sw = output->impl->set_cursor == NULL;
+	// Disable hardware cursor
+	// TODO: support hardware cursors
+	output->cursor.is_sw = true;
+	if (output->impl->set_cursor) {
+		output->impl->set_cursor(output, NULL, 0, 0, 0, hotspot_x, hotspot_y,
+			true);
+	}
+
+	//output->cursor.is_sw = output->impl->set_cursor == NULL;
 	output->cursor.surface = surface;
 
 	if (surface != NULL) {

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -127,7 +127,7 @@ static bool set_cursor(struct wlr_output *output, const uint8_t *buf,
 		int32_t hotspot_y) {
 	if (output->impl->set_cursor
 			&& output->impl->set_cursor(output, buf, stride, width, height,
-				hotspot_x, hotspot_y)) {
+				hotspot_x, hotspot_y, true)) {
 		output->cursor.is_sw = false;
 		return true;
 	}
@@ -237,6 +237,15 @@ void wlr_output_set_cursor_surface(struct wlr_output *output,
 
 	output->cursor.hotspot_x = hotspot_x;
 	output->cursor.hotspot_y = hotspot_y;
+
+	if (surface && surface == output->cursor.surface) {
+		if (output->impl->set_cursor && !output->cursor.is_sw) {
+			// Only update the hotspot
+			output->impl->set_cursor(output, NULL, 0, 0, 0, hotspot_x,
+				hotspot_y, false);
+		}
+		return;
+	}
 
 	if (output->cursor.surface) {
 		wl_list_remove(&output->cursor.surface_commit.link);

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -231,7 +231,7 @@ static void handle_cursor_surface_destroy(struct wl_listener *listener,
 
 void wlr_output_set_cursor_surface(struct wlr_output *output,
 		struct wlr_surface *surface, int32_t hotspot_x, int32_t hotspot_y) {
-	if (surface && strcmp(surface->role, "cursor") != 0) {
+	if (surface && strcmp(surface->role, "wl_pointer-cursor") != 0) {
 		return;
 	}
 

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -179,8 +179,7 @@ static inline int64_t timespec_to_msec(const struct timespec *a) {
 
 static void commit_cursor_surface(struct wlr_output *output,
 		struct wlr_surface *surface) {
-	if (!output->impl->set_cursor) {
-		output->cursor.is_sw = true;
+	if (output->cursor.is_sw) {
 		return;
 	}
 
@@ -258,6 +257,7 @@ void wlr_output_set_cursor_surface(struct wlr_output *output,
 		output->cursor.surface = NULL;
 	}
 
+	output->cursor.is_sw = output->impl->set_cursor == NULL;
 	output->cursor.surface = surface;
 
 	if (surface != NULL) {

--- a/types/wlr_seat.c
+++ b/types/wlr_seat.c
@@ -28,7 +28,7 @@ static void wl_pointer_set_cursor(struct wl_client *client,
 	if (surface_resource != NULL) {
 		surface = wl_resource_get_user_data(surface_resource);
 
-		if (wlr_surface_set_role(surface, "cursor", resource,
+		if (wlr_surface_set_role(surface, "wl_pointer-cursor", resource,
 				WL_POINTER_ERROR_ROLE) < 0) {
 			return;
 		}

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -359,7 +359,7 @@ static void wlr_surface_flush_damage(struct wlr_surface *surface,
 		if (wlr_renderer_buffer_is_drm(surface->renderer,
 					surface->current->buffer)) {
 			wlr_texture_upload_drm(surface->texture, surface->current->buffer);
-			goto release;
+			goto clear_damage;
 		} else {
 			wlr_log(L_INFO, "Unknown buffer handle attached");
 			return;
@@ -372,7 +372,7 @@ static void wlr_surface_flush_damage(struct wlr_surface *surface,
 	} else {
 		pixman_region32_t damage = surface->current->buffer_damage;
 		if (!pixman_region32_not_empty(&damage)) {
-			goto release;
+			goto clear_damage;
 		}
 		int n;
 		pixman_box32_t *rects = pixman_region32_rectangles(&damage, &n);
@@ -388,7 +388,7 @@ static void wlr_surface_flush_damage(struct wlr_surface *surface,
 		}
 	}
 
-release:
+clear_damage:
 	pixman_region32_clear(&surface->current->surface_damage);
 	pixman_region32_clear(&surface->current->buffer_damage);
 }

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -429,7 +429,8 @@ static void wlr_surface_commit_pending(struct wlr_surface *surface) {
 
 	// Release the buffer after calling commit, because some listeners
 	// might need it (e.g. for cursor surfaces)
-	wlr_surface_state_release_buffer(surface->current);
+	// TODO: breaks weston-subsurfaces
+	//wlr_surface_state_release_buffer(surface->current);
 }
 
 static bool wlr_subsurface_is_synchronized(struct wlr_subsurface *subsurface) {

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -391,8 +391,6 @@ static void wlr_surface_flush_damage(struct wlr_surface *surface,
 release:
 	pixman_region32_clear(&surface->current->surface_damage);
 	pixman_region32_clear(&surface->current->buffer_damage);
-
-	wlr_surface_state_release_buffer(surface->current);
 }
 
 static void wlr_surface_commit_pending(struct wlr_surface *surface) {
@@ -428,6 +426,8 @@ static void wlr_surface_commit_pending(struct wlr_surface *surface) {
 
 	// TODO: add the invalid bitfield to this callback
 	wl_signal_emit(&surface->events.commit, surface);
+
+	wlr_surface_state_release_buffer(surface->current);
 }
 
 static bool wlr_subsurface_is_synchronized(struct wlr_subsurface *subsurface) {

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -427,8 +427,9 @@ static void wlr_surface_commit_pending(struct wlr_surface *surface) {
 	// TODO: add the invalid bitfield to this callback
 	wl_signal_emit(&surface->events.commit, surface);
 
-	// TODO: call this
-	//wlr_surface_state_release_buffer(surface->current);
+	// Release the buffer after calling commit, because some listeners
+	// might need it (e.g. for cursor surfaces)
+	wlr_surface_state_release_buffer(surface->current);
 }
 
 static bool wlr_subsurface_is_synchronized(struct wlr_subsurface *subsurface) {

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -427,7 +427,8 @@ static void wlr_surface_commit_pending(struct wlr_surface *surface) {
 	// TODO: add the invalid bitfield to this callback
 	wl_signal_emit(&surface->events.commit, surface);
 
-	wlr_surface_state_release_buffer(surface->current);
+	// TODO: call this
+	//wlr_surface_state_release_buffer(surface->current);
 }
 
 static bool wlr_subsurface_is_synchronized(struct wlr_subsurface *subsurface) {


### PR DESCRIPTION
- [x] in request_set_cursor, to tell if there is pointer focus don't check what's under the cursor, check if the seat handle has a focused surface for the pointer, look in pointer_state, ~~that will probably fix the jump~~

Test clients:
- [ ] qutebrowser
- [ ] gnome-calculator, gnome-terminal
- [ ] weston-subsurfaces

See https://github.com/swaywm/wlroots/pull/255#issuecomment-335585656

Fixes #253