### PR TITLE
Fix a bunch of mistakes detected with scan-build

### DIFF
--- a/backend/libinput/events.c
+++ b/backend/libinput/events.c
@@ -66,10 +66,11 @@ static void handle_device_added(struct wlr_libinput_backend *backend,
 	int product = libinput_device_get_id_product(libinput_dev);
 	const char *name = libinput_device_get_name(libinput_dev);
 	struct wl_list *wlr_devices = calloc(1, sizeof(struct wl_list));
-	wl_list_init(wlr_devices);
 	if (!wlr_devices) {
-		goto fail;
+		wlr_log(L_ERROR, "Allocation failed");
+		return;
 	}
+	wl_list_init(wlr_devices);
 	wlr_log(L_DEBUG, "Added %s [%d:%d]", name, vendor, product);
 
 	if (libinput_device_has_capability(libinput_dev, LIBINPUT_DEVICE_CAP_KEYBOARD)) {

--- a/backend/session/session.c
+++ b/backend/session/session.c
@@ -249,7 +249,7 @@ static size_t explicit_find_gpus(struct wlr_session *session,
 		}
 	} while ((ptr = strtok_r(NULL, ":", &save)));
 
-	free(ptr);
+	free(gpus);
 	return i;
 }
 

--- a/rootston/config.c
+++ b/rootston/config.c
@@ -405,7 +405,7 @@ void roots_config_destroy(struct roots_config *config) {
 	}
 
 	struct roots_keyboard_config *kc, *ktmp = NULL;
-	wl_list_for_each_safe(kc, ktmp, &config->bindings, link) {
+	wl_list_for_each_safe(kc, ktmp, &config->keyboards, link) {
 		free(kc->name);
 		free(kc->rules);
 		free(kc->model);

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -18,9 +18,9 @@ struct roots_cursor *roots_cursor_create(struct roots_seat *seat) {
 	}
 	cursor->cursor = wlr_cursor_create();
 	if (!cursor->cursor) {
+		free(cursor);
 		return NULL;
 	}
-
 	return cursor;
 }
 

--- a/rootston/keyboard.c
+++ b/rootston/keyboard.c
@@ -141,6 +141,7 @@ static bool keyboard_keysyms_xkb(struct roots_keyboard *keyboard,
 	uint32_t consumed = xkb_state_key_get_consumed_mods2(
 		keyboard->device->keyboard->xkb_state, keycode, XKB_CONSUMED_MODE_XKB);
 
+	// TODO: actually use this value
 	modifiers = modifiers & ~consumed;
 
 	bool handled = false;

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -252,7 +252,6 @@ struct roots_seat *roots_seat_create(struct roots_input *input, char *name) {
 	seat->seat = wlr_seat_create(input->server->wl_display, name);
 	if (!seat->seat) {
 		free(seat);
-		roots_cursor_destroy(seat->cursor);
 		return NULL;
 	}
 

--- a/types/wlr_data_device.c
+++ b/types/wlr_data_device.c
@@ -636,7 +636,10 @@ static void data_device_start_drag(struct wl_client *client,
 
 	if (!seat_client_start_drag(seat_client, source, icon)) {
 		wl_resource_post_no_memory(device_resource);
-	} else {
+		return;
+	}
+
+	if (source) {
 		source->seat_client = seat_client;
 	}
 }

--- a/types/wlr_keyboard.c
+++ b/types/wlr_keyboard.c
@@ -105,7 +105,10 @@ void wlr_keyboard_init(struct wlr_keyboard *kb,
 }
 
 void wlr_keyboard_destroy(struct wlr_keyboard *kb) {
-	if (kb && kb->impl && kb->impl->destroy) {
+	if (kb == NULL) {
+		return;
+	}
+	if (kb->impl && kb->impl->destroy) {
 		kb->impl->destroy(kb);
 	} else {
 		wl_list_remove(&kb->events.key.listener_list);

--- a/types/wlr_screenshooter.c
+++ b/types/wlr_screenshooter.c
@@ -85,6 +85,7 @@ static void screenshooter_shoot(struct wl_client *client,
 	struct wlr_screenshot *screenshot =
 		calloc(1, sizeof(struct wlr_screenshot));
 	if (!screenshot) {
+		free(pixels);
 		wl_resource_post_no_memory(screenshooter_resource);
 		return;
 	}
@@ -96,6 +97,7 @@ static void screenshooter_shoot(struct wl_client *client,
 		wl_resource_get_version(screenshooter_resource), id);
 	if (screenshot->resource == NULL) {
 		free(screenshot);
+		free(pixels);
 		wl_resource_post_no_memory(screenshooter_resource);
 		return;
 	}
@@ -109,6 +111,7 @@ static void screenshooter_shoot(struct wl_client *client,
 	if (!state) {
 		wl_resource_destroy(screenshot->resource);
 		free(screenshot);
+		free(pixels);
 		wl_resource_post_no_memory(screenshooter_resource);
 		return;
 	}

--- a/types/wlr_wl_shell.c
+++ b/types/wlr_wl_shell.c
@@ -347,7 +347,7 @@ static void shell_surface_protocol_set_popup(struct wl_client *client,
 	transient_state->flags = flags;
 
 	struct wlr_wl_shell_surface_popup_state *popup_state =
-		calloc(1, sizeof(struct wlr_wl_shell_surface_transient_state));
+		calloc(1, sizeof(struct wlr_wl_shell_surface_popup_state));
 	if (popup_state == NULL) {
 		free(transient_state);
 		wl_client_post_no_memory(client);


### PR DESCRIPTION
To run the static analyzer:

```
ninja scan-build -C build
```

I didn't fix the keyboard thing because I'll refactor it anyway when fixing #398.