### PR TITLE
Remove transform support from Wayland backend

### DIFF
--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -46,12 +46,6 @@ static void wlr_wl_output_swap_buffers(struct wlr_output *_output) {
 	}
 }
 
-static void wlr_wl_output_transform(struct wlr_output *_output,
-		enum wl_output_transform transform) {
-	struct wlr_wl_backend_output *output = (struct wlr_wl_backend_output *)_output;
-	output->wlr_output.transform = transform;
-}
-
 static bool wlr_wl_output_set_cursor(struct wlr_output *_output,
 		const uint8_t *buf, int32_t stride, uint32_t width, uint32_t height,
 		int32_t hotspot_x, int32_t hotspot_y, bool update_pixels) {
@@ -178,7 +172,6 @@ bool wlr_wl_output_move_cursor(struct wlr_output *_output, int x, int y) {
 }
 
 static struct wlr_output_impl output_impl = {
-	.transform = wlr_wl_output_transform,
 	.destroy = wlr_wl_output_destroy,
 	.make_current = wlr_wl_output_make_current,
 	.swap_buffers = wlr_wl_output_swap_buffers,

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -169,8 +169,10 @@ void wlr_output_update_size(struct wlr_output *output, int32_t width,
 
 void wlr_output_transform(struct wlr_output *output,
 		enum wl_output_transform transform) {
-	output->impl->transform(output, transform);
-	wlr_output_update_matrix(output);
+	if (output->impl->transform) {
+		output->impl->transform(output, transform);
+		wlr_output_update_matrix(output);
+	}
 }
 
 void wlr_output_set_position(struct wlr_output *output, int32_t lx,


### PR DESCRIPTION
Try this config:

```ini
[output:WL-1]
rotate = 90
```

Since hardware cursors are used, this breaks the desktop: the transformation cannot be applied to the parent compositor's cursor.

This PR makes `transform` optional for output interfaces and removes the Wayland implementation. 