### PR TITLE
abstract buffer exists

### DIFF
--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -110,6 +110,14 @@ int wlr_surface_set_role(struct wlr_surface *surface, const char *role,
 		struct wl_resource *error_resource, uint32_t error_code);
 
 /**
+ * Whether or not this surface currently has an attached buffer. A surface has
+ * an attached buffer when it commits with a non-null buffer in its pending
+ * state. A surface will not have a buffer if it has never committed one, has
+ * committed a null buffer, or something went wrong with uploading the buffer.
+ */
+bool wlr_surface_has_buffer(struct wlr_surface *surface);
+
+/**
  * Create the subsurface implementation for this surface.
  */
 void wlr_surface_make_subsurface(struct wlr_surface *surface,

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -655,6 +655,10 @@ void wlr_surface_get_matrix(struct wlr_surface *surface,
 	wlr_matrix_mul(projection, matrix, matrix);
 }
 
+bool wlr_surface_has_buffer(struct wlr_surface *surface) {
+	return surface->texture && surface->texture->valid;
+}
+
 int wlr_surface_set_role(struct wlr_surface *surface, const char *role,
 		struct wl_resource *error_resource, uint32_t error_code) {
 	assert(role);

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -406,7 +406,8 @@ static void wlr_surface_commit_pending(struct wlr_surface *surface) {
 	wlr_surface_move_state(surface, surface->pending, surface->current);
 
 	if (null_buffer_commit) {
-		surface->texture->valid = false;
+		wlr_texture_destroy(surface->texture);
+		surface->texture = NULL;
 	}
 
 	bool reupload_buffer = oldw != surface->current->buffer_width ||

--- a/types/wlr_wl_shell.c
+++ b/types/wlr_wl_shell.c
@@ -8,7 +8,6 @@
 #include <wlr/types/wlr_wl_shell.h>
 #include <stdlib.h>
 #include <wayland-server-protocol.h>
-#include <wlr/render/interface.h>
 
 static const char *wlr_wl_shell_surface_role = "wl-shell-surface";
 
@@ -482,7 +481,7 @@ static void handle_wlr_surface_committed(struct wl_listener *listener,
 	struct wlr_wl_shell_surface *surface =
 		wl_container_of(listener, surface, surface_commit_listener);
 	if (!surface->configured &&
-			surface->surface->texture->valid &&
+			wlr_surface_has_buffer(surface->surface) &&
 			surface->state != WLR_WL_SHELL_SURFACE_STATE_NONE) {
 		surface->configured = true;
 		wl_signal_emit(&surface->shell->events.new_surface, surface);
@@ -490,7 +489,7 @@ static void handle_wlr_surface_committed(struct wl_listener *listener,
 
 	if (surface->popup_mapped &&
 			surface->state == WLR_WL_SHELL_SURFACE_STATE_POPUP &&
-			!surface->surface->texture->valid) {
+			!wlr_surface_has_buffer(surface->surface)) {
 		surface->popup_mapped = false;
 		struct wlr_wl_shell_popup_grab *grab =
 			shell_popup_grab_from_seat(surface->shell,

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -9,7 +9,6 @@
 #include <wlr/types/wlr_surface.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/util/log.h>
-#include <wlr/render/interface.h>
 #include "xdg-shell-unstable-v6-protocol.h"
 
 static const char *wlr_desktop_xdg_toplevel_role = "xdg_toplevel";
@@ -1018,7 +1017,8 @@ static void wlr_xdg_surface_v6_toplevel_committed(
 		struct wlr_xdg_surface_v6 *surface) {
 	assert(surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL);
 
-	if (!surface->surface->texture->valid && !surface->toplevel_state->added) {
+	if (!wlr_surface_has_buffer(surface->surface)
+			&& !surface->toplevel_state->added) {
 		// on the first commit, send a configure request to tell the client it
 		// is added
 		wlr_xdg_surface_v6_schedule_configure(surface);
@@ -1026,7 +1026,7 @@ static void wlr_xdg_surface_v6_toplevel_committed(
 		return;
 	}
 
-	if (!surface->surface->texture->valid) {
+	if (!wlr_surface_has_buffer(surface->surface)) {
 		return;
 	}
 
@@ -1048,7 +1048,7 @@ static void handle_wlr_surface_committed(struct wl_listener *listener,
 	struct wlr_xdg_surface_v6 *surface =
 		wl_container_of(listener, surface, surface_commit_listener);
 
-	if (surface->surface->texture->valid && !surface->configured) {
+	if (wlr_surface_has_buffer(surface->surface) && !surface->configured) {
 		wl_resource_post_error(surface->resource,
 			ZXDG_SURFACE_V6_ERROR_UNCONFIGURED_BUFFER,
 			"xdg_surface has never been configured");
@@ -1117,7 +1117,7 @@ static void xdg_shell_get_xdg_surface(struct wl_client *wl_client,
 		&zxdg_surface_v6_interface, wl_resource_get_version(client_resource),
 		id);
 
-	if (surface->surface->texture->valid) {
+	if (wlr_surface_has_buffer(surface->surface)) {
 		wl_resource_post_error(surface->resource,
 			ZXDG_SURFACE_V6_ERROR_UNCONFIGURED_BUFFER,
 			"xdg_surface must not have a buffer at creation");


### PR DESCRIPTION
Add `wlr_surface_has_buffer` and use it instead of `surface->texture->valid` in dependent interfaces. See #319 .