### PR TITLE
Set compositor cursor for move, resize and rotate

### DIFF
--- a/include/rootston/input.h
+++ b/include/rootston/input.h
@@ -88,8 +88,7 @@ struct roots_input {
 
 	// TODO: multiseat, multicursor
 	struct wlr_cursor *cursor;
-	struct wlr_xcursor_theme *theme;
-	struct wlr_xcursor *xcursor;
+	struct wlr_xcursor_theme *xcursor_theme;
 	struct wlr_seat *wl_seat;
 	struct wl_list drag_icons;
 	struct wl_client *cursor_client;
@@ -157,6 +156,12 @@ void view_begin_move(struct roots_input *input, struct wlr_cursor *cursor,
 		struct roots_view *view);
 void view_begin_resize(struct roots_input *input, struct wlr_cursor *cursor,
 		struct roots_view *view, uint32_t edges);
+
+struct wlr_xcursor *get_default_xcursor(struct wlr_xcursor_theme *theme);
+struct wlr_xcursor *get_move_xcursor(struct wlr_xcursor_theme *theme);
+struct wlr_xcursor *get_resize_xcursor(struct wlr_xcursor_theme *theme,
+	uint32_t edges);
+struct wlr_xcursor *get_rotate_xcursor(struct wlr_xcursor_theme *theme);
 
 void set_view_focus(struct roots_input *input, struct roots_desktop *desktop,
 	struct roots_view *view);

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -62,34 +62,10 @@ void view_begin_move(struct roots_input *input, struct wlr_cursor *cursor,
 	input->view_y = view->y;
 	wlr_seat_pointer_clear_focus(input->wl_seat);
 
-	struct wlr_xcursor *xcursor = wlr_xcursor_theme_get_cursor(input->theme,
-		"grabbing");
+	struct wlr_xcursor *xcursor = get_move_xcursor(input->xcursor_theme);
 	if (xcursor != NULL) {
 		cursor_set_xcursor_image(input, xcursor->images[0]);
 	}
-}
-
-static const char *get_resize_cursor_name(uint32_t edges) {
-	if (edges & ROOTS_CURSOR_RESIZE_EDGE_TOP) {
-		if (edges & ROOTS_CURSOR_RESIZE_EDGE_RIGHT) {
-			return "ne-resize";
-		} else if (edges & ROOTS_CURSOR_RESIZE_EDGE_LEFT) {
-			return "nw-resize";
-		}
-		return "n-resize";
-	} else if (edges & ROOTS_CURSOR_RESIZE_EDGE_BOTTOM) {
-		if (edges & ROOTS_CURSOR_RESIZE_EDGE_RIGHT) {
-			return "se-resize";
-		} else if (edges & ROOTS_CURSOR_RESIZE_EDGE_LEFT) {
-			return "sw-resize";
-		}
-		return "s-resize";
-	} else if (edges & ROOTS_CURSOR_RESIZE_EDGE_RIGHT) {
-		return "e-resize";
-	} else if (edges & ROOTS_CURSOR_RESIZE_EDGE_LEFT) {
-		return "w-resize";
-	}
-	return "se-resize"; // fallback
 }
 
 void view_begin_resize(struct roots_input *input, struct wlr_cursor *cursor,
@@ -106,8 +82,7 @@ void view_begin_resize(struct roots_input *input, struct wlr_cursor *cursor,
 	input->resize_edges = edges;
 	wlr_seat_pointer_clear_focus(input->wl_seat);
 
-	struct wlr_xcursor *xcursor = wlr_xcursor_theme_get_cursor(input->theme,
-		get_resize_cursor_name(edges));
+	struct wlr_xcursor *xcursor = get_resize_xcursor(input->xcursor_theme, edges);
 	if (xcursor != NULL) {
 		cursor_set_xcursor_image(input, xcursor->images[0]);
 	}
@@ -121,8 +96,7 @@ void view_begin_rotate(struct roots_input *input, struct wlr_cursor *cursor,
 	input->view_rotation = view->rotation;
 	wlr_seat_pointer_clear_focus(input->wl_seat);
 
-	struct wlr_xcursor *xcursor = wlr_xcursor_theme_get_cursor(input->theme,
-		"grabbing");
+	struct wlr_xcursor *xcursor = get_rotate_xcursor(input->xcursor_theme);
 	if (xcursor != NULL) {
 		cursor_set_xcursor_image(input, xcursor->images[0]);
 	}
@@ -144,7 +118,8 @@ void cursor_update_position(struct roots_input *input, uint32_t time) {
 			set_compositor_cursor = view_client != input->cursor_client;
 		}
 		if (set_compositor_cursor) {
-			cursor_set_xcursor_image(input, input->xcursor->images[0]);
+			struct wlr_xcursor *xcursor = get_default_xcursor(input->xcursor_theme);
+			cursor_set_xcursor_image(input, xcursor->images[0]);
 			input->cursor_client = NULL;
 		}
 		if (view) {

--- a/rootston/input.c
+++ b/rootston/input.c
@@ -81,16 +81,17 @@ struct roots_input *input_create(struct roots_server *server,
 	input->config = config;
 	input->server = server;
 
-	input->theme = wlr_xcursor_theme_load("default", 16);
-	if (input->theme == NULL) {
+	input->xcursor_theme = wlr_xcursor_theme_load("default", 16);
+	if (input->xcursor_theme == NULL) {
 		wlr_log(L_ERROR, "Cannot load xcursor theme");
 		free(input);
 		return NULL;
 	}
-	input->xcursor = wlr_xcursor_theme_get_cursor(input->theme, "left_ptr");
-	if (input->xcursor == NULL) {
+
+	struct wlr_xcursor *xcursor = get_default_xcursor(input->xcursor_theme);
+	if (xcursor == NULL) {
 		wlr_log(L_ERROR, "Cannot load xcursor from theme");
-		wlr_xcursor_theme_destroy(input->theme);
+		wlr_xcursor_theme_destroy(input->xcursor_theme);
 		free(input);
 		return NULL;
 	}
@@ -98,7 +99,7 @@ struct roots_input *input_create(struct roots_server *server,
 	input->wl_seat = wlr_seat_create(server->wl_display, "seat0");
 	if (input->wl_seat == NULL) {
 		wlr_log(L_ERROR, "Cannot create seat");
-		wlr_xcursor_theme_destroy(input->theme);
+		wlr_xcursor_theme_destroy(input->xcursor_theme);
 		free(input);
 		return NULL;
 	}
@@ -117,7 +118,7 @@ struct roots_input *input_create(struct roots_server *server,
 
 	input->cursor = wlr_cursor_create();
 	cursor_initialize(input);
-	wlr_cursor_set_xcursor(input->cursor, input->xcursor);
+	wlr_cursor_set_xcursor(input->cursor, xcursor);
 
 	wlr_cursor_attach_output_layout(input->cursor, server->desktop->layout);
 	wlr_cursor_map_to_region(input->cursor, config->cursor.mapped_box);

--- a/rootston/meson.build
+++ b/rootston/meson.build
@@ -10,6 +10,7 @@ sources = [
 	'pointer.c',
 	'tablet_tool.c',
 	'touch.c',
+	'xcursor.c',
 	'xdg_shell_v6.c',
 	'wl_shell.c',
 ]

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -200,7 +200,8 @@ void output_add_notify(struct wl_listener *listener, void *data) {
 
 	cursor_load_config(config, input->cursor, input, desktop);
 
-	struct wlr_xcursor_image *image = input->xcursor->images[0];
+	struct wlr_xcursor *xcursor = get_default_xcursor(input->xcursor_theme);
+	struct wlr_xcursor_image *image = xcursor->images[0];
 	// TODO the cursor must be set depending on which surface it is displayed
 	// over which should happen in the compositor.
 	if (!wlr_output_set_cursor(wlr_output, image->buffer,

--- a/rootston/xcursor.c
+++ b/rootston/xcursor.c
@@ -1,0 +1,42 @@
+#include <wlr/types/wlr_cursor.h>
+#include "rootston/input.h"
+
+struct wlr_xcursor *get_default_xcursor(struct wlr_xcursor_theme *theme) {
+	return wlr_xcursor_theme_get_cursor(theme, "left_ptr");
+}
+
+struct wlr_xcursor *get_move_xcursor(struct wlr_xcursor_theme *theme) {
+	return wlr_xcursor_theme_get_cursor(theme, "grabbing");
+}
+
+static const char *get_resize_xcursor_name(uint32_t edges) {
+	if (edges & ROOTS_CURSOR_RESIZE_EDGE_TOP) {
+		if (edges & ROOTS_CURSOR_RESIZE_EDGE_RIGHT) {
+			return "ne-resize";
+		} else if (edges & ROOTS_CURSOR_RESIZE_EDGE_LEFT) {
+			return "nw-resize";
+		}
+		return "n-resize";
+	} else if (edges & ROOTS_CURSOR_RESIZE_EDGE_BOTTOM) {
+		if (edges & ROOTS_CURSOR_RESIZE_EDGE_RIGHT) {
+			return "se-resize";
+		} else if (edges & ROOTS_CURSOR_RESIZE_EDGE_LEFT) {
+			return "sw-resize";
+		}
+		return "s-resize";
+	} else if (edges & ROOTS_CURSOR_RESIZE_EDGE_RIGHT) {
+		return "e-resize";
+	} else if (edges & ROOTS_CURSOR_RESIZE_EDGE_LEFT) {
+		return "w-resize";
+	}
+	return "se-resize"; // fallback
+}
+
+struct wlr_xcursor *get_resize_xcursor(struct wlr_xcursor_theme *theme,
+	uint32_t edges) {
+	return wlr_xcursor_theme_get_cursor(theme, get_resize_xcursor_name(edges));
+}
+
+struct wlr_xcursor *get_rotate_xcursor(struct wlr_xcursor_theme *theme) {
+	return wlr_xcursor_theme_get_cursor(theme, "grabbing");
+}


### PR DESCRIPTION
Test plan:
- Move a window with its border or with the meta key, check that the cursor is a hand
- Resize a window from each edge, check cursor
- Rotate a window, check cursor
- Make sure the surface cursor is used when move/resize/rotate ends

Updates #342