### PR TITLE
Enforce resize bounds in rootston

### DIFF
--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -160,6 +160,13 @@ void cursor_update_position(struct roots_input *input, uint32_t time) {
 				width += dx;
 			}
 
+			if (width < 0) {
+				width = 0;
+			}
+			if (height < 0) {
+				height = 0;
+			}
+
 			// TODO we might need one configure event for this
 			if (active_x != input->active_view->x ||
 					active_y != input->active_view->y) {

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -29,6 +29,21 @@ static void resize(struct roots_view *view, uint32_t width, uint32_t height) {
 	assert(view->type == ROOTS_XDG_SHELL_V6_VIEW);
 	struct wlr_xdg_surface_v6 *surf = view->xdg_surface_v6;
 	if (surf->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL) {
+		struct wlr_xdg_toplevel_v6_state *state =
+			&surf->toplevel_state->current;
+		if (width < state->min_width) {
+			width = state->min_width;
+		} else if (state->max_width > 0 &&
+				width < state->max_width) {
+			width = state->max_width;
+		}
+		if (height < state->min_height) {
+			height = state->min_height;
+		} else if (state->max_height > 0 &&
+				height < state->max_height) {
+			height = state->max_height;
+		}
+
 		wlr_xdg_toplevel_v6_set_size(surf, width, height);
 	}
 }

--- a/rootston/xwayland.c
+++ b/rootston/xwayland.c
@@ -22,6 +22,24 @@ static void activate(struct roots_view *view, bool active) {
 static void resize(struct roots_view *view, uint32_t width, uint32_t height) {
 	assert(view->type == ROOTS_XWAYLAND_VIEW);
 	struct wlr_xwayland_surface *xwayland_surface = view->xwayland_surface;
+
+	struct wlr_xwayland_surface_size_hints *size_hints =
+		xwayland_surface->size_hints;
+	if (size_hints != NULL) {
+		if (width < (uint32_t)size_hints->min_width) {
+			width = size_hints->min_width;
+		} else if (size_hints->max_width > 0 &&
+				width > (uint32_t)size_hints->max_width) {
+			width = size_hints->max_width;
+		}
+		if (height < (uint32_t)size_hints->min_height) {
+			height = size_hints->min_height;
+		} else if (size_hints->max_height > 0 &&
+				height > (uint32_t)size_hints->max_height) {
+			height = size_hints->max_height;
+		}
+	}
+
 	wlr_xwayland_surface_configure(view->desktop->xwayland, xwayland_surface,
 		xwayland_surface->x, xwayland_surface->y, width, height);
 }


### PR DESCRIPTION
`wl_shell` doesn't have resize bounds.

Test plan: try to resize a xdg shell surface or a xwayland surface, check it doesn't get smaller than the minimum size.

Fixes #346