### PR TITLE
Focus last view on close in rootston

### DIFF
--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -80,6 +80,7 @@ void view_resize(struct roots_view *view, uint32_t width, uint32_t height);
 void view_set_position(struct roots_view *view, double x, double y);
 void view_close(struct roots_view *view);
 bool view_center(struct roots_view *view);
-void view_initialize(struct roots_view *view);
+void view_setup(struct roots_view *view);
+void view_teardown(struct roots_view *view);
 
 #endif

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -107,12 +107,24 @@ bool view_center(struct roots_view *view) {
 	return true;
 }
 
-void view_initialize(struct roots_view *view) {
+void view_setup(struct roots_view *view) {
 	view_center(view);
-	struct roots_input *input = view->desktop->server->input;
 
+	struct roots_input *input = view->desktop->server->input;
 	set_view_focus(input, view->desktop, view);
 	wlr_seat_keyboard_notify_enter(input->wl_seat, view->wlr_surface);
+}
+
+void view_teardown(struct roots_view *view) {
+	struct wlr_list *views = view->desktop->views;
+	if (views->length < 2 || views->items[views->length-1] != view) {
+		return;
+	}
+
+	struct roots_view *prev_view = views->items[views->length-2];
+	struct roots_input *input = prev_view->desktop->server->input;
+	set_view_focus(input, prev_view->desktop, prev_view);
+	wlr_seat_keyboard_notify_enter(input->wl_seat, prev_view->wlr_surface);
 }
 
 struct roots_view *view_at(struct roots_desktop *desktop, double lx, double ly,

--- a/rootston/wl_shell.c
+++ b/rootston/wl_shell.c
@@ -56,6 +56,7 @@ static void handle_surface_commit(struct wl_listener *listener, void *data) {
 static void handle_destroy(struct wl_listener *listener, void *data) {
 	struct roots_wl_shell_surface *roots_surface =
 		wl_container_of(listener, roots_surface, destroy);
+	view_teardown(roots_surface->view);
 	wl_list_remove(&roots_surface->destroy.link);
 	wl_list_remove(&roots_surface->request_move.link);
 	wl_list_remove(&roots_surface->request_resize.link);
@@ -111,7 +112,7 @@ void handle_wl_shell_surface(struct wl_listener *listener, void *data) {
 	view->desktop = desktop;
 	roots_surface->view = view;
 	wlr_list_add(desktop->views, view);
-	view_initialize(view);
+	view_setup(view);
 
 	if (surface->state == WLR_WL_SHELL_SURFACE_STATE_TRANSIENT) {
 		// we need to map it relative to the parent

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -74,6 +74,7 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 static void handle_destroy(struct wl_listener *listener, void *data) {
 	struct roots_xdg_surface_v6 *roots_xdg_surface =
 		wl_container_of(listener, roots_xdg_surface, destroy);
+	view_teardown(roots_xdg_surface->view);
 	wl_list_remove(&roots_xdg_surface->commit.link);
 	wl_list_remove(&roots_xdg_surface->destroy.link);
 	wl_list_remove(&roots_xdg_surface->request_move.link);
@@ -126,5 +127,5 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	roots_surface->view = view;
 	wlr_list_add(desktop->views, view);
 
-	view_initialize(view);
+	view_setup(view);
 }

--- a/rootston/xwayland.c
+++ b/rootston/xwayland.c
@@ -43,6 +43,7 @@ static void close(struct roots_view *view) {
 static void handle_destroy(struct wl_listener *listener, void *data) {
 	struct roots_xwayland_surface *roots_surface =
 		wl_container_of(listener, roots_surface, destroy);
+	view_teardown(roots_surface->view);
 	wl_list_remove(&roots_surface->destroy.link);
 	view_destroy(roots_surface->view);
 	free(roots_surface);
@@ -101,6 +102,6 @@ void handle_xwayland_surface(struct wl_listener *listener, void *data) {
 	wlr_list_add(desktop->views, view);
 
 	if (!surface->override_redirect) {
-		view_initialize(view);
+		view_setup(view);
 	}
 }


### PR DESCRIPTION
I renamed `view-initialize` to `view_setup` because I want to keep `initialize` when initializing memory of a struct (like `wlr_keyboard_init`). I added the counterpart `view_teardown`.

Test plan: open a window, open another window, close the active window. Check that the previously unfocused window gets active.