### PR TITLE
Remove input.last_active_view

### DIFF
--- a/include/rootston/input.h
+++ b/include/rootston/input.h
@@ -95,7 +95,7 @@ struct roots_input {
 	struct wl_client *cursor_client;
 
 	enum roots_cursor_mode mode;
-	struct roots_view *active_view, *last_active_view;
+	struct roots_view *active_view;
 	int offs_x, offs_y;
 	int view_x, view_y, view_width, view_height;
 	float view_rotation;

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -172,7 +172,6 @@ void set_view_focus(struct roots_input *input, struct roots_desktop *desktop,
 	if (!view) {
 		return;
 	}
-	input->last_active_view = view;
 
 	size_t index = 0;
 	for (size_t i = 0; i < desktop->views->length; ++i) {

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -24,9 +24,6 @@ void view_destroy(struct roots_view *view) {
 		input->active_view = NULL;
 		input->mode = ROOTS_CURSOR_PASSTHROUGH;
 	}
-	if (input->last_active_view == view) {
-		input->last_active_view = NULL;
-	}
 
 	for (size_t i = 0; i < desktop->views->length; ++i) {
 		struct roots_view *_view = desktop->views->items[i];

--- a/rootston/keyboard.c
+++ b/rootston/keyboard.c
@@ -29,8 +29,10 @@ static void keyboard_binding_execute(struct roots_keyboard *keyboard,
 	if (strcmp(command, "exit") == 0) {
 		wl_display_terminate(server->wl_display);
 	} else if (strcmp(command, "close") == 0) {
-		if (keyboard->input->last_active_view != NULL) {
-			view_close(keyboard->input->last_active_view);
+		if (server->desktop->views->length > 0) {
+			struct roots_view *view =
+				server->desktop->views->items[server->desktop->views->length-1];
+			view_close(view);
 		}
 	} else if (strcmp(command, "next_window") == 0) {
 		if (server->desktop->views->length > 0) {


### PR DESCRIPTION
This field is useless and not at the right place.

Test plan: check that the shortcut to close the active view still works.