### PR TITLE
rootston: fix startup with no config

### DIFF
--- a/rootston/config.c
+++ b/rootston/config.c
@@ -361,6 +361,7 @@ struct roots_config *parse_args(int argc, char *argv[]) {
 		add_binding_config(&config->bindings, "Alt+Tab", "next_window");
 		struct keyboard_config *kc = calloc(1, sizeof(struct keyboard_config));
 		kc->meta_key = WLR_MODIFIER_LOGO;
+		kc->name = strdup("");
 		wl_list_insert(&config->keyboards, &kc->link);
 	} else if (result == -2) {
 		wlr_log(L_ERROR, "Could not allocate memory to parse config file");


### PR DESCRIPTION
Would choke on NULL name on strcmp later on:
 #0  0x00007ffff6e0ad4a in __strcmp_sse2_unaligned () at /usr/lib/libc.so.6
 #1  0x00005555555593d2 in config_get_keyboard (config=0x555555774f80, device=0x555555775768) at ../rootston/config.c:443
 #2  0x000055555555d7e3 in keyboard_add (device=0x555555775768, input=0x555555e96d70) at ../rootston/keyboard.c:206
 #3  0x000055555555ca39 in input_add_notify (listener=0x555555e96fa8, data=0x555555775768) at ../rootston/input.c:34
 #4  0x00007ffff7ba2b80 in wl_signal_emit (signal=0x5555557754f8, data=0x555555775768) at /usr/include/wayland-server-core.h:388
 #5  0x00007ffff7ba37e0 in wlr_x11_backend_start (backend=0x5555557754f0) at ../backend/x11/backend.c:286
 #6  0x00007ffff7b9372d in wlr_backend_start (backend=0x5555557754f0) at ../backend/backend.c:29
 #7  0x000055555555dcc0 in main (argc=1, argv=0x7fffffffe408) at ../rootston/main.c:39