### PR TITLE
Destroy surfaces on client destruction (XDG shell)

### DIFF
--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -1147,8 +1147,7 @@ static void wlr_xdg_client_v6_destroy(struct wl_resource *resource) {
 
 	struct wlr_xdg_surface_v6 *surface, *tmp = NULL;
 	wl_list_for_each_safe(surface, tmp, &client->surfaces, link) {
-		wl_list_remove(&surface->link);
-		wl_list_init(&surface->link);
+		xdg_surface_destroy(surface);
 	}
 
 	if (client->ping_timer != NULL) {


### PR DESCRIPTION
Prevents accessing freed `wlr_xdg_client_v6` from `xdg_surface_destroy()` after it has been freed.
Prevents segfault when closing `weston-transformed`.