### PR TITLE
Fix unused-result error while building with PKGBUILD

### DIFF
--- a/examples/screenshot.c
+++ b/examples/screenshot.c
@@ -187,7 +187,10 @@ static void write_image(const char *filename, int width, int height) {
 	sprintf(size, "%dx%d+0", width, height);
 
 	int fd[2];
-	pipe(fd);
+	if (pipe(fd) != 0) {
+		fprintf(stderr, "cannot create pipe: %s\n", strerror(errno));
+		exit(EXIT_FAILURE);
+	}
 
 	pid_t child = fork();
 	if (child < 0) {
@@ -195,7 +198,10 @@ static void write_image(const char *filename, int width, int height) {
 		exit(EXIT_FAILURE);
 	} else if (child != 0) {
 		close(fd[0]);
-		write(fd[1], data, buffer_stride * height);
+		if (write(fd[1], data, buffer_stride * height) < 0) {
+			fprintf(stderr, "write() failed: %s\n", strerror(errno));
+			exit(EXIT_FAILURE);
+		}
 		close(fd[1]);
 		free(data);
 		waitpid(child, NULL, 0);


### PR DESCRIPTION
I cloned this repo and ran makepkg against the `PKGBUILD` in the `dist/archlinux` directory and resulted in the following error:

```% makepkg
==> Making package: wlroots r1270.a538ef3-1 (sab 11 nov 2017, 16.34.51, CET)
==> Checking runtime dependencies...
==> Checking buildtime dependencies...
==> Retrieving sources...
  -> Cloning wlroots git repo...
Cloning into bare repository '/home/tancredi/Projects/swaywm/wlroots/dist/archlinux/wlroots'...
remote: Counting objects: 10343, done.
remote: Compressing objects: 100% (46/46), done.
remote: Total 10343 (delta 17), reused 26 (delta 10), pack-reused 10287
Receiving objects: 100% (10343/10343), 2.14 MiB | 3.33 MiB/s, done.
Resolving deltas: 100% (7585/7585), done.
==> Validating source files with sha1sums...
    wlroots ... Skipped
==> Extracting sources...
  -> Creating working copy of wlroots git repo...
Cloning into 'wlroots'...
done.
==> Starting pkgver()...
==> Starting build()...
The Meson build system
Version: 0.43.0
Source dir: /home/tancredi/Projects/swaywm/wlroots/dist/archlinux/src/wlroots
Build dir: /home/tancredi/Projects/swaywm/wlroots/dist/archlinux/src/wlroots/build
Build type: native build
Project name: wlroots
Native C compiler: cc (gcc 7.2.0)
Appending CFLAGS from environment: '-march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -fno-plt'
Appending LDFLAGS from environment: '-Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now'
Appending CPPFLAGS from environment: '-D_FORTIFY_SOURCE=2'
Build machine cpu family: x86_64
Build machine cpu: x86_64
Found pkg-config: /usr/bin/pkg-config (0.29.2)
Native dependency wayland-server found: YES 1.14.0
Native dependency wayland-client found: YES 1.14.0
Native dependency wayland-egl found: YES 17.2.4
Native dependency wayland-protocols found: YES 1.11
Native dependency egl found: YES 17.2.4
Native dependency glesv2 found: YES 17.2.4
Native dependency libdrm found: YES 2.4.88
Native dependency gbm found: YES 17.2.4
Native dependency libinput found: YES 1.9.1
Native dependency xkbcommon found: YES 0.7.2
Native dependency libudev found: YES 235
Native dependency pixman-1 found: YES 0.34.0
Native dependency xcb found: YES 1.12
Native dependency xcb-composite found: YES 1.12
Native dependency xcb-xfixes found: YES 1.12
Native dependency xcb-image found: YES 0.4.0
Native dependency xcb-render found: YES 1.12
Native dependency xcb-icccm found: YES 0.4.1
Native dependency x11-xcb found: YES 1.6.5
Native dependency libcap found: YES 2.25
Native dependency libsystemd found: YES 235
Dependency libelogind found: NO
Library m found: YES
Configuring config.h using configuration
Program wayland-scanner found: YES (/usr/bin/wayland-scanner)
Program ../glgen.sh found: YES (/home/tancredi/Projects/swaywm/wlroots/dist/archlinux/src/wlroots/render/../glgen.sh)
Build targets in project: 20
Found ninja-1.8.2 at /usr/bin/ninja
ninja: Entering directory `build'
[147/158] Compiling C object 'examples/screenshot@exe/screenshot.c.o'.
FAILED: examples/screenshot@exe/screenshot.c.o 
cc  -Iexamples/screenshot@exe -Iexamples -I../examples -I/home/tancredi/Projects/swaywm/wlroots/dist/archlinux/src/wlroots/build -flto -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -std=c11 -O0 -g -Wno-unused-parameter '-DWLR_SRC_DIR="/home/tancredi/Projects/swaywm/wlroots/dist/archlinux/src/wlroots"' -DWL_HIDE_DEPRECATED -DHAS_XCB_ICCCM -DHAS_LIBCAP -DHAS_SYSTEMD -DHAS_XWAYLAND -march=x86-64 -mtune=generic -O2 -fstack-protector-strong -fno-plt -D_FORTIFY_SOURCE=2 -MMD -MQ 'examples/screenshot@exe/screenshot.c.o' -MF 'examples/screenshot@exe/screenshot.c.o.d' -o 'examples/screenshot@exe/screenshot.c.o' -c ../examples/screenshot.c
../examples/screenshot.c: In function ‘write_image’:
../examples/screenshot.c:190:2: error: ignoring return value of ‘pipe’, declared with attribute warn_unused_result [-Werror=unused-result]
  pipe(fd);
  ^~~~~~~~
../examples/screenshot.c:198:3: error: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Werror=unused-result]
   write(fd[1], data, buffer_stride * height);
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
[148/158] Linking target libwlroots.so.
ninja: build stopped: subcommand failed.
==> ERROR: A failure occurred in build().
    Aborting...
```

This patch includes some extra checks around the code.

---

What I don't understand is why I don't get any error message when I run the build commands specified in the `PKGBUILD` file from the root directory of this repo:

```
% meson build \          
                --prefix=/usr \
                -Dbuildtype=debugoptimized \
                -Db_lto=True \
                -Denable-systemd=True \
                -Denable-elogind=False \
                -Denable-libcap=False
The Meson build system
Version: 0.43.0
Source dir: /home/tancredi/Projects/swaywm/wlroots
Build dir: /home/tancredi/Projects/swaywm/wlroots/build
Build type: native build
Project name: wlroots
Native C compiler: cc (gcc 7.2.0)
Build machine cpu family: x86_64
Build machine cpu: x86_64
Found pkg-config: /usr/bin/pkg-config (0.29.2)
Native dependency wayland-server found: YES 1.14.0
Native dependency wayland-client found: YES 1.14.0
Native dependency wayland-egl found: YES 17.2.4
Native dependency wayland-protocols found: YES 1.11
Native dependency egl found: YES 17.2.4
Native dependency glesv2 found: YES 17.2.4
Native dependency libdrm found: YES 2.4.88
Native dependency gbm found: YES 17.2.4
Native dependency libinput found: YES 1.9.1
Native dependency xkbcommon found: YES 0.7.2
Native dependency libudev found: YES 235
Native dependency pixman-1 found: YES 0.34.0
Native dependency xcb found: YES 1.12
Native dependency xcb-composite found: YES 1.12
Native dependency xcb-xfixes found: YES 1.12
Native dependency xcb-image found: YES 0.4.0
Native dependency xcb-render found: YES 1.12
Native dependency xcb-icccm found: YES 0.4.1
Native dependency x11-xcb found: YES 1.6.5
Native dependency libcap found: YES 2.25
Native dependency libsystemd found: YES 235
Dependency libelogind found: NO
Library m found: YES
Configuring config.h using configuration
Program wayland-scanner found: YES (/usr/bin/wayland-scanner)
Program ../glgen.sh found: YES (/home/tancredi/Projects/swaywm/wlroots/render/../glgen.sh)
Build targets in project: 20
Found ninja-1.8.2 at /usr/bin/ninja
% ninja -C build   
ninja: Entering directory `build'
[158/158] Linking target examples/output-layout.
```