### PR TITLE
rootston: xwayland ready listener

### DIFF
--- a/include/rootston/desktop.h
+++ b/include/rootston/desktop.h
@@ -50,6 +50,7 @@ struct roots_desktop {
 #ifdef HAS_XWAYLAND
 	struct wlr_xwayland *xwayland;
 	struct wl_listener xwayland_surface;
+	struct wl_listener xwayland_ready;
 #endif
 };
 

--- a/rootston/main.c
+++ b/rootston/main.c
@@ -59,8 +59,9 @@ int main(int argc, char **argv) {
 	ready(NULL, NULL);
 #else
 	if (server.desktop->xwayland != NULL) {
-		struct wl_listener xwayland_ready = { .notify = ready };
-		wl_signal_add(&server.desktop->xwayland->events.ready, &xwayland_ready);
+		wl_signal_add(&server.desktop->xwayland->events.ready,
+			&server.desktop->xwayland_ready);
+		server.desktop->xwayland_ready.notify = ready;
 	} else {
 		ready(NULL, NULL);
 	}


### PR DESCRIPTION
```
==24914==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7ffe0e537748 at pc 0x7fdf27134e20 bp 0x7ffe0e537340 sp 0x7ffe0e537330
READ of size 8 at 0x7ffe0e537748 thread T0
    #0 0x7fdf27134e1f in wl_signal_emit /usr/include/wayland-server-core.h:387
    #1 0x7fdf2713680c in xserver_handle_ready ../xwayland/xwayland.c:214
    #2 0x7fdf26eff611  (/lib64/libwayland-server.so.0+0x9611)
    #3 0x7fdf26effc51 in wl_event_loop_dispatch (/lib64/libwayland-server.so.0+0x9c51)
    #4 0x7fdf26efe499 in wl_display_run (/lib64/libwayland-server.so.0+0x8499)
    #5 0x414ddd in main ../rootston/main.c:69
    #6 0x7fdf26346889 in __libc_start_main (/lib64/libc.so.6+0x20889)
    #7 0x404739 in _start (/home/tony/projects/wlroots/build/rootston/rootston+0x404739)

Address 0x7ffe0e537748 is located in stack of thread T0 at offset 40 in frame
    #0 0x414905 in main ../rootston/main.c:27

  This frame has 1 object(s):
    [32, 56) 'xwayland_ready' <== Memory access at offset 40 is inside this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism or swapcontext
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-use-after-scope /usr/include/wayland-server-core.h:387 in wl_signal_emit
Shadow bytes around the buggy address:
  0x100041c9ee90: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100041c9eea0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100041c9eeb0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100041c9eec0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100041c9eed0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x100041c9eee0: 00 00 00 00 f1 f1 f1 f1 f8[f8]f8 f2 f3 f3 f3 f3
  0x100041c9eef0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100041c9ef00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100041c9ef10: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100041c9ef20: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100041c9ef30: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==24914==ABORTING
```