### PR TITLE
Use anonymous shared memory fds for tmpfiles when available

### DIFF
--- a/examples/screenshot.c
+++ b/examples/screenshot.c
@@ -23,6 +23,12 @@
 
 #define _XOPEN_SOURCE 700
 #define _POSIX_C_SOURCE 199309L
+// for os-compatibility.c:
+#ifdef __FreeBSD__
+#define __BSD_VISIBLE 1
+#elif HAS_MEMFD
+#define _GNU_SOURCE
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/meson.build
+++ b/meson.build
@@ -81,6 +81,9 @@ endif
 exclude_files = []
 wlr_parts = []
 conf_data = configuration_data()
+if cc.has_header('linux/memfd.h')
+	add_project_arguments('-DHAS_MEMFD', language: 'c')
+endif
 if get_option('enable_xwayland')
 	add_project_arguments('-DHAS_XWAYLAND', language: 'c')
 	subdir('xwayland')


### PR DESCRIPTION
On Linux >= 3.17, memfd is used.
On FreeBSD, shm_open with SHM_ANON is used.

This reduces potential filesystem pollution and avoids potential problems such as usage of posix_fallocate on ZFS filesystems (which was disallowed in FreeBSD 12).

I haven't tested that memfd works, only that it compiles — the only Linux box I have right now is a headless VM.