### PR TITLE
Remove VLA from session.h

### DIFF
--- a/backend/session/session.c
+++ b/backend/session/session.c
@@ -257,7 +257,7 @@ static size_t explicit_find_gpus(struct wlr_session *session,
  * If it's not found, it returns the first valid GPU it finds.
  */
 size_t wlr_session_find_gpus(struct wlr_session *session,
-		size_t ret_len, int ret[static ret_len]) {
+		size_t ret_len, int *ret) {
 	const char *explicit = getenv("WLR_DRM_DEVICES");
 	if (explicit) {
 		return explicit_find_gpus(session, ret_len, ret, explicit);

--- a/include/wlr/backend/session.h
+++ b/include/wlr/backend/session.h
@@ -79,6 +79,6 @@ void wlr_session_signal_add(struct wlr_session *session, int fd,
 bool wlr_session_change_vt(struct wlr_session *session, unsigned vt);
 
 size_t wlr_session_find_gpus(struct wlr_session *session,
-	size_t ret_len, int ret[static ret_len]);
+	size_t ret_len, int *ret);
 
 #endif


### PR DESCRIPTION
VLAs are optional C11 features and not supported by C++.