### PR TITLE
Remove unneeded linux include

### DIFF
--- a/backend/wayland/os-compatibility.c
+++ b/backend/wayland/os-compatibility.c
@@ -29,9 +29,6 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
-#ifdef __linux__
-#include <sys/epoll.h>
-#endif
 #include <string.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
This isn't used. It's probably just an artifact from the file originally being copied from weston.