### PR TITLE
Fix popups position for rotated views

### DIFF
--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -210,6 +210,12 @@ void wlr_xdg_toplevel_v6_set_resizing(struct wlr_xdg_surface_v6 *surface,
 void wlr_xdg_toplevel_v6_send_close(struct wlr_xdg_surface_v6 *surface);
 
 /**
+ * Compute the popup position in surface-local coordinates.
+ */
+void wlr_xdg_surface_v6_popup_get_position(struct wlr_xdg_surface_v6 *surface,
+		double *popup_sx, double *popup_sy);
+
+/**
  * Find a popup within this surface at the surface-local coordinates. Returns
  * the popup and coordinates in the topmost surface coordinate system or NULL if
  * no popup is found at that location.

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -115,17 +115,15 @@ static void render_xdg_v6_popups(struct wlr_xdg_surface_v6 *surface,
 		double popup_width = popup->surface->current->width;
 		double popup_height = popup->surface->current->height;
 
-		double popup_x = surface->geometry->x + popup->popup_state->geometry.x -
-			popup->geometry->x;
-		double popup_y = surface->geometry->y + popup->popup_state->geometry.y -
-			popup->geometry->y;
-		rotate_child_position(&popup_x, &popup_y, popup_width, popup_height,
+		double popup_sx, popup_sy;
+		wlr_xdg_surface_v6_popup_get_position(popup, &popup_sx, &popup_sy);
+		rotate_child_position(&popup_sx, &popup_sy, popup_width, popup_height,
 			width, height, rotation);
 
 		render_surface(popup->surface, desktop, wlr_output, when,
-			base_x + popup_x, base_y + popup_y, rotation);
-		render_xdg_v6_popups(popup, desktop, wlr_output, when, base_x + popup_x,
-			base_y + popup_y, rotation);
+			base_x + popup_sx, base_y + popup_sy, rotation);
+		render_xdg_v6_popups(popup, desktop, wlr_output, when,
+			base_x + popup_sx, base_y + popup_sy, rotation);
 	}
 }
 

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -39,9 +39,8 @@ static void render_surface(struct wlr_surface *surface,
 		struct roots_desktop *desktop, struct wlr_output *wlr_output,
 		struct timespec *when, double lx, double ly, float rotation) {
 	if (surface->texture->valid) {
-		double surface_scale = surface->current->scale;
-		double width = (double)surface->current->buffer_width / surface_scale;
-		double height = (double)surface->current->buffer_height / surface_scale;
+		int width = surface->current->width;
+		int height = surface->current->height;
 		int render_width = width * wlr_output->scale;
 		int render_height = height * wlr_output->scale;
 		double ox = lx, oy = ly;

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -1350,6 +1350,16 @@ void wlr_xdg_toplevel_v6_send_close(struct wlr_xdg_surface_v6 *surface) {
 	zxdg_toplevel_v6_send_close(surface->toplevel_state->resource);
 }
 
+void wlr_xdg_surface_v6_popup_get_position(struct wlr_xdg_surface_v6 *surface,
+		double *popup_sx, double *popup_sy) {
+	assert(surface->role == WLR_XDG_SURFACE_V6_ROLE_POPUP);
+	struct wlr_xdg_surface_v6 *parent = surface->popup_state->parent;
+	*popup_sx = parent->geometry->x + surface->popup_state->geometry.x -
+		surface->geometry->x;
+	*popup_sy = parent->geometry->y + surface->popup_state->geometry.y -
+		surface->geometry->y;
+}
+
 struct wlr_xdg_surface_v6 *wlr_xdg_surface_v6_popup_at(
 		struct wlr_xdg_surface_v6 *surface, double sx, double sy,
 		double *popup_sx, double *popup_sy) {


### PR DESCRIPTION
Test plan: open `gnome-calculator`, rotate it, click on the combobox. Test with a different screen scale factor too.

Fixes #415
