### PR TITLE
Fix order of WM_HINTS and WM_PROTOCOLS in xwm atom_map

### DIFF
--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -16,8 +16,8 @@
 const char *atom_map[ATOM_LAST] = {
 	"WL_SURFACE_ID",
 	"WM_DELETE_WINDOW",
-	"WM_HINTS",
 	"WM_PROTOCOLS",
+	"WM_HINTS",
 	"WM_NORMAL_HINTS",
 	"WM_SIZE_HINTS",
 	"_MOTIF_WM_HINTS",


### PR DESCRIPTION
This seems to fix https://github.com/swaywm/wlroots/issues/232 .

The issue there seems to arise from the fact that the xwayland protocols for the surface are not set up correctly, because the order of items in `atom_map` does not match the order of `atom_name` xwm.h.