### PR TITLE
Do not set hw cursor if disabled when switching VT

### DIFF
--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -76,7 +76,7 @@ static void session_signal(struct wl_listener *listener, void *data) {
 
 			struct wlr_drm_plane *plane = conn->crtc->cursor;
 			drm->iface->crtc_set_cursor(drm, conn->crtc,
-				plane ? plane->cursor_bo : NULL);
+				(plane && plane->cursor_enabled) ? plane->cursor_bo : NULL);
 		}
 	} else {
 		wlr_log(L_INFO, "DRM fd paused");

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -505,8 +505,10 @@ static bool wlr_drm_connector_set_cursor(struct wlr_output *output,
 
 	if (!buf && update_pixels) {
 		// Hide the cursor
+		plane->cursor_enabled = false;
 		return drm->iface->crtc_set_cursor(drm, crtc, NULL);
 	}
+	plane->cursor_enabled = true;
 
 	// We don't have a real cursor plane, so we make a fake one
 	if (!plane) {

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -33,6 +33,7 @@ struct wlr_drm_plane {
 	float matrix[16];
 	struct wlr_texture *wlr_tex;
 	struct gbm_bo *cursor_bo;
+	bool cursor_enabled;
 
 	union wlr_drm_plane_props props;
 };


### PR DESCRIPTION
Fixes the bug reported by @Timidger in this comment: https://github.com/swaywm/wlroots/pull/331#issuecomment-339531064

Test plan:
1. Open `qutebrowser` in rootston, move the mouse in the window
2. Switch VT
3. Switch back to rootston
4. There's only one cursor: the software cursor in the `qutebrowser` window. There's no hardware cursor in the top-left corner.