### PR TITLE
wlr-seat bug: dont set focus surface to null then clear focus

### DIFF
--- a/types/wlr_seat.c
+++ b/types/wlr_seat.c
@@ -408,7 +408,6 @@ static void pointer_surface_destroy_notify(struct wl_listener *listener,
 			listener, state, surface_destroy);
 	wl_list_remove(&state->surface_destroy.link);
 	wl_list_init(&state->surface_destroy.link);
-	state->focused_surface = NULL;
 	wlr_seat_pointer_clear_focus(state->seat);
 }
 
@@ -418,7 +417,6 @@ static void pointer_resource_destroy_notify(struct wl_listener *listener,
 			listener, state, resource_destroy);
 	wl_list_remove(&state->resource_destroy.link);
 	wl_list_init(&state->resource_destroy.link);
-	state->focused_surface = NULL;
 	wlr_seat_pointer_clear_focus(state->seat);
 }
 
@@ -674,7 +672,6 @@ static void keyboard_surface_destroy_notify(struct wl_listener *listener,
 			listener, state, surface_destroy);
 	wl_list_remove(&state->surface_destroy.link);
 	wl_list_init(&state->surface_destroy.link);
-	state->focused_surface = NULL;
 	wlr_seat_keyboard_clear_focus(state->seat);
 }
 
@@ -684,7 +681,6 @@ static void keyboard_resource_destroy_notify(struct wl_listener *listener,
 			listener, state, resource_destroy);
 	wl_list_remove(&state->resource_destroy.link);
 	wl_list_init(&state->resource_destroy.link);
-	state->focused_surface = NULL;
 	wlr_seat_keyboard_clear_focus(state->seat);
 }
 


### PR DESCRIPTION
The focus surface for the state should get cleared in the `*_clear_focus()` functions for the input, not here. If you clear it here, the focus surface won't get cleaned up properly and will lead to crashes.

You can reproduce a crash in wl-shell by closing a transient window (such as qgit about dialog).

The dialog takes a different code path to destroy itself by destroying the resource before using the surface destroy interface which is why we only get the crash in that case.