### PR TITLE
Remove unused include to improve C++ interop

### DIFF
--- a/examples/support/shared.h
+++ b/examples/support/shared.h
@@ -8,7 +8,6 @@
 #include <xkbcommon/xkbcommon.h>
 #include <wayland-server-protocol.h>
 #include <wlr/backend.h>
-#include <wlr/backend/session.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_input_device.h>
 

--- a/include/wlr/backend.h
+++ b/include/wlr/backend.h
@@ -2,7 +2,6 @@
 #define WLR_BACKEND_H
 
 #include <wayland-server.h>
-#include <wlr/backend/session.h>
 #include <wlr/render/egl.h>
 
 struct wlr_backend_impl;


### PR DESCRIPTION
It appears that session.h is not intended to be exposed externally. This change removes unused session.h includes from the files below. This also improves interoperability as it avoids exposing the C99 array qualifier in session.h which is not compatible with C++.