### PR TITLE
Moved comments in rootston keybinding example config

### DIFF
--- a/rootston/rootston.ini.example
+++ b/rootston/rootston.ini.example
@@ -34,8 +34,12 @@ meta-key = Logo
 
 # Keybindings
 # Maps key combinations with commands to execute
-# Use the prefix "exec" to execute a shell command
+# Commands include:
+# - "exit" to stop the compositor
+# - "exec" to execute a shell command
+# - "close" to close the current view
+# - "next_window" to cycle through windows
 [bindings]
-Logo+Shift+e = exit # Stop the compositor
-Logo+q = close # Close the current view
-Alt+Tab = next_window # Cycle through windows
+Logo+Shift+e = exit
+Logo+q = close
+Alt+Tab = next_window


### PR DESCRIPTION
The comment strings are not stripped so the commands are not currently recognised.