### PR TITLE
wlr-seat: touch

### DIFF
--- a/backend/libinput/touch.c
+++ b/backend/libinput/touch.c
@@ -33,7 +33,7 @@ void handle_touch_down(struct libinput_event *event,
 	wlr_event.device = wlr_dev;
 	wlr_event.time_msec =
 		usec_to_msec(libinput_event_touch_get_time_usec(tevent));
-	wlr_event.slot = libinput_event_touch_get_slot(tevent);
+	wlr_event.touch_id = libinput_event_touch_get_slot(tevent);
 	wlr_event.x_mm = libinput_event_touch_get_x(tevent);
 	wlr_event.y_mm = libinput_event_touch_get_y(tevent);
 	libinput_device_get_size(libinput_dev, &wlr_event.width_mm, &wlr_event.height_mm);
@@ -54,7 +54,7 @@ void handle_touch_up(struct libinput_event *event,
 	wlr_event.device = wlr_dev;
 	wlr_event.time_msec =
 		usec_to_msec(libinput_event_touch_get_time_usec(tevent));
-	wlr_event.slot = libinput_event_touch_get_slot(tevent);
+	wlr_event.touch_id = libinput_event_touch_get_slot(tevent);
 	wl_signal_emit(&wlr_dev->touch->events.up, &wlr_event);
 }
 
@@ -72,7 +72,7 @@ void handle_touch_motion(struct libinput_event *event,
 	wlr_event.device = wlr_dev;
 	wlr_event.time_msec =
 		usec_to_msec(libinput_event_touch_get_time_usec(tevent));
-	wlr_event.slot = libinput_event_touch_get_slot(tevent);
+	wlr_event.touch_id = libinput_event_touch_get_slot(tevent);
 	wlr_event.x_mm = libinput_event_touch_get_x(tevent);
 	wlr_event.y_mm = libinput_event_touch_get_y(tevent);
 	libinput_device_get_size(libinput_dev, &wlr_event.width_mm, &wlr_event.height_mm);
@@ -93,6 +93,6 @@ void handle_touch_cancel(struct libinput_event *event,
 	wlr_event.device = wlr_dev;
 	wlr_event.time_msec =
 		usec_to_msec(libinput_event_touch_get_time_usec(tevent));
-	wlr_event.slot = libinput_event_touch_get_slot(tevent);
+	wlr_event.touch_id = libinput_event_touch_get_slot(tevent);
 	wl_signal_emit(&wlr_dev->touch->events.cancel, &wlr_event);
 }

--- a/examples/pointer.c
+++ b/examples/pointer.c
@@ -55,7 +55,7 @@ struct sample_state {
 };
 
 struct touch_point {
-	int32_t slot;
+	int32_t touch_id;
 	double x, y;
 };
 
@@ -199,7 +199,7 @@ static void handle_touch_up(struct wl_listener *listener, void *data) {
 	struct wlr_event_touch_up *event = data;
 	for (size_t i = 0; i < sample->touch_points->length; ++i) {
 		struct touch_point *point = sample->touch_points->items[i];
-		if (point->slot == event->slot) {
+		if (point->touch_id == event->touch_id) {
 			wlr_list_del(sample->touch_points, i);
 			break;
 		}
@@ -212,7 +212,7 @@ static void handle_touch_down(struct wl_listener *listener, void *data) {
 	struct sample_state *sample = wl_container_of(listener, sample, touch_down);
 	struct wlr_event_touch_down *event = data;
 	struct touch_point *point = calloc(1, sizeof(struct touch_point));
-	point->slot = event->slot;
+	point->touch_id = event->touch_id;
 	point->x = event->x_mm / event->width_mm;
 	point->y = event->y_mm / event->height_mm;
 	if (wlr_list_add(sample->touch_points, point) == -1) {
@@ -228,7 +228,7 @@ static void handle_touch_motion(struct wl_listener *listener, void *data) {
 	struct wlr_event_touch_motion *event = data;
 	for (size_t i = 0; i < sample->touch_points->length; ++i) {
 		struct touch_point *point = sample->touch_points->items[i];
-		if (point->slot == event->slot) {
+		if (point->touch_id == event->touch_id) {
 			point->x = event->x_mm / event->width_mm;
 			point->y = event->y_mm / event->height_mm;
 			break;

--- a/examples/support/shared.c
+++ b/examples/support/shared.c
@@ -136,7 +136,7 @@ static void touch_down_notify(struct wl_listener *listener, void *data) {
 	struct wlr_event_touch_down *event = data;
 	struct touch_state *tstate = wl_container_of(listener, tstate, down);
 	if (tstate->compositor->touch_down_cb) {
-		tstate->compositor->touch_down_cb(tstate, event->slot,
+		tstate->compositor->touch_down_cb(tstate, event->touch_id,
 			event->x_mm, event->y_mm, event->width_mm, event->height_mm);
 	}
 }
@@ -145,7 +145,7 @@ static void touch_motion_notify(struct wl_listener *listener, void *data) {
 	struct wlr_event_touch_motion *event = data;
 	struct touch_state *tstate = wl_container_of(listener, tstate, motion);
 	if (tstate->compositor->touch_motion_cb) {
-		tstate->compositor->touch_motion_cb(tstate, event->slot,
+		tstate->compositor->touch_motion_cb(tstate, event->touch_id,
 			event->x_mm, event->y_mm, event->width_mm, event->height_mm);
 	}
 }
@@ -154,7 +154,7 @@ static void touch_up_notify(struct wl_listener *listener, void *data) {
 	struct wlr_event_touch_up *event = data;
 	struct touch_state *tstate = wl_container_of(listener, tstate, up);
 	if (tstate->compositor->touch_up_cb) {
-		tstate->compositor->touch_up_cb(tstate, event->slot);
+		tstate->compositor->touch_up_cb(tstate, event->touch_id);
 	}
 }
 
@@ -162,7 +162,7 @@ static void touch_cancel_notify(struct wl_listener *listener, void *data) {
 	struct wlr_event_touch_cancel *event = data;
 	struct touch_state *tstate = wl_container_of(listener, tstate, cancel);
 	if (tstate->compositor->touch_cancel_cb) {
-		tstate->compositor->touch_cancel_cb(tstate, event->slot);
+		tstate->compositor->touch_cancel_cb(tstate, event->touch_id);
 	}
 }
 

--- a/examples/support/shared.h
+++ b/examples/support/shared.h
@@ -95,12 +95,12 @@ struct compositor_state {
 		enum wlr_axis_source source,
 		enum wlr_axis_orientation orientation,
 		double delta);
-	void (*touch_down_cb)(struct touch_state *s, int32_t slot,
+	void (*touch_down_cb)(struct touch_state *s, int32_t touch_id,
 		double x, double y, double width, double height);
-	void (*touch_motion_cb)(struct touch_state *s, int32_t slot,
+	void (*touch_motion_cb)(struct touch_state *s, int32_t touch_id,
 		double x, double y, double width, double height);
-	void (*touch_up_cb)(struct touch_state *s, int32_t slot);
-	void (*touch_cancel_cb)(struct touch_state *s, int32_t slot);
+	void (*touch_up_cb)(struct touch_state *s, int32_t touch_id);
+	void (*touch_cancel_cb)(struct touch_state *s, int32_t touch_id);
 	void (*tool_axis_cb)(struct tablet_tool_state *s,
 			struct wlr_event_tablet_tool_axis *event);
 	void (*tool_proximity_cb)(struct tablet_tool_state *s,

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -28,7 +28,7 @@ struct sample_state {
 };
 
 struct touch_point {
-	int32_t slot;
+	int32_t touch_id;
 	double x, y;
 };
 
@@ -58,11 +58,11 @@ static void handle_output_frame(struct output_state *output, struct timespec *ts
 	wlr_output_swap_buffers(wlr_output);
 }
 
-static void handle_touch_down(struct touch_state *tstate, int32_t slot,
+static void handle_touch_down(struct touch_state *tstate, int32_t touch_id,
 		double x, double y, double width, double height) {
 	struct sample_state *sample = tstate->compositor->data;
 	struct touch_point *point = calloc(1, sizeof(struct touch_point));
-	point->slot = slot;
+	point->touch_id = touch_id;
 	point->x = x / width;
 	point->y = y / height;
 	if (wlr_list_add(sample->touch_points, point) == -1) {
@@ -70,23 +70,23 @@ static void handle_touch_down(struct touch_state *tstate, int32_t slot,
 	}
 }
 
-static void handle_touch_up(struct touch_state *tstate, int32_t slot) {
+static void handle_touch_up(struct touch_state *tstate, int32_t touch_id) {
 	struct sample_state *sample = tstate->compositor->data;
 	for (size_t i = 0; i < sample->touch_points->length; ++i) {
 		struct touch_point *point = sample->touch_points->items[i];
-		if (point->slot == slot) {
+		if (point->touch_id == touch_id) {
 			wlr_list_del(sample->touch_points, i);
 			break;
 		}
 	}
 }
 
-static void handle_touch_motion(struct touch_state *tstate, int32_t slot,
+static void handle_touch_motion(struct touch_state *tstate, int32_t touch_id,
 		double x, double y, double width, double height) {
 	struct sample_state *sample = tstate->compositor->data;
 	for (size_t i = 0; i < sample->touch_points->length; ++i) {
 		struct touch_point *point = sample->touch_points->items[i];
-		if (point->slot == slot) {
+		if (point->touch_id == touch_id) {
 			point->x = x / width;
 			point->y = y / height;
 			break;

--- a/include/rootston/cursor.h
+++ b/include/rootston/cursor.h
@@ -56,6 +56,9 @@ struct roots_cursor {
 	struct wl_listener pointer_grab_begin;
 	struct wl_listener pointer_grab_end;
 
+	struct wl_listener touch_grab_begin;
+	struct wl_listener touch_grab_end;
+
 	struct wl_listener request_set_cursor;
 };
 
@@ -98,5 +101,11 @@ void roots_cursor_handle_pointer_grab_begin(struct roots_cursor *cursor,
 
 void roots_cursor_handle_pointer_grab_end(struct roots_cursor *cursor,
 		struct wlr_seat_pointer_grab *grab);
+
+void roots_cursor_handle_touch_grab_begin(struct roots_cursor *cursor,
+		struct wlr_seat_touch_grab *grab);
+
+void roots_cursor_handle_touch_grab_end(struct roots_cursor *cursor,
+		struct wlr_seat_touch_grab *grab);
 
 #endif

--- a/include/rootston/cursor.h
+++ b/include/rootston/cursor.h
@@ -39,7 +39,6 @@ struct roots_cursor {
 	uint32_t resize_edges;
 	// Ring buffer of input events that could trigger move/resize/rotate
 	int input_events_idx;
-	struct wl_list touch_points;
 	struct roots_input_event input_events[16];
 
 	struct wl_listener motion;

--- a/include/rootston/seat.h
+++ b/include/rootston/seat.h
@@ -26,6 +26,9 @@ struct roots_seat {
 	struct wl_list link;
 	struct wl_list drag_icons;
 
+	// coordinates of the touch grab if one exists
+	double touch_grab_x, touch_grab_y;
+
 	struct roots_view *focus;
 
 	struct wl_list keyboards;

--- a/include/rootston/seat.h
+++ b/include/rootston/seat.h
@@ -10,7 +10,7 @@ struct roots_drag_icon {
 	bool mapped;
 
 	bool is_pointer;
-	bool touch_id;
+	int32_t touch_id;
 
 	int32_t sx;
 	int32_t sy;
@@ -26,8 +26,9 @@ struct roots_seat {
 	struct wl_list link;
 	struct wl_list drag_icons;
 
-	// coordinates of the touch grab if one exists
-	double touch_grab_x, touch_grab_y;
+	// coordinates of the first touch point if it exists
+	int32_t touch_id;
+	double touch_x, touch_y;
 
 	struct roots_view *focus;
 

--- a/include/rootston/seat.h
+++ b/include/rootston/seat.h
@@ -9,6 +9,9 @@ struct roots_drag_icon {
 	struct wl_list link; // roots_seat::drag_icons
 	bool mapped;
 
+	bool is_pointer;
+	bool touch_id;
+
 	int32_t sx;
 	int32_t sy;
 

--- a/include/rootston/seat.h
+++ b/include/rootston/seat.h
@@ -43,13 +43,6 @@ struct roots_touch {
 	struct wl_list link;
 };
 
-struct roots_touch_point {
-	struct roots_touch *device;
-	int32_t slot;
-	double x, y;
-	struct wl_list link;
-};
-
 struct roots_tablet_tool {
 	struct roots_seat *seat;
 	struct wlr_input_device *device;

--- a/include/wlr/types/wlr_cursor.h
+++ b/include/wlr/types/wlr_cursor.h
@@ -126,4 +126,11 @@ void wlr_cursor_map_to_region(struct wlr_cursor *cur, struct wlr_box *box);
 void wlr_cursor_map_input_to_region(struct wlr_cursor *cur,
 	struct wlr_input_device *dev, struct wlr_box *box);
 
+/**
+ * Convert absolute coordinates to layout coordinates for the device.
+ */
+bool wlr_cursor_absolute_to_layout_coords(struct wlr_cursor *cur,
+		struct wlr_input_device *device, double x_mm, double y_mm,
+		double width_mm, double height_mm, double *lx, double *ly);
+
 #endif

--- a/include/wlr/types/wlr_data_device.h
+++ b/include/wlr/types/wlr_data_device.h
@@ -71,6 +71,7 @@ struct wlr_drag {
 	bool cancelling;
 	int32_t grab_touch_id;
 
+	struct wl_listener point_destroy;
 	struct wl_listener icon_destroy;
 	struct wl_listener source_destroy;
 	struct wl_listener seat_client_unbound;

--- a/include/wlr/types/wlr_data_device.h
+++ b/include/wlr/types/wlr_data_device.h
@@ -10,6 +10,9 @@ wlr_pointer_grab_interface wlr_data_device_pointer_drag_interface;
 extern const struct
 wlr_keyboard_grab_interface wlr_data_device_keyboard_drag_interface;
 
+extern const struct
+wlr_touch_grab_interface wlr_data_device_touch_drag_interface;
+
 struct wlr_data_device_manager {
 	struct wl_global *global;
 };
@@ -55,14 +58,18 @@ struct wlr_drag {
 	struct wlr_seat_keyboard_grab keyboard_grab;
 	struct wlr_seat_touch_grab touch_grab;
 
+	struct wlr_seat *seat;
 	struct wlr_seat_client *seat_client;
 	struct wlr_seat_client *focus_client;
+
+	bool is_pointer_grab;
 
 	struct wlr_surface *icon;
 	struct wlr_surface *focus;
 	struct wlr_data_source *source;
 
 	bool cancelling;
+	int32_t grab_touch_id;
 
 	struct wl_listener icon_destroy;
 	struct wl_listener source_destroy;

--- a/include/wlr/types/wlr_data_device.h
+++ b/include/wlr/types/wlr_data_device.h
@@ -53,6 +53,7 @@ struct wlr_data_source {
 struct wlr_drag {
 	struct wlr_seat_pointer_grab pointer_grab;
 	struct wlr_seat_keyboard_grab keyboard_grab;
+	struct wlr_seat_touch_grab touch_grab;
 
 	struct wlr_seat_client *seat_client;
 	struct wlr_seat_client *focus_client;

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -488,6 +488,11 @@ void wlr_seat_touch_send_motion(struct wlr_seat *seat, uint32_t time,
 		int32_t touch_id, double sx, double sy);
 
 /**
+ * How many touch points are currently down for the seat.
+ */
+int wlr_seat_touch_num_points(struct wlr_seat *seat);
+
+/**
  * Whether or not the seat has a touch grab other than the default grab.
  */
 bool wlr_seat_touch_has_grab(struct wlr_seat *seat);

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -144,6 +144,7 @@ struct wlr_seat_touch_state {
 	struct wl_list touch_points; // wlr_touch_point::link
 
 	uint32_t grab_serial;
+	uint32_t grab_id;
 
 	struct wlr_seat_touch_grab *grab;
 	struct wlr_seat_touch_grab *default_grab;

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -49,6 +49,29 @@ struct wlr_keyboard_grab_interface {
 	void (*cancel)(struct wlr_seat_keyboard_grab *grab);
 };
 
+struct wlr_seat_touch_grab;
+
+struct wlr_touch_grab_interface {
+	void (*down)(struct wlr_seat_touch_grab *grab, struct wlr_surface *surface,
+			uint32_t time, int32_t touch_id, double sx, double sy);
+	void (*up)(struct wlr_seat_touch_grab *grab, uint32_t time, int32_t touch_id);
+	void (*motion)(struct wlr_seat_touch_grab *grab, uint32_t time, int32_t
+			touch_id, double sx, double sy);
+	// XXX this will conflict with the actual touch cancel which is different so
+	// we need to rename this
+	void (*cancel)(struct wlr_seat_touch_grab *grab);
+};
+
+/**
+ * Passed to `wlr_seat_touch_start_grab()` to start a grab of the touch device.
+ * The grabber is responsible for handling touch events for the seat.
+ */
+struct wlr_seat_touch_grab {
+	const struct wlr_touch_grab_interface *interface;
+	struct wlr_seat *seat;
+	void *data;
+};
+
 /**
  * Passed to `wlr_seat_keyboard_start_grab()` to start a grab of the keyboard.
  * The grabber is responsible for handling keyboard events for the seat.
@@ -118,6 +141,9 @@ struct wlr_touch_point {
 struct wlr_seat_touch_state {
 	struct wlr_seat *seat;
 	struct wl_list touch_points; // wlr_touch_point::link
+
+	struct wlr_seat_touch_grab *grab;
+	struct wlr_seat_touch_grab *default_grab;
 };
 
 struct wlr_seat {
@@ -357,6 +383,16 @@ void wlr_seat_touch_notify_up(struct wlr_seat *seat, uint32_t time,
 		int32_t touch_id);
 
 void wlr_seat_touch_notify_motion(struct wlr_seat *seat, uint32_t time,
+		int32_t touch_id, double sx, double sy);
+
+void wlr_seat_touch_send_down(struct wlr_seat *seat,
+		struct wlr_surface *surface, uint32_t time, int32_t touch_id, double sx,
+		double sy);
+
+void wlr_seat_touch_send_up(struct wlr_seat *seat, uint32_t time,
+		int32_t touch_id);
+
+void wlr_seat_touch_send_motion(struct wlr_seat *seat, uint32_t time,
 		int32_t touch_id, double sx, double sy);
 
 #endif

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -143,6 +143,8 @@ struct wlr_seat_touch_state {
 	struct wlr_seat *seat;
 	struct wl_list touch_points; // wlr_touch_point::link
 
+	uint32_t grab_serial;
+
 	struct wlr_seat_touch_grab *grab;
 	struct wlr_seat_touch_grab *default_grab;
 };

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -175,6 +175,9 @@ struct wlr_seat {
 		struct wl_signal keyboard_grab_begin;
 		struct wl_signal keyboard_grab_end;
 
+		struct wl_signal touch_grab_begin;
+		struct wl_signal touch_grab_end;
+
 		struct wl_signal request_set_cursor;
 
 		struct wl_signal selection;
@@ -370,6 +373,19 @@ void wlr_seat_keyboard_enter(struct wlr_seat *wlr_seat,
  * Clear the focused surface for the keyboard and leave all entered surfaces.
  */
 void wlr_seat_keyboard_clear_focus(struct wlr_seat *wlr_seat);
+
+/**
+ * Start a grab of the touch device of this seat. The grabber is responsible for
+ * handling all touch events until the grab ends.
+ */
+void wlr_seat_touch_start_grab(struct wlr_seat *wlr_seat,
+		struct wlr_seat_touch_grab *grab);
+
+/**
+ * End the grab of the touch device of this seat. This reverts the grab back to
+ * the default grab for the touch device.
+ */
+void wlr_seat_touch_end_grab(struct wlr_seat *wlr_seat);
 
 /**
  * Get the active touch point with the given `touch_id`. If the touch point does

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -109,6 +109,7 @@ struct wlr_seat_pointer_state {
 	struct wl_listener resource_destroy;
 };
 
+// TODO: May be useful to be able to simulate keyboard input events
 struct wlr_seat_keyboard_state {
 	struct wlr_seat *seat;
 	struct wlr_keyboard *keyboard;
@@ -370,28 +371,62 @@ void wlr_seat_keyboard_enter(struct wlr_seat *wlr_seat,
  */
 void wlr_seat_keyboard_clear_focus(struct wlr_seat *wlr_seat);
 
-// TODO: May be useful to be able to simulate keyboard input events
-
+/**
+ * Get the active touch point with the given `touch_id`. If the touch point does
+ * not exist or is no longer active, returns NULL.
+ */
 struct wlr_touch_point *wlr_seat_touch_get_point(struct wlr_seat *seat,
 		int32_t touch_id);
 
+/**
+ * Notify the seat of a touch down on the given surface. Defers to any grab of
+ * the touch device.
+ */
 void wlr_seat_touch_notify_down(struct wlr_seat *seat,
 		struct wlr_surface *surface, uint32_t time, int32_t touch_id, double sx,
 		double sy);
 
+/**
+ * Notify the seat that the touch point given by `touch_id` is up. Defers to any
+ * grab of the touch device.
+ */
 void wlr_seat_touch_notify_up(struct wlr_seat *seat, uint32_t time,
 		int32_t touch_id);
 
+/**
+ * Notify the seat that the touch point given by `touch_id` has moved. Defers to
+ * any grab of the touch device.
+ */
 void wlr_seat_touch_notify_motion(struct wlr_seat *seat, uint32_t time,
 		int32_t touch_id, double sx, double sy);
 
+/**
+ * Send a touch down event to the client of the given surface. All future touch
+ * events for this point will go to this surface. If the touch down is valid,
+ * this will add a new touch point with the given `touch_id`. The touch down may
+ * not be valid if the surface seat client does not accept touch input.
+ * Coordinates are surface-local. Compositors should use
+ * `wlr_seat_touch_notify_down()` to respect any grabs of the touch device.
+ */
 void wlr_seat_touch_send_down(struct wlr_seat *seat,
 		struct wlr_surface *surface, uint32_t time, int32_t touch_id, double sx,
 		double sy);
 
+/**
+ * Send a touch up event for the touch point given by the `touch_id`. The event
+ * will go to the client for the surface given in the cooresponding touch down
+ * event. This will remove the touch point. Compositors should use
+ * `wlr_seat_touch_notify_up()` to respect any grabs of the touch device.
+ */
 void wlr_seat_touch_send_up(struct wlr_seat *seat, uint32_t time,
 		int32_t touch_id);
 
+/**
+ * Send a touch motion event for the touch point given by the `touch_id`. The
+ * event will go to the cleint for the surface given in the corresponding touch
+ * down event. Compositors should use `wlr_seat_touch_notify_motion()` to
+ * respect any grabs of the touch device.
+ */
 void wlr_seat_touch_send_motion(struct wlr_seat *seat, uint32_t time,
 		int32_t touch_id, double sx, double sy);
 

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -103,6 +103,23 @@ struct wlr_seat_keyboard_state {
 	struct wlr_seat_keyboard_grab *default_grab;
 };
 
+struct wlr_touch_point {
+	int32_t touch_id;
+	struct wlr_surface *surface;
+	struct wlr_seat_client *client;
+	double sx, sy;
+
+	struct wl_listener surface_destroy;
+	struct wl_listener resource_destroy;
+
+	struct wl_list link;
+};
+
+struct wlr_seat_touch_state {
+	struct wlr_seat *seat;
+	struct wl_list touch_points; // wlr_touch_point::link
+};
+
 struct wlr_seat {
 	struct wl_global *wl_global;
 	struct wl_display *display;
@@ -117,6 +134,7 @@ struct wlr_seat {
 
 	struct wlr_seat_pointer_state pointer_state;
 	struct wlr_seat_keyboard_state keyboard_state;
+	struct wlr_seat_touch_state touch_state;
 
 	struct wl_listener selection_data_source_destroy;
 
@@ -327,5 +345,18 @@ void wlr_seat_keyboard_enter(struct wlr_seat *wlr_seat,
 void wlr_seat_keyboard_clear_focus(struct wlr_seat *wlr_seat);
 
 // TODO: May be useful to be able to simulate keyboard input events
+
+struct wlr_touch_point *wlr_seat_touch_get_point(struct wlr_seat *seat,
+		int32_t touch_id);
+
+void wlr_seat_touch_notify_down(struct wlr_seat *seat,
+		struct wlr_surface *surface, uint32_t time, int32_t touch_id, double sx,
+		double sy);
+
+void wlr_seat_touch_notify_up(struct wlr_seat *seat, uint32_t time,
+		int32_t touch_id);
+
+void wlr_seat_touch_notify_motion(struct wlr_seat *seat, uint32_t time,
+		int32_t touch_id, double sx, double sy);
 
 #endif

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -322,6 +322,11 @@ void wlr_seat_pointer_notify_axis(struct wlr_seat *wlr_seat, uint32_t time,
 		enum wlr_axis_orientation orientation, double value);
 
 /**
+ * Whether or not the pointer has a grab other than the default grab.
+ */
+bool wlr_seat_pointer_has_grab(struct wlr_seat *seat);
+
+/**
  * Set this keyboard as the active keyboard for the seat.
  */
 void wlr_seat_set_keyboard(struct wlr_seat *seat, struct wlr_input_device *dev);
@@ -387,6 +392,11 @@ void wlr_seat_keyboard_enter(struct wlr_seat *wlr_seat,
  * Clear the focused surface for the keyboard and leave all entered surfaces.
  */
 void wlr_seat_keyboard_clear_focus(struct wlr_seat *wlr_seat);
+
+/**
+ * Whether or not the keyboard has a grab other than the default grab
+ */
+bool wlr_seat_keyboard_has_grab(struct wlr_seat *seat);
 
 /**
  * Start a grab of the touch device of this seat. The grabber is responsible for
@@ -476,5 +486,10 @@ void wlr_seat_touch_send_up(struct wlr_seat *seat, uint32_t time,
  */
 void wlr_seat_touch_send_motion(struct wlr_seat *seat, uint32_t time,
 		int32_t touch_id, double sx, double sy);
+
+/**
+ * Whether or not the seat has a touch grab other than the default grab.
+ */
+bool wlr_seat_touch_has_grab(struct wlr_seat *seat);
 
 #endif

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -28,9 +28,13 @@ struct wlr_touch_point {
 	int32_t touch_id;
 	struct wlr_surface *surface;
 	struct wlr_seat_client *client;
+
+	struct wlr_surface *focus_surface;
+	struct wlr_seat_client *focus_client;
 	double sx, sy;
 
 	struct wl_listener surface_destroy;
+	struct wl_listener focus_surface_destroy;
 	struct wl_listener resource_destroy;
 
 	struct {
@@ -73,6 +77,8 @@ struct wlr_touch_grab_interface {
 	void (*up)(struct wlr_seat_touch_grab *grab, uint32_t time,
 			struct wlr_touch_point *point);
 	void (*motion)(struct wlr_seat_touch_grab *grab, uint32_t time,
+			struct wlr_touch_point *point);
+	void (*enter)(struct wlr_seat_touch_grab *grab, uint32_t time,
 			struct wlr_touch_point *point);
 	// XXX this will conflict with the actual touch cancel which is different so
 	// we need to rename this
@@ -423,9 +429,23 @@ void wlr_seat_touch_notify_up(struct wlr_seat *seat, uint32_t time,
  * even if the surface is not the owner of the touch point for processing by
  * grabs.
  */
-void wlr_seat_touch_notify_motion(struct wlr_seat *seat,
+void wlr_seat_touch_notify_motion(struct wlr_seat *seat, uint32_t time,
+		int32_t touch_id, double sx, double sy);
+
+/**
+ * Notify the seat that the touch point given by `touch_id` has entered a new
+ * surface. The surface is required. To clear focus, use
+ * `wlr_seat_touch_point_clear_focus()`.
+ */
+void wlr_seat_touch_point_focus(struct wlr_seat *seat,
 		struct wlr_surface *surface, uint32_t time, int32_t touch_id, double sx,
 		double sy);
+
+/**
+ * Clear the focused surface for the touch point given by `touch_id`.
+ */
+void wlr_seat_touch_point_clear_focus(struct wlr_seat *seat, uint32_t time,
+		int32_t touch_id);
 
 /**
  * Send a touch down event to the client of the given surface. All future touch

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -72,7 +72,7 @@ struct wlr_keyboard_grab_interface {
 struct wlr_seat_touch_grab;
 
 struct wlr_touch_grab_interface {
-	void (*down)(struct wlr_seat_touch_grab *grab, uint32_t time,
+	uint32_t (*down)(struct wlr_seat_touch_grab *grab, uint32_t time,
 			struct wlr_touch_point *point);
 	void (*up)(struct wlr_seat_touch_grab *grab, uint32_t time,
 			struct wlr_touch_point *point);
@@ -422,7 +422,7 @@ struct wlr_touch_point *wlr_seat_touch_get_point(struct wlr_seat *seat,
  * Notify the seat of a touch down on the given surface. Defers to any grab of
  * the touch device.
  */
-void wlr_seat_touch_notify_down(struct wlr_seat *seat,
+uint32_t wlr_seat_touch_notify_down(struct wlr_seat *seat,
 		struct wlr_surface *surface, uint32_t time, int32_t touch_id, double sx,
 		double sy);
 
@@ -465,7 +465,7 @@ void wlr_seat_touch_point_clear_focus(struct wlr_seat *seat, uint32_t time,
  * Coordinates are surface-local. Compositors should use
  * `wlr_seat_touch_notify_down()` to respect any grabs of the touch device.
  */
-void wlr_seat_touch_send_down(struct wlr_seat *seat,
+uint32_t wlr_seat_touch_send_down(struct wlr_seat *seat,
 		struct wlr_surface *surface, uint32_t time, int32_t touch_id, double sx,
 		double sy);
 

--- a/include/wlr/types/wlr_touch.h
+++ b/include/wlr/types/wlr_touch.h
@@ -22,7 +22,7 @@ struct wlr_touch {
 struct wlr_event_touch_down {
 	struct wlr_input_device *device;
 	uint32_t time_msec;
-	int32_t slot;
+	int32_t touch_id;
 	double x_mm, y_mm;
 	double width_mm, height_mm;
 };
@@ -30,13 +30,13 @@ struct wlr_event_touch_down {
 struct wlr_event_touch_up {
 	struct wlr_input_device *device;
 	uint32_t time_msec;
-	int32_t slot;
+	int32_t touch_id;
 };
 
 struct wlr_event_touch_motion {
 	struct wlr_input_device *device;
 	uint32_t time_msec;
-	int32_t slot;
+	int32_t touch_id;
 	double x_mm, y_mm;
 	double width_mm, height_mm;
 };
@@ -44,7 +44,7 @@ struct wlr_event_touch_motion {
 struct wlr_event_touch_cancel {
 	struct wlr_input_device *device;
 	uint32_t time_msec;
-	int32_t slot;
+	int32_t touch_id;
 };
 
 #endif

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -270,6 +270,11 @@ void roots_cursor_handle_touch_motion(struct roots_cursor *cursor,
 		wlr_seat_touch_point_clear_focus(cursor->seat->seat, event->time_msec,
 			event->slot);
 	}
+
+	if (wlr_seat_touch_has_grab(cursor->seat->seat)) {
+		cursor->seat->touch_grab_x = lx;
+		cursor->seat->touch_grab_y = ly;
+	}
 }
 
 void roots_cursor_handle_tool_axis(struct roots_cursor *cursor,

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -234,12 +234,13 @@ void roots_cursor_handle_touch_down(struct roots_cursor *cursor,
 	double sx, sy;
 	view_at(desktop, lx, ly, &surface, &sx, &sy);
 
+	uint32_t serial = 0;
 	if (surface) {
-		wlr_seat_touch_notify_down(cursor->seat->seat, surface,
+		serial = wlr_seat_touch_notify_down(cursor->seat->seat, surface,
 			event->time_msec, event->slot, sx, sy);
 	}
 
-	if (wlr_seat_touch_num_points(cursor->seat->seat) == 1) {
+	if (serial && wlr_seat_touch_num_points(cursor->seat->seat) == 1) {
 		cursor->seat->touch_id = event->slot;
 		cursor->seat->touch_x = lx;
 		cursor->seat->touch_y = ly;

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -235,7 +235,6 @@ void roots_cursor_handle_touch_down(struct roots_cursor *cursor,
 
 void roots_cursor_handle_touch_up(struct roots_cursor *cursor,
 		struct wlr_event_touch_up *event) {
-	// TODO
 	wlr_seat_touch_notify_up(cursor->seat->seat, event->time_msec, event->slot);
 	//roots_cursor_press_button(cursor, event->device, event->time_msec, BTN_LEFT, 0);
 }

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -261,8 +261,8 @@ void roots_cursor_handle_touch_motion(struct roots_cursor *cursor,
 	double sx, sy;
 	view_at(desktop, lx, ly, &surface, &sx, &sy);
 
-	if (surface == point->surface) {
-		wlr_seat_touch_notify_motion(cursor->seat->seat, event->time_msec,
+	if (surface) {
+		wlr_seat_touch_notify_motion(cursor->seat->seat, surface, event->time_msec,
 			event->slot, sx, sy);
 	}
 }

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -262,8 +262,13 @@ void roots_cursor_handle_touch_motion(struct roots_cursor *cursor,
 	view_at(desktop, lx, ly, &surface, &sx, &sy);
 
 	if (surface) {
-		wlr_seat_touch_notify_motion(cursor->seat->seat, surface, event->time_msec,
+		wlr_seat_touch_point_focus(cursor->seat->seat, surface,
+			event->time_msec, event->slot, sx, sy);
+		wlr_seat_touch_notify_motion(cursor->seat->seat, event->time_msec,
 			event->slot, sx, sy);
+	} else {
+		wlr_seat_touch_point_clear_focus(cursor->seat->seat, event->time_msec,
+			event->slot);
 	}
 }
 

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -328,33 +328,59 @@ static void handle_drag_icon_destroy(struct wl_listener *listener, void *data) {
 	free(drag_icon);
 }
 
+static struct roots_drag_icon *seat_add_drag_icon(struct roots_seat *seat,
+		struct wlr_surface *icon_surface) {
+	if (!icon_surface) {
+		return NULL;
+	}
+
+	struct roots_drag_icon *iter_icon;
+	wl_list_for_each(iter_icon, &seat->drag_icons, link) {
+		if (iter_icon->surface == icon_surface) {
+			// already in the list
+			return iter_icon;
+		}
+	}
+
+	struct roots_drag_icon *drag_icon =
+		calloc(1, sizeof(struct roots_drag_icon));
+	drag_icon->mapped = true;
+	drag_icon->surface = icon_surface;
+	wl_list_insert(&seat->drag_icons, &drag_icon->link);
+
+	wl_signal_add(&icon_surface->events.destroy,
+			&drag_icon->surface_destroy);
+	drag_icon->surface_destroy.notify = handle_drag_icon_destroy;
+
+	wl_signal_add(&icon_surface->events.commit,
+			&drag_icon->surface_commit);
+	drag_icon->surface_commit.notify = handle_drag_icon_commit;
+
+	return drag_icon;
+}
+
+static void seat_unmap_drag_icon(struct roots_seat *seat,
+		struct wlr_surface *icon_surface) {
+	if (!icon_surface) {
+		return;
+	}
+
+	struct roots_drag_icon *icon;
+	wl_list_for_each(icon, &seat->drag_icons, link) {
+		if (icon->surface == icon_surface) {
+			icon->mapped = false;
+		}
+	}
+}
+
 void roots_cursor_handle_pointer_grab_begin(struct roots_cursor *cursor,
 		struct wlr_seat_pointer_grab *grab) {
-	struct roots_seat *seat = cursor->seat;
 	if (grab->interface == &wlr_data_device_pointer_drag_interface) {
 		struct wlr_drag *drag = grab->data;
-		if (drag->icon) {
-			struct roots_drag_icon *iter_icon;
-			wl_list_for_each(iter_icon, &seat->drag_icons, link) {
-				if (iter_icon->surface == drag->icon) {
-					// already in the list
-					return;
-				}
-			}
-
-			struct roots_drag_icon *drag_icon =
-				calloc(1, sizeof(struct roots_drag_icon));
-			drag_icon->mapped = true;
-			drag_icon->surface = drag->icon;
-			wl_list_insert(&seat->drag_icons, &drag_icon->link);
-
-			wl_signal_add(&drag->icon->events.destroy,
-				&drag_icon->surface_destroy);
-			drag_icon->surface_destroy.notify = handle_drag_icon_destroy;
-
-			wl_signal_add(&drag->icon->events.commit,
-				&drag_icon->surface_commit);
-			drag_icon->surface_commit.notify = handle_drag_icon_commit;
+		struct roots_drag_icon *icon =
+			seat_add_drag_icon(cursor->seat, drag->icon);
+		if (icon) {
+			icon->is_pointer = true;
 		}
 	}
 }
@@ -363,13 +389,27 @@ void roots_cursor_handle_pointer_grab_end(struct roots_cursor *cursor,
 		struct wlr_seat_pointer_grab *grab) {
 	if (grab->interface == &wlr_data_device_pointer_drag_interface) {
 		struct wlr_drag *drag = grab->data;
-		struct roots_drag_icon *icon;
-		wl_list_for_each(icon, &cursor->seat->drag_icons, link) {
-			if (icon->surface == drag->icon) {
-				icon->mapped = false;
-			}
+		seat_unmap_drag_icon(cursor->seat, drag->icon);
+	}
+}
+
+void roots_cursor_handle_touch_grab_begin(struct roots_cursor *cursor,
+		struct wlr_seat_touch_grab *grab) {
+	if (grab->interface == &wlr_data_device_touch_drag_interface) {
+		struct wlr_drag *drag = grab->data;
+		struct roots_drag_icon *icon =
+			seat_add_drag_icon(cursor->seat, drag->icon);
+		if (icon) {
+			icon->is_pointer = false;
+			icon->touch_id = drag->grab_touch_id;
 		}
 	}
+}
 
-	roots_cursor_update_position(cursor, 0);
+void roots_cursor_handle_touch_grab_end(struct roots_cursor *cursor,
+		struct wlr_seat_touch_grab *grab) {
+	if (grab->interface == &wlr_data_device_touch_drag_interface) {
+		struct wlr_drag *drag = grab->data;
+		seat_unmap_drag_icon(cursor->seat, drag->icon);
+	}
 }

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -28,7 +28,8 @@ void roots_cursor_destroy(struct roots_cursor *cursor) {
 	// TODO
 }
 
-static void roots_cursor_update_position(struct roots_cursor *cursor, uint32_t time) {
+static void roots_cursor_update_position(struct roots_cursor *cursor,
+		uint32_t time) {
 	struct roots_desktop *desktop = cursor->seat->input->server->desktop;
 	struct roots_seat *seat = cursor->seat;
 	struct roots_view *view;
@@ -137,7 +138,9 @@ static void roots_cursor_press_button(struct roots_cursor *cursor,
 	double sx, sy;
 	struct roots_view *view = view_at(desktop, lx, ly, &surface, &sx, &sy);
 
-	if (state == WLR_BUTTON_PRESSED && view && roots_seat_has_meta_pressed(seat)) {
+	if (state == WLR_BUTTON_PRESSED &&
+			view &&
+			roots_seat_has_meta_pressed(seat)) {
 		roots_seat_focus_view(seat, view);
 
 		uint32_t edges;
@@ -170,7 +173,8 @@ static void roots_cursor_press_button(struct roots_cursor *cursor,
 	if (is_touch) {
 		serial = wl_display_get_serial(desktop->server->wl_display);
 	} else {
-		serial = wlr_seat_pointer_notify_button(seat->seat, time, button, state);
+		serial =
+			wlr_seat_pointer_notify_button(seat->seat, time, button, state);
 	}
 
 	int i;
@@ -251,7 +255,8 @@ void roots_cursor_handle_touch_down(struct roots_cursor *cursor,
 
 void roots_cursor_handle_touch_up(struct roots_cursor *cursor,
 		struct wlr_event_touch_up *event) {
-	struct wlr_touch_point *point = wlr_seat_touch_get_point(cursor->seat->seat, event->touch_id);
+	struct wlr_touch_point *point =
+		wlr_seat_touch_get_point(cursor->seat->seat, event->touch_id);
 	if (!point) {
 		return;
 	}
@@ -261,7 +266,8 @@ void roots_cursor_handle_touch_up(struct roots_cursor *cursor,
 			BTN_LEFT, 0, cursor->seat->touch_x, cursor->seat->touch_y);
 	}
 
-	wlr_seat_touch_notify_up(cursor->seat->seat, event->time_msec, event->touch_id);
+	wlr_seat_touch_notify_up(cursor->seat->seat, event->time_msec,
+		event->touch_id);
 }
 
 void roots_cursor_handle_touch_motion(struct roots_cursor *cursor,
@@ -331,7 +337,8 @@ void roots_cursor_handle_request_set_cursor(struct roots_cursor *cursor,
 		struct wlr_seat_pointer_request_set_cursor_event *event) {
 	struct wlr_surface *focused_surface =
 		event->seat_client->seat->pointer_state.focused_surface;
-	bool has_focused = focused_surface != NULL && focused_surface->resource != NULL;
+	bool has_focused =
+		focused_surface != NULL && focused_surface->resource != NULL;
 	struct wl_client *focused_client = NULL;
 	if (has_focused) {
 		focused_client = wl_resource_get_client(focused_surface->resource);

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -237,11 +237,11 @@ void roots_cursor_handle_touch_down(struct roots_cursor *cursor,
 	uint32_t serial = 0;
 	if (surface) {
 		serial = wlr_seat_touch_notify_down(cursor->seat->seat, surface,
-			event->time_msec, event->slot, sx, sy);
+			event->time_msec, event->touch_id, sx, sy);
 	}
 
 	if (serial && wlr_seat_touch_num_points(cursor->seat->seat) == 1) {
-		cursor->seat->touch_id = event->slot;
+		cursor->seat->touch_id = event->touch_id;
 		cursor->seat->touch_x = lx;
 		cursor->seat->touch_y = ly;
 		roots_cursor_press_button(cursor, event->device, event->time_msec,
@@ -251,7 +251,7 @@ void roots_cursor_handle_touch_down(struct roots_cursor *cursor,
 
 void roots_cursor_handle_touch_up(struct roots_cursor *cursor,
 		struct wlr_event_touch_up *event) {
-	struct wlr_touch_point *point = wlr_seat_touch_get_point(cursor->seat->seat, event->slot);
+	struct wlr_touch_point *point = wlr_seat_touch_get_point(cursor->seat->seat, event->touch_id);
 	if (!point) {
 		return;
 	}
@@ -261,14 +261,14 @@ void roots_cursor_handle_touch_up(struct roots_cursor *cursor,
 			BTN_LEFT, 0, cursor->seat->touch_x, cursor->seat->touch_y);
 	}
 
-	wlr_seat_touch_notify_up(cursor->seat->seat, event->time_msec, event->slot);
+	wlr_seat_touch_notify_up(cursor->seat->seat, event->time_msec, event->touch_id);
 }
 
 void roots_cursor_handle_touch_motion(struct roots_cursor *cursor,
 		struct wlr_event_touch_motion *event) {
 	struct roots_desktop *desktop = cursor->seat->input->server->desktop;
 	struct wlr_touch_point *point =
-		wlr_seat_touch_get_point(cursor->seat->seat, event->slot);
+		wlr_seat_touch_get_point(cursor->seat->seat, event->touch_id);
 	if (!point) {
 		return;
 	}
@@ -288,15 +288,15 @@ void roots_cursor_handle_touch_motion(struct roots_cursor *cursor,
 
 	if (surface) {
 		wlr_seat_touch_point_focus(cursor->seat->seat, surface,
-			event->time_msec, event->slot, sx, sy);
+			event->time_msec, event->touch_id, sx, sy);
 		wlr_seat_touch_notify_motion(cursor->seat->seat, event->time_msec,
-			event->slot, sx, sy);
+			event->touch_id, sx, sy);
 	} else {
 		wlr_seat_touch_point_clear_focus(cursor->seat->seat, event->time_msec,
-			event->slot);
+			event->touch_id);
 	}
 
-	if (event->slot == cursor->seat->touch_id) {
+	if (event->touch_id == cursor->seat->touch_id) {
 		cursor->seat->touch_x = lx;
 		cursor->seat->touch_y = ly;
 	}

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -209,8 +209,8 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 				struct wlr_touch_point *point =
 					wlr_seat_touch_get_point(seat->seat, drag_icon->touch_id);
 				if (point) {
-					icon_x = seat->touch_grab_x + drag_icon->sx;
-					icon_y = seat->touch_grab_y + drag_icon->sy;
+					icon_x = seat->touch_x + drag_icon->sx;
+					icon_y = seat->touch_y + drag_icon->sy;
 					render_surface(icon, desktop, wlr_output, &now, icon_x, icon_y, 0);
 				}
 			}

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -200,9 +200,20 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 			}
 			struct wlr_surface *icon = drag_icon->surface;
 			struct wlr_cursor *cursor = seat->cursor->cursor;
-			double icon_x = cursor->x + drag_icon->sx;
-			double icon_y = cursor->y + drag_icon->sy;
-			render_surface(icon, desktop, wlr_output, &now, icon_x, icon_y, 0);
+			double icon_x = 0, icon_y = 0;
+			if (drag_icon->is_pointer) {
+				icon_x = cursor->x + drag_icon->sx;
+				icon_y = cursor->y + drag_icon->sy;
+				render_surface(icon, desktop, wlr_output, &now, icon_x, icon_y, 0);
+			} else {
+				struct wlr_touch_point *point =
+					wlr_seat_touch_get_point(seat->seat, drag_icon->touch_id);
+				if (point) {
+					icon_x = point->sx + drag_icon->sx; // TODO plus view x
+					icon_y = point->sy + drag_icon->sy; // TODO plus view y
+					render_surface(icon, desktop, wlr_output, &now, icon_x, icon_y, 0);
+				}
+			}
 		}
 	}
 

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -209,8 +209,8 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 				struct wlr_touch_point *point =
 					wlr_seat_touch_get_point(seat->seat, drag_icon->touch_id);
 				if (point) {
-					icon_x = point->sx + drag_icon->sx; // TODO plus view x
-					icon_y = point->sy + drag_icon->sy; // TODO plus view y
+					icon_x = seat->touch_grab_x + drag_icon->sx;
+					icon_y = seat->touch_grab_y + drag_icon->sy;
 					render_surface(icon, desktop, wlr_output, &now, icon_x, icon_y, 0);
 				}
 			}

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -31,7 +31,8 @@ static void handle_cursor_motion(struct wl_listener *listener, void *data) {
 	roots_cursor_handle_motion(cursor, event);
 }
 
-static void handle_cursor_motion_absolute(struct wl_listener *listener, void *data) {
+static void handle_cursor_motion_absolute(struct wl_listener *listener,
+		void *data) {
 	struct roots_cursor *cursor =
 		wl_container_of(listener, cursor, motion_absolute);
 	struct wlr_event_pointer_motion_absolute *event = data;
@@ -127,7 +128,8 @@ static void handle_touch_grab_end(struct wl_listener *listener,
 	roots_cursor_handle_touch_grab_end(cursor, grab);
 }
 
-static void seat_reset_device_mappings(struct roots_seat *seat, struct wlr_input_device *device) {
+static void seat_reset_device_mappings(struct roots_seat *seat,
+		struct wlr_input_device *device) {
 	struct wlr_cursor *cursor = seat->cursor->cursor;
 	struct roots_config *config = seat->input->config;
 
@@ -233,10 +235,12 @@ static void roots_seat_init_cursor(struct roots_seat *seat) {
 	wl_signal_add(&wlr_cursor->events.touch_up, &seat->cursor->touch_up);
 	seat->cursor->touch_up.notify = handle_touch_up;
 
-	wl_signal_add(&wlr_cursor->events.touch_motion, &seat->cursor->touch_motion);
+	wl_signal_add(&wlr_cursor->events.touch_motion,
+		&seat->cursor->touch_motion);
 	seat->cursor->touch_motion.notify = handle_touch_motion;
 
-	wl_signal_add(&wlr_cursor->events.tablet_tool_axis, &seat->cursor->tool_axis);
+	wl_signal_add(&wlr_cursor->events.tablet_tool_axis,
+		&seat->cursor->tool_axis);
 	seat->cursor->tool_axis.notify = handle_tool_axis;
 
 	wl_signal_add(&wlr_cursor->events.tablet_tool_tip, &seat->cursor->tool_tip);
@@ -304,9 +308,11 @@ void roots_seat_destroy(struct roots_seat *seat) {
 	// TODO
 }
 
-static void seat_add_keyboard(struct roots_seat *seat, struct wlr_input_device *device) {
+static void seat_add_keyboard(struct roots_seat *seat,
+		struct wlr_input_device *device) {
 	assert(device->type == WLR_INPUT_DEVICE_KEYBOARD);
-	struct roots_keyboard *keyboard = roots_keyboard_create(device, seat->input);
+	struct roots_keyboard *keyboard =
+		roots_keyboard_create(device, seat->input);
 	if (keyboard == NULL) {
 		wlr_log(L_ERROR, "could not allocate keyboard for seat");
 		return;
@@ -327,7 +333,8 @@ static void seat_add_keyboard(struct roots_seat *seat, struct wlr_input_device *
 	wlr_seat_set_keyboard(seat->seat, device);
 }
 
-static void seat_add_pointer(struct roots_seat *seat, struct wlr_input_device *device) {
+static void seat_add_pointer(struct roots_seat *seat,
+		struct wlr_input_device *device) {
 	struct roots_pointer *pointer = calloc(sizeof(struct roots_pointer), 1);
 	if (!pointer) {
 		wlr_log(L_ERROR, "could not allocate pointer for seat");
@@ -342,7 +349,8 @@ static void seat_add_pointer(struct roots_seat *seat, struct wlr_input_device *d
 	roots_seat_configure_cursor(seat);
 }
 
-static void seat_add_touch(struct roots_seat *seat, struct wlr_input_device *device) {
+static void seat_add_touch(struct roots_seat *seat,
+		struct wlr_input_device *device) {
 	struct roots_touch *touch = calloc(sizeof(struct roots_touch), 1);
 	if (!touch) {
 		wlr_log(L_ERROR, "could not allocate touch for seat");
@@ -357,12 +365,15 @@ static void seat_add_touch(struct roots_seat *seat, struct wlr_input_device *dev
 	roots_seat_configure_cursor(seat);
 }
 
-static void seat_add_tablet_pad(struct roots_seat *seat, struct wlr_input_device *device) {
+static void seat_add_tablet_pad(struct roots_seat *seat,
+		struct wlr_input_device *device) {
 	// TODO
 }
 
-static void seat_add_tablet_tool(struct roots_seat *seat, struct wlr_input_device *device) {
-	struct roots_tablet_tool *tablet_tool = calloc(sizeof(struct roots_tablet_tool), 1);
+static void seat_add_tablet_tool(struct roots_seat *seat,
+		struct wlr_input_device *device) {
+	struct roots_tablet_tool *tablet_tool =
+		calloc(sizeof(struct roots_tablet_tool), 1);
 	if (!tablet_tool) {
 		wlr_log(L_ERROR, "could not allocate tablet_tool for seat");
 		return;

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -111,6 +111,22 @@ static void handle_pointer_grab_end(struct wl_listener *listener,
 	roots_cursor_handle_pointer_grab_end(cursor, grab);
 }
 
+static void handle_touch_grab_begin(struct wl_listener *listener,
+		void *data) {
+	struct roots_cursor *cursor =
+		wl_container_of(listener, cursor, touch_grab_begin);
+	struct wlr_seat_touch_grab *grab = data;
+	roots_cursor_handle_touch_grab_begin(cursor, grab);
+}
+
+static void handle_touch_grab_end(struct wl_listener *listener,
+		void *data) {
+	struct roots_cursor *cursor =
+		wl_container_of(listener, cursor, touch_grab_end);
+	struct wlr_seat_touch_grab *grab = data;
+	roots_cursor_handle_touch_grab_end(cursor, grab);
+}
+
 static void seat_reset_device_mappings(struct roots_seat *seat, struct wlr_input_device *device) {
 	struct wlr_cursor *cursor = seat->cursor->cursor;
 	struct roots_config *config = seat->input->config;
@@ -231,6 +247,14 @@ static void roots_seat_init_cursor(struct roots_seat *seat) {
 	wl_signal_add(&seat->seat->events.pointer_grab_end,
 			&seat->cursor->pointer_grab_end);
 	seat->cursor->pointer_grab_end.notify = handle_pointer_grab_end;
+
+	wl_signal_add(&seat->seat->events.touch_grab_begin,
+			&seat->cursor->touch_grab_begin);
+	seat->cursor->touch_grab_begin.notify = handle_touch_grab_begin;
+
+	wl_signal_add(&seat->seat->events.touch_grab_end,
+			&seat->cursor->touch_grab_end);
+	seat->cursor->touch_grab_end.notify = handle_touch_grab_end;
 }
 
 struct roots_seat *roots_seat_create(struct roots_input *input, char *name) {

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -188,8 +188,6 @@ static void roots_seat_init_cursor(struct roots_seat *seat) {
 	// TODO: be able to configure per-seat cursor themes
 	seat->cursor->xcursor_manager = desktop->xcursor_manager;
 
-	wl_list_init(&seat->cursor->touch_points);
-
 	roots_seat_configure_cursor(seat);
 	roots_seat_configure_xcursor(seat);
 

--- a/types/wlr_cursor.c
+++ b/types/wlr_cursor.c
@@ -637,3 +637,21 @@ void wlr_cursor_map_input_to_region(struct wlr_cursor *cur,
 
 	c_device->mapped_box = box;
 }
+
+bool wlr_cursor_absolute_to_layout_coords(struct wlr_cursor *cur,
+		struct wlr_input_device *device, double x_mm, double y_mm,
+		double width_mm, double height_mm, double *lx, double *ly) {
+	if (width_mm <= 0 || height_mm <= 0) {
+		return false;
+	}
+
+	struct wlr_box *mapping = get_mapping(cur, device);
+	if (!mapping) {
+		mapping = wlr_output_layout_get_box(cur->state->layout, NULL);
+	}
+
+	*lx = x_mm > 0 ? mapping->width * (x_mm / width_mm) + mapping->x : cur->x;
+	*ly = y_mm > 0 ? mapping->height * (y_mm / height_mm) + mapping->y : cur->y;
+
+	return true;
+}

--- a/types/wlr_data_device.c
+++ b/types/wlr_data_device.c
@@ -527,15 +527,14 @@ wlr_pointer_grab_interface wlr_data_device_pointer_drag_interface = {
 };
 
 static void touch_drag_down(struct wlr_seat_touch_grab *grab,
-		struct wlr_surface *surface,
-			uint32_t time, int32_t touch_id, double sx, double sy) {
+		uint32_t time, struct wlr_touch_point *point) {
 	// eat the event
 }
 
 static void touch_drag_up(struct wlr_seat_touch_grab *grab, uint32_t time,
-		int32_t touch_id) {
+		struct wlr_touch_point *point) {
 	struct wlr_drag *drag = grab->data;
-	if (drag->grab_touch_id != touch_id) {
+	if (drag->grab_touch_id != point->touch_id) {
 		return;
 	}
 
@@ -547,11 +546,11 @@ static void touch_drag_up(struct wlr_seat_touch_grab *grab, uint32_t time,
 }
 
 static void touch_drag_motion(struct wlr_seat_touch_grab *grab, uint32_t time,
-		int32_t touch_id, double sx, double sy) {
+		struct wlr_touch_point *point) {
 	struct wlr_drag *drag = grab->data;
 	if (drag->focus && drag->focus_client && drag->focus_client->data_device) {
 		wl_data_device_send_motion(drag->focus_client->data_device, time,
-			wl_fixed_from_double(sx), wl_fixed_from_double(sy));
+			wl_fixed_from_double(point->sx), wl_fixed_from_double(point->sy));
 	}
 }
 

--- a/types/wlr_data_device.c
+++ b/types/wlr_data_device.c
@@ -554,6 +554,12 @@ static void touch_drag_motion(struct wlr_seat_touch_grab *grab, uint32_t time,
 	}
 }
 
+static void touch_drag_enter(struct wlr_seat_touch_grab *grab, uint32_t time,
+		struct wlr_touch_point *point) {
+	struct wlr_drag *drag = grab->data;
+	wlr_drag_set_focus(drag, point->focus_surface, point->sx, point->sy);
+}
+
 static void touch_drag_cancel(struct wlr_seat_touch_grab *grab) {
 	struct wlr_drag *drag = grab->data;
 	wlr_drag_end(drag);
@@ -563,6 +569,7 @@ const struct wlr_touch_grab_interface wlr_data_device_touch_drag_interface = {
 	.down = touch_drag_down,
 	.up = touch_drag_up,
 	.motion = touch_drag_motion,
+	.enter = touch_drag_enter,
 	.cancel = touch_drag_cancel,
 };
 

--- a/types/wlr_data_device.c
+++ b/types/wlr_data_device.c
@@ -630,15 +630,15 @@ static bool seat_client_start_drag(struct wlr_seat_client *client,
 		client->seat->pointer_state.focused_surface == origin;
 
 	bool is_touch_grab = client->touch &&
-		wl_list_length(&client->seat->touch_state.touch_points) == 1 &&
+		wlr_seat_touch_num_points(client->seat) == 1 &&
 		client->seat->touch_state.grab_serial == serial;
 
+	// set in the iteration
 	struct wlr_touch_point *point = NULL;
+
 	if (is_touch_grab) {
 		wl_list_for_each(point, &client->seat->touch_state.touch_points, link) {
-			if (point->surface && point->surface == origin) {
-				is_touch_grab = true;
-			}
+			is_touch_grab = point->surface && point->surface == origin;
 			break;
 		}
 	}
@@ -677,6 +677,7 @@ static bool seat_client_start_drag(struct wlr_seat_client *client,
 		wlr_seat_pointer_clear_focus(drag->seat);
 		wlr_seat_pointer_start_grab(drag->seat, &drag->pointer_grab);
 	} else {
+		assert(point);
 		wlr_seat_touch_start_grab(drag->seat, &drag->touch_grab);
 		wlr_drag_set_focus(drag, point->surface, point->sx, point->sy);
 	}

--- a/types/wlr_data_device.c
+++ b/types/wlr_data_device.c
@@ -526,9 +526,10 @@ wlr_pointer_grab_interface wlr_data_device_pointer_drag_interface = {
 	.cancel = pointer_drag_cancel,
 };
 
-static void touch_drag_down(struct wlr_seat_touch_grab *grab,
+uint32_t touch_drag_down(struct wlr_seat_touch_grab *grab,
 		uint32_t time, struct wlr_touch_point *point) {
 	// eat the event
+	return 0;
 }
 
 static void touch_drag_up(struct wlr_seat_touch_grab *grab, uint32_t time,

--- a/types/wlr_data_device.c
+++ b/types/wlr_data_device.c
@@ -275,7 +275,8 @@ void wlr_seat_client_send_selection(struct wlr_seat_client *seat_client) {
 		struct wlr_data_offer *offer =
 			wlr_data_source_send_offer(seat_client->seat->selection_source,
 				seat_client->data_device);
-		wl_data_device_send_selection(seat_client->data_device, offer->resource);
+		wl_data_device_send_selection(seat_client->data_device,
+			offer->resource);
 	} else {
 		wl_data_device_send_selection(seat_client->data_device, NULL);
 	}
@@ -525,12 +526,14 @@ wlr_pointer_grab_interface wlr_data_device_pointer_drag_interface = {
 	.cancel = pointer_drag_cancel,
 };
 
-static void touch_drag_down(struct wlr_seat_touch_grab *grab, struct wlr_surface *surface,
+static void touch_drag_down(struct wlr_seat_touch_grab *grab,
+		struct wlr_surface *surface,
 			uint32_t time, int32_t touch_id, double sx, double sy) {
 	// eat the event
 }
 
-static void touch_drag_up(struct wlr_seat_touch_grab *grab, uint32_t time, int32_t touch_id) {
+static void touch_drag_up(struct wlr_seat_touch_grab *grab, uint32_t time,
+		int32_t touch_id) {
 	struct wlr_drag *drag = grab->data;
 	if (drag->grab_touch_id != touch_id) {
 		return;
@@ -543,8 +546,8 @@ static void touch_drag_up(struct wlr_seat_touch_grab *grab, uint32_t time, int32
 	wlr_drag_end(drag);
 }
 
-static void touch_drag_motion(struct wlr_seat_touch_grab *grab, uint32_t time, int32_t
-			touch_id, double sx, double sy) {
+static void touch_drag_motion(struct wlr_seat_touch_grab *grab, uint32_t time,
+		int32_t touch_id, double sx, double sy) {
 	struct wlr_drag *drag = grab->data;
 	if (drag->focus && drag->focus_client && drag->focus_client->data_device) {
 		wl_data_device_send_motion(drag->focus_client->data_device, time,
@@ -680,7 +683,8 @@ static void data_device_start_drag(struct wl_client *client,
 		struct wl_resource *source_resource,
 		struct wl_resource *origin_resource, struct wl_resource *icon_resource,
 		uint32_t serial) {
-	struct wlr_seat_client *seat_client = wl_resource_get_user_data(device_resource);
+	struct wlr_seat_client *seat_client =
+		wl_resource_get_user_data(device_resource);
 	struct wlr_surface *origin = wl_resource_get_user_data(origin_resource);
 	struct wlr_data_source *source = NULL;
 	struct wlr_surface *icon = NULL;
@@ -717,7 +721,8 @@ static const struct wl_data_device_interface data_device_impl = {
 void data_device_manager_get_data_device(struct wl_client *client,
 		struct wl_resource *manager_resource, uint32_t id,
 		struct wl_resource *seat_resource) {
-	struct wlr_seat_client *seat_client = wl_resource_get_user_data(seat_resource);
+	struct wlr_seat_client *seat_client =
+		wl_resource_get_user_data(seat_resource);
 
 	struct wl_resource *resource =
 		wl_resource_create(client,
@@ -884,9 +889,9 @@ struct wlr_data_device_manager *wlr_data_device_manager_create(
 }
 
 void wlr_data_device_manager_destroy(struct wlr_data_device_manager *manager) {
-  if (!manager) {
-    return;
-  }
-  wl_global_destroy(manager->global);
-  free(manager);
+	if (!manager) {
+		return;
+	}
+	wl_global_destroy(manager->global);
+	free(manager);
 }

--- a/types/wlr_data_device.c
+++ b/types/wlr_data_device.c
@@ -645,6 +645,7 @@ static bool seat_client_start_drag(struct wlr_seat_client *client,
 	}
 
 	if (!drag->is_pointer_grab && !is_touch_grab) {
+		free(drag);
 		return true;
 	}
 

--- a/types/wlr_seat.c
+++ b/types/wlr_seat.c
@@ -961,6 +961,9 @@ void wlr_seat_touch_notify_down(struct wlr_seat *seat,
 		double sy) {
 	struct wlr_seat_touch_grab *grab = seat->touch_state.grab;
 	grab->interface->down(grab, surface, time, touch_id, sx, sy);
+	if (wl_list_length(&seat->touch_state.touch_points) == 1) {
+		seat->touch_state.grab_serial = wl_display_get_serial(seat->display);
+	}
 }
 
 void wlr_seat_touch_notify_up(struct wlr_seat *seat, uint32_t time,

--- a/types/wlr_seat.c
+++ b/types/wlr_seat.c
@@ -1138,6 +1138,10 @@ void wlr_seat_touch_send_motion(struct wlr_seat *seat, uint32_t time, int32_t to
 	wl_touch_send_frame(point->client->touch);
 }
 
+int wlr_seat_touch_num_points(struct wlr_seat *seat) {
+	return wl_list_length(&seat->touch_state.touch_points);
+}
+
 bool wlr_seat_touch_has_grab(struct wlr_seat *seat) {
 	return seat->touch_state.grab->interface != &default_touch_grab_impl;
 }

--- a/types/wlr_seat.c
+++ b/types/wlr_seat.c
@@ -672,6 +672,10 @@ void wlr_seat_pointer_notify_axis(struct wlr_seat *wlr_seat, uint32_t time,
 	grab->interface->axis(grab, time, orientation, value);
 }
 
+bool wlr_seat_pointer_has_grab(struct wlr_seat *seat) {
+	return seat->pointer_state.grab->interface != &default_pointer_grab_impl;
+}
+
 void wlr_seat_keyboard_send_key(struct wlr_seat *wlr_seat, uint32_t time,
 		uint32_t key, uint32_t state) {
 	struct wlr_seat_client *client = wlr_seat->keyboard_state.focused_client;
@@ -867,6 +871,10 @@ void wlr_seat_keyboard_clear_focus(struct wlr_seat *seat) {
 	struct wl_array keys;
 	wl_array_init(&keys);
 	wlr_seat_keyboard_enter(seat, NULL);
+}
+
+bool wlr_seat_keyboard_has_grab(struct wlr_seat *seat) {
+	return seat->keyboard_state.grab->interface != &default_keyboard_grab_impl;
 }
 
 void wlr_seat_keyboard_notify_modifiers(struct wlr_seat *seat) {
@@ -1128,4 +1136,8 @@ void wlr_seat_touch_send_motion(struct wlr_seat *seat, uint32_t time, int32_t to
 	wl_touch_send_motion(point->client->touch, time, touch_id,
 		wl_fixed_from_double(sx), wl_fixed_from_double(sy));
 	wl_touch_send_frame(point->client->touch);
+}
+
+bool wlr_seat_touch_has_grab(struct wlr_seat *seat) {
+	return seat->touch_state.grab->interface != &default_touch_grab_impl;
 }


### PR DESCRIPTION
Proper touch support in wlroots.

Move touch point struct from rootston into wlr-seat which now keeps track of touch state.

Touch points are created on "down", moved on "motion", and destroyed on "up". They are bound to a single surface for their lifetime and are destroyed when the surface is destroyed.

The decision of what pointer-like features to give to the touch device belongs to rootston. The compositor can choose to give it a cursor, or press buttons on touch down if it so chooses.

Test with `weston-simple-touch`. Test dnd with `weston-dnd` (try moving across two windows).

You should be able to focus and move windows around with the cursor.

TODO:

* [ ] <s>rootston touch cursor features</s> move to another pr
* [ ] <s>xdg|wl-shell touch grab</s> probably not necessary
* [x] put drag icon in the right place on dnd
* [x] send dnd motion across surfaces
* [x] refactor touch grab interface
