### PR TITLE
Add server-decoration protocol

### DIFF
--- a/include/rootston/desktop.h
+++ b/include/rootston/desktop.h
@@ -37,11 +37,13 @@ struct roots_desktop {
 	struct wlr_xdg_shell_v6 *xdg_shell_v6;
 	struct wlr_gamma_control_manager *gamma_control_manager;
 	struct wlr_screenshooter *screenshooter;
+	struct wlr_server_decoration_manager *server_decoration_manager;
 
 	struct wl_listener output_add;
 	struct wl_listener output_remove;
 	struct wl_listener xdg_shell_v6_surface;
 	struct wl_listener wl_shell_surface;
+	struct wl_listener decoration_new;
 
 #ifdef HAS_XWAYLAND
 	struct wlr_xwayland *xwayland;

--- a/include/wlr/types/wlr_server_decoration.h
+++ b/include/wlr/types/wlr_server_decoration.h
@@ -1,0 +1,29 @@
+#ifndef WLR_TYPES_WLR_SERVER_DECORATION_H
+#define WLR_TYPES_WLR_SERVER_DECORATION_H
+
+#include <wayland-server.h>
+
+struct wlr_server_decoration_manager {
+	struct wl_global *wl_global;
+	struct wl_list decorations; // wlr_server_decoration::link
+
+	void *data;
+};
+
+struct wlr_server_decoration {
+	struct wl_resource *resource;
+	struct wl_list link;
+
+	struct {
+		struct wl_signal destroy;
+	} events;
+
+	void *data;
+};
+
+struct wlr_server_decoration_manager *wlr_server_decoration_manager_create(
+	struct wl_display *display);
+void wlr_server_decoration_manager_destroy(
+	struct wlr_server_decoration_manager *manager);
+
+#endif

--- a/include/wlr/types/wlr_server_decoration.h
+++ b/include/wlr/types/wlr_server_decoration.h
@@ -5,25 +5,45 @@
 
 struct wlr_server_decoration_manager {
 	struct wl_global *wl_global;
+	struct wl_list wl_resources;
 	struct wl_list decorations; // wlr_server_decoration::link
+
+	uint32_t default_mode; // enum org_kde_kwin_server_decoration_manager_mode
+
+	struct {
+		struct wl_signal new_decoration;
+	} events;
 
 	void *data;
 };
 
 struct wlr_server_decoration {
 	struct wl_resource *resource;
+	struct wlr_surface *surface;
 	struct wl_list link;
+
+	// enum org_kde_kwin_server_decoration_manager_mode
+	uint32_t requested_mode;
+	uint32_t sent_mode;
 
 	struct {
 		struct wl_signal destroy;
+		struct wl_signal request_mode;
 	} events;
+
+	struct wl_listener surface_destroy_listener;
 
 	void *data;
 };
 
 struct wlr_server_decoration_manager *wlr_server_decoration_manager_create(
 	struct wl_display *display);
+void wlr_server_decoration_manager_set_default_mode(
+	struct wlr_server_decoration_manager *manager, uint32_t default_mode);
 void wlr_server_decoration_manager_destroy(
 	struct wlr_server_decoration_manager *manager);
+
+void wlr_server_decoration_send_mode(struct wlr_server_decoration *decoration,
+	uint32_t mode);
 
 #endif

--- a/include/wlr/types/wlr_server_decoration.h
+++ b/include/wlr/types/wlr_server_decoration.h
@@ -22,13 +22,11 @@ struct wlr_server_decoration {
 	struct wlr_surface *surface;
 	struct wl_list link;
 
-	// enum org_kde_kwin_server_decoration_manager_mode
-	uint32_t requested_mode;
-	uint32_t sent_mode;
+	uint32_t mode; // enum org_kde_kwin_server_decoration_manager_mode
 
 	struct {
 		struct wl_signal destroy;
-		struct wl_signal request_mode;
+		struct wl_signal mode;
 	} events;
 
 	struct wl_listener surface_destroy_listener;
@@ -42,8 +40,5 @@ void wlr_server_decoration_manager_set_default_mode(
 	struct wlr_server_decoration_manager *manager, uint32_t default_mode);
 void wlr_server_decoration_manager_destroy(
 	struct wlr_server_decoration_manager *manager);
-
-void wlr_server_decoration_send_mode(struct wlr_server_decoration *decoration,
-	uint32_t mode);
 
 #endif

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -24,12 +24,14 @@ protocols = [
 	[wl_protocol_dir, 'unstable/xdg-shell/xdg-shell-unstable-v6.xml'],
 	'gamma-control.xml',
 	'screenshooter.xml',
+	'server-decoration.xml',
 ]
 
 client_protocols = [
 	[wl_protocol_dir, 'unstable/xdg-shell/xdg-shell-unstable-v6.xml'],
 	'gamma-control.xml',
 	'screenshooter.xml',
+	'server-decoration.xml',
 ]
 
 wl_protos_src = []

--- a/protocol/server-decoration.xml
+++ b/protocol/server-decoration.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="server_decoration">
+  <copyright><![CDATA[
+    Copyright (C) 2015 Martin Gräßlin
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 2.1 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  ]]></copyright>
+  <interface  name="org_kde_kwin_server_decoration_manager" version="1">
+    <description summary="Server side window decoration manager">
+      This interface allows to coordinate whether the server should create
+      a server-side window decoration around a wl_surface representing a
+      shell surface (wl_shell_surface or similar). By announcing support
+      for this interface the server indicates that it supports server
+      side decorations.
+    </description>
+    <request name="create">
+      <description summary="Create a server-side decoration object for a given surface">
+        When a client creates a server-side decoration object it indicates
+        that it supports the protocol. The client is supposed to tell the
+        server whether it wants server-side decorations or will provide
+        client-side decorations.
+
+        If the client does not create a server-side decoration object for
+        a surface the server interprets this as lack of support for this
+        protocol and considers it as client-side decorated. Nevertheless a
+        client-side decorated surface should use this protocol to indicate
+        to the server that it does not want a server-side deco.
+      </description>
+      <arg name="id" type="new_id" interface="org_kde_kwin_server_decoration"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+    </request>
+    <enum name="mode">
+      <description summary="Possible values to use in request_mode and the event mode."/>
+      <entry name="None" value="0" summary="Undecorated: The surface is not decorated at all, neither server nor client-side. An example is a popup surface which should not be decorated."/>
+      <entry name="Client" value="1" summary="Client-side decoration: The decoration is part of the surface and the client."/>
+      <entry name="Server" value="2" summary="Server-side decoration: The server embeds the surface into a decoration frame."/>
+    </enum>
+    <event name="default_mode">
+      <description summary="The default mode used on the server">
+        This event is emitted directly after binding the interface. It contains
+        the default mode for the decoration. When a new server decoration object
+        is created this new object will be in the default mode until the first
+        request_mode is requested.
+
+        The server may change the default mode at any time.
+      </description>
+      <arg name="mode" type="uint" summary="The default decoration mode applied to newly created server decorations."/>
+    </event>
+  </interface>
+  <interface name="org_kde_kwin_server_decoration" version="1">
+    <request name="release" type="destructor">
+      <description summary="release the server decoration object"/>
+    </request>
+    <enum name="mode">
+      <description summary="Possible values to use in request_mode and the event mode."/>
+      <entry name="None" value="0" summary="Undecorated: The surface is not decorated at all, neither server nor client-side. An example is a popup surface which should not be decorated."/>
+      <entry name="Client" value="1" summary="Client-side decoration: The decoration is part of the surface and the client."/>
+      <entry name="Server" value="2" summary="Server-side decoration: The server embeds the surface into a decoration frame."/>
+    </enum>
+    <request name="request_mode">
+      <description summary="The decoration mode the surface wants to use."/>
+      <arg name="mode" type="uint" summary="The mode this surface wants to use."/>
+    </request>
+    <event name="mode">
+      <description summary="The new decoration mode applied by the server">
+        This event is emitted directly after the decoration is created and
+        represents the base decoration policy by the server. E.g. a server
+        which wants all surfaces to be client-side decorated will send Client,
+        a server which wants server-side decoration will send Server.
+
+        The client can request a different mode through the decoration request.
+        The server will acknowledge this by another event with the same mode. So
+        even if a server prefers server-side decoration it's possible to force a
+        client-side decoration.
+
+        The server may emit this event at any time. In this case the client can
+        again request a different mode. It's the responsibility of the server to
+        prevent a feedback loop.
+      </description>
+      <arg name="mode" type="uint" summary="The decoration mode applied to the surface by the server."/>
+    </event>
+  </interface>
+</protocol>

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -7,11 +7,13 @@
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_gamma_control.h>
+#include <wlr/types/wlr_server_decoration.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_wl_shell.h>
 #include <wlr/types/wlr_xdg_shell_v6.h>
 #include <wlr/util/log.h>
-#include "rootston/desktop.h"
+#include <server-decoration-protocol.h>
+#include "rootston/server.h"
 #include "rootston/server.h"
 
 void view_destroy(struct roots_view *view) {
@@ -252,6 +254,11 @@ struct roots_desktop *desktop_create(struct roots_server *server,
 		server->wl_display);
 	desktop->screenshooter = wlr_screenshooter_create(server->wl_display,
 		server->renderer);
+	desktop->server_decoration_manager =
+		wlr_server_decoration_manager_create(server->wl_display);
+	wlr_server_decoration_manager_set_default_mode(
+		desktop->server_decoration_manager,
+		ORG_KDE_KWIN_SERVER_DECORATION_MANAGER_MODE_CLIENT);
 
 	return desktop;
 }

--- a/rootston/meson.build
+++ b/rootston/meson.build
@@ -17,5 +17,5 @@ if get_option('enable_xwayland')
 	sources += ['xwayland.c']
 endif
 executable(
-	'rootston', sources, dependencies: wlroots
+	'rootston', sources, dependencies: [wlroots, wlr_protos]
 )

--- a/types/meson.build
+++ b/types/meson.build
@@ -15,6 +15,7 @@ lib_wlr_types = static_library(
 		'wlr_region.c',
 		'wlr_screenshooter.c',
 		'wlr_seat.c',
+		'wlr_server_decoration.c',
 		'wlr_surface.c',
 		'wlr_tablet_pad.c',
 		'wlr_tablet_tool.c',

--- a/types/wlr_server_decoration.c
+++ b/types/wlr_server_decoration.c
@@ -1,0 +1,64 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <server-decoration-protocol.h>
+#include <wlr/types/wlr_server_decoration.h>
+
+static const struct org_kde_kwin_server_decoration_manager_interface
+server_decoration_manager_impl = {
+	// TODO
+};
+
+static void server_decoration_manager_bind(struct wl_client *client,
+		void *_manager, uint32_t version, uint32_t id) {
+	struct wlr_server_decoration_manager *manager = _manager;
+	assert(client && manager);
+
+	struct wl_resource *resource = wl_resource_create(client,
+		&org_kde_kwin_server_decoration_manager_interface, version, id);
+	if (resource == NULL) {
+		wl_client_post_no_memory(client);
+		return;
+	}
+	wl_resource_set_implementation(resource, &server_decoration_manager_impl,
+		manager, NULL);
+}
+
+static void server_decoration_destroy(
+		struct wlr_server_decoration *decoration) {
+	wl_signal_emit(&decoration->events.destroy, decoration);
+	wl_resource_set_user_data(decoration->resource, NULL);
+	wl_list_remove(&decoration->link);
+	free(decoration);
+}
+
+struct wlr_server_decoration_manager *wlr_server_decoration_manager_create(
+		struct wl_display *display) {
+	struct wlr_server_decoration_manager *manager =
+		calloc(1, sizeof(struct wlr_server_decoration_manager));
+	if (manager == NULL) {
+		return NULL;
+	}
+	manager->wl_global = wl_global_create(display,
+		&org_kde_kwin_server_decoration_manager_interface, 1, manager,
+		server_decoration_manager_bind);
+	if (manager->wl_global == NULL) {
+		free(manager);
+		return NULL;
+	}
+	wl_list_init(&manager->decorations);
+	return manager;
+}
+
+void wlr_server_decoration_manager_destroy(
+		struct wlr_server_decoration_manager *manager) {
+	if (manager == NULL) {
+		return;
+	}
+	struct wlr_server_decoration *decoration, *tmp;
+	wl_list_for_each_safe(decoration, tmp, &manager->decorations,
+			link) {
+		server_decoration_destroy(decoration);
+	}
+	wl_global_destroy(manager->wl_global);
+	free(manager);
+}

--- a/types/wlr_server_decoration.c
+++ b/types/wlr_server_decoration.c
@@ -1,12 +1,130 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <server-decoration-protocol.h>
+#include <wlr/types/wlr_surface.h>
 #include <wlr/types/wlr_server_decoration.h>
+#include <wlr/util/log.h>
+
+static void server_decoration_handle_release(struct wl_client *client,
+		struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+
+static void server_decoration_handle_request_mode(struct wl_client *client,
+		struct wl_resource *resource, uint32_t mode) {
+	struct wlr_server_decoration *decoration =
+		wl_resource_get_user_data(resource);
+	decoration->requested_mode = mode;
+	wl_signal_emit(&decoration->events.request_mode, decoration);
+}
+
+void wlr_server_decoration_send_mode(struct wlr_server_decoration *decoration,
+		uint32_t mode) {
+	if (decoration->sent_mode == mode) {
+		return;
+	}
+	org_kde_kwin_server_decoration_send_mode(decoration->resource, mode);
+	decoration->sent_mode = mode;
+}
+
+static void server_decoration_destroy(
+		struct wlr_server_decoration *decoration) {
+	wl_signal_emit(&decoration->events.destroy, decoration);
+	wl_list_remove(&decoration->surface_destroy_listener.link);
+	wl_resource_set_user_data(decoration->resource, NULL);
+	wl_list_remove(&decoration->link);
+	free(decoration);
+}
+
+static void server_decoration_destroy_resource(struct wl_resource *resource) {
+	struct wlr_server_decoration *decoration =
+		wl_resource_get_user_data(resource);
+	if (decoration != NULL) {
+		server_decoration_destroy(decoration);
+	}
+}
+
+static void server_decoration_handle_surface_destroy(
+		struct wl_listener *listener, void *data) {
+	struct wlr_server_decoration *decoration =
+		wl_container_of(listener, decoration, surface_destroy_listener);
+	server_decoration_destroy(decoration);
+}
+
+static const struct org_kde_kwin_server_decoration_interface
+server_decoration_impl = {
+	.release = server_decoration_handle_release,
+	.request_mode = server_decoration_handle_request_mode,
+};
+
+static void server_decoration_manager_handle_create(struct wl_client *client,
+		struct wl_resource *manager_resource, uint32_t id,
+		struct wl_resource *surface_resource) {
+	struct wlr_server_decoration_manager *manager =
+		wl_resource_get_user_data(manager_resource);
+	struct wlr_surface *surface = wl_resource_get_user_data(surface_resource);
+
+	struct wlr_server_decoration *decoration =
+		calloc(1, sizeof(struct wlr_server_decoration));
+	if (decoration == NULL) {
+		wl_client_post_no_memory(client);
+		return;
+	}
+	decoration->surface = surface;
+	decoration->requested_mode =
+		ORG_KDE_KWIN_SERVER_DECORATION_MANAGER_MODE_NONE;
+
+	int version = wl_resource_get_version(manager_resource);
+	decoration->resource = wl_resource_create(client,
+		&org_kde_kwin_server_decoration_interface, version, id);
+	if (decoration->resource == NULL) {
+		wl_client_post_no_memory(client);
+		free(decoration);
+		return;
+	}
+	wl_resource_set_implementation(decoration->resource,
+		&server_decoration_impl, decoration,
+		server_decoration_destroy_resource);
+
+	wlr_log(L_DEBUG, "new server_decoration %p (res %p)", decoration,
+		decoration->resource);
+
+	wl_signal_init(&decoration->events.destroy);
+	wl_signal_init(&decoration->events.request_mode);
+
+	wl_signal_add(&surface->events.destroy,
+		&decoration->surface_destroy_listener);
+	decoration->surface_destroy_listener.notify =
+		server_decoration_handle_surface_destroy;
+
+	wl_list_insert(&manager->decorations, &decoration->link);
+
+	org_kde_kwin_server_decoration_send_mode(decoration->resource,
+		manager->default_mode);
+	decoration->sent_mode = manager->default_mode;
+
+	wl_signal_emit(&manager->events.new_decoration, decoration);
+}
 
 static const struct org_kde_kwin_server_decoration_manager_interface
 server_decoration_manager_impl = {
-	// TODO
+	.create = server_decoration_manager_handle_create,
 };
+
+void wlr_server_decoration_manager_set_default_mode(
+		struct wlr_server_decoration_manager *manager, uint32_t default_mode) {
+	manager->default_mode = default_mode;
+
+	struct wl_resource *resource;
+	wl_resource_for_each(resource, &manager->wl_resources) {
+		org_kde_kwin_server_decoration_manager_send_default_mode(resource,
+			manager->default_mode);
+	}
+}
+
+void server_decoration_manager_destroy_resource(struct wl_resource *resource) {
+	wl_list_remove(wl_resource_get_link(resource));
+}
 
 static void server_decoration_manager_bind(struct wl_client *client,
 		void *_manager, uint32_t version, uint32_t id) {
@@ -20,15 +138,12 @@ static void server_decoration_manager_bind(struct wl_client *client,
 		return;
 	}
 	wl_resource_set_implementation(resource, &server_decoration_manager_impl,
-		manager, NULL);
-}
+		manager, server_decoration_manager_destroy_resource);
 
-static void server_decoration_destroy(
-		struct wlr_server_decoration *decoration) {
-	wl_signal_emit(&decoration->events.destroy, decoration);
-	wl_resource_set_user_data(decoration->resource, NULL);
-	wl_list_remove(&decoration->link);
-	free(decoration);
+	wl_list_insert(&manager->wl_resources, wl_resource_get_link(resource));
+
+	org_kde_kwin_server_decoration_manager_send_default_mode(resource,
+		manager->default_mode);
 }
 
 struct wlr_server_decoration_manager *wlr_server_decoration_manager_create(
@@ -45,7 +160,10 @@ struct wlr_server_decoration_manager *wlr_server_decoration_manager_create(
 		free(manager);
 		return NULL;
 	}
+	manager->default_mode = ORG_KDE_KWIN_SERVER_DECORATION_MANAGER_MODE_NONE;
+	wl_list_init(&manager->wl_resources);
 	wl_list_init(&manager->decorations);
+	wl_signal_init(&manager->events.new_decoration);
 	return manager;
 }
 
@@ -54,10 +172,14 @@ void wlr_server_decoration_manager_destroy(
 	if (manager == NULL) {
 		return;
 	}
-	struct wlr_server_decoration *decoration, *tmp;
-	wl_list_for_each_safe(decoration, tmp, &manager->decorations,
+	struct wlr_server_decoration *decoration, *tmp_decoration;
+	wl_list_for_each_safe(decoration, tmp_decoration, &manager->decorations,
 			link) {
 		server_decoration_destroy(decoration);
+	}
+	struct wl_resource *resource, *tmp_resource;
+	wl_resource_for_each_safe(resource, tmp_resource, &manager->wl_resources) {
+		server_decoration_manager_destroy_resource(resource);
 	}
 	wl_global_destroy(manager->wl_global);
 	free(manager);


### PR DESCRIPTION
* [x] Set and communicate server preference
* [x] Bubble up what the client picked
* [x] Rootston implementation

Test plan:
1. Launch a server-decoration-aware client (such as KDE or GTK tip)
2. Switch server preference in rootston
3. See that if preference is server, the client respects that (or not)