### PR TITLE
Revert "wlr-surface: destroy texture on null buffer commit"

### DIFF
--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -406,8 +406,7 @@ static void wlr_surface_commit_pending(struct wlr_surface *surface) {
 	wlr_surface_move_state(surface, surface->pending, surface->current);
 
 	if (null_buffer_commit) {
-		wlr_texture_destroy(surface->texture);
-		surface->texture = NULL;
+		surface->texture->valid = false;
 	}
 
 	bool reupload_buffer = oldw != surface->current->buffer_width ||


### PR DESCRIPTION
This reverts commit 0e7d13fab7f23658a85df58ad26c6c77c9638bff.