### PR TITLE
rootston: set keyboard for seat on keyboard add

### DIFF
--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -322,6 +322,8 @@ static void seat_add_keyboard(struct roots_seat *seat, struct wlr_input_device *
 	keyboard->keyboard_modifiers.notify = handle_keyboard_modifiers;
 	wl_signal_add(&keyboard->device->keyboard->events.modifiers,
 		&keyboard->keyboard_modifiers);
+
+	wlr_seat_set_keyboard(seat->seat, device);
 }
 
 static void seat_add_pointer(struct roots_seat *seat, struct wlr_input_device *device) {


### PR DESCRIPTION
Since wlr-seat requires a keyboard to be set to send enter, this fixes a bug where the surface doesn't get keyboard focus if the view appears before any keyboard events have been received.