### PR TITLE
Fix pointer axis delta in Wayland backend

### DIFF
--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -90,7 +90,7 @@ static void pointer_handle_axis(void *data, struct wl_pointer *wl_pointer,
 
 	struct wlr_event_pointer_axis wlr_event;
 	wlr_event.device = dev;
-	wlr_event.delta = value;
+	wlr_event.delta = wl_fixed_to_double(value);
 	wlr_event.orientation = axis;
 	wlr_event.time_msec = time;
 	wlr_event.source = wlr_wl_pointer->axis_source;


### PR DESCRIPTION
Test plan: open a file in Gedit with Wayland backend. Scroll. It shouldn't scroll directly to the end of the buffer.

Fixes #372
