### PR TITLE
Add cursor theme to rootston config

### DIFF
--- a/include/rootston/config.h
+++ b/include/rootston/config.h
@@ -48,6 +48,7 @@ struct roots_config {
 	struct {
 		char *mapped_output;
 		struct wlr_box *mapped_box;
+		char *theme;
 	} cursor;
 
 	struct wl_list outputs;

--- a/include/rootston/config.h
+++ b/include/rootston/config.h
@@ -3,6 +3,8 @@
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_input_device.h>
 
+#define ROOTS_CONFIG_DEFAULT_SEAT_NAME "seat0"
+
 struct roots_output_config {
 	char *name;
 	enum wl_output_transform transform;
@@ -17,9 +19,9 @@ struct roots_output_config {
 
 struct roots_device_config {
 	char *name;
+	char *seat;
 	char *mapped_output;
 	struct wlr_box *mapped_box;
-	char *seat;
 	struct wl_list link;
 };
 
@@ -33,6 +35,7 @@ struct roots_binding_config {
 
 struct roots_keyboard_config {
 	char *name;
+	char *seat;
 	uint32_t meta_key;
 	char *rules;
 	char *model;
@@ -42,19 +45,22 @@ struct roots_keyboard_config {
 	struct wl_list link;
 };
 
+struct roots_cursor_config {
+	char *seat;
+	char *mapped_output;
+	struct wlr_box *mapped_box;
+	char *theme;
+	struct wl_list link;
+};
+
 struct roots_config {
 	bool xwayland;
-
-	struct {
-		char *mapped_output;
-		struct wlr_box *mapped_box;
-		char *theme;
-	} cursor;
 
 	struct wl_list outputs;
 	struct wl_list devices;
 	struct wl_list bindings;
 	struct wl_list keyboards;
+	struct wl_list cursors;
 	char *config_path;
 	char *startup_cmd;
 };
@@ -90,6 +96,13 @@ struct roots_device_config *roots_config_get_device(struct roots_config *config,
  * returns NULL. A NULL device returns the default config for keyboards.
  */
 struct roots_keyboard_config *roots_config_get_keyboard(
-		struct roots_config *config, struct wlr_input_device *device);
+	struct roots_config *config, struct wlr_input_device *device);
+
+/**
+ * Get configuration for the cursor. If the cursor is not configured, returns
+ * NULL. A NULL seat_name returns the default config for cursors.
+ */
+struct roots_cursor_config *roots_config_get_cursor(struct roots_config *config,
+	const char *seat_name);
 
 #endif

--- a/rootston/config.c
+++ b/rootston/config.c
@@ -150,6 +150,37 @@ void add_binding_config(struct wl_list *bindings, const char* combination,
 	}
 }
 
+static void config_handle_cursor(struct roots_config *config,
+		const char *seat_name, const char *name, const char *value) {
+	struct roots_cursor_config *cc;
+	bool found = false;
+	wl_list_for_each(cc, &config->cursors, link) {
+		if (strcmp(cc->seat, seat_name) == 0) {
+			found = true;
+			break;
+		}
+	}
+
+	if (!found) {
+		cc = calloc(1, sizeof(struct roots_cursor_config));
+		cc->seat = strdup(seat_name);
+		wl_list_insert(&config->cursors, &cc->link);
+	}
+
+	if (strcmp(name, "map-to-output") == 0) {
+		free(cc->mapped_output);
+		cc->mapped_output = strdup(value);
+	} else if (strcmp(name, "geometry") == 0) {
+		free(cc->mapped_box);
+		cc->mapped_box = parse_geometry(value);
+	} else if (strcmp(name, "theme") == 0) {
+		free(cc->theme);
+		cc->theme = strdup(value);
+	} else {
+		wlr_log(L_ERROR, "got unknown cursor config: %s", name);
+	}
+}
+
 static void config_handle_keyboard(struct roots_config *config,
 		const char *device_name, const char *name, const char *value) {
 	struct roots_keyboard_config *kc;
@@ -190,6 +221,7 @@ static void config_handle_keyboard(struct roots_config *config,
 static const char *output_prefix = "output:";
 static const char *device_prefix = "device:";
 static const char *keyboard_prefix = "keyboard:";
+static const char *cursor_prefix = "cursor:";
 
 static int config_ini_handler(void *user, const char *section, const char *name,
 		const char *value) {
@@ -269,19 +301,12 @@ static int config_ini_handler(void *user, const char *section, const char *name,
 					oc->name, oc->mode.width, oc->mode.height,
 					oc->mode.refresh_rate);
 		}
+	} else if (strncmp(cursor_prefix, section, strlen(cursor_prefix)) == 0) {
+		const char *seat_name = section + strlen(cursor_prefix);
+		config_handle_cursor(config, seat_name, name, value);
 	} else if (strcmp(section, "cursor") == 0) {
-		if (strcmp(name, "map-to-output") == 0) {
-			free(config->cursor.mapped_output);
-			config->cursor.mapped_output = strdup(value);
-		} else if (strcmp(name, "geometry") == 0) {
-			free(config->cursor.mapped_box);
-			config->cursor.mapped_box = parse_geometry(value);
-		} else if (strcmp(name, "theme") == 0) {
-			free(config->cursor.theme);
-			config->cursor.theme = strdup(value);
-		} else {
-			wlr_log(L_ERROR, "got unknown cursor config: %s", name);
-		}
+		config_handle_cursor(config, ROOTS_CONFIG_DEFAULT_SEAT_NAME, name,
+			value);
 	} else if (strncmp(device_prefix, section, strlen(device_prefix)) == 0) {
 		const char *device_name = section + strlen(device_prefix);
 
@@ -297,7 +322,7 @@ static int config_ini_handler(void *user, const char *section, const char *name,
 		if (!found) {
 			dc = calloc(1, sizeof(struct roots_device_config));
 			dc->name = strdup(device_name);
-			dc->seat = strdup("seat0");
+			dc->seat = strdup(ROOTS_CONFIG_DEFAULT_SEAT_NAME);
 			wl_list_insert(&config->devices, &dc->link);
 		}
 
@@ -338,6 +363,7 @@ struct roots_config *roots_config_create_from_args(int argc, char *argv[]) {
 	wl_list_init(&config->outputs);
 	wl_list_init(&config->devices);
 	wl_list_init(&config->keyboards);
+	wl_list_init(&config->cursors);
 	wl_list_init(&config->bindings);
 
 	int c;
@@ -418,6 +444,15 @@ void roots_config_destroy(struct roots_config *config) {
 		free(kc);
 	}
 
+	struct roots_cursor_config *cc, *ctmp = NULL;
+	wl_list_for_each_safe(cc, ctmp, &config->cursors, link) {
+		free(cc->seat);
+		free(cc->mapped_output);
+		free(cc->mapped_box);
+		free(cc->theme);
+		free(cc);
+	}
+
 	struct roots_binding_config *bc, *btmp = NULL;
 	wl_list_for_each_safe(bc, btmp, &config->bindings, link) {
 		free(bc->keysyms);
@@ -426,8 +461,6 @@ void roots_config_destroy(struct roots_config *config) {
 	}
 
 	free(config->config_path);
-	free(config->cursor.mapped_output);
-	free(config->cursor.mapped_box);
 	free(config);
 }
 
@@ -457,11 +490,31 @@ struct roots_device_config *roots_config_get_device(struct roots_config *config,
 
 struct roots_keyboard_config *roots_config_get_keyboard(
 		struct roots_config *config, struct wlr_input_device *device) {
+	const char *device_name = "";
+	if (device != NULL) {
+		device_name = device->name;
+	}
+
 	struct roots_keyboard_config *kc;
 	wl_list_for_each(kc, &config->keyboards, link) {
-		if ((device != NULL && strcmp(kc->name, device->name) == 0) ||
-				(device == NULL && strcmp(kc->name, "") == 0)) {
+		if (strcmp(kc->name, device_name) == 0) {
 			return kc;
+		}
+	}
+
+	return NULL;
+}
+
+struct roots_cursor_config *roots_config_get_cursor(struct roots_config *config,
+		const char *seat_name) {
+	if (seat_name == NULL) {
+		seat_name = ROOTS_CONFIG_DEFAULT_SEAT_NAME;
+	}
+
+	struct roots_cursor_config *cc;
+	wl_list_for_each(cc, &config->cursors, link) {
+		if (strcmp(cc->seat, seat_name) == 0) {
+			return cc;
 		}
 	}
 

--- a/rootston/config.c
+++ b/rootston/config.c
@@ -276,6 +276,9 @@ static int config_ini_handler(void *user, const char *section, const char *name,
 		} else if (strcmp(name, "geometry") == 0) {
 			free(config->cursor.mapped_box);
 			config->cursor.mapped_box = parse_geometry(value);
+		} else if (strcmp(name, "theme") == 0) {
+			free(config->cursor.theme);
+			config->cursor.theme = strdup(value);
 		} else {
 			wlr_log(L_ERROR, "got unknown cursor config: %s", name);
 		}

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -338,11 +338,18 @@ struct roots_desktop *desktop_create(struct roots_server *server,
 	desktop->server = server;
 	desktop->config = config;
 
-	desktop->xcursor_manager = wlr_xcursor_manager_create(config->cursor.theme,
+	const char *cursor_theme = NULL;
+	struct roots_cursor_config *cc =
+		roots_config_get_cursor(config, ROOTS_CONFIG_DEFAULT_SEAT_NAME);
+	if (cc != NULL) {
+		cursor_theme = cc->theme;
+	}
+
+	desktop->xcursor_manager = wlr_xcursor_manager_create(cursor_theme,
 		ROOTS_XCURSOR_SIZE);
 	if (desktop->xcursor_manager == NULL) {
 		wlr_log(L_ERROR, "Cannot create XCursor manager for theme %s",
-			config->cursor.theme);
+			cursor_theme);
 		wlr_list_free(desktop->views);
 		free(desktop);
 		return NULL;

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -338,10 +338,11 @@ struct roots_desktop *desktop_create(struct roots_server *server,
 	desktop->server = server;
 	desktop->config = config;
 
-	desktop->xcursor_manager = wlr_xcursor_manager_create(NULL,
+	desktop->xcursor_manager = wlr_xcursor_manager_create(config->cursor.theme,
 		ROOTS_XCURSOR_SIZE);
 	if (desktop->xcursor_manager == NULL) {
-		wlr_log(L_ERROR, "Cannot create XCursor manager");
+		wlr_log(L_ERROR, "Cannot create XCursor manager for theme %s",
+			config->cursor.theme);
 		wlr_list_free(desktop->views);
 		free(desktop);
 		return NULL;

--- a/rootston/input.c
+++ b/rootston/input.c
@@ -43,7 +43,7 @@ static void input_add_notify(struct wl_listener *listener, void *data) {
 	struct wlr_input_device *device = data;
 	struct roots_input *input = wl_container_of(listener, input, input_add);
 
-	char *seat_name = "seat0";
+	char *seat_name = ROOTS_CONFIG_DEFAULT_SEAT_NAME;
 	struct roots_device_config *dc =
 		roots_config_get_device(input->config, device);
 	if (dc) {

--- a/rootston/rootston.ini.example
+++ b/rootston/rootston.ini.example
@@ -21,6 +21,8 @@ rotate = 90
 map-to-output = VGA-1
 # Restrict cursor movements to concrete rectangle
 geometry = 2500x800
+# Load a custom XCursor theme
+theme = default
 
 # Single device configuration. String after semicolon must match device's name.
 [device:PixArt Dell MS116 USB Optical Mouse]

--- a/types/wlr_xcursor_manager.c
+++ b/types/wlr_xcursor_manager.c
@@ -46,7 +46,7 @@ int wlr_xcursor_manager_load(struct wlr_xcursor_manager *manager,
 		return 1;
 	}
 	theme->scale = scale;
-	theme->theme = wlr_xcursor_theme_load(NULL, manager->size * scale);
+	theme->theme = wlr_xcursor_theme_load(manager->name, manager->size * scale);
 	if (theme->theme == NULL) {
 		free(theme);
 		return 1;


### PR DESCRIPTION
Test plan: install a [XCursor theme](https://www.archlinux.org/packages/?sort=&q=xcursor-&maintainer=&last_update=&flagged=&limit=50) and update your config, For instance, install `xcursor-themes` and use this config:

```ini
[cursor]
theme = redglass
```