### PR TITLE
Update Connector-CRTC bindings after resume in DRM backend

### DIFF
--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -62,10 +62,13 @@ static void session_signal(struct wl_listener *listener, void *data) {
 
 	if (session->active) {
 		wlr_log(L_INFO, "DRM fd resumed");
+		wlr_drm_scan_connectors(drm);
 
 		struct wlr_drm_connector *conn;
 		wl_list_for_each(conn, &drm->outputs, link){
-			wlr_drm_connector_start_renderer(conn);
+			if (conn->output.current_mode) {
+				wlr_output_set_mode(&conn->output, conn->output.current_mode);
+			}
 
 			if (!conn->crtc) {
 				continue;

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -437,10 +437,12 @@ static bool wlr_drm_connector_set_mode(struct wlr_output *output,
 		crtc->cursor ? crtc->cursor - drm->cursor_planes : -1);
 
 	conn->state = WLR_DRM_CONN_CONNECTED;
-	conn->output.width = mode->width;
-	conn->output.height = mode->height;
 	conn->output.current_mode = mode;
-	wl_signal_emit(&conn->output.events.resolution, &conn->output);
+	if (conn->output.width != mode->width || conn->output.height != mode->height) {
+		conn->output.width = mode->width;
+		conn->output.height = mode->height;
+		wl_signal_emit(&conn->output.events.resolution, &conn->output);
+	}
 
 	// Since realloc_crtcs can deallocate planes on OTHER outputs,
 	// we actually need to reinitalise all of them


### PR DESCRIPTION
Fix #204

~~Fix `match_obj()` behaviour on `[0, 0b11], [UNMATCHED, 1]`~~ (not required)
- [x] Fix deactivated monitors check