### PR TITLE
Configure outputs with make, model, serial in rootston

### DIFF
--- a/backend/drm/util.c
+++ b/backend/drm/util.c
@@ -93,6 +93,12 @@ void parse_edid(struct wlr_output *restrict output, size_t len, const uint8_t *d
 	uint16_t id = (data[8] << 8) | data[9];
 	snprintf(output->make, sizeof(output->make), "%s", get_manufacturer(id));
 
+	uint16_t model = data[10] | (data[11] << 8);
+	snprintf(output->model, sizeof(output->model), "0x%04X", model);
+
+	uint32_t serial = data[12] | (data[13] << 8) | (data[14] << 8) | (data[15] << 8);
+	snprintf(output->serial, sizeof(output->serial), "0x%08X", serial);
+
 	output->phys_width = ((data[68] & 0xf0) << 4) | data[66];
 	output->phys_height = ((data[68] & 0x0f) << 8) | data[67];
 

--- a/rootston/config.c
+++ b/rootston/config.c
@@ -120,7 +120,7 @@ void add_binding_config(struct wl_list *bindings, const char* combination,
 
 	xkb_keysym_t keysyms[ROOTS_KEYBOARD_PRESSED_KEYSYMS_CAP];
 	char *symnames = strdup(combination);
-	char* symname = strtok(symnames, "+");
+	char *symname = strtok(symnames, "+");
 	while (symname) {
 		uint32_t modifier = parse_modifier(symname);
 		if (modifier != 0) {
@@ -466,10 +466,15 @@ void roots_config_destroy(struct roots_config *config) {
 
 struct roots_output_config *roots_config_get_output(struct roots_config *config,
 		struct wlr_output *output) {
-	struct roots_output_config *o_config;
-	wl_list_for_each(o_config, &config->outputs, link) {
-		if (strcmp(o_config->name, output->name) == 0) {
-			return o_config;
+	char name[83];
+	snprintf(name, sizeof(name), "%s %s %s", output->make, output->model,
+		output->serial);
+
+	struct roots_output_config *oc;
+	wl_list_for_each(oc, &config->outputs, link) {
+		if (strcmp(oc->name, output->name) == 0 ||
+				strcmp(oc->name, name) == 0) {
+			return oc;
 		}
 	}
 

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -291,7 +291,7 @@ void output_add_notify(struct wl_listener *listener, void *data) {
 	struct roots_config *config = desktop->config;
 
 	wlr_log(L_DEBUG, "Output '%s' added", wlr_output->name);
-	wlr_log(L_DEBUG, "%s %s %s %"PRId32"mm x %"PRId32"mm", wlr_output->make,
+	wlr_log(L_DEBUG, "'%s %s %s' %"PRId32"mm x %"PRId32"mm", wlr_output->make,
 		wlr_output->model, wlr_output->serial, wlr_output->phys_width,
 		wlr_output->phys_height);
 	if (wl_list_length(&wlr_output->modes) > 0) {


### PR DESCRIPTION
This allows for instance to configure the screen you plug in your HDMI connector at home differently from the one you plug in the same connector at work.

Also added fallbacks in DRM backend in case EDID extension data for model and serial is missing.

Test plan: get your output name in rootston logs:

```
2017-12-07 13:57:23 - [rootston/output.c:293] Output 'LVDS-1' added
2017-12-07 13:57:23 - [rootston/output.c:296] 'Chimei Innolux Corporation 0x1484 0x00000000' 310mm x 174mm
```

Add it to your config:

```ini
[output:Chimei Innolux Corporation 0x1484 0x00000000]
scale = 2
```

Check that the config is applied to the output.

Updates #403