### PR TITLE
bugfix: dnd force cancel

### DIFF
--- a/include/rootston/input.h
+++ b/include/rootston/input.h
@@ -68,6 +68,7 @@ struct roots_input_event {
 struct roots_drag_icon {
 	struct wlr_surface *surface;
 	struct wl_list link; // roots_input::drag_icons
+	bool mapped;
 
 	int32_t sx;
 	int32_t sy;

--- a/include/wlr/types/wlr_data_device.h
+++ b/include/wlr/types/wlr_data_device.h
@@ -61,6 +61,8 @@ struct wlr_drag {
 	struct wlr_surface *focus;
 	struct wlr_data_source *source;
 
+	bool cancelling;
+
 	struct wl_listener icon_destroy;
 	struct wl_listener source_destroy;
 	struct wl_listener seat_client_unbound;

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -152,6 +152,9 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 
 	struct roots_drag_icon *drag_icon = NULL;
 	wl_list_for_each(drag_icon, &server->input->drag_icons, link) {
+		if (!drag_icon->mapped) {
+			continue;
+		}
 		struct wlr_surface *icon = drag_icon->surface;
 		struct wlr_cursor *cursor = server->input->cursor;
 		double icon_x = cursor->x + drag_icon->sx;

--- a/types/wlr_seat.c
+++ b/types/wlr_seat.c
@@ -547,6 +547,9 @@ void wlr_seat_pointer_end_grab(struct wlr_seat *wlr_seat) {
 	if (grab != wlr_seat->pointer_state.default_grab) {
 		wlr_seat->pointer_state.grab = wlr_seat->pointer_state.default_grab;
 		wl_signal_emit(&wlr_seat->events.pointer_grab_end, grab);
+		if (grab->interface->cancel) {
+			grab->interface->cancel(grab);
+		}
 	}
 }
 
@@ -665,6 +668,9 @@ void wlr_seat_keyboard_end_grab(struct wlr_seat *wlr_seat) {
 	if (grab != wlr_seat->keyboard_state.default_grab) {
 		wlr_seat->keyboard_state.grab = wlr_seat->keyboard_state.default_grab;
 		wl_signal_emit(&wlr_seat->events.keyboard_grab_end, grab);
+		if (grab->interface->cancel) {
+			grab->interface->cancel(grab);
+		}
 	}
 }
 


### PR DESCRIPTION
Cancel a drag and drop operation by pressing the escape key in rootston and make sure that works with weston-dnd and gtk test testdnd2.