### PR TITLE
xwayland: remove xwayland param from xsurface methods

### DIFF
--- a/include/wlr/xwayland.h
+++ b/include/wlr/xwayland.h
@@ -153,20 +153,18 @@ void wlr_xwayland_set_cursor(struct wlr_xwayland *wlr_xwayland,
 	uint8_t *pixels, uint32_t stride, uint32_t width, uint32_t height,
 	int32_t hotspot_x, int32_t hotspot_y);
 
-void wlr_xwayland_surface_activate(struct wlr_xwayland *wlr_xwayland,
-	struct wlr_xwayland_surface *surface, bool activated);
+void wlr_xwayland_surface_activate(struct wlr_xwayland_surface *surface,
+		bool activated);
 
-void wlr_xwayland_surface_configure(struct wlr_xwayland *wlr_xwayland,
-	struct wlr_xwayland_surface *surface, int16_t x, int16_t y,
-	uint16_t width, uint16_t height);
+void wlr_xwayland_surface_configure(struct wlr_xwayland_surface *surface,
+		int16_t x, int16_t y, uint16_t width, uint16_t height);
 
-void wlr_xwayland_surface_close(struct wlr_xwayland *wlr_xwayland,
-	struct wlr_xwayland_surface *surface);
+void wlr_xwayland_surface_close(struct wlr_xwayland_surface *surface);
 
-void wlr_xwayland_surface_set_maximized(struct wlr_xwayland *wlr_xwayland,
-	struct wlr_xwayland_surface *surface, bool maximized);
+void wlr_xwayland_surface_set_maximized(struct wlr_xwayland_surface *surface,
+		bool maximized);
 
-void wlr_xwayland_surface_set_fullscreen(struct wlr_xwayland *wlr_xwayland,
-	struct wlr_xwayland_surface *surface, bool fullscreen);
+void wlr_xwayland_surface_set_fullscreen(struct wlr_xwayland_surface *surface,
+		bool fullscreen);
 
 #endif

--- a/rootston/xwayland.c
+++ b/rootston/xwayland.c
@@ -11,8 +11,7 @@
 
 static void activate(struct roots_view *view, bool active) {
 	assert(view->type == ROOTS_XWAYLAND_VIEW);
-	struct wlr_xwayland *xwayland = view->desktop->xwayland;
-	wlr_xwayland_surface_activate(xwayland, view->xwayland_surface, active);
+	wlr_xwayland_surface_activate(view->xwayland_surface, active);
 }
 
 static void move(struct roots_view *view, double x, double y) {
@@ -20,8 +19,8 @@ static void move(struct roots_view *view, double x, double y) {
 	struct wlr_xwayland_surface *xwayland_surface = view->xwayland_surface;
 	view->x = x;
 	view->y = y;
-	wlr_xwayland_surface_configure(view->desktop->xwayland, xwayland_surface,
-		x, y, xwayland_surface->width, xwayland_surface->height);
+	wlr_xwayland_surface_configure(xwayland_surface, x, y,
+		xwayland_surface->width, xwayland_surface->height);
 }
 
 static void apply_size_constraints(
@@ -56,9 +55,8 @@ static void resize(struct roots_view *view, uint32_t width, uint32_t height) {
 	apply_size_constraints(xwayland_surface, width, height, &constrained_width,
 		&constrained_height);
 
-	wlr_xwayland_surface_configure(view->desktop->xwayland, xwayland_surface,
-		xwayland_surface->x, xwayland_surface->y, constrained_width,
-		constrained_height);
+	wlr_xwayland_surface_configure(xwayland_surface, xwayland_surface->x,
+			xwayland_surface->y, constrained_width, constrained_height);
 }
 
 static void move_resize(struct roots_view *view, double x, double y,
@@ -87,27 +85,25 @@ static void move_resize(struct roots_view *view, double x, double y,
 	view->pending_move_resize.width = constrained_width;
 	view->pending_move_resize.height = constrained_height;
 
-	wlr_xwayland_surface_configure(view->desktop->xwayland, xwayland_surface,
-		x, y, constrained_width, constrained_height);
+	wlr_xwayland_surface_configure(xwayland_surface, x, y, constrained_width,
+		constrained_height);
 }
 
 static void close(struct roots_view *view) {
 	assert(view->type == ROOTS_XWAYLAND_VIEW);
-	wlr_xwayland_surface_close(view->desktop->xwayland, view->xwayland_surface);
+	wlr_xwayland_surface_close(view->xwayland_surface);
 }
 
 static void maximize(struct roots_view *view, bool maximized) {
 	assert(view->type == ROOTS_XWAYLAND_VIEW);
 
-	wlr_xwayland_surface_set_maximized(view->desktop->xwayland,
-		view->xwayland_surface, maximized);
+	wlr_xwayland_surface_set_maximized(view->xwayland_surface, maximized);
 }
 
 static void set_fullscreen(struct roots_view *view, bool fullscreen) {
 	assert(view->type == ROOTS_XWAYLAND_VIEW);
 
-	wlr_xwayland_surface_set_fullscreen(view->desktop->xwayland,
-		view->xwayland_surface, fullscreen);
+	wlr_xwayland_surface_set_fullscreen(view->xwayland_surface, fullscreen);
 }
 
 static void handle_destroy(struct wl_listener *listener, void *data) {
@@ -139,8 +135,8 @@ static void handle_request_configure(struct wl_listener *listener, void *data) {
 	roots_surface->view->x = (double)event->x;
 	roots_surface->view->y = (double)event->y;
 
-	wlr_xwayland_surface_configure(roots_surface->view->desktop->xwayland,
-		xwayland_surface, event->x, event->y, event->width, event->height);
+	wlr_xwayland_surface_configure(xwayland_surface, event->x, event->y,
+		event->width, event->height);
 }
 
 static struct roots_seat *guess_seat_for_view(struct roots_view *view) {

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -590,7 +590,7 @@ static void xwm_handle_configure_request(struct wlr_xwm *xwm,
 
 	if (xsurface->surface == NULL) {
 		// Surface has not been mapped yet
-		wlr_xwayland_surface_configure(xwm->xwayland, xsurface, ev->x, ev->y,
+		wlr_xwayland_surface_configure(xsurface, ev->x, ev->y,
 			ev->width, ev->height);
 	} else {
 		struct wlr_xwayland_surface_configure_event *wlr_event =
@@ -981,25 +981,24 @@ static void handle_compositor_surface_create(struct wl_listener *listener,
 	}
 }
 
-void wlr_xwayland_surface_activate(struct wlr_xwayland *wlr_xwayland,
-		struct wlr_xwayland_surface *xsurface, bool activated) {
-	struct wlr_xwayland_surface *focused = wlr_xwayland->xwm->focus_surface;
+void wlr_xwayland_surface_activate(struct wlr_xwayland_surface *xsurface,
+		bool activated) {
+	struct wlr_xwayland_surface *focused = xsurface->xwm->focus_surface;
 	if (activated) {
-		xwm_surface_activate(wlr_xwayland->xwm, xsurface);
+		xwm_surface_activate(xsurface->xwm, xsurface);
 	} else if (focused == xsurface) {
-		xwm_surface_activate(wlr_xwayland->xwm, NULL);
+		xwm_surface_activate(xsurface->xwm, NULL);
 	}
 }
 
-void wlr_xwayland_surface_configure(struct wlr_xwayland *wlr_xwayland,
-		struct wlr_xwayland_surface *xsurface, int16_t x, int16_t y,
-		uint16_t width, uint16_t height) {
+void wlr_xwayland_surface_configure(struct wlr_xwayland_surface *xsurface,
+		int16_t x, int16_t y, uint16_t width, uint16_t height) {
 	xsurface->x = x;
 	xsurface->y = y;
 	xsurface->width = width;
 	xsurface->height = height;
 
-	struct wlr_xwm *xwm = wlr_xwayland->xwm;
+	struct wlr_xwm *xwm = xsurface->xwm;
 	uint32_t mask = XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y |
 		XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT |
 		XCB_CONFIG_WINDOW_BORDER_WIDTH;
@@ -1008,9 +1007,8 @@ void wlr_xwayland_surface_configure(struct wlr_xwayland *wlr_xwayland,
 	xcb_flush(xwm->xcb_conn);
 }
 
-void wlr_xwayland_surface_close(struct wlr_xwayland *wlr_xwayland,
-		struct wlr_xwayland_surface *xsurface) {
-	struct wlr_xwm *xwm = wlr_xwayland->xwm;
+void wlr_xwayland_surface_close(struct wlr_xwayland_surface *xsurface) {
+	struct wlr_xwm *xwm = xsurface->xwm;
 
 	bool supports_delete = false;
 	for (size_t i = 0; i < xsurface->protocols_len; i++) {
@@ -1343,16 +1341,16 @@ struct wlr_xwm *xwm_create(struct wlr_xwayland *wlr_xwayland) {
 	return xwm;
 }
 
-void wlr_xwayland_surface_set_maximized(struct wlr_xwayland *wlr_xwayland,
-		struct wlr_xwayland_surface *surface, bool maximized) {
+void wlr_xwayland_surface_set_maximized(struct wlr_xwayland_surface *surface,
+		bool maximized) {
 	surface->maximized_horz = maximized;
 	surface->maximized_vert = maximized;
 	xsurface_set_net_wm_state(surface);
 	xcb_flush(surface->xwm->xcb_conn);
 }
 
-void wlr_xwayland_surface_set_fullscreen(struct wlr_xwayland *wlr_xwayland,
-		struct wlr_xwayland_surface *surface, bool fullscreen) {
+void wlr_xwayland_surface_set_fullscreen(struct wlr_xwayland_surface *surface,
+		bool fullscreen) {
 	surface->fullscreen = fullscreen;
 	xsurface_set_net_wm_state(surface);
 	xcb_flush(surface->xwm->xcb_conn);


### PR DESCRIPTION
Simplification to make the api easier to use.