### PR TITLE
refactor input time_sec to time_msec

### DIFF
--- a/backend/backend.c
+++ b/backend/backend.c
@@ -136,3 +136,7 @@ error_session:
 	wlr_session_destroy(session);
 	return NULL;
 }
+
+uint32_t usec_to_msec(uint64_t usec) {
+	return (uint32_t)(usec / 1000);
+}

--- a/backend/libinput/keyboard.c
+++ b/backend/libinput/keyboard.c
@@ -54,8 +54,8 @@ void handle_keyboard_key(struct libinput_event *event,
 	struct libinput_event_keyboard *kbevent =
 		libinput_event_get_keyboard_event(event);
 	struct wlr_event_keyboard_key wlr_event = { 0 };
-	wlr_event.time_usec = libinput_event_keyboard_get_time_usec(kbevent);
-	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
+	wlr_event.time_msec =
+		usec_to_msec(libinput_event_keyboard_get_time_usec(kbevent));
 	wlr_event.keycode = libinput_event_keyboard_get_key(kbevent);
 	enum libinput_key_state state = 
 		libinput_event_keyboard_get_key_state(kbevent);

--- a/backend/libinput/keyboard.c
+++ b/backend/libinput/keyboard.c
@@ -54,8 +54,8 @@ void handle_keyboard_key(struct libinput_event *event,
 	struct libinput_event_keyboard *kbevent =
 		libinput_event_get_keyboard_event(event);
 	struct wlr_event_keyboard_key wlr_event = { 0 };
-	wlr_event.time_sec = libinput_event_keyboard_get_time(kbevent);
 	wlr_event.time_usec = libinput_event_keyboard_get_time_usec(kbevent);
+	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
 	wlr_event.keycode = libinput_event_keyboard_get_key(kbevent);
 	enum libinput_key_state state = 
 		libinput_event_keyboard_get_key_state(kbevent);

--- a/backend/libinput/pointer.c
+++ b/backend/libinput/pointer.c
@@ -31,8 +31,8 @@ void handle_pointer_motion(struct libinput_event *event,
 		libinput_event_get_pointer_event(event);
 	struct wlr_event_pointer_motion wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
-	wlr_event.time_usec = libinput_event_pointer_get_time_usec(pevent);
-	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
+	wlr_event.time_msec =
+		usec_to_msec(libinput_event_pointer_get_time_usec(pevent));
 	wlr_event.delta_x = libinput_event_pointer_get_dx(pevent);
 	wlr_event.delta_y = libinput_event_pointer_get_dy(pevent);
 	wl_signal_emit(&wlr_dev->pointer->events.motion, &wlr_event);
@@ -50,8 +50,8 @@ void handle_pointer_motion_abs(struct libinput_event *event,
 		libinput_event_get_pointer_event(event);
 	struct wlr_event_pointer_motion_absolute wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
-	wlr_event.time_usec = libinput_event_pointer_get_time_usec(pevent);
-	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
+	wlr_event.time_msec =
+		usec_to_msec(libinput_event_pointer_get_time_usec(pevent));
 	wlr_event.x_mm = libinput_event_pointer_get_absolute_x(pevent);
 	wlr_event.y_mm = libinput_event_pointer_get_absolute_y(pevent);
 	libinput_device_get_size(libinput_dev, &wlr_event.width_mm, &wlr_event.height_mm);
@@ -70,8 +70,8 @@ void handle_pointer_button(struct libinput_event *event,
 		libinput_event_get_pointer_event(event);
 	struct wlr_event_pointer_button wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
-	wlr_event.time_usec = libinput_event_pointer_get_time_usec(pevent);
-	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
+	wlr_event.time_msec =
+		usec_to_msec(libinput_event_pointer_get_time_usec(pevent));
 	wlr_event.button = libinput_event_pointer_get_button(pevent);
 	switch (libinput_event_pointer_get_button_state(pevent)) {
 	case LIBINPUT_BUTTON_STATE_PRESSED:
@@ -96,8 +96,8 @@ void handle_pointer_axis(struct libinput_event *event,
 		libinput_event_get_pointer_event(event);
 	struct wlr_event_pointer_axis wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
-	wlr_event.time_usec = libinput_event_pointer_get_time_usec(pevent);
-	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
+	wlr_event.time_msec =
+		usec_to_msec(libinput_event_pointer_get_time_usec(pevent));
 	switch (libinput_event_pointer_get_axis_source(pevent)) {
 	case LIBINPUT_POINTER_AXIS_SOURCE_WHEEL:
 		wlr_event.source = WLR_AXIS_SOURCE_WHEEL;

--- a/backend/libinput/pointer.c
+++ b/backend/libinput/pointer.c
@@ -31,8 +31,8 @@ void handle_pointer_motion(struct libinput_event *event,
 		libinput_event_get_pointer_event(event);
 	struct wlr_event_pointer_motion wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
-	wlr_event.time_sec = libinput_event_pointer_get_time(pevent);
 	wlr_event.time_usec = libinput_event_pointer_get_time_usec(pevent);
+	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
 	wlr_event.delta_x = libinput_event_pointer_get_dx(pevent);
 	wlr_event.delta_y = libinput_event_pointer_get_dy(pevent);
 	wl_signal_emit(&wlr_dev->pointer->events.motion, &wlr_event);
@@ -50,8 +50,8 @@ void handle_pointer_motion_abs(struct libinput_event *event,
 		libinput_event_get_pointer_event(event);
 	struct wlr_event_pointer_motion_absolute wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
-	wlr_event.time_sec = libinput_event_pointer_get_time(pevent);
 	wlr_event.time_usec = libinput_event_pointer_get_time_usec(pevent);
+	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
 	wlr_event.x_mm = libinput_event_pointer_get_absolute_x(pevent);
 	wlr_event.y_mm = libinput_event_pointer_get_absolute_y(pevent);
 	libinput_device_get_size(libinput_dev, &wlr_event.width_mm, &wlr_event.height_mm);
@@ -70,8 +70,8 @@ void handle_pointer_button(struct libinput_event *event,
 		libinput_event_get_pointer_event(event);
 	struct wlr_event_pointer_button wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
-	wlr_event.time_sec = libinput_event_pointer_get_time(pevent);
 	wlr_event.time_usec = libinput_event_pointer_get_time_usec(pevent);
+	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
 	wlr_event.button = libinput_event_pointer_get_button(pevent);
 	switch (libinput_event_pointer_get_button_state(pevent)) {
 	case LIBINPUT_BUTTON_STATE_PRESSED:
@@ -96,8 +96,8 @@ void handle_pointer_axis(struct libinput_event *event,
 		libinput_event_get_pointer_event(event);
 	struct wlr_event_pointer_axis wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
-	wlr_event.time_sec = libinput_event_pointer_get_time(pevent);
 	wlr_event.time_usec = libinput_event_pointer_get_time_usec(pevent);
+	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
 	switch (libinput_event_pointer_get_axis_source(pevent)) {
 	case LIBINPUT_POINTER_AXIS_SOURCE_WHEEL:
 		wlr_event.source = WLR_AXIS_SOURCE_WHEEL;

--- a/backend/libinput/tablet_pad.c
+++ b/backend/libinput/tablet_pad.c
@@ -30,8 +30,8 @@ void handle_tablet_pad_button(struct libinput_event *event,
 	struct libinput_event_tablet_pad *pevent =
 		libinput_event_get_tablet_pad_event(event);
 	struct wlr_event_tablet_pad_button wlr_event = { 0 };
-	wlr_event.time_sec = libinput_event_tablet_pad_get_time(pevent);
 	wlr_event.time_usec = libinput_event_tablet_pad_get_time_usec(pevent);
+	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
 	wlr_event.button = libinput_event_tablet_pad_get_button_number(pevent);
 	switch (libinput_event_tablet_pad_get_button_state(pevent)) {
 	case LIBINPUT_BUTTON_STATE_PRESSED:
@@ -55,8 +55,8 @@ void handle_tablet_pad_ring(struct libinput_event *event,
 	struct libinput_event_tablet_pad *pevent =
 		libinput_event_get_tablet_pad_event(event);
 	struct wlr_event_tablet_pad_ring wlr_event = { 0 };
-	wlr_event.time_sec = libinput_event_tablet_pad_get_time(pevent);
 	wlr_event.time_usec = libinput_event_tablet_pad_get_time_usec(pevent);
+	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
 	wlr_event.ring = libinput_event_tablet_pad_get_ring_number(pevent);
 	wlr_event.position = libinput_event_tablet_pad_get_ring_position(pevent);
 	switch (libinput_event_tablet_pad_get_ring_source(pevent)) {
@@ -81,8 +81,8 @@ void handle_tablet_pad_strip(struct libinput_event *event,
 	struct libinput_event_tablet_pad *pevent =
 		libinput_event_get_tablet_pad_event(event);
 	struct wlr_event_tablet_pad_strip wlr_event = { 0 };
-	wlr_event.time_sec = libinput_event_tablet_pad_get_time(pevent);
 	wlr_event.time_usec = libinput_event_tablet_pad_get_time_usec(pevent);
+	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
 	wlr_event.strip = libinput_event_tablet_pad_get_strip_number(pevent);
 	wlr_event.position = libinput_event_tablet_pad_get_strip_position(pevent);
 	switch (libinput_event_tablet_pad_get_strip_source(pevent)) {

--- a/backend/libinput/tablet_pad.c
+++ b/backend/libinput/tablet_pad.c
@@ -30,8 +30,8 @@ void handle_tablet_pad_button(struct libinput_event *event,
 	struct libinput_event_tablet_pad *pevent =
 		libinput_event_get_tablet_pad_event(event);
 	struct wlr_event_tablet_pad_button wlr_event = { 0 };
-	wlr_event.time_usec = libinput_event_tablet_pad_get_time_usec(pevent);
-	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
+	wlr_event.time_msec =
+		usec_to_msec(libinput_event_tablet_pad_get_time_usec(pevent));
 	wlr_event.button = libinput_event_tablet_pad_get_button_number(pevent);
 	switch (libinput_event_tablet_pad_get_button_state(pevent)) {
 	case LIBINPUT_BUTTON_STATE_PRESSED:
@@ -55,8 +55,8 @@ void handle_tablet_pad_ring(struct libinput_event *event,
 	struct libinput_event_tablet_pad *pevent =
 		libinput_event_get_tablet_pad_event(event);
 	struct wlr_event_tablet_pad_ring wlr_event = { 0 };
-	wlr_event.time_usec = libinput_event_tablet_pad_get_time_usec(pevent);
-	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
+	wlr_event.time_msec =
+		usec_to_msec(libinput_event_tablet_pad_get_time_usec(pevent));
 	wlr_event.ring = libinput_event_tablet_pad_get_ring_number(pevent);
 	wlr_event.position = libinput_event_tablet_pad_get_ring_position(pevent);
 	switch (libinput_event_tablet_pad_get_ring_source(pevent)) {
@@ -81,8 +81,8 @@ void handle_tablet_pad_strip(struct libinput_event *event,
 	struct libinput_event_tablet_pad *pevent =
 		libinput_event_get_tablet_pad_event(event);
 	struct wlr_event_tablet_pad_strip wlr_event = { 0 };
-	wlr_event.time_usec = libinput_event_tablet_pad_get_time_usec(pevent);
-	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
+	wlr_event.time_msec =
+		usec_to_msec(libinput_event_tablet_pad_get_time_usec(pevent));
 	wlr_event.strip = libinput_event_tablet_pad_get_strip_number(pevent);
 	wlr_event.position = libinput_event_tablet_pad_get_strip_position(pevent);
 	switch (libinput_event_tablet_pad_get_strip_source(pevent)) {

--- a/backend/libinput/tablet_tool.c
+++ b/backend/libinput/tablet_tool.c
@@ -31,8 +31,8 @@ void handle_tablet_tool_axis(struct libinput_event *event,
 		libinput_event_get_tablet_tool_event(event);
 	struct wlr_event_tablet_tool_axis wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
-	wlr_event.time_usec = libinput_event_tablet_tool_get_time_usec(tevent);
-	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
+	wlr_event.time_msec =
+		usec_to_msec(libinput_event_tablet_tool_get_time_usec(tevent));
 	libinput_device_get_size(libinput_dev, &wlr_event.width_mm, &wlr_event.height_mm);
 	if (libinput_event_tablet_tool_x_has_changed(tevent)) {
 		wlr_event.updated_axes |= WLR_TABLET_TOOL_AXIS_X;
@@ -85,8 +85,8 @@ void handle_tablet_tool_proximity(struct libinput_event *event,
 		libinput_event_get_tablet_tool_event(event);
 	struct wlr_event_tablet_tool_proximity wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
-	wlr_event.time_usec = libinput_event_tablet_tool_get_time_usec(tevent);
-	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
+	wlr_event.time_msec =
+		usec_to_msec(libinput_event_tablet_tool_get_time_usec(tevent));
 	switch (libinput_event_tablet_tool_get_proximity_state(tevent)) {
 	case LIBINPUT_TABLET_TOOL_PROXIMITY_STATE_OUT:
 		wlr_event.state = WLR_TABLET_TOOL_PROXIMITY_OUT;
@@ -112,8 +112,8 @@ void handle_tablet_tool_tip(struct libinput_event *event,
 		libinput_event_get_tablet_tool_event(event);
 	struct wlr_event_tablet_tool_tip wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
-	wlr_event.time_usec = libinput_event_tablet_tool_get_time_usec(tevent);
-	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
+	wlr_event.time_msec =
+		usec_to_msec(libinput_event_tablet_tool_get_time_usec(tevent));
 	switch (libinput_event_tablet_tool_get_tip_state(tevent)) {
 	case LIBINPUT_TABLET_TOOL_TIP_UP:
 		wlr_event.state = WLR_TABLET_TOOL_TIP_UP;
@@ -138,8 +138,8 @@ void handle_tablet_tool_button(struct libinput_event *event,
 		libinput_event_get_tablet_tool_event(event);
 	struct wlr_event_tablet_tool_button wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
-	wlr_event.time_usec = libinput_event_tablet_tool_get_time_usec(tevent);
-	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
+	wlr_event.time_msec =
+		usec_to_msec(libinput_event_tablet_tool_get_time_usec(tevent));
 	wlr_event.button = libinput_event_tablet_tool_get_button(tevent);
 	switch (libinput_event_tablet_tool_get_button_state(tevent)) {
 	case LIBINPUT_BUTTON_STATE_RELEASED:

--- a/backend/libinput/tablet_tool.c
+++ b/backend/libinput/tablet_tool.c
@@ -31,8 +31,8 @@ void handle_tablet_tool_axis(struct libinput_event *event,
 		libinput_event_get_tablet_tool_event(event);
 	struct wlr_event_tablet_tool_axis wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
-	wlr_event.time_sec = libinput_event_tablet_tool_get_time(tevent);
 	wlr_event.time_usec = libinput_event_tablet_tool_get_time_usec(tevent);
+	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
 	libinput_device_get_size(libinput_dev, &wlr_event.width_mm, &wlr_event.height_mm);
 	if (libinput_event_tablet_tool_x_has_changed(tevent)) {
 		wlr_event.updated_axes |= WLR_TABLET_TOOL_AXIS_X;
@@ -85,8 +85,8 @@ void handle_tablet_tool_proximity(struct libinput_event *event,
 		libinput_event_get_tablet_tool_event(event);
 	struct wlr_event_tablet_tool_proximity wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
-	wlr_event.time_sec = libinput_event_tablet_tool_get_time(tevent);
 	wlr_event.time_usec = libinput_event_tablet_tool_get_time_usec(tevent);
+	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
 	switch (libinput_event_tablet_tool_get_proximity_state(tevent)) {
 	case LIBINPUT_TABLET_TOOL_PROXIMITY_STATE_OUT:
 		wlr_event.state = WLR_TABLET_TOOL_PROXIMITY_OUT;
@@ -112,8 +112,8 @@ void handle_tablet_tool_tip(struct libinput_event *event,
 		libinput_event_get_tablet_tool_event(event);
 	struct wlr_event_tablet_tool_tip wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
-	wlr_event.time_sec = libinput_event_tablet_tool_get_time(tevent);
 	wlr_event.time_usec = libinput_event_tablet_tool_get_time_usec(tevent);
+	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
 	switch (libinput_event_tablet_tool_get_tip_state(tevent)) {
 	case LIBINPUT_TABLET_TOOL_TIP_UP:
 		wlr_event.state = WLR_TABLET_TOOL_TIP_UP;
@@ -138,8 +138,8 @@ void handle_tablet_tool_button(struct libinput_event *event,
 		libinput_event_get_tablet_tool_event(event);
 	struct wlr_event_tablet_tool_button wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
-	wlr_event.time_sec = libinput_event_tablet_tool_get_time(tevent);
 	wlr_event.time_usec = libinput_event_tablet_tool_get_time_usec(tevent);
+	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
 	wlr_event.button = libinput_event_tablet_tool_get_button(tevent);
 	switch (libinput_event_tablet_tool_get_button_state(tevent)) {
 	case LIBINPUT_BUTTON_STATE_RELEASED:

--- a/backend/libinput/touch.c
+++ b/backend/libinput/touch.c
@@ -31,8 +31,8 @@ void handle_touch_down(struct libinput_event *event,
 		libinput_event_get_touch_event(event);
 	struct wlr_event_touch_down wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
-	wlr_event.time_sec = libinput_event_touch_get_time(tevent);
 	wlr_event.time_usec = libinput_event_touch_get_time_usec(tevent);
+	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
 	wlr_event.slot = libinput_event_touch_get_slot(tevent);
 	wlr_event.x_mm = libinput_event_touch_get_x(tevent);
 	wlr_event.y_mm = libinput_event_touch_get_y(tevent);
@@ -52,8 +52,8 @@ void handle_touch_up(struct libinput_event *event,
 		libinput_event_get_touch_event(event);
 	struct wlr_event_touch_up wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
-	wlr_event.time_sec = libinput_event_touch_get_time(tevent);
 	wlr_event.time_usec = libinput_event_touch_get_time_usec(tevent);
+	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
 	wlr_event.slot = libinput_event_touch_get_slot(tevent);
 	wl_signal_emit(&wlr_dev->touch->events.up, &wlr_event);
 }
@@ -70,8 +70,8 @@ void handle_touch_motion(struct libinput_event *event,
 		libinput_event_get_touch_event(event);
 	struct wlr_event_touch_motion wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
-	wlr_event.time_sec = libinput_event_touch_get_time(tevent);
 	wlr_event.time_usec = libinput_event_touch_get_time_usec(tevent);
+	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
 	wlr_event.slot = libinput_event_touch_get_slot(tevent);
 	wlr_event.x_mm = libinput_event_touch_get_x(tevent);
 	wlr_event.y_mm = libinput_event_touch_get_y(tevent);
@@ -91,8 +91,8 @@ void handle_touch_cancel(struct libinput_event *event,
 		libinput_event_get_touch_event(event);
 	struct wlr_event_touch_cancel wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
-	wlr_event.time_sec = libinput_event_touch_get_time(tevent);
 	wlr_event.time_usec = libinput_event_touch_get_time_usec(tevent);
+	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
 	wlr_event.slot = libinput_event_touch_get_slot(tevent);
 	wl_signal_emit(&wlr_dev->touch->events.cancel, &wlr_event);
 }

--- a/backend/libinput/touch.c
+++ b/backend/libinput/touch.c
@@ -31,8 +31,8 @@ void handle_touch_down(struct libinput_event *event,
 		libinput_event_get_touch_event(event);
 	struct wlr_event_touch_down wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
-	wlr_event.time_usec = libinput_event_touch_get_time_usec(tevent);
-	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
+	wlr_event.time_msec =
+		usec_to_msec(libinput_event_touch_get_time_usec(tevent));
 	wlr_event.slot = libinput_event_touch_get_slot(tevent);
 	wlr_event.x_mm = libinput_event_touch_get_x(tevent);
 	wlr_event.y_mm = libinput_event_touch_get_y(tevent);
@@ -52,8 +52,8 @@ void handle_touch_up(struct libinput_event *event,
 		libinput_event_get_touch_event(event);
 	struct wlr_event_touch_up wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
-	wlr_event.time_usec = libinput_event_touch_get_time_usec(tevent);
-	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
+	wlr_event.time_msec =
+		usec_to_msec(libinput_event_touch_get_time_usec(tevent));
 	wlr_event.slot = libinput_event_touch_get_slot(tevent);
 	wl_signal_emit(&wlr_dev->touch->events.up, &wlr_event);
 }
@@ -70,8 +70,8 @@ void handle_touch_motion(struct libinput_event *event,
 		libinput_event_get_touch_event(event);
 	struct wlr_event_touch_motion wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
-	wlr_event.time_usec = libinput_event_touch_get_time_usec(tevent);
-	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
+	wlr_event.time_msec =
+		usec_to_msec(libinput_event_touch_get_time_usec(tevent));
 	wlr_event.slot = libinput_event_touch_get_slot(tevent);
 	wlr_event.x_mm = libinput_event_touch_get_x(tevent);
 	wlr_event.y_mm = libinput_event_touch_get_y(tevent);
@@ -91,8 +91,8 @@ void handle_touch_cancel(struct libinput_event *event,
 		libinput_event_get_touch_event(event);
 	struct wlr_event_touch_cancel wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
-	wlr_event.time_usec = libinput_event_touch_get_time_usec(tevent);
-	wlr_event.time_msec = (uint32_t)(wlr_event.time_usec / 1000);
+	wlr_event.time_msec =
+		usec_to_msec(libinput_event_touch_get_time_usec(tevent));
 	wlr_event.slot = libinput_event_touch_get_slot(tevent);
 	wl_signal_emit(&wlr_dev->touch->events.cancel, &wlr_event);
 }

--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -53,7 +53,6 @@ static void pointer_handle_motion(void *data, struct wl_pointer *wl_pointer,
 	struct wlr_event_pointer_motion_absolute wlr_event;
 	wlr_event.device = dev;
 	wlr_event.time_msec = time;
-	wlr_event.time_usec = time * 1000;
 	wlr_event.width_mm = width;
 	wlr_event.height_mm = height;
 	wlr_event.x_mm = wl_fixed_to_double(surface_x);
@@ -71,7 +70,6 @@ static void pointer_handle_button(void *data, struct wl_pointer *wl_pointer,
 	wlr_event.button = button;
 	wlr_event.state = state;
 	wlr_event.time_msec = time;
-	wlr_event.time_usec = time * 1000;
 	wl_signal_emit(&dev->pointer->events.button, &wlr_event);
 }
 
@@ -86,7 +84,6 @@ static void pointer_handle_axis(void *data, struct wl_pointer *wl_pointer,
 	wlr_event.delta = value;
 	wlr_event.orientation = axis;
 	wlr_event.time_msec = time;
-	wlr_event.time_usec = time * 1000;
 	wlr_event.source = wlr_wl_pointer->axis_source;
 	wl_signal_emit(&dev->pointer->events.axis, &wlr_event);
 }
@@ -148,7 +145,6 @@ static void keyboard_handle_key(void *data, struct wl_keyboard *wl_keyboard,
 	wlr_event.keycode = key;
 	wlr_event.state = state;
 	wlr_event.time_msec = time;
-	wlr_event.time_usec = time * 1000;
 	wlr_keyboard_notify_key(dev->keyboard, &wlr_event);
 }
 

--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -52,7 +52,7 @@ static void pointer_handle_motion(void *data, struct wl_pointer *wl_pointer,
 		&width, &height);
 	struct wlr_event_pointer_motion_absolute wlr_event;
 	wlr_event.device = dev;
-	wlr_event.time_sec = time / 1000;
+	wlr_event.time_msec = time;
 	wlr_event.time_usec = time * 1000;
 	wlr_event.width_mm = width;
 	wlr_event.height_mm = height;
@@ -70,7 +70,7 @@ static void pointer_handle_button(void *data, struct wl_pointer *wl_pointer,
 	wlr_event.device = dev;
 	wlr_event.button = button;
 	wlr_event.state = state;
-	wlr_event.time_sec = time / 1000;
+	wlr_event.time_msec = time;
 	wlr_event.time_usec = time * 1000;
 	wl_signal_emit(&dev->pointer->events.button, &wlr_event);
 }
@@ -85,7 +85,7 @@ static void pointer_handle_axis(void *data, struct wl_pointer *wl_pointer,
 	wlr_event.device = dev;
 	wlr_event.delta = value;
 	wlr_event.orientation = axis;
-	wlr_event.time_sec = time / 1000;
+	wlr_event.time_msec = time;
 	wlr_event.time_usec = time * 1000;
 	wlr_event.source = wlr_wl_pointer->axis_source;
 	wl_signal_emit(&dev->pointer->events.axis, &wlr_event);
@@ -147,7 +147,7 @@ static void keyboard_handle_key(void *data, struct wl_keyboard *wl_keyboard,
 	struct wlr_event_keyboard_key wlr_event;
 	wlr_event.keycode = key;
 	wlr_event.state = state;
-	wlr_event.time_sec = time / 1000;
+	wlr_event.time_msec = time;
 	wlr_event.time_usec = time * 1000;
 	wlr_keyboard_notify_key(dev->keyboard, &wlr_event);
 }

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -51,7 +51,6 @@ static bool handle_x11_event(struct wlr_x11_backend *x11, xcb_generic_event_t *e
 		xcb_key_press_event_t *ev = (xcb_key_press_event_t *)event;
 		struct wlr_event_keyboard_key key = {
 			.time_msec = ev->time,
-			.time_usec = ev->time * 1000,
 			.keycode = ev->detail - 8,
 			.state = event->response_type == XCB_KEY_PRESS ?
 				WLR_KEY_PRESSED : WLR_KEY_RELEASED,
@@ -72,7 +71,6 @@ static bool handle_x11_event(struct wlr_x11_backend *x11, xcb_generic_event_t *e
 			struct wlr_event_pointer_axis axis = {
 				.device = &x11->pointer_dev,
 				.time_msec = ev->time,
-				.time_usec = ev->time * 1000,
 				.source = WLR_AXIS_SOURCE_WHEEL,
 				.orientation = WLR_AXIS_ORIENTATION_VERTICAL,
 				.delta = delta,
@@ -91,7 +89,6 @@ static bool handle_x11_event(struct wlr_x11_backend *x11, xcb_generic_event_t *e
 			struct wlr_event_pointer_button button = {
 				.device = &x11->pointer_dev,
 				.time_msec = ev->time,
-				.time_usec = ev->time * 1000,
 				.button = xcb_button_to_wl(ev->detail),
 				.state = event->response_type == XCB_BUTTON_PRESS ?
 					WLR_BUTTON_PRESSED : WLR_BUTTON_RELEASED,
@@ -107,7 +104,6 @@ static bool handle_x11_event(struct wlr_x11_backend *x11, xcb_generic_event_t *e
 		struct wlr_event_pointer_motion_absolute abs = {
 			.device = &x11->pointer_dev,
 			.time_msec = ev->time,
-			.time_usec = ev->time * 1000,
 			.x_mm = ev->event_x,
 			.y_mm = ev->event_y,
 			.width_mm = output->wlr_output.width,
@@ -136,7 +132,6 @@ static bool handle_x11_event(struct wlr_x11_backend *x11, xcb_generic_event_t *e
 		struct wlr_event_pointer_motion_absolute abs = {
 			.device = &x11->pointer_dev,
 			.time_msec = x11->time,
-			.time_usec = x11->time * 1000,
 			.x_mm = pointer->root_x,
 			.y_mm = pointer->root_y,
 			.width_mm = output->wlr_output.width,

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -50,7 +50,7 @@ static bool handle_x11_event(struct wlr_x11_backend *x11, xcb_generic_event_t *e
 	case XCB_KEY_RELEASE: {
 		xcb_key_press_event_t *ev = (xcb_key_press_event_t *)event;
 		struct wlr_event_keyboard_key key = {
-			.time_sec = ev->time / 1000,
+			.time_msec = ev->time,
 			.time_usec = ev->time * 1000,
 			.keycode = ev->detail - 8,
 			.state = event->response_type == XCB_KEY_PRESS ?
@@ -71,7 +71,7 @@ static bool handle_x11_event(struct wlr_x11_backend *x11, xcb_generic_event_t *e
 			double delta = (ev->detail == XCB_BUTTON_INDEX_4 ? -15 : 15);
 			struct wlr_event_pointer_axis axis = {
 				.device = &x11->pointer_dev,
-				.time_sec = ev->time / 1000,
+				.time_msec = ev->time,
 				.time_usec = ev->time * 1000,
 				.source = WLR_AXIS_SOURCE_WHEEL,
 				.orientation = WLR_AXIS_ORIENTATION_VERTICAL,
@@ -90,7 +90,7 @@ static bool handle_x11_event(struct wlr_x11_backend *x11, xcb_generic_event_t *e
 				ev->detail != XCB_BUTTON_INDEX_5) {
 			struct wlr_event_pointer_button button = {
 				.device = &x11->pointer_dev,
-				.time_sec = ev->time / 1000,
+				.time_msec = ev->time,
 				.time_usec = ev->time * 1000,
 				.button = xcb_button_to_wl(ev->detail),
 				.state = event->response_type == XCB_BUTTON_PRESS ?
@@ -106,7 +106,7 @@ static bool handle_x11_event(struct wlr_x11_backend *x11, xcb_generic_event_t *e
 		xcb_motion_notify_event_t *ev = (xcb_motion_notify_event_t *)event;
 		struct wlr_event_pointer_motion_absolute abs = {
 			.device = &x11->pointer_dev,
-			.time_sec = ev->time / 1000,
+			.time_msec = ev->time,
 			.time_usec = ev->time * 1000,
 			.x_mm = ev->event_x,
 			.y_mm = ev->event_y,
@@ -135,7 +135,7 @@ static bool handle_x11_event(struct wlr_x11_backend *x11, xcb_generic_event_t *e
 
 		struct wlr_event_pointer_motion_absolute abs = {
 			.device = &x11->pointer_dev,
-			.time_sec = x11->time / 1000,
+			.time_msec = x11->time,
 			.time_usec = x11->time * 1000,
 			.x_mm = pointer->root_x,
 			.y_mm = pointer->root_y,

--- a/examples/shared.c
+++ b/examples/shared.c
@@ -38,7 +38,7 @@ static void keyboard_key_notify(struct wl_listener *listener, void *data) {
 		}
 		if (kbstate->compositor->keyboard_key_cb) {
 			kbstate->compositor->keyboard_key_cb(kbstate, event->keycode, sym,
-				key_state, event->time_usec);
+				key_state, event->time_msec * 1000);
 		}
 		if (sym == XKB_KEY_Escape) {
 			wl_display_terminate(kbstate->compositor->display);

--- a/include/wlr/backend.h
+++ b/include/wlr/backend.h
@@ -23,4 +23,6 @@ bool wlr_backend_start(struct wlr_backend *backend);
 void wlr_backend_destroy(struct wlr_backend *backend);
 struct wlr_egl *wlr_backend_get_egl(struct wlr_backend *backend);
 
+uint32_t usec_to_msec(uint64_t usec);
+
 #endif

--- a/include/wlr/types/wlr_keyboard.h
+++ b/include/wlr/types/wlr_keyboard.h
@@ -63,7 +63,7 @@ enum wlr_key_state {
 };
 
 struct wlr_event_keyboard_key {
-	uint32_t time_sec;
+	uint32_t time_msec;
 	uint64_t time_usec;
 	uint32_t keycode;
 	bool update_state;

--- a/include/wlr/types/wlr_keyboard.h
+++ b/include/wlr/types/wlr_keyboard.h
@@ -64,7 +64,6 @@ enum wlr_key_state {
 
 struct wlr_event_keyboard_key {
 	uint32_t time_msec;
-	uint64_t time_usec;
 	uint32_t keycode;
 	bool update_state;
 	enum wlr_key_state state;

--- a/include/wlr/types/wlr_pointer.h
+++ b/include/wlr/types/wlr_pointer.h
@@ -22,14 +22,14 @@ struct wlr_pointer {
 
 struct wlr_event_pointer_motion {
 	struct wlr_input_device *device;
-	uint32_t time_sec;
+	uint32_t time_msec;
 	uint64_t time_usec;
 	double delta_x, delta_y;
 };
 
 struct wlr_event_pointer_motion_absolute {
 	struct wlr_input_device *device;
-	uint32_t time_sec;
+	uint32_t time_msec;
 	uint64_t time_usec;
 	double x_mm, y_mm;
 	double width_mm, height_mm;
@@ -37,7 +37,7 @@ struct wlr_event_pointer_motion_absolute {
 
 struct wlr_event_pointer_button {
 	struct wlr_input_device *device;
-	uint32_t time_sec;
+	uint32_t time_msec;
 	uint64_t time_usec;
 	uint32_t button;
 	enum wlr_button_state state;
@@ -57,7 +57,7 @@ enum wlr_axis_orientation {
 
 struct wlr_event_pointer_axis {
 	struct wlr_input_device *device;
-	uint32_t time_sec;
+	uint32_t time_msec;
 	uint64_t time_usec;
 	enum wlr_axis_source source;
 	enum wlr_axis_orientation orientation;

--- a/include/wlr/types/wlr_pointer.h
+++ b/include/wlr/types/wlr_pointer.h
@@ -23,14 +23,12 @@ struct wlr_pointer {
 struct wlr_event_pointer_motion {
 	struct wlr_input_device *device;
 	uint32_t time_msec;
-	uint64_t time_usec;
 	double delta_x, delta_y;
 };
 
 struct wlr_event_pointer_motion_absolute {
 	struct wlr_input_device *device;
 	uint32_t time_msec;
-	uint64_t time_usec;
 	double x_mm, y_mm;
 	double width_mm, height_mm;
 };
@@ -38,7 +36,6 @@ struct wlr_event_pointer_motion_absolute {
 struct wlr_event_pointer_button {
 	struct wlr_input_device *device;
 	uint32_t time_msec;
-	uint64_t time_usec;
 	uint32_t button;
 	enum wlr_button_state state;
 };
@@ -58,7 +55,6 @@ enum wlr_axis_orientation {
 struct wlr_event_pointer_axis {
 	struct wlr_input_device *device;
 	uint32_t time_msec;
-	uint64_t time_usec;
 	enum wlr_axis_source source;
 	enum wlr_axis_orientation orientation;
 	double delta;

--- a/include/wlr/types/wlr_tablet_pad.h
+++ b/include/wlr/types/wlr_tablet_pad.h
@@ -27,7 +27,6 @@ struct wlr_tablet_pad {
 
 struct wlr_event_tablet_pad_button {
 	uint32_t time_msec;
-	uint64_t time_usec;
 	uint32_t button;
 	enum wlr_button_state state;
 };
@@ -39,7 +38,6 @@ enum wlr_tablet_pad_ring_source {
 
 struct wlr_event_tablet_pad_ring {
 	uint32_t time_msec;
-	uint64_t time_usec;
 	enum wlr_tablet_pad_ring_source source;
 	uint32_t ring;
 	double position;
@@ -52,7 +50,6 @@ enum wlr_tablet_pad_strip_source {
 
 struct wlr_event_tablet_pad_strip {
 	uint32_t time_msec;
-	uint64_t time_usec;
 	enum wlr_tablet_pad_strip_source source;
 	uint32_t strip;
 	double position;

--- a/include/wlr/types/wlr_tablet_pad.h
+++ b/include/wlr/types/wlr_tablet_pad.h
@@ -26,7 +26,7 @@ struct wlr_tablet_pad {
 };
 
 struct wlr_event_tablet_pad_button {
-	uint32_t time_sec;
+	uint32_t time_msec;
 	uint64_t time_usec;
 	uint32_t button;
 	enum wlr_button_state state;
@@ -38,7 +38,7 @@ enum wlr_tablet_pad_ring_source {
 };
 
 struct wlr_event_tablet_pad_ring {
-	uint32_t time_sec;
+	uint32_t time_msec;
 	uint64_t time_usec;
 	enum wlr_tablet_pad_ring_source source;
 	uint32_t ring;
@@ -51,7 +51,7 @@ enum wlr_tablet_pad_strip_source {
 };
 
 struct wlr_event_tablet_pad_strip {
-	uint32_t time_sec;
+	uint32_t time_msec;
 	uint64_t time_usec;
 	enum wlr_tablet_pad_strip_source source;
 	uint32_t strip;

--- a/include/wlr/types/wlr_tablet_tool.h
+++ b/include/wlr/types/wlr_tablet_tool.h
@@ -34,7 +34,7 @@ enum wlr_tablet_tool_axes {
 
 struct wlr_event_tablet_tool_axis {
 	struct wlr_input_device *device;
-	uint32_t time_sec;
+	uint32_t time_msec;
 	uint64_t time_usec;
 	uint32_t updated_axes;
 	double x_mm, y_mm;
@@ -54,7 +54,7 @@ enum wlr_tablet_tool_proximity_state {
 
 struct wlr_event_tablet_tool_proximity {
 	struct wlr_input_device *device;
-	uint32_t time_sec;
+	uint32_t time_msec;
 	uint64_t time_usec;
 	double x_mm, y_mm;
 	double width_mm, height_mm;
@@ -68,7 +68,7 @@ enum wlr_tablet_tool_tip_state {
 
 struct wlr_event_tablet_tool_tip {
 	struct wlr_input_device *device;
-	uint32_t time_sec;
+	uint32_t time_msec;
 	uint64_t time_usec;
 	double x_mm, y_mm;
 	double width_mm, height_mm;
@@ -77,7 +77,7 @@ struct wlr_event_tablet_tool_tip {
 
 struct wlr_event_tablet_tool_button {
 	struct wlr_input_device *device;
-	uint32_t time_sec;
+	uint32_t time_msec;
 	uint64_t time_usec;
 	uint32_t button;
 	enum wlr_button_state state;

--- a/include/wlr/types/wlr_tablet_tool.h
+++ b/include/wlr/types/wlr_tablet_tool.h
@@ -35,7 +35,6 @@ enum wlr_tablet_tool_axes {
 struct wlr_event_tablet_tool_axis {
 	struct wlr_input_device *device;
 	uint32_t time_msec;
-	uint64_t time_usec;
 	uint32_t updated_axes;
 	double x_mm, y_mm;
 	double width_mm, height_mm;
@@ -55,7 +54,6 @@ enum wlr_tablet_tool_proximity_state {
 struct wlr_event_tablet_tool_proximity {
 	struct wlr_input_device *device;
 	uint32_t time_msec;
-	uint64_t time_usec;
 	double x_mm, y_mm;
 	double width_mm, height_mm;
 	enum wlr_tablet_tool_proximity_state state;
@@ -69,7 +67,6 @@ enum wlr_tablet_tool_tip_state {
 struct wlr_event_tablet_tool_tip {
 	struct wlr_input_device *device;
 	uint32_t time_msec;
-	uint64_t time_usec;
 	double x_mm, y_mm;
 	double width_mm, height_mm;
 	enum wlr_tablet_tool_tip_state state;
@@ -78,7 +75,6 @@ struct wlr_event_tablet_tool_tip {
 struct wlr_event_tablet_tool_button {
 	struct wlr_input_device *device;
 	uint32_t time_msec;
-	uint64_t time_usec;
 	uint32_t button;
 	enum wlr_button_state state;
 };

--- a/include/wlr/types/wlr_touch.h
+++ b/include/wlr/types/wlr_touch.h
@@ -21,7 +21,7 @@ struct wlr_touch {
 
 struct wlr_event_touch_down {
 	struct wlr_input_device *device;
-	uint32_t time_sec;
+	uint32_t time_msec;
 	uint64_t time_usec;
 	int32_t slot;
 	double x_mm, y_mm;
@@ -30,14 +30,14 @@ struct wlr_event_touch_down {
 
 struct wlr_event_touch_up {
 	struct wlr_input_device *device;
-	uint32_t time_sec;
+	uint32_t time_msec;
 	uint64_t time_usec;
 	int32_t slot;
 };
 
 struct wlr_event_touch_motion {
 	struct wlr_input_device *device;
-	uint32_t time_sec;
+	uint32_t time_msec;
 	uint64_t time_usec;
 	int32_t slot;
 	double x_mm, y_mm;
@@ -46,7 +46,7 @@ struct wlr_event_touch_motion {
 
 struct wlr_event_touch_cancel {
 	struct wlr_input_device *device;
-	uint32_t time_sec;
+	uint32_t time_msec;
 	uint64_t time_usec;
 	int32_t slot;
 };

--- a/include/wlr/types/wlr_touch.h
+++ b/include/wlr/types/wlr_touch.h
@@ -22,7 +22,6 @@ struct wlr_touch {
 struct wlr_event_touch_down {
 	struct wlr_input_device *device;
 	uint32_t time_msec;
-	uint64_t time_usec;
 	int32_t slot;
 	double x_mm, y_mm;
 	double width_mm, height_mm;
@@ -31,14 +30,12 @@ struct wlr_event_touch_down {
 struct wlr_event_touch_up {
 	struct wlr_input_device *device;
 	uint32_t time_msec;
-	uint64_t time_usec;
 	int32_t slot;
 };
 
 struct wlr_event_touch_motion {
 	struct wlr_input_device *device;
 	uint32_t time_msec;
-	uint64_t time_usec;
 	int32_t slot;
 	double x_mm, y_mm;
 	double width_mm, height_mm;
@@ -47,7 +44,6 @@ struct wlr_event_touch_motion {
 struct wlr_event_touch_cancel {
 	struct wlr_input_device *device;
 	uint32_t time_msec;
-	uint64_t time_usec;
 	int32_t slot;
 };
 

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -230,7 +230,7 @@ static void handle_cursor_motion(struct wl_listener *listener, void *data) {
 	struct wlr_event_pointer_motion *event = data;
 	wlr_cursor_move(input->cursor, event->device,
 			event->delta_x, event->delta_y);
-	cursor_update_position(input, (uint32_t)(event->time_usec / 1000));
+	cursor_update_position(input, event->time_msec);
 }
 
 static void handle_cursor_motion_absolute(struct wl_listener *listener,
@@ -240,14 +240,14 @@ static void handle_cursor_motion_absolute(struct wl_listener *listener,
 	struct wlr_event_pointer_motion_absolute *event = data;
 	wlr_cursor_warp_absolute(input->cursor, event->device,
 		event->x_mm / event->width_mm, event->y_mm / event->height_mm);
-	cursor_update_position(input, (uint32_t)(event->time_usec / 1000));
+	cursor_update_position(input, event->time_msec);
 }
 
 static void handle_cursor_axis(struct wl_listener *listener, void *data) {
 	struct roots_input *input =
 		wl_container_of(listener, input, cursor_axis);
 	struct wlr_event_pointer_axis *event = data;
-	wlr_seat_pointer_notify_axis(input->wl_seat, event->time_sec,
+	wlr_seat_pointer_notify_axis(input->wl_seat, event->time_msec,
 		event->orientation, event->delta);
 }
 
@@ -339,7 +339,7 @@ static void handle_cursor_button(struct wl_listener *listener, void *data) {
 	struct roots_input *input = wl_container_of(listener, input, cursor_button);
 	struct wlr_event_pointer_button *event = data;
 	do_cursor_button_press(input, input->cursor, event->device,
-			(uint32_t)(event->time_usec / 1000), event->button, event->state);
+			event->time_msec, event->button, event->state);
 }
 
 static void handle_touch_down(struct wl_listener *listener, void *data) {
@@ -353,10 +353,10 @@ static void handle_touch_down(struct wl_listener *listener, void *data) {
 	point->x = event->x_mm / event->width_mm;
 	point->y = event->y_mm / event->height_mm;
 	wlr_cursor_warp_absolute(input->cursor, event->device, point->x, point->y);
-	cursor_update_position(input, (uint32_t)(event->time_usec / 1000));
+	cursor_update_position(input, event->time_msec);
 	wl_list_insert(&input->touch_points, &point->link);
 	do_cursor_button_press(input, input->cursor, event->device,
-			(uint32_t)(event->time_usec / 1000), BTN_LEFT, 1);
+		event->time_msec, BTN_LEFT, 1);
 }
 
 static void handle_touch_up(struct wl_listener *listener, void *data) {
@@ -371,7 +371,7 @@ static void handle_touch_up(struct wl_listener *listener, void *data) {
 		}
 	}
 	do_cursor_button_press(input, input->cursor, event->device,
-			(uint32_t)(event->time_usec / 1000), BTN_LEFT, 0);
+		event->time_msec, BTN_LEFT, 0);
 }
 
 static void handle_touch_motion(struct wl_listener *listener, void *data) {
@@ -385,8 +385,7 @@ static void handle_touch_motion(struct wl_listener *listener, void *data) {
 			point->y = event->y_mm / event->height_mm;
 			wlr_cursor_warp_absolute(input->cursor, event->device,
 					point->x, point->y);
-			cursor_update_position(input,
-					(uint32_t)(event->time_usec / 1000));
+			cursor_update_position(input, event->time_msec);
 			break;
 		}
 	}
@@ -399,7 +398,7 @@ static void handle_tool_axis(struct wl_listener *listener, void *data) {
 			(event->updated_axes & WLR_TABLET_TOOL_AXIS_Y)) {
 		wlr_cursor_warp_absolute(input->cursor, event->device,
 			event->x_mm / event->width_mm, event->y_mm / event->height_mm);
-		cursor_update_position(input, (uint32_t)(event->time_usec / 1000));
+		cursor_update_position(input, event->time_msec);
 	}
 }
 
@@ -407,7 +406,7 @@ static void handle_tool_tip(struct wl_listener *listener, void *data) {
 	struct roots_input *input = wl_container_of(listener, input, cursor_tool_tip);
 	struct wlr_event_tablet_tool_tip *event = data;
 	do_cursor_button_press(input, input->cursor, event->device,
-			(uint32_t)(event->time_usec / 1000), BTN_LEFT, event->state);
+		event->time_msec, BTN_LEFT, event->state);
 }
 
 static void handle_drag_icon_destroy(struct wl_listener *listener, void *data) {

--- a/rootston/keyboard.c
+++ b/rootston/keyboard.c
@@ -138,8 +138,8 @@ static void keyboard_key_notify(struct wl_listener *listener, void *data) {
 
 	if (!handled) {
 		wlr_seat_set_keyboard(keyboard->input->wl_seat, keyboard->device);
-		wlr_seat_keyboard_notify_key(keyboard->input->wl_seat,
-			(uint32_t)(event->time_usec / 1000), event->keycode, event->state);
+		wlr_seat_keyboard_notify_key(keyboard->input->wl_seat, event->time_msec,
+			event->keycode, event->state);
 	}
 }
 


### PR DESCRIPTION
Makes rootston code a bit simpler because now it doesn't have to do the weird casting.

`time_usec` is now unused.