### PR TITLE
Changed broken example rootston keybinding

### DIFF
--- a/rootston/rootston.ini.example
+++ b/rootston/rootston.ini.example
@@ -40,6 +40,6 @@ meta-key = Logo
 # - "close" to close the current view
 # - "next_window" to cycle through windows
 [bindings]
-Logo+Shift+e = exit
+Logo+Shift+E = exit
 Logo+q = close
 Alt+Tab = next_window


### PR DESCRIPTION
Since `Shift` is part of the `Logo+Shift+e` keybinding, the `e` keysym is never received, only `E`.

Should rootston be detecting the presence of `Shift` and automatically working out that it should switch the expected keysyms to uppercase (I guess by querying the xkb layout)? I looked into it briefly, but couldn't tell if there is any simple way to do this.