### PR TITLE
Input grab tweaks and fixes

### DIFF
--- a/rootston/keyboard.c
+++ b/rootston/keyboard.c
@@ -83,6 +83,11 @@ static bool keyboard_keysym_press(struct roots_keyboard *keyboard,
 		return true;
 	}
 
+	if (keysym == XKB_KEY_Escape) {
+		wlr_seat_pointer_end_grab(keyboard->input->wl_seat);
+		wlr_seat_keyboard_end_grab(keyboard->input->wl_seat);
+	}
+
 	uint32_t modifiers = wlr_keyboard_get_modifiers(keyboard->device->keyboard);
 	struct wl_list *bindings = &keyboard->input->server->config->bindings;
 	struct binding_config *bc;


### PR DESCRIPTION
I'm trying to find bugs and rough edges with the grab interface.

Currently we grab on popups in xdg-shell and wl-shell as well as drag and drop operations.

Rootston now cancels a grab when you press the esc key. Use this to test grab cancels.

* Press esc key when a popup window is shown. It should close all the popups.
* Press the esc key in the middle of a dnd operation. It should end the dnd operation and destroy the dnd icon (buggy).