### PR TITLE
Cursors ✕ Output Transformations fixes

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -558,39 +558,17 @@ static bool wlr_drm_connector_set_cursor(struct wlr_output *output,
 		}
 	}
 
-	switch (output->transform) {
-	case WL_OUTPUT_TRANSFORM_90:
-		plane->cursor_hotspot_x = hotspot_x;
-		plane->cursor_hotspot_y = -plane->surf.height + hotspot_y;
-		break;
-	case WL_OUTPUT_TRANSFORM_180:
-		plane->cursor_hotspot_x = plane->surf.width - hotspot_x;
-		plane->cursor_hotspot_y = plane->surf.height - hotspot_y;
-		break;
-	case WL_OUTPUT_TRANSFORM_270:
-		plane->cursor_hotspot_x = -plane->surf.height + hotspot_x;
-		plane->cursor_hotspot_y = hotspot_y;
-		break;
-	case WL_OUTPUT_TRANSFORM_FLIPPED:
-		plane->cursor_hotspot_x = plane->surf.width - hotspot_x;
-		plane->cursor_hotspot_y = hotspot_y;
-		break;
-	case WL_OUTPUT_TRANSFORM_FLIPPED_90:
-		plane->cursor_hotspot_x = hotspot_x;
-		plane->cursor_hotspot_y = -hotspot_y;
-		break;
-	case WL_OUTPUT_TRANSFORM_FLIPPED_180:
-		plane->cursor_hotspot_x = hotspot_x;
-		plane->cursor_hotspot_y = plane->surf.height - hotspot_y;
-		break;
-	case WL_OUTPUT_TRANSFORM_FLIPPED_270:
-		plane->cursor_hotspot_x = -plane->surf.height + hotspot_x;
-		plane->cursor_hotspot_y = plane->surf.width - hotspot_y;
-		break;
-	default: // WL_OUTPUT_TRANSFORM_NORMAL
-		plane->cursor_hotspot_x = hotspot_x;
-		plane->cursor_hotspot_y = hotspot_y;
-	}
+	struct wlr_box hotspot_box = {
+		.width = plane->surf.width,
+		.height = plane->surf.height,
+		.x = hotspot_x,
+		.y = hotspot_y,
+	};
+	struct wlr_box transformed_hotspot_box;
+	wlr_output_transform_apply_to_box(output->transform,
+		&hotspot_box, &transformed_hotspot_box);
+	plane->cursor_hotspot_x = transformed_hotspot_box.x;
+	plane->cursor_hotspot_y = transformed_hotspot_box.y;
 
 	if (!update_pixels) {
 		// Only update the cursor hotspot

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -533,13 +533,14 @@ static bool wlr_drm_connector_set_cursor(struct wlr_output *output,
 			return false;
 		}
 
-		if (!wlr_drm_surface_init(&plane->surf, renderer, w, h, GBM_FORMAT_ARGB8888, 0)) {
+		if (!wlr_drm_surface_init(&plane->surf, renderer, w, h,
+				GBM_FORMAT_ARGB8888, 0)) {
 			wlr_log(L_ERROR, "Cannot allocate cursor resources");
 			return false;
 		}
 
-		plane->cursor_bo = gbm_bo_create(renderer->gbm, w, h, GBM_FORMAT_ARGB8888,
-			GBM_BO_USE_CURSOR | GBM_BO_USE_WRITE);
+		plane->cursor_bo = gbm_bo_create(renderer->gbm, w, h,
+			GBM_FORMAT_ARGB8888, GBM_BO_USE_CURSOR | GBM_BO_USE_WRITE);
 		if (!plane->cursor_bo) {
 			wlr_log_errno(L_ERROR, "Failed to create cursor bo");
 			return false;
@@ -552,34 +553,26 @@ static bool wlr_drm_connector_set_cursor(struct wlr_output *output,
 
 		// TODO the image needs to be rotated depending on the output rotation
 
-		plane->wlr_tex = wlr_render_texture_create(plane->surf.renderer->wlr_rend);
+		plane->wlr_tex =
+			wlr_render_texture_create(plane->surf.renderer->wlr_rend);
 		if (!plane->wlr_tex) {
 			return false;
 		}
 	}
 
-	switch (output->transform) {
-	case WL_OUTPUT_TRANSFORM_NORMAL:
-	case WL_OUTPUT_TRANSFORM_FLIPPED_90:
-		plane->cursor_hotspot_x = hotspot_x;
-		plane->cursor_hotspot_y = hotspot_y;
-		break;
-	case WL_OUTPUT_TRANSFORM_90:
-	case WL_OUTPUT_TRANSFORM_FLIPPED_180:
-		plane->cursor_hotspot_x = hotspot_x;
-		plane->cursor_hotspot_y = -plane->surf.height + hotspot_y;
-		break;
-	case WL_OUTPUT_TRANSFORM_180:
-	case WL_OUTPUT_TRANSFORM_FLIPPED_270:
-		plane->cursor_hotspot_x = -plane->surf.width + hotspot_x;
-		plane->cursor_hotspot_y = -plane->surf.height + hotspot_y;
-		break;
-	case WL_OUTPUT_TRANSFORM_FLIPPED:
-	case WL_OUTPUT_TRANSFORM_270:
-		plane->cursor_hotspot_x = -plane->surf.width + hotspot_x;
-		plane->cursor_hotspot_y = hotspot_y;
-		break;
-	}
+	struct wlr_box hotspot = {
+		.width = plane->surf.width,
+		.height = plane->surf.height,
+		.x = hotspot_x,
+		.y = hotspot_y,
+	};
+	enum wl_output_transform transform =
+		wlr_output_transform_invert(output->transform);
+	struct wlr_box transformed_hotspot;
+	wlr_output_transform_apply_to_box(transform, &hotspot,
+		&transformed_hotspot);
+	plane->cursor_hotspot_x = transformed_hotspot.x;
+	plane->cursor_hotspot_y = transformed_hotspot.y;
 
 	if (!update_pixels) {
 		// Only update the cursor hotspot
@@ -609,11 +602,13 @@ static bool wlr_drm_connector_set_cursor(struct wlr_output *output,
 
 	float matrix[16];
 	wlr_texture_get_matrix(plane->wlr_tex, &matrix, &plane->matrix, 0, 0);
-	wlr_render_with_matrix(plane->surf.renderer->wlr_rend, plane->wlr_tex, &matrix);
+	wlr_render_with_matrix(plane->surf.renderer->wlr_rend, plane->wlr_tex,
+		&matrix);
 
 	glFinish();
 	glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, bo_stride);
-	glReadPixels(0, 0, plane->surf.width, plane->surf.height, GL_BGRA_EXT, GL_UNSIGNED_BYTE, bo_data);
+	glReadPixels(0, 0, plane->surf.width, plane->surf.height, GL_BGRA_EXT,
+		GL_UNSIGNED_BYTE, bo_data);
 	glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, 0);
 
 	wlr_drm_surface_swap_buffers(&plane->surf);
@@ -627,10 +622,7 @@ static bool wlr_drm_connector_move_cursor(struct wlr_output *output,
 		int x, int y) {
 	struct wlr_drm_connector *conn = (struct wlr_drm_connector *)output;
 	struct wlr_drm_backend *drm = (struct wlr_drm_backend *)output->backend;
-
 	struct wlr_drm_plane *plane = conn->crtc->cursor;
-	x -= plane->cursor_hotspot_x;
-	y -= plane->cursor_hotspot_y;
 
 	struct wlr_box box;
 	box.x = x;
@@ -641,6 +633,9 @@ static bool wlr_drm_connector_move_cursor(struct wlr_output *output,
 		wlr_output_transform_invert(output->transform);
 	struct wlr_box transformed_box;
 	wlr_output_transform_apply_to_box(transform, &box, &transformed_box);
+
+	transformed_box.x -= plane->cursor_hotspot_x;
+	transformed_box.y -= plane->cursor_hotspot_y;
 
 	return drm->iface->crtc_move_cursor(drm, conn->crtc, transformed_box.x,
 		transformed_box.y);

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -59,6 +59,7 @@ static bool wlr_wl_output_set_cursor(struct wlr_output *_output,
 		(struct wlr_wl_backend_output *)_output;
 	struct wlr_wl_backend *backend = output->backend;
 
+	// TODO: use output->wlr_output.transform to transform pixels and hotpot
 	output->cursor.hotspot_x = hotspot_x;
 	output->cursor.hotspot_y = hotspot_y;
 

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -34,5 +34,6 @@ void wlr_output_destroy_global(struct wlr_output *wlr_output);
 
 void wlr_output_transform_apply_to_box(enum wl_output_transform transform,
 	struct wlr_box *box, struct wlr_box *dest);
+enum wl_output_transform wlr_output_transform_invert(enum wl_output_transform);
 
 #endif

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -2,6 +2,7 @@
 #define WLR_INTERFACES_WLR_OUTPUT_H
 
 #include <stdbool.h>
+#include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/backend.h>
 
@@ -30,5 +31,8 @@ void wlr_output_update_size(struct wlr_output *output, int32_t width,
 struct wl_global *wlr_output_create_global(struct wlr_output *wlr_output,
 	struct wl_display *display);
 void wlr_output_destroy_global(struct wlr_output *wlr_output);
+
+void wlr_output_transform_apply_to_box(enum wl_output_transform transform,
+	struct wlr_box *box, struct wlr_box *dest);
 
 #endif

--- a/rootston/config.c
+++ b/rootston/config.c
@@ -228,7 +228,9 @@ static int config_ini_handler(void *user, const char *section, const char *name,
 		} else if (strcmp(name, "y") == 0) {
 			oc->y = strtol(value, NULL, 10);
 		} else if (strcmp(name, "rotate") == 0) {
-			if (strcmp(value, "90") == 0) {
+			if (strcmp(value, "normal") == 0) {
+				oc->transform = WL_OUTPUT_TRANSFORM_NORMAL;
+			} else if (strcmp(value, "90") == 0) {
 				oc->transform = WL_OUTPUT_TRANSFORM_90;
 			} else if (strcmp(value, "180") == 0) {
 				oc->transform = WL_OUTPUT_TRANSFORM_180;

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -267,8 +267,8 @@ static void output_cursor_render(struct wlr_output_cursor *cursor) {
 
 	struct wlr_box output_box;
 	output_box.x = output_box.y = 0;
-	output_box.width = cursor->output->width;
-	output_box.height = cursor->output->height;
+	wlr_output_effective_resolution(cursor->output, &output_box.width,
+		&output_box.height);
 
 	struct wlr_box cursor_box;
 	output_cursor_get_box(cursor, &cursor_box);
@@ -294,7 +294,7 @@ void wlr_output_swap_buffers(struct wlr_output *output) {
 	struct wlr_output_cursor *cursor;
 	wl_list_for_each(cursor, &output->cursors, link) {
 		if (output->hardware_cursor == cursor) {
-			continue;
+			//continue; // TODO
 		}
 		output_cursor_render(cursor);
 	}
@@ -342,7 +342,7 @@ bool wlr_output_cursor_set_image(struct wlr_output_cursor *cursor,
 			stride, width, height, hotspot_x, hotspot_y, true);
 		if (ok) {
 			cursor->output->hardware_cursor = cursor;
-			return true;
+			//return true; // TODO
 		}
 	}
 
@@ -545,4 +545,13 @@ void wlr_output_transform_apply_to_box(enum wl_output_transform transform,
 		dest->y = box->width - box->x;
 		break;
 	}
+}
+
+enum wl_output_transform wlr_output_transform_invert(
+		enum wl_output_transform transform) {
+	if ((transform & WL_OUTPUT_TRANSFORM_90) &&
+			!(transform & WL_OUTPUT_TRANSFORM_FLIPPED)) {
+		transform ^= WL_OUTPUT_TRANSFORM_180;
+	}
+	return transform;
 }

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -500,3 +500,57 @@ void wlr_output_cursor_destroy(struct wlr_output_cursor *cursor) {
 	wl_list_remove(&cursor->link);
 	free(cursor);
 }
+
+void wlr_output_transform_apply_to_box(enum wl_output_transform transform,
+		struct wlr_box *box, struct wlr_box *dest) {
+	switch (transform) {
+	case WL_OUTPUT_TRANSFORM_NORMAL:
+	case WL_OUTPUT_TRANSFORM_180:
+	case WL_OUTPUT_TRANSFORM_FLIPPED:
+	case WL_OUTPUT_TRANSFORM_FLIPPED_180:
+		dest->width = box->width;
+		dest->height = box->height;
+		break;
+	case WL_OUTPUT_TRANSFORM_90:
+	case WL_OUTPUT_TRANSFORM_270:
+	case WL_OUTPUT_TRANSFORM_FLIPPED_90:
+	case WL_OUTPUT_TRANSFORM_FLIPPED_270:
+		dest->width = box->height;
+		dest->height = box->width;
+		break;
+	}
+
+	switch (transform) {
+	case WL_OUTPUT_TRANSFORM_NORMAL:
+		dest->x = box->x;
+		dest->y = box->y;
+		break;
+	case WL_OUTPUT_TRANSFORM_90:
+		dest->x = box->y;
+		dest->y = box->width - box->x;
+		break;
+	case WL_OUTPUT_TRANSFORM_180:
+		dest->x = box->width - box->x;
+		dest->y = box->height - box->y;
+		break;
+	case WL_OUTPUT_TRANSFORM_270:
+		dest->x = box->height - box->y;
+		dest->y = box->x;
+		break;
+	case WL_OUTPUT_TRANSFORM_FLIPPED:
+		dest->x = box->width - box->x;
+		dest->y = box->y;
+		break;
+	case WL_OUTPUT_TRANSFORM_FLIPPED_90:
+		dest->x = box->y;
+		dest->y = box->x;
+		break;
+	case WL_OUTPUT_TRANSFORM_FLIPPED_180:
+		dest->x = box->x;
+		dest->y = box->height - box->y;
+		break;
+	case WL_OUTPUT_TRANSFORM_FLIPPED_270:
+		dest->x = box->height - box->y;
+		dest->y = box->width - box->x;
+	}
+}

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -503,21 +503,12 @@ void wlr_output_cursor_destroy(struct wlr_output_cursor *cursor) {
 
 void wlr_output_transform_apply_to_box(enum wl_output_transform transform,
 		struct wlr_box *box, struct wlr_box *dest) {
-	switch (transform) {
-	case WL_OUTPUT_TRANSFORM_NORMAL:
-	case WL_OUTPUT_TRANSFORM_180:
-	case WL_OUTPUT_TRANSFORM_FLIPPED:
-	case WL_OUTPUT_TRANSFORM_FLIPPED_180:
+	if (transform % 2 == 0) {
 		dest->width = box->width;
 		dest->height = box->height;
-		break;
-	case WL_OUTPUT_TRANSFORM_90:
-	case WL_OUTPUT_TRANSFORM_270:
-	case WL_OUTPUT_TRANSFORM_FLIPPED_90:
-	case WL_OUTPUT_TRANSFORM_FLIPPED_270:
+	} else {
 		dest->width = box->height;
 		dest->height = box->width;
-		break;
 	}
 
 	switch (transform) {
@@ -552,5 +543,6 @@ void wlr_output_transform_apply_to_box(enum wl_output_transform transform,
 	case WL_OUTPUT_TRANSFORM_FLIPPED_270:
 		dest->x = box->height - box->y;
 		dest->y = box->width - box->x;
+		break;
 	}
 }

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -294,7 +294,7 @@ void wlr_output_swap_buffers(struct wlr_output *output) {
 	struct wlr_output_cursor *cursor;
 	wl_list_for_each(cursor, &output->cursors, link) {
 		if (output->hardware_cursor == cursor) {
-			//continue; // TODO
+			continue;
 		}
 		output_cursor_render(cursor);
 	}
@@ -342,7 +342,7 @@ bool wlr_output_cursor_set_image(struct wlr_output_cursor *cursor,
 			stride, width, height, hotspot_x, hotspot_y, true);
 		if (ok) {
 			cursor->output->hardware_cursor = cursor;
-			//return true; // TODO
+			return true;
 		}
 	}
 


### PR DESCRIPTION
* Transforms pointer events under Wayland backend (see #364)
* Fixes broken 180 and flipped transformation under DRM backend (introduced in #188, probably never worked properly)
* Fixes disappearing software cursors when applying a 90 or 270 transformation (regression introduced in #352)
* Replaces mysterious switches with easy-to-understand calls to `wlr_output_transformation_*` helpers

Test plan: try all 8 transformations under Wayland and DRM. Open a view, check that the pointer doesn't jump when entering the view. Check (e.g. with a GTK app with buttons) that the view receives pointer events with the right position.

Currently the hardware cursor isn't transformed under the Wayland backend, waiting for #319 to do this.