### PR TITLE
Xwayland signal confusion fix & non-Linux socket path fix

### DIFF
--- a/backend/session/direct-freebsd.c
+++ b/backend/session/direct-freebsd.c
@@ -148,8 +148,8 @@ static bool setup_tty(struct direct_session *session, struct wl_display *display
 
 	struct vt_mode mode = {
 		.mode = VT_PROCESS,
-		.relsig = SIGUSR1,
-		.acqsig = SIGUSR1,
+		.relsig = SIGUSR2,
+		.acqsig = SIGUSR2,
 		.frsig = SIGIO, // has to be set
 	};
 
@@ -159,7 +159,7 @@ static bool setup_tty(struct direct_session *session, struct wl_display *display
 	}
 
 	struct wl_event_loop *loop = wl_display_get_event_loop(display);
-	session->vt_source = wl_event_loop_add_signal(loop, SIGUSR1,
+	session->vt_source = wl_event_loop_add_signal(loop, SIGUSR2,
 		vt_handler, session);
 	if (!session->vt_source) {
 		goto error;

--- a/backend/session/direct.c
+++ b/backend/session/direct.c
@@ -184,8 +184,8 @@ static bool setup_tty(struct direct_session *session, struct wl_display *display
 
 	struct vt_mode mode = {
 		.mode = VT_PROCESS,
-		.relsig = SIGUSR1,
-		.acqsig = SIGUSR1,
+		.relsig = SIGUSR2,
+		.acqsig = SIGUSR2,
 	};
 
 	if (ioctl(fd, VT_SETMODE, &mode) < 0) {
@@ -194,7 +194,7 @@ static bool setup_tty(struct direct_session *session, struct wl_display *display
 	}
 
 	struct wl_event_loop *loop = wl_display_get_event_loop(display);
-	session->vt_source = wl_event_loop_add_signal(loop, SIGUSR1,
+	session->vt_source = wl_event_loop_add_signal(loop, SIGUSR2,
 		vt_handler, session);
 	if (!session->vt_source) {
 		goto error;

--- a/xwayland/sockets.c
+++ b/xwayland/sockets.c
@@ -21,7 +21,9 @@
 static const char *lock_fmt = "/tmp/.X%d-lock";
 static const char *socket_dir = "/tmp/.X11-unix";
 static const char *socket_fmt = "/tmp/.X11-unix/X%d";
+#ifndef __linux__
 static const char *socket_fmt2 = "/tmp/.X11-unix/X%d_";
+#endif
 
 static int open_socket(struct sockaddr_un *addr, size_t path_size) {
 	int fd, rc;

--- a/xwayland/sockets.c
+++ b/xwayland/sockets.c
@@ -21,6 +21,7 @@
 static const char *lock_fmt = "/tmp/.X%d-lock";
 static const char *socket_dir = "/tmp/.X11-unix";
 static const char *socket_fmt = "/tmp/.X11-unix/X%d";
+static const char *socket_fmt2 = "/tmp/.X11-unix/X%d_";
 
 static int open_socket(struct sockaddr_un *addr, size_t path_size) {
 	int fd, rc;
@@ -73,7 +74,7 @@ static bool open_sockets(int socks[2], int display) {
 	addr.sun_path[0] = 0;
 	path_size = snprintf(addr.sun_path + 1, sizeof(addr.sun_path) - 1, socket_fmt, display);
 #else
-	path_size = snprintf(addr.sun_path, sizeof(addr.sun_path), socket_fmt, display);
+	path_size = snprintf(addr.sun_path, sizeof(addr.sun_path), socket_fmt2, display);
 #endif
 	socks[0] = open_socket(&addr, path_size);
 	if (socks[0] < 0) {
@@ -96,6 +97,11 @@ void unlink_display_sockets(int display) {
 
 	snprintf(sun_path, sizeof(sun_path), socket_fmt, display);
 	unlink(sun_path);
+
+#ifndef __linux__
+	snprintf(sun_path, sizeof(sun_path), socket_fmt2, display);
+	unlink(sun_path);
+#endif
 
 	snprintf(sun_path, sizeof(sun_path), lock_fmt, display);
 	unlink(sun_path);


### PR DESCRIPTION
I managed to get Xwayland working on FreeBSD, writing this from a GPU accelerated Firefox running under rootston :)

Turns out the problem was literally the same as this from 2014: [Weston confuses SIGUSR1 signals from Xwayland and VT switch](https://phabricator.freedesktop.org/T7080). Xwayland sends SIGUSR1, rootston interprets it as vt switch and freezes the whole desktop. "I'm surprised it hasn't blown up for anyone else yet" indeed. I guess most testing was done with logind.

Also fixed a socket creation error, it was creating at the same path twice (my copy-paste mistake when doing the same changes here as in wlc, forgot the second path thing)