### PR TITLE
Refactor rootston keyboard

### DIFF
--- a/include/rootston/keyboard.h
+++ b/include/rootston/keyboard.h
@@ -16,7 +16,8 @@ struct roots_keyboard {
 	struct wl_listener keyboard_key;
 	struct wl_listener keyboard_modifiers;
 
-	xkb_keysym_t pressed_keysyms[ROOTS_KEYBOARD_PRESSED_KEYSYMS_CAP];
+	xkb_keysym_t pressed_keysyms_translated[ROOTS_KEYBOARD_PRESSED_KEYSYMS_CAP];
+	xkb_keysym_t pressed_keysyms_raw[ROOTS_KEYBOARD_PRESSED_KEYSYMS_CAP];
 };
 
 struct roots_keyboard *roots_keyboard_create(struct wlr_input_device *device,

--- a/rootston/rootston.ini.example
+++ b/rootston/rootston.ini.example
@@ -40,6 +40,6 @@ meta-key = Logo
 # - "close" to close the current view
 # - "next_window" to cycle through windows
 [bindings]
-Logo+Shift+E = exit
+Logo+Shift+e = exit
 Logo+q = close
 Alt+Tab = next_window


### PR DESCRIPTION
Test plan: keybinds such as `Ctrl+Shift+E` shouldn't work anymore. Keybinds such as `Ctrl+Shift+e` and `Ctrl+E` should work. Check that switching VTs works.

Fixes #398