### PR TITLE
Per-keyboard configuration

### DIFF
--- a/include/rootston/config.h
+++ b/include/rootston/config.h
@@ -73,7 +73,7 @@ struct device_config *config_get_device(struct roots_config *config,
 
 /**
  * Get configuration for the keyboard. If the keyboard is not configured,
- * returns NULL.
+ * returns NULL. A NULL device returns the default config for keyboards.
  */
 struct keyboard_config *config_get_keyboard(struct roots_config *config,
 	struct wlr_input_device *device);

--- a/include/rootston/config.h
+++ b/include/rootston/config.h
@@ -26,6 +26,17 @@ struct binding_config {
 	struct wl_list link;
 };
 
+struct keyboard_config {
+	char *name;
+	uint32_t meta_key;
+	char *rules;
+	char *model;
+	char *layout;
+	char *variant;
+	char *options;
+	struct wl_list link;
+};
+
 struct roots_config {
 	bool xwayland;
 	// TODO: Multiple cursors, multiseat
@@ -34,13 +45,10 @@ struct roots_config {
 		struct wlr_box *mapped_box;
 	} cursor;
 
-	struct {
-		uint32_t meta_key;
-	} keyboard;
-
 	struct wl_list outputs;
 	struct wl_list devices;
 	struct wl_list bindings;
+	struct wl_list keyboards;
 	char *config_path;
 	char *startup_cmd;
 };
@@ -54,13 +62,20 @@ void roots_config_destroy(struct roots_config *config);
  * NULL.
  */
 struct output_config *config_get_output(struct roots_config *config,
-		struct wlr_output *output);
+	struct wlr_output *output);
 
 /**
  * Get configuration for the device. If the device is not configured, returns
  * NULL.
  */
 struct device_config *config_get_device(struct roots_config *config,
-		struct wlr_input_device *device);
+	struct wlr_input_device *device);
+
+/**
+ * Get configuration for the keyboard. If the keyboard is not configured,
+ * returns NULL.
+ */
+struct keyboard_config *config_get_keyboard(struct roots_config *config,
+	struct wlr_input_device *device);
 
 #endif

--- a/rootston/config.c
+++ b/rootston/config.c
@@ -417,14 +417,12 @@ struct device_config *config_get_device(struct roots_config *config,
 struct keyboard_config *config_get_keyboard(struct roots_config *config,
 		struct wlr_input_device *device) {
 	struct keyboard_config *kc;
-	struct keyboard_config *default_kc = NULL;
 	wl_list_for_each(kc, &config->keyboards, link) {
-		if (strcmp(kc->name, "*") == 0) {
-			default_kc = kc;
-		} else if (strcmp(kc->name, device->name) == 0) {
+		if ((device != NULL && strcmp(kc->name, device->name) == 0) ||
+				(device == NULL && strcmp(kc->name, "*") == 0)) {
 			return kc;
 		}
 	}
 
-	return default_kc;
+	return NULL;
 }

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -217,10 +217,12 @@ static void handle_cursor_axis(struct wl_listener *listener, void *data) {
 
 static bool is_meta_pressed(struct roots_input *input,
 		struct wlr_input_device *device) {
-	struct keyboard_config *config = config_get_keyboard(input->server->config,
-		device);
 	uint32_t meta_key = 0;
-	if (config != NULL) {
+	struct keyboard_config *config;
+	if ((config = config_get_keyboard(input->server->config, device))) {
+		meta_key = config->meta_key;
+	} else if (!meta_key && (config = config_get_keyboard(input->server->config,
+			NULL))) {
 		meta_key = config->meta_key;
 	}
 	if (meta_key == 0) {

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -215,8 +215,14 @@ static void handle_cursor_axis(struct wl_listener *listener, void *data) {
 		event->orientation, event->delta);
 }
 
-static bool is_meta_pressed(struct roots_input *input) {
-	uint32_t meta_key = input->server->config->keyboard.meta_key;
+static bool is_meta_pressed(struct roots_input *input,
+		struct wlr_input_device *device) {
+	struct keyboard_config *config = config_get_keyboard(input->server->config,
+		device);
+	uint32_t meta_key = 0;
+	if (config != NULL) {
+		meta_key = config->meta_key;
+	}
 	if (meta_key == 0) {
 		return false;
 	}
@@ -241,7 +247,7 @@ static void do_cursor_button_press(struct roots_input *input,
 	struct roots_view *view = view_at(desktop,
 		input->cursor->x, input->cursor->y, &surface, &sx, &sy);
 
-	if (state == WLR_BUTTON_PRESSED && view && is_meta_pressed(input)) {
+	if (state == WLR_BUTTON_PRESSED && view && is_meta_pressed(input, device)) {
 		set_view_focus(input, desktop, view);
 
 		switch (button) {

--- a/rootston/keyboard.c
+++ b/rootston/keyboard.c
@@ -125,6 +125,28 @@ static void keyboard_key_notify(struct wl_listener *listener, void *data) {
 	}
 }
 
+static void keyboard_config_merge(struct keyboard_config *config,
+		struct keyboard_config *fallback) {
+	if (fallback == NULL) {
+		return;
+	}
+	if (config->rules == NULL) {
+		config->rules = fallback->rules;
+	}
+	if (config->model == NULL) {
+		config->model = fallback->model;
+	}
+	if (config->layout == NULL) {
+		config->layout = fallback->layout;
+	}
+	if (config->variant == NULL) {
+		config->variant = fallback->variant;
+	}
+	if (config->options == NULL) {
+		config->options = fallback->options;
+	}
+}
+
 void keyboard_add(struct wlr_input_device *device, struct roots_input *input) {
 	struct roots_keyboard *keyboard = calloc(sizeof(struct roots_keyboard), 1);
 	if (keyboard == NULL) {
@@ -137,33 +159,27 @@ void keyboard_add(struct wlr_input_device *device, struct roots_input *input) {
 	wl_signal_add(&device->keyboard->events.key, &keyboard->key);
 	wl_list_insert(&input->keyboards, &keyboard->link);
 
-	struct keyboard_config *config = config_get_keyboard(input->config,
-		device);
+	struct keyboard_config config;
+	memset(&config, 0, sizeof(config));
+	keyboard_config_merge(&config, config_get_keyboard(input->config, device));
+	keyboard_config_merge(&config, config_get_keyboard(input->config, NULL));
+
+	struct keyboard_config env_config = {
+		.rules = getenv("XKB_DEFAULT_RULES"),
+		.model = getenv("XKB_DEFAULT_MODEL"),
+		.layout = getenv("XKB_DEFAULT_LAYOUT"),
+		.variant = getenv("XKB_DEFAULT_VARIANT"),
+		.options = getenv("XKB_DEFAULT_OPTIONS"),
+	};
+	keyboard_config_merge(&config, &env_config);
 
 	struct xkb_rule_names rules;
 	memset(&rules, 0, sizeof(rules));
-	if (config != NULL) {
-		rules.rules = config->rules;
-		rules.model = config->model;
-		rules.layout = config->layout;
-		rules.variant = config->variant;
-		rules.options = config->options;
-	}
-	if (rules.rules == NULL) {
-		rules.rules = getenv("XKB_DEFAULT_RULES");
-	}
-	if (rules.model == NULL) {
-		rules.model = getenv("XKB_DEFAULT_MODEL");
-	}
-	if (rules.layout == NULL) {
-		rules.layout = getenv("XKB_DEFAULT_LAYOUT");
-	}
-	if (rules.variant == NULL) {
-		rules.variant = getenv("XKB_DEFAULT_VARIANT");
-	}
-	if (rules.options == NULL) {
-		rules.options = getenv("XKB_DEFAULT_OPTIONS");
-	}
+	rules.rules = config.rules;
+	rules.model = config.model;
+	rules.layout = config.layout;
+	rules.variant = config.variant;
+	rules.options = config.options;
 	struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
 	if (context == NULL) {
 		wlr_log(L_ERROR, "Cannot create XKB context");

--- a/rootston/keyboard.c
+++ b/rootston/keyboard.c
@@ -137,13 +137,33 @@ void keyboard_add(struct wlr_input_device *device, struct roots_input *input) {
 	wl_signal_add(&device->keyboard->events.key, &keyboard->key);
 	wl_list_insert(&input->keyboards, &keyboard->link);
 
+	struct keyboard_config *config = config_get_keyboard(input->config,
+		device);
+
 	struct xkb_rule_names rules;
 	memset(&rules, 0, sizeof(rules));
-	rules.rules = getenv("XKB_DEFAULT_RULES");
-	rules.model = getenv("XKB_DEFAULT_MODEL");
-	rules.layout = getenv("XKB_DEFAULT_LAYOUT");
-	rules.variant = getenv("XKB_DEFAULT_VARIANT");
-	rules.options = getenv("XKB_DEFAULT_OPTIONS");
+	if (config != NULL) {
+		rules.rules = config->rules;
+		rules.model = config->model;
+		rules.layout = config->layout;
+		rules.variant = config->variant;
+		rules.options = config->options;
+	}
+	if (rules.rules == NULL) {
+		rules.rules = getenv("XKB_DEFAULT_RULES");
+	}
+	if (rules.model == NULL) {
+		rules.model = getenv("XKB_DEFAULT_MODEL");
+	}
+	if (rules.layout == NULL) {
+		rules.layout = getenv("XKB_DEFAULT_LAYOUT");
+	}
+	if (rules.variant == NULL) {
+		rules.variant = getenv("XKB_DEFAULT_VARIANT");
+	}
+	if (rules.options == NULL) {
+		rules.options = getenv("XKB_DEFAULT_OPTIONS");
+	}
 	struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
 	if (context == NULL) {
 		wlr_log(L_ERROR, "Cannot create XKB context");

--- a/rootston/rootston.ini.example
+++ b/rootston/rootston.ini.example
@@ -29,7 +29,7 @@ map-to-output = VGA-1
 # Restrict cursor movements for this mouse to concrete rectangle
 geometry = 2500x800
 
-[keyboard]
+[keyboard:*]
 meta-key = Logo
 
 # Keybindings

--- a/rootston/rootston.ini.example
+++ b/rootston/rootston.ini.example
@@ -29,7 +29,7 @@ map-to-output = VGA-1
 # Restrict cursor movements for this mouse to concrete rectangle
 geometry = 2500x800
 
-[keyboard:*]
+[keyboard]
 meta-key = Logo
 
 # Keybindings


### PR DESCRIPTION
* We may want to use `config.devices` instead of `config.keyboard`?

Test plan:
1. Set nothing, no meta key should be set
2. Set `meta-key` in the `keyboard:*` section, meta key should work
3. Set `layout` in the `keyboard:*` section, should change the layout
4. Set another `layout` or `meta-key` in a `keyboard:<device name>` section, should change it for only this keyboard
5. `XKB_DEFAULT_LAYOUT` should still work

Fixes #326