### PR TITLE
Fix rotated views on HiDPI outputs

### DIFF
--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -247,7 +247,6 @@ struct roots_view *view_at(struct roots_desktop *desktop, double lx, double ly,
 		}
 
 		if (view->type == ROOTS_XDG_SHELL_V6_VIEW) {
-			// TODO: test if this works with rotated views
 			double popup_sx, popup_sy;
 			struct wlr_xdg_surface_v6 *popup =
 				wlr_xdg_surface_v6_popup_at(view->xdg_surface_v6,
@@ -262,7 +261,6 @@ struct roots_view *view_at(struct roots_desktop *desktop, double lx, double ly,
 		}
 
 		if (view->type == ROOTS_WL_SHELL_VIEW) {
-			// TODO: test if this works with rotated views
 			double popup_sx, popup_sy;
 			struct wlr_wl_shell_surface *popup =
 				wlr_wl_shell_surface_popup_at(view->wl_shell_surface,

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -216,7 +216,7 @@ void view_teardown(struct roots_view *view) {
 
 struct roots_view *view_at(struct roots_desktop *desktop, double lx, double ly,
 		struct wlr_surface **surface, double *sx, double *sy) {
-	for (int i = desktop->views->length - 1; i >= 0; --i) {
+	for (ssize_t i = desktop->views->length - 1; i >= 0; --i) {
 		struct roots_view *view = desktop->views->items[i];
 
 		if (view->type == ROOTS_WL_SHELL_VIEW &&
@@ -228,11 +228,12 @@ struct roots_view *view_at(struct roots_desktop *desktop, double lx, double ly,
 		double view_sx = lx - view->x;
 		double view_sy = ly - view->y;
 
+		struct wlr_surface_state *state = view->wlr_surface->current;
 		struct wlr_box box = {
 			.x = 0,
 			.y = 0,
-			.width = view->wlr_surface->current->buffer_width,
-			.height = view->wlr_surface->current->buffer_height,
+			.width = state->buffer_width / state->scale,
+			.height = state->buffer_height / state->scale,
 		};
 		if (view->rotation != 0.0) {
 			// Coordinates relative to the center of the view


### PR DESCRIPTION
Test plan: set output scale to 2, open `gnome-calculator`, rotate it, check that pointer events work (clicking on buttons, text inputs...). Check that views are rendered at the correct position (open menus), **except** the combobox. The combobox uses a popup and these don't work anymore on non-HiDPI outputs (hence, this is an unrelated regression, #415).

Fixes #402