### PR TITLE
bug: detect invalid texture in xdg-shell

### DIFF
--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -9,6 +9,7 @@
 #include <wlr/types/wlr_surface.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/util/log.h>
+#include <wlr/render/interface.h>
 #include "xdg-shell-unstable-v6-protocol.h"
 
 static const char *wlr_desktop_xdg_toplevel_role = "xdg_toplevel";
@@ -993,7 +994,7 @@ static void wlr_xdg_surface_v6_toplevel_committed(
 		struct wlr_xdg_surface_v6 *surface) {
 	assert(surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL);
 
-	if (!surface->surface->current->buffer && !surface->toplevel_state->added) {
+	if (!surface->surface->texture->valid && !surface->toplevel_state->added) {
 		// on the first commit, send a configure request to tell the client it
 		// is added
 		wlr_xdg_surface_v6_schedule_configure(surface, true);
@@ -1001,7 +1002,7 @@ static void wlr_xdg_surface_v6_toplevel_committed(
 		return;
 	}
 
-	if (!surface->surface->current->buffer) {
+	if (!surface->surface->texture->valid) {
 		return;
 	}
 
@@ -1023,7 +1024,7 @@ static void handle_wlr_surface_committed(struct wl_listener *listener,
 	struct wlr_xdg_surface_v6 *surface =
 		wl_container_of(listener, surface, surface_commit_listener);
 
-	if (surface->surface->current->buffer && !surface->configured) {
+	if (surface->surface->texture->valid && !surface->configured) {
 		wl_resource_post_error(surface->resource,
 			ZXDG_SURFACE_V6_ERROR_UNCONFIGURED_BUFFER,
 			"xdg_surface has never been configured");
@@ -1092,7 +1093,7 @@ static void xdg_shell_get_xdg_surface(struct wl_client *wl_client,
 		&zxdg_surface_v6_interface, wl_resource_get_version(client_resource),
 		id);
 
-	if (surface->surface->current->buffer != NULL) {
+	if (surface->surface->texture->valid) {
 		wl_resource_post_error(surface->resource,
 			ZXDG_SURFACE_V6_ERROR_UNCONFIGURED_BUFFER,
 			"xdg_surface must not have a buffer at creation");


### PR DESCRIPTION
Use `surface->texture->valid` instead of `current->buffer != null` to detect whether the surface has a buffer. This fixes configure requests, since now we upload the buffer and set it to NULL immediately, `current->buffer` is always NULL.