### PR TITLE
wl-shell: add commit event

### DIFF
--- a/include/wlr/types/wlr_wl_shell.h
+++ b/include/wlr/types/wlr_wl_shell.h
@@ -77,6 +77,7 @@ struct wlr_wl_shell_surface {
 
 	struct {
 		struct wl_signal destroy;
+		struct wl_signal commit;
 		struct wl_signal ping_timeout;
 
 		struct wl_signal request_move;

--- a/rootston/wl_shell.c
+++ b/rootston/wl_shell.c
@@ -150,8 +150,7 @@ void handle_wl_shell_surface(struct wl_listener *listener, void *data) {
 	roots_surface->set_state.notify = handle_set_state;
 	wl_signal_add(&surface->events.set_state, &roots_surface->set_state);
 	roots_surface->surface_commit.notify = handle_surface_commit;
-	wl_signal_add(&surface->surface->events.commit,
-		&roots_surface->surface_commit);
+	wl_signal_add(&surface->events.commit, &roots_surface->surface_commit);
 
 	struct roots_view *view = calloc(1, sizeof(struct roots_view));
 	if (!view) {

--- a/types/wlr_wl_shell.c
+++ b/types/wlr_wl_shell.c
@@ -459,6 +459,8 @@ static void handle_wlr_surface_committed(struct wl_listener *listener,
 				surface->popup_state->seat);
 		shell_pointer_grab_maybe_end(&grab->pointer_grab);
 	}
+
+	wl_signal_emit(&surface->events.commit, surface);
 }
 
 static int shell_surface_ping_timeout(void *user_data) {
@@ -509,6 +511,7 @@ static void shell_protocol_get_shell_surface(struct wl_client *client,
 		wl_surface->resource);
 
 	wl_signal_init(&wl_surface->events.destroy);
+	wl_signal_init(&wl_surface->events.commit);
 	wl_signal_init(&wl_surface->events.ping_timeout);
 	wl_signal_init(&wl_surface->events.request_move);
 	wl_signal_init(&wl_surface->events.request_resize);


### PR DESCRIPTION
Like xdg-shell commit event, makes sure the user commit handler always runs after the surface commit handlers.