### PR TITLE
Add minimum meson version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,6 +2,7 @@ project(
 	'wlroots',
 	'c',
 	license: 'MIT',
+	meson_version: '>=0.43.0',
 	default_options: [
 		'c_std=c11',
 		'warning_level=2',


### PR DESCRIPTION
c3e0fbdb8f0cb16d99e70d14bb5cef6bd48d4591 breaks older meson versions, so just be explicit about what version is needed before someone complains.