### PR TITLE
bug: keyboard focus a view on button release too

### DIFF
--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -248,6 +248,9 @@ static void do_cursor_button_press(struct roots_input *input,
 	switch (state) {
 	case WLR_BUTTON_RELEASED:
 		set_view_focus(input, desktop, NULL);
+		if (view) {
+			wlr_seat_keyboard_notify_enter(input->wl_seat, surface);
+		}
 		break;
 	case WLR_BUTTON_PRESSED:
 		i = input->input_events_idx;


### PR DESCRIPTION
This is technically not what weston or X11 does, and I think it's going to lead to some wonky behavior to always focus on button release, but you must call `set_view_focus()` to end the window grab and I don't feel like untangling that right now. Note that if you ever call `set_view_focus()` without also setting the keyboard focus, you can end up in a state where rootston focus and keyboard focus differ.

To reproduce:

Open a popup (right click menu on gnome-calculator) and then click into another window. The button down is swallowed and the button up focuses the new window. Rootston focus and keyboard focus are different.