### PR TITLE
Fix hidden cursors

### DIFF
--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -66,10 +66,12 @@ static bool wlr_wl_output_set_cursor(struct wlr_output *_output,
 	}
 	if (!buf) {
 		// Hide cursor
-		wl_surface_destroy(output->cursor_surface);
-		munmap(output->cursor_data, output->cursor_buf_size);
-		output->cursor_surface = NULL;
-		output->cursor_buf_size = 0;
+		if (output->cursor_surface) {
+			wl_surface_destroy(output->cursor_surface);
+			munmap(output->cursor_data, output->cursor_buf_size);
+			output->cursor_surface = NULL;
+			output->cursor_buf_size = 0;
+		}
 		wlr_wl_output_update_cursor(output, output->enter_serial, hotspot_x,
 			hotspot_y);
 		return true;

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -361,7 +361,9 @@ void wlr_output_swap_buffers(struct wlr_output *output) {
 			renderer = output->cursor.surface->renderer;
 		}
 
-		if (texture && renderer) {
+		// We check texture->valid because some clients set a cursor surface
+		// with a NULL buffer to hide it
+		if (renderer && texture && texture->valid) {
 			float matrix[16];
 			wlr_texture_get_matrix(texture, &matrix, &output->transform_matrix,
 				output->cursor.x, output->cursor.y);


### PR DESCRIPTION
- Fixes `mpv` hidden cursors on wayland backend
- Fixes `gnome-terminal` hidden cursors