### PR TITLE
Send current keyboard state when entering a surface

### DIFF
--- a/include/wlr/types/wlr_keyboard.h
+++ b/include/wlr/types/wlr_keyboard.h
@@ -28,6 +28,8 @@ enum wlr_keyboard_modifier {
 	WLR_MODIFIER_MOD5 = 128,
 };
 
+#define WLR_KEYBOARD_KEYS_CAP 32
+
 struct wlr_keyboard_impl;
 
 struct wlr_keyboard {
@@ -41,6 +43,7 @@ struct wlr_keyboard {
 	xkb_led_index_t led_indexes[WLR_LED_COUNT];
 	xkb_mod_index_t mod_indexes[WLR_MODIFIER_COUNT];
 
+	uint32_t keycodes[WLR_KEYBOARD_KEYS_CAP];
 	struct {
 		xkb_mod_mask_t depressed;
 		xkb_mod_mask_t latched;

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -45,9 +45,7 @@ struct wlr_keyboard_grab_interface {
 			struct wlr_surface *surface);
 	void (*key)(struct wlr_seat_keyboard_grab *grab, uint32_t time,
 			uint32_t key, uint32_t state);
-	void (*modifiers)(struct wlr_seat_keyboard_grab *grab,
-			uint32_t mods_depressed, uint32_t mods_latched,
-			uint32_t mods_locked, uint32_t group);
+	void (*modifiers)(struct wlr_seat_keyboard_grab *grab);
 	void (*cancel)(struct wlr_seat_keyboard_grab *grab);
 };
 
@@ -296,17 +294,13 @@ void wlr_seat_keyboard_notify_key(struct wlr_seat *seat, uint32_t time,
  * Send the modifier state to focused keyboard resources. Compositors should use
  * `wlr_seat_keyboard_notify_modifiers()` to respect any keyboard grabs.
  */
-void wlr_seat_keyboard_send_modifiers(struct wlr_seat *seat,
-		uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked,
-		uint32_t group);
+void wlr_seat_keyboard_send_modifiers(struct wlr_seat *seat);
 
 /**
  * Notify the seat that the modifiers for the keyboard have changed. Defers to
  * any keyboard grabs.
  */
-void wlr_seat_keyboard_notify_modifiers(struct wlr_seat *seat,
-		uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked,
-		uint32_t group);
+void wlr_seat_keyboard_notify_modifiers(struct wlr_seat *seat);
 
 /**
  * Notify the seat that the keyboard focus has changed and request it to be the

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -133,7 +133,6 @@ void view_teardown(struct roots_view *view) {
 	struct roots_view *prev_view = views->items[views->length-2];
 	struct roots_input *input = prev_view->desktop->server->input;
 	set_view_focus(input, prev_view->desktop, prev_view);
-	wlr_seat_keyboard_notify_enter(input->wl_seat, prev_view->wlr_surface);
 }
 
 struct roots_view *view_at(struct roots_desktop *desktop, double lx, double ly,

--- a/rootston/keyboard.c
+++ b/rootston/keyboard.c
@@ -135,8 +135,8 @@ static bool keyboard_keysyms_simple(struct roots_keyboard *keyboard,
 	const xkb_keysym_t *syms;
 	xkb_layout_index_t layout_index = xkb_state_key_get_layout(
 		keyboard->device->keyboard->xkb_state, keycode);
-	int syms_len = xkb_keymap_key_get_syms_by_level(keyboard->device->keyboard->keymap,
-		keycode, layout_index, 0, &syms);
+	int syms_len = xkb_keymap_key_get_syms_by_level(
+		keyboard->device->keyboard->keymap, keycode, layout_index, 0, &syms);
 
 	bool handled = false;
 	for (int i = 0; i < syms_len; i++) {
@@ -195,7 +195,8 @@ static void keyboard_key_notify(struct wl_listener *listener, void *data) {
 	bool handled = keyboard_keysyms_xkb(keyboard, keycode, event->state);
 
 	if (!handled) {
-		bool key_handled = keyboard_keysyms_simple(keyboard, keycode, event->state);
+		bool key_handled = keyboard_keysyms_simple(keyboard, keycode,
+			event->state);
 		handled = handled || key_handled;
 	}
 
@@ -207,17 +208,11 @@ static void keyboard_key_notify(struct wl_listener *listener, void *data) {
 }
 
 static void keyboard_modifiers_notify(struct wl_listener *listener, void *data) {
-	struct roots_keyboard *r_keyboard =
-		wl_container_of(listener, r_keyboard, modifiers);
-	struct wlr_seat *seat = r_keyboard->input->wl_seat;
-	struct wlr_keyboard *keyboard = r_keyboard->device->keyboard;
-	wlr_seat_set_keyboard(seat, r_keyboard->device);
-	wlr_seat_keyboard_notify_modifiers(seat,
-		keyboard->modifiers.depressed,
-		keyboard->modifiers.latched,
-		keyboard->modifiers.locked,
-		keyboard->modifiers.group);
-
+	struct roots_keyboard *keyboard =
+		wl_container_of(listener, keyboard, modifiers);
+	struct wlr_seat *seat = keyboard->input->wl_seat;
+	wlr_seat_set_keyboard(seat, keyboard->device);
+	wlr_seat_keyboard_notify_modifiers(seat);
 }
 
 static void keyboard_config_merge(struct keyboard_config *config,

--- a/types/wlr_data_device.c
+++ b/types/wlr_data_device.c
@@ -531,9 +531,8 @@ static void keyboard_drag_key(struct wlr_seat_keyboard_grab *grab,
 	// no keyboard input during drags
 }
 
-static void keyboard_drag_modifiers(struct wlr_seat_keyboard_grab *grab,
-		uint32_t mods_depressed, uint32_t mods_latched,
-		uint32_t mods_locked, uint32_t group) {
+static void keyboard_drag_modifiers(struct wlr_seat_keyboard_grab *grab) {
+	//struct wlr_keyboard *keyboard = grab->seat->keyboard_state.keyboard;
 	// TODO change the dnd action based on what modifier is pressed on the
 	// keyboard
 }

--- a/types/wlr_keyboard.c
+++ b/types/wlr_keyboard.c
@@ -45,6 +45,30 @@ static void keyboard_modifier_update(struct wlr_keyboard *keyboard) {
 	wl_signal_emit(&keyboard->events.modifiers, keyboard);
 }
 
+static void keyboard_key_update(struct wlr_keyboard *keyboard,
+		struct wlr_event_keyboard_key *event) {
+	bool found = false;
+	size_t i = 0;
+	for (; i < WLR_KEYBOARD_KEYS_CAP; ++i) {
+		if (keyboard->keycodes[i] == event->keycode) {
+			found = true;
+			break;
+		}
+	}
+
+	if (event->state == WLR_KEY_PRESSED && !found) {
+		for (size_t i = 0; i < WLR_KEYBOARD_KEYS_CAP; ++i) {
+			if (keyboard->keycodes[i] == 0) {
+				keyboard->keycodes[i] = event->keycode;
+				break;
+			}
+		}
+	}
+	if (event->state == WLR_KEY_RELEASED && found) {
+		keyboard->keycodes[i] = 0;
+	}
+}
+
 void wlr_keyboard_notify_modifiers(struct wlr_keyboard *keyboard,
 		uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked,
 		uint32_t group) {
@@ -68,6 +92,7 @@ void wlr_keyboard_notify_key(struct wlr_keyboard *keyboard,
 	}
 	keyboard_led_update(keyboard);
 	keyboard_modifier_update(keyboard);
+	keyboard_key_update(keyboard, event);
 	wl_signal_emit(&keyboard->events.key, event);
 }
 

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -111,11 +111,8 @@ static void xdg_keyboard_grab_key(struct wlr_seat_keyboard_grab *grab, uint32_t 
 	wlr_seat_keyboard_send_key(grab->seat, time, key, state);
 }
 
-static void xdg_keyboard_grab_modifiers(struct wlr_seat_keyboard_grab *grab,
-		uint32_t mods_depressed, uint32_t mods_latched,
-		uint32_t mods_locked, uint32_t group) {
-	wlr_seat_keyboard_send_modifiers(grab->seat, mods_depressed, mods_latched,
-		mods_locked, group);
+static void xdg_keyboard_grab_modifiers(struct wlr_seat_keyboard_grab *grab) {
+	wlr_seat_keyboard_send_modifiers(grab->seat);
 }
 
 static void xdg_keyboard_grab_cancel(struct wlr_seat_keyboard_grab *grab) {


### PR DESCRIPTION
- [x] Should we read the current keyboard state like this? The compositor might want to filter some keys, and we might end up in an inconsistent state if the compositor is simulating keypresses. Would it be better to take the state as a parameter to `wlr_seat_keyboard_enter`?
- [ ] ~~Remove list of pressed keysyms in rootston, use list of pressed keycodes in `wlr_keyboard`?~~ Can't fix easily after #394

Test plan: open two terminals. Press two times <kbd>Ctrl</kbd> + <kbd>D</kbd> without releasing <kbd>Ctrl</kbd>. This should close both terminals.

Fixes #389