### PR TITLE
Add wlr_output.serial

### DIFF
--- a/backend/drm/util.c
+++ b/backend/drm/util.c
@@ -106,8 +106,15 @@ void parse_edid(struct wlr_output *restrict output, size_t len, const uint8_t *d
 			if (nl) {
 				*nl = '\0';
 			}
+		} else if (flag == 0 && data[i + 3] == 0xFF) {
+			sprintf(output->serial, "%.13s", &data[i + 5]);
 
-			break;
+			// Monitor serial numbers are terminated by newline if they're too
+			// short
+			char *nl = strchr(output->serial, '\n');
+			if (nl) {
+				*nl = '\0';
+			}
 		}
 	}
 }

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -43,6 +43,7 @@ struct wlr_output {
 	char name[16];
 	char make[48];
 	char model[16];
+	char serial[16];
 	uint32_t scale;
 	int32_t width, height;
 	int32_t phys_width, phys_height; // mm

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -210,8 +210,9 @@ void output_add_notify(struct wl_listener *listener, void *data) {
 	struct roots_config *config = desktop->config;
 
 	wlr_log(L_DEBUG, "Output '%s' added", wlr_output->name);
-	wlr_log(L_DEBUG, "%s %s %"PRId32"mm x %"PRId32"mm", wlr_output->make,
-		wlr_output->model, wlr_output->phys_width, wlr_output->phys_height);
+	wlr_log(L_DEBUG, "%s %s %s %"PRId32"mm x %"PRId32"mm", wlr_output->make,
+		wlr_output->model, wlr_output->serial, wlr_output->phys_width,
+		wlr_output->phys_height);
 	if (wl_list_length(&wlr_output->modes) > 0) {
 		struct wlr_output_mode *mode = NULL;
 		mode = wl_container_of((&wlr_output->modes)->prev, mode, link);


### PR DESCRIPTION
Test plan: you should see something similar in your logs:

```
2017-11-11 19:04:28 - [rootston/output.c:212] Output 'VGA-1' added
2017-11-11 19:04:28 - [rootston/output.c:215] Samsung Electric Company SyncMaster HS3P701105 474mm x 296mm
```

Updates #403