### PR TITLE
Fixes #321, not using result of wl_container_of

### DIFF
--- a/examples/shared.c
+++ b/examples/shared.c
@@ -414,8 +414,8 @@ static void output_add_notify(struct wl_listener *listener, void *data) {
 	wlr_log(L_DEBUG, "%s %s %"PRId32"mm x %"PRId32"mm", output->make, output->model,
 		output->phys_width, output->phys_height);
 	if (wl_list_length(&output->modes) > 0) {
-		struct wlr_output_mode *mode = NULL;
-		wl_container_of((&output->modes)->prev, mode, link);
+		struct wlr_output_mode *mode;
+		mode = wl_container_of((&output->modes)->prev, mode, link);
 		wlr_output_set_mode(output, mode);
 	}
 	struct output_state *ostate = calloc(1, sizeof(struct output_state));


### PR DESCRIPTION
Did a grep through the codebase and this is the only place where we don't use the result of `wl_container_of`, so this should be the only place where we misused it.