### PR TITLE
Fix disabled cursors

### DIFF
--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -15,10 +15,12 @@ struct wlr_output_mode {
 struct wlr_output_cursor {
 	struct wlr_output *output;
 	int32_t x, y;
+	bool enabled;
 	uint32_t width, height;
 	int32_t hotspot_x, hotspot_y;
 	struct wl_list link;
 
+	// only when using a software cursor without a surface
 	struct wlr_renderer *renderer;
 	struct wlr_texture *texture;
 

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -504,6 +504,12 @@ void wlr_output_cursor_destroy(struct wlr_output_cursor *cursor) {
 		}
 		cursor->output->hardware_cursor = NULL;
 	}
+	if (cursor->texture != NULL) {
+		wlr_texture_destroy(cursor->texture);
+	}
+	if (cursor->renderer != NULL) {
+		wlr_renderer_destroy(cursor->renderer);
+	}
 	wl_list_remove(&cursor->link);
 	free(cursor);
 }


### PR DESCRIPTION
When a client requests to disable a cursor, the last compositor cursor is displayed instead.

This PR also allows compositors to hide cursors by calling `wlr_output_cursor_set_image` with a NULL buffer.

Test plan: open `weston-terminal`, start typing, the cursor should disappear. Move the cursor, it should appear again.
