### PR TITLE
bug: fix view centering

### DIFF
--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -17,8 +17,6 @@ struct roots_wl_shell_surface {
 	struct wl_listener request_set_maximized;
 
 	struct wl_listener surface_commit;
-
-	bool initialized;
 };
 
 struct roots_xdg_surface_v6 {
@@ -32,8 +30,6 @@ struct roots_xdg_surface_v6 {
 	struct wl_listener request_move;
 	struct wl_listener request_resize;
 	struct wl_listener request_show_window_menu;
-
-	bool initialized;
 };
 
 struct roots_xwayland_surface {
@@ -85,6 +81,6 @@ void view_activate(struct roots_view *view, bool active);
 void view_resize(struct roots_view *view, uint32_t width, uint32_t height);
 void view_close(struct roots_view *view);
 bool view_center(struct roots_view *view);
-bool view_initialize(struct roots_view *view);
+void view_initialize(struct roots_view *view);
 
 #endif

--- a/include/wlr/types/wlr_output_layout.h
+++ b/include/wlr/types/wlr_output_layout.h
@@ -84,4 +84,10 @@ struct wlr_box *wlr_output_layout_get_box(
 void wlr_output_layout_add_auto(struct wlr_output_layout *layout,
 		struct wlr_output *output);
 
+/**
+ * Get the output closest to the center of the layout extents.
+ */
+struct wlr_output *wlr_output_layout_get_center_output(
+		struct wlr_output_layout *layout);
+
 #endif

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -106,6 +106,7 @@ struct wlr_xdg_surface_v6 {
 	struct wl_list popup_link;
 
 	bool configured;
+	bool added;
 	struct wl_event_source *configure_idle;
 	struct wl_list configure_list;
 

--- a/rootston/wl_shell.c
+++ b/rootston/wl_shell.c
@@ -50,14 +50,7 @@ static void handle_request_resize(struct wl_listener *listener, void *data) {
 }
 
 static void handle_surface_commit(struct wl_listener *listener, void *data) {
-	struct roots_wl_shell_surface *roots_surface =
-		wl_container_of(listener, roots_surface, surface_commit);
-	struct roots_view *view = roots_surface->view;
-
-	if (view->wl_shell_surface->state == WLR_WL_SHELL_SURFACE_STATE_TOPLEVEL &&
-			!roots_surface->initialized) {
-		roots_surface->initialized = view_initialize(view);
-	}
+	// TODO do we need to do anything here?
 }
 
 static void handle_destroy(struct wl_listener *listener, void *data) {
@@ -137,4 +130,5 @@ void handle_wl_shell_surface(struct wl_listener *listener, void *data) {
 	view->desktop = desktop;
 	roots_surface->view = view;
 	list_add(desktop->views, view);
+	view_initialize(view);
 }

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -68,14 +68,7 @@ static void handle_request_resize(struct wl_listener *listener, void *data) {
 }
 
 static void handle_commit(struct wl_listener *listener, void *data) {
-	struct roots_xdg_surface_v6 *roots_xdg_surface =
-		wl_container_of(listener, roots_xdg_surface, commit);
-	struct roots_view *view = roots_xdg_surface->view;
-
-	if (view->xdg_surface_v6->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL &&
-			!roots_xdg_surface->initialized) {
-		roots_xdg_surface->initialized = view_initialize(view);
-	}
+	// TODO is there anything we need to do here?
 }
 
 static void handle_destroy(struct wl_listener *listener, void *data) {
@@ -141,4 +134,6 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	view->desktop = desktop;
 	roots_surface->view = view;
 	list_add(desktop->views, view);
+
+	view_initialize(view);
 }

--- a/types/wlr_output_layout.c
+++ b/types/wlr_output_layout.c
@@ -343,3 +343,20 @@ void wlr_output_layout_add_auto(struct wlr_output_layout *layout,
 	l_output->state->auto_configured = true;
 	wlr_output_layout_reconfigure(layout);
 }
+
+struct wlr_output *wlr_output_layout_get_center_output(
+		struct wlr_output_layout *layout) {
+	if (wl_list_empty(&layout->outputs)) {
+		return NULL;
+	}
+
+	struct wlr_box *extents = wlr_output_layout_get_box(layout, NULL);
+	double center_x = extents->width / 2 + extents->x;
+	double center_y = extents->height / 2 + extents->y;
+
+	double dest_x = 0, dest_y = 0;
+	wlr_output_layout_closest_point(layout, NULL, center_x, center_y,
+		&dest_x, &dest_y);
+
+	return wlr_output_layout_output_at(layout, dest_x, dest_y);
+}

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -802,10 +802,7 @@ static void xdg_surface_ack_configure(struct wl_client *client,
 		break;
 	}
 
-	if (!surface->configured) {
-		surface->configured = true;
-		wl_signal_emit(&surface->client->shell->events.new_surface, surface);
-	}
+	surface->configured = true;
 
 	wl_signal_emit(&surface->events.ack_configure, surface);
 
@@ -1053,6 +1050,11 @@ static void handle_wlr_surface_committed(struct wl_listener *listener,
 	case WLR_XDG_SURFACE_V6_ROLE_POPUP:
 		wlr_xdg_surface_v6_popup_committed(surface);
 		break;
+	}
+
+	if (surface->configured && !surface->added) {
+		surface->added = true;
+		wl_signal_emit(&surface->client->shell->events.new_surface, surface);
 	}
 
 	wl_signal_emit(&surface->events.commit, surface);


### PR DESCRIPTION
Make view initialization never fail instead of doing the initialization at some point in the future and flashing partially rendered content:

1. fix xdg-shell so it emits the new event with window geometry (the first commit after ack_configure)
2. pick the center output if no output is found under the cursor as a sensible default

Also, use the effective resolution of the output to determine centering so it works correctly on rotated outputs (this is understandably confusing and probably needs to be made clearer).