### PR TITLE
Remove wl_list_init when using wl_signal_add

### DIFF
--- a/backend/multi/backend.c
+++ b/backend/multi/backend.c
@@ -130,11 +130,6 @@ void wlr_multi_backend_add(struct wlr_backend *_multi,
 	sub->output_add.notify = output_add_reemit;
 	sub->output_remove.notify = output_remove_reemit;
 
-	wl_list_init(&sub->input_add.link);
-	wl_list_init(&sub->input_remove.link);
-	wl_list_init(&sub->output_add.link);
-	wl_list_init(&sub->output_remove.link);
-
 	wl_signal_add(&backend->events.input_add, &sub->input_add);
 	wl_signal_add(&backend->events.input_remove, &sub->input_remove);
 	wl_signal_add(&backend->events.output_add, &sub->output_add);

--- a/examples/pointer.c
+++ b/examples/pointer.c
@@ -284,7 +284,7 @@ int main(int argc, char *argv[]) {
 	state.cursor_motion.notify = handle_cursor_motion;
 
 	wl_signal_add(&state.cursor->events.motion_absolute,
-        &state.cursor_motion_absolute);
+		&state.cursor_motion_absolute);
 	state.cursor_motion_absolute.notify = handle_cursor_motion_absolute;
 
 	wl_signal_add(&state.cursor->events.button, &state.cursor_button);
@@ -308,7 +308,7 @@ int main(int argc, char *argv[]) {
 
 	// tool events
 	wl_signal_add(&state.cursor->events.tablet_tool_axis,
-        &state.tablet_tool_axis);
+		&state.tablet_tool_axis);
 	state.tablet_tool_axis.notify = handle_tablet_tool_axis;
 
 	struct compositor_state compositor = { 0 };

--- a/examples/shared.c
+++ b/examples/shared.c
@@ -60,7 +60,6 @@ static void keyboard_add(struct wlr_input_device *device, struct compositor_stat
 	struct keyboard_state *kbstate = calloc(sizeof(struct keyboard_state), 1);
 	kbstate->device = device;
 	kbstate->compositor = state;
-	wl_list_init(&kbstate->key.link);
 	kbstate->key.notify = keyboard_key_notify;
 	wl_signal_add(&device->keyboard->events.key, &kbstate->key);
 	wl_list_insert(&state->keyboards, &kbstate->link);
@@ -122,10 +121,6 @@ static void pointer_add(struct wlr_input_device *device, struct compositor_state
 	struct pointer_state *pstate = calloc(sizeof(struct pointer_state), 1);
 	pstate->device = device;
 	pstate->compositor = state;
-	wl_list_init(&pstate->motion.link);
-	wl_list_init(&pstate->motion_absolute.link);
-	wl_list_init(&pstate->button.link);
-	wl_list_init(&pstate->axis.link);
 	pstate->motion.notify = pointer_motion_notify;
 	pstate->motion_absolute.notify = pointer_motion_absolute_notify;
 	pstate->button.notify = pointer_button_notify;
@@ -175,10 +170,6 @@ static void touch_add(struct wlr_input_device *device, struct compositor_state *
 	struct touch_state *tstate = calloc(sizeof(struct touch_state), 1);
 	tstate->device = device;
 	tstate->compositor = state;
-	wl_list_init(&tstate->down.link);
-	wl_list_init(&tstate->motion.link);
-	wl_list_init(&tstate->up.link);
-	wl_list_init(&tstate->cancel.link);
 	tstate->down.notify = touch_down_notify;
 	tstate->motion.notify = touch_motion_notify;
 	tstate->up.notify = touch_up_notify;
@@ -219,10 +210,6 @@ static void tablet_tool_add(struct wlr_input_device *device,
 	struct tablet_tool_state *tstate = calloc(sizeof(struct tablet_tool_state), 1);
 	tstate->device = device;
 	tstate->compositor = state;
-	wl_list_init(&tstate->axis.link);
-	wl_list_init(&tstate->proximity.link);
-	wl_list_init(&tstate->tip.link);
-	wl_list_init(&tstate->button.link);
 	tstate->axis.notify = tablet_tool_axis_notify;
 	tstate->proximity.notify = tablet_tool_proximity_notify;
 	//tstate->tip.notify = tablet_tool_tip_notify;
@@ -247,7 +234,6 @@ static void tablet_pad_add(struct wlr_input_device *device,
 	struct tablet_pad_state *pstate = calloc(sizeof(struct tablet_pad_state), 1);
 	pstate->device = device;
 	pstate->compositor = state;
-	wl_list_init(&pstate->button.link);
 	pstate->button.notify = tablet_pad_button_notify;
 	wl_signal_add(&device->tablet_pad->events.button, &pstate->button);
 	wl_list_insert(&state->tablet_pads, &pstate->link);
@@ -436,7 +422,6 @@ static void output_add_notify(struct wl_listener *listener, void *data) {
 	ostate->compositor = state;
 	ostate->frame.notify = output_frame_notify;
 	ostate->resolution.notify = output_resolution_notify;
-	wl_list_init(&ostate->frame.link);
 	wl_signal_add(&output->events.frame, &ostate->frame);
 	wl_signal_add(&output->events.resolution, &ostate->resolution);
 	wl_list_insert(&state->outputs, &ostate->link);
@@ -476,15 +461,11 @@ void compositor_init(struct compositor_state *state) {
 	wl_list_init(&state->touch);
 	wl_list_init(&state->tablet_tools);
 	wl_list_init(&state->tablet_pads);
-	wl_list_init(&state->input_add.link);
 	state->input_add.notify = input_add_notify;
-	wl_list_init(&state->input_remove.link);
 	state->input_remove.notify = input_remove_notify;
 
 	wl_list_init(&state->outputs);
-	wl_list_init(&state->output_add.link);
 	state->output_add.notify = output_add_notify;
-	wl_list_init(&state->output_remove.link);
 	state->output_remove.notify = output_remove_notify;
 
 	struct wlr_backend *wlr = wlr_backend_autocreate(state->display);

--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -8,13 +8,12 @@
 
 struct roots_wl_shell_surface {
 	struct roots_view *view;
+
 	// TODO: Maybe destroy listener should go in roots_view
 	struct wl_listener destroy;
 	struct wl_listener ping_timeout;
 	struct wl_listener request_move;
 	struct wl_listener request_resize;
-	struct wl_listener request_set_fullscreen;
-	struct wl_listener request_set_maximized;
 
 	struct wl_listener surface_commit;
 };
@@ -25,15 +24,13 @@ struct roots_xdg_surface_v6 {
 	// TODO: Maybe destroy listener should go in roots_view
 	struct wl_listener commit;
 	struct wl_listener destroy;
-	struct wl_listener ping_timeout;
-	struct wl_listener request_minimize;
 	struct wl_listener request_move;
 	struct wl_listener request_resize;
-	struct wl_listener request_show_window_menu;
 };
 
 struct roots_xwayland_surface {
 	struct roots_view *view;
+
 	// TODO: Maybe destroy listener should go in roots_view
 	struct wl_listener destroy;
 	struct wl_listener request_configure;

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -393,51 +393,41 @@ static void handle_request_set_cursor(struct wl_listener *listener,
 
 void cursor_initialize(struct roots_input *input) {
 	struct wlr_cursor *cursor = input->cursor;
-	
+
 	// TODO: Does this belong here
 	wl_list_init(&input->touch_points);
 
-	wl_list_init(&input->cursor_motion.link);
 	wl_signal_add(&cursor->events.motion, &input->cursor_motion);
 	input->cursor_motion.notify = handle_cursor_motion;
 
-	wl_list_init(&input->cursor_motion_absolute.link);
 	wl_signal_add(&cursor->events.motion_absolute,
 		&input->cursor_motion_absolute);
 	input->cursor_motion_absolute.notify = handle_cursor_motion_absolute;
 
-	wl_list_init(&input->cursor_button.link);
 	wl_signal_add(&cursor->events.button, &input->cursor_button);
 	input->cursor_button.notify = handle_cursor_button;
 
-	wl_list_init(&input->cursor_axis.link);
 	wl_signal_add(&cursor->events.axis, &input->cursor_axis);
 	input->cursor_axis.notify = handle_cursor_axis;
 
-	wl_list_init(&input->cursor_touch_down.link);
 	wl_signal_add(&cursor->events.touch_down, &input->cursor_touch_down);
 	input->cursor_touch_down.notify = handle_touch_down;
 
-	wl_list_init(&input->cursor_touch_up.link);
 	wl_signal_add(&cursor->events.touch_up, &input->cursor_touch_up);
 	input->cursor_touch_up.notify = handle_touch_up;
 
-	wl_list_init(&input->cursor_touch_motion.link);
 	wl_signal_add(&cursor->events.touch_motion, &input->cursor_touch_motion);
 	input->cursor_touch_motion.notify = handle_touch_motion;
 
-	wl_list_init(&input->cursor_tool_axis.link);
 	wl_signal_add(&cursor->events.tablet_tool_axis, &input->cursor_tool_axis);
 	input->cursor_tool_axis.notify = handle_tool_axis;
 
-	wl_list_init(&input->cursor_tool_tip.link);
 	wl_signal_add(&cursor->events.tablet_tool_tip, &input->cursor_tool_tip);
 	input->cursor_tool_tip.notify = handle_tool_tip;
 
 	wl_signal_add(&input->wl_seat->events.pointer_grab_end, &input->pointer_grab_end);
 	input->pointer_grab_end.notify = handle_pointer_grab_end;
 
-	wl_list_init(&input->request_set_cursor.link);
 	wl_signal_add(&input->wl_seat->events.request_set_cursor,
 		&input->request_set_cursor);
 	input->request_set_cursor.notify = handle_request_set_cursor;

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -202,11 +202,18 @@ struct roots_view *view_at(struct roots_desktop *desktop, double lx, double ly,
 
 struct roots_desktop *desktop_create(struct roots_server *server,
 		struct roots_config *config) {
-	struct roots_desktop *desktop = calloc(1, sizeof(struct roots_desktop));
-	assert(desktop);
 	wlr_log(L_DEBUG, "Initializing roots desktop");
 
-	assert(desktop->views = list_create());
+	struct roots_desktop *desktop = calloc(1, sizeof(struct roots_desktop));
+	if (desktop == NULL) {
+		return NULL;
+	}
+
+	desktop->views = list_create();
+	if (desktop->views == NULL) {
+		free(desktop);
+		return NULL;
+	}
 	wl_list_init(&desktop->outputs);
 
 	desktop->output_add.notify = output_add_notify;

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -203,16 +203,15 @@ struct roots_view *view_at(struct roots_desktop *desktop, double lx, double ly,
 struct roots_desktop *desktop_create(struct roots_server *server,
 		struct roots_config *config) {
 	struct roots_desktop *desktop = calloc(1, sizeof(struct roots_desktop));
+	assert(desktop);
 	wlr_log(L_DEBUG, "Initializing roots desktop");
 
 	assert(desktop->views = list_create());
 	wl_list_init(&desktop->outputs);
-	wl_list_init(&desktop->output_add.link);
-	desktop->output_add.notify = output_add_notify;
-	wl_list_init(&desktop->output_remove.link);
-	desktop->output_remove.notify = output_remove_notify;
 
+	desktop->output_add.notify = output_add_notify;
 	wl_signal_add(&server->backend->events.output_add, &desktop->output_add);
+	desktop->output_remove.notify = output_remove_notify;
 	wl_signal_add(&server->backend->events.output_remove,
 		&desktop->output_remove);
 

--- a/rootston/input.c
+++ b/rootston/input.c
@@ -74,15 +74,34 @@ struct roots_input *input_create(struct roots_server *server,
 	assert(server->desktop);
 
 	struct roots_input *input = calloc(1, sizeof(struct roots_input));
-	assert(input);
+	if (input == NULL) {
+		return NULL;
+	}
 
 	input->config = config;
 	input->server = server;
 
-	assert(input->theme = wlr_xcursor_theme_load("default", 16));
-	assert(input->xcursor = wlr_xcursor_theme_get_cursor(input->theme, "left_ptr"));
+	input->theme = wlr_xcursor_theme_load("default", 16);
+	if (input->theme == NULL) {
+		wlr_log(L_ERROR, "Cannot load xcursor theme");
+		free(input);
+		return NULL;
+	}
+	input->xcursor = wlr_xcursor_theme_get_cursor(input->theme, "left_ptr");
+	if (input->xcursor == NULL) {
+		wlr_log(L_ERROR, "Cannot load xcursor from theme");
+		wlr_xcursor_theme_destroy(input->theme);
+		free(input);
+		return NULL;
+	}
 
-	assert(input->wl_seat = wlr_seat_create(server->wl_display, "seat0"));
+	input->wl_seat = wlr_seat_create(server->wl_display, "seat0");
+	if (input->wl_seat == NULL) {
+		wlr_log(L_ERROR, "Cannot create seat");
+		wlr_xcursor_theme_destroy(input->theme);
+		free(input);
+		return NULL;
+	}
 	wlr_seat_set_capabilities(input->wl_seat, WL_SEAT_CAPABILITY_KEYBOARD
 		| WL_SEAT_CAPABILITY_POINTER | WL_SEAT_CAPABILITY_TOUCH);
 

--- a/rootston/input.c
+++ b/rootston/input.c
@@ -91,15 +91,10 @@ struct roots_input *input_create(struct roots_server *server,
 	wl_list_init(&input->touch);
 	wl_list_init(&input->tablet_tools);
 
-	wl_list_init(&input->input_add.link);
 	input->input_add.notify = input_add_notify;
-	wl_list_init(&input->input_remove.link);
+	wl_signal_add(&server->backend->events.input_add, &input->input_add);
 	input->input_remove.notify = input_remove_notify;
-
-	wl_signal_add(&server->backend->events.input_add,
-			&input->input_add);
-	wl_signal_add(&server->backend->events.input_remove,
-			&input->input_remove);
+	wl_signal_add(&server->backend->events.input_remove, &input->input_remove);
 
 	input->cursor = wlr_cursor_create();
 	cursor_initialize(input);

--- a/rootston/keyboard.c
+++ b/rootston/keyboard.c
@@ -127,6 +127,9 @@ static void keyboard_key_notify(struct wl_listener *listener, void *data) {
 
 void keyboard_add(struct wlr_input_device *device, struct roots_input *input) {
 	struct roots_keyboard *keyboard = calloc(sizeof(struct roots_keyboard), 1);
+	if (keyboard == NULL) {
+		return;
+	}
 	device->data = keyboard;
 	keyboard->device = device;
 	keyboard->input = input;
@@ -141,11 +144,15 @@ void keyboard_add(struct wlr_input_device *device, struct roots_input *input) {
 	rules.layout = getenv("XKB_DEFAULT_LAYOUT");
 	rules.variant = getenv("XKB_DEFAULT_VARIANT");
 	rules.options = getenv("XKB_DEFAULT_OPTIONS");
-	struct xkb_context *context;
-	assert(context = xkb_context_new(XKB_CONTEXT_NO_FLAGS));
+	struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+	if (context == NULL) {
+		wlr_log(L_ERROR, "Cannot create XKB context");
+		return;
+	}
 	wlr_keyboard_set_keymap(device->keyboard, xkb_map_new_from_names(context,
-				&rules, XKB_KEYMAP_COMPILE_NO_FLAGS));
+		&rules, XKB_KEYMAP_COMPILE_NO_FLAGS));
 	xkb_context_unref(context);
+
 	wlr_seat_attach_keyboard(input->wl_seat, device);
 }
 

--- a/rootston/keyboard.c
+++ b/rootston/keyboard.c
@@ -130,7 +130,6 @@ void keyboard_add(struct wlr_input_device *device, struct roots_input *input) {
 	device->data = keyboard;
 	keyboard->device = device;
 	keyboard->input = input;
-	wl_list_init(&keyboard->key.link);
 	keyboard->key.notify = keyboard_key_notify;
 	wl_signal_add(&device->keyboard->events.key, &keyboard->key);
 	wl_list_insert(&input->keyboards, &keyboard->link);

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -175,7 +175,6 @@ void output_add_notify(struct wl_listener *listener, void *data) {
 	output->desktop = desktop;
 	output->wlr_output = wlr_output;
 	output->frame.notify = output_frame_notify;
-	wl_list_init(&output->frame.link);
 	wl_signal_add(&wlr_output->events.frame, &output->frame);
 	wl_list_insert(&desktop->outputs, &output->link);
 

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -74,12 +74,10 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 static void handle_destroy(struct wl_listener *listener, void *data) {
 	struct roots_xdg_surface_v6 *roots_xdg_surface =
 		wl_container_of(listener, roots_xdg_surface, destroy);
+	wl_list_remove(&roots_xdg_surface->commit.link);
 	wl_list_remove(&roots_xdg_surface->destroy.link);
-	wl_list_remove(&roots_xdg_surface->ping_timeout.link);
 	wl_list_remove(&roots_xdg_surface->request_move.link);
 	wl_list_remove(&roots_xdg_surface->request_resize.link);
-	wl_list_remove(&roots_xdg_surface->request_show_window_menu.link);
-	wl_list_remove(&roots_xdg_surface->request_minimize.link);
 	view_destroy(roots_xdg_surface->view);
 	free(roots_xdg_surface);
 }
@@ -105,22 +103,15 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	if (!roots_surface) {
 		return;
 	}
-	wl_list_init(&roots_surface->commit.link);
 	roots_surface->commit.notify = handle_commit;
 	wl_signal_add(&surface->events.commit, &roots_surface->commit);
-	wl_list_init(&roots_surface->destroy.link);
 	roots_surface->destroy.notify = handle_destroy;
 	wl_signal_add(&surface->events.destroy, &roots_surface->destroy);
-	wl_list_init(&roots_surface->ping_timeout.link);
-	wl_list_init(&roots_surface->request_minimize.link);
-	wl_list_init(&roots_surface->request_move.link);
 	roots_surface->request_move.notify = handle_request_move;
 	wl_signal_add(&surface->events.request_move, &roots_surface->request_move);
-	wl_list_init(&roots_surface->request_resize.link);
 	roots_surface->request_resize.notify = handle_request_resize;
 	wl_signal_add(&surface->events.request_resize,
 		&roots_surface->request_resize);
-	wl_list_init(&roots_surface->request_show_window_menu.link);
 
 	struct roots_view *view = calloc(1, sizeof(struct roots_view));
 	view->type = ROOTS_XDG_SHELL_V6_VIEW;

--- a/rootston/xwayland.c
+++ b/rootston/xwayland.c
@@ -75,10 +75,8 @@ void handle_xwayland_surface(struct wl_listener *listener, void *data) {
 	if (roots_surface == NULL) {
 		return;
 	}
-	wl_list_init(&roots_surface->destroy.link);
 	roots_surface->destroy.notify = handle_destroy;
 	wl_signal_add(&surface->events.destroy, &roots_surface->destroy);
-	wl_list_init(&roots_surface->request_configure.link);
 	roots_surface->request_configure.notify = handle_request_configure;
 	wl_signal_add(&surface->events.request_configure,
 		&roots_surface->request_configure);

--- a/types/wlr_seat.c
+++ b/types/wlr_seat.c
@@ -635,17 +635,13 @@ void wlr_seat_attach_keyboard(struct wlr_seat *seat,
 		calloc(1, sizeof(struct wlr_seat_keyboard));
 	seat_kb->keyboard = kb;
 	seat_kb->seat = seat;
-	wl_list_init(&seat_kb->key.link);
 	seat_kb->key.notify = keyboard_key_notify;
 	wl_signal_add(&kb->events.key, &seat_kb->key);
-	wl_list_init(&seat_kb->modifiers.link);
 	seat_kb->modifiers.notify = keyboard_modifiers_notify;
 	wl_signal_add(&kb->events.modifiers, &seat_kb->modifiers);
-	wl_list_init(&seat_kb->keymap.link);
 	seat_kb->keymap.notify = keyboard_keymap_notify;
 	wl_signal_add(&kb->events.keymap, &seat_kb->keymap);
 	// TODO: update keymap as necessary
-	wl_list_init(&seat_kb->destroy.link);
 	seat_kb->destroy.notify = keyboard_destroy_notify;
 	wl_signal_add(&dev->events.destroy, &seat_kb->destroy);
 	wl_list_insert(&seat->keyboards, &seat_kb->link);


### PR DESCRIPTION
I removed some fields in rootston views because they were not used. Calling `wl_list_remove` on a listener not initialized with `wl_signal_add` segfaults.

Also cleanups rootston:
* Add missing allocation checks
* Remove assertions used to check runtime errors

Fixes #283