### PR TITLE
Create globals only for enabled outputs in DRM backend

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -748,7 +748,6 @@ void wlr_drm_scan_connectors(struct wlr_drm_backend *drm) {
 			free(edid);
 
 			wl_list_insert(&drm->outputs, &wlr_conn->link);
-			wlr_output_create_global(&wlr_conn->output, drm->display);
 			wlr_log(L_INFO, "Found display '%s'", wlr_conn->output.name);
 		} else {
 			seen[index] = true;
@@ -756,7 +755,6 @@ void wlr_drm_scan_connectors(struct wlr_drm_backend *drm) {
 
 		if (wlr_conn->state == WLR_DRM_CONN_DISCONNECTED &&
 				drm_conn->connection == DRM_MODE_CONNECTED) {
-
 			wlr_log(L_INFO, "'%s' connected", wlr_conn->output.name);
 			wlr_log(L_INFO, "Detected modes:");
 
@@ -778,14 +776,17 @@ void wlr_drm_scan_connectors(struct wlr_drm_backend *drm) {
 				wl_list_insert(&wlr_conn->output.modes, &mode->wlr_mode.link);
 			}
 
+			wlr_output_create_global(&wlr_conn->output, drm->display);
+
 			wlr_conn->state = WLR_DRM_CONN_NEEDS_MODESET;
 			wlr_log(L_INFO, "Sending modesetting signal for '%s'",
 				wlr_conn->output.name);
 			wl_signal_emit(&drm->backend.events.output_add, &wlr_conn->output);
 		} else if (wlr_conn->state == WLR_DRM_CONN_CONNECTED &&
 				drm_conn->connection != DRM_MODE_CONNECTED) {
-
 			wlr_log(L_INFO, "'%s' disconnected", wlr_conn->output.name);
+
+			wlr_output_destroy_global(&wlr_conn->output);
 			wlr_drm_connector_cleanup(wlr_conn);
 		}
 

--- a/examples/screenshot.c
+++ b/examples/screenshot.c
@@ -267,10 +267,6 @@ int main(int argc, char *argv[]) {
 
 	struct screenshooter_output *output;
 	wl_list_for_each(output, &output_list, link) {
-		if (output->width == 0 || output->height == 0) {
-			continue;
-		}
-
 		output->buffer = create_shm_buffer(output->width, output->height, &output->data);
 		if (output->buffer == NULL) {
 			return -1;

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -26,7 +26,8 @@ void wlr_output_init(struct wlr_output *output, struct wlr_backend *backend,
 	const struct wlr_output_impl *impl);
 void wlr_output_free(struct wlr_output *output);
 void wlr_output_update_matrix(struct wlr_output *output);
-struct wl_global *wlr_output_create_global(
-	struct wlr_output *wlr_output, struct wl_display *display);
+struct wl_global *wlr_output_create_global(struct wlr_output *wlr_output,
+	struct wl_display *display);
+void wlr_output_destroy_global(struct wlr_output *wlr_output);
 
 #endif


### PR DESCRIPTION
Test by running `weston-info`, plugging a monitor, running it again, unplugging a monitor, and running it again.

Fixes #317
