### PR TITLE
Send wl_surface.{enter,leave} to cursor surfaces

### DIFF
--- a/include/rootston/xcursor.h
+++ b/include/rootston/xcursor.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-#define ROOTS_XCURSOR_SIZE 16
+#define ROOTS_XCURSOR_SIZE 24
 
 #define ROOTS_XCURSOR_DEFAULT "left_ptr"
 #define ROOTS_XCURSOR_MOVE "grabbing"

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -16,6 +16,7 @@ struct wlr_output_cursor {
 	struct wlr_output *output;
 	double x, y;
 	bool enabled;
+	bool visible;
 	uint32_t width, height;
 	int32_t hotspot_x, hotspot_y;
 	struct wl_list link;
@@ -98,6 +99,9 @@ void wlr_output_set_fullscreen_surface(struct wlr_output *output,
 	struct wlr_surface *surface);
 
 struct wlr_output_cursor *wlr_output_cursor_create(struct wlr_output *output);
+/**
+ * Sets the cursor image. The image must be already scaled for the output.
+ */
 bool wlr_output_cursor_set_image(struct wlr_output_cursor *cursor,
 	const uint8_t *pixels, int32_t stride, uint32_t width, uint32_t height,
 	int32_t hotspot_x, int32_t hotspot_y);

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -346,12 +346,6 @@ static void output_cursor_render(struct wlr_output_cursor *cursor,
 	float translate[16];
 	wlr_matrix_translate(&translate, cursor_box.x, cursor_box.y, 0);
 
-	// Assume cursors without a surface are already scaled for the output
-	if (cursor->surface != NULL) {
-		cursor_box.width *= cursor->output->scale;
-		cursor_box.height *= cursor->output->scale;
-	}
-
 	float scale[16];
 	wlr_matrix_scale(&scale, cursor_box.width, cursor_box.height, 1);
 
@@ -546,8 +540,8 @@ static void output_cursor_update_visible(struct wlr_output_cursor *cursor) {
 static void output_cursor_commit(struct wlr_output_cursor *cursor) {
 	// Some clients commit a cursor surface with a NULL buffer to hide it.
 	cursor->enabled = wlr_surface_has_buffer(cursor->surface);
-	cursor->width = cursor->surface->current->width;
-	cursor->height = cursor->surface->current->height;
+	cursor->width = cursor->surface->current->width * cursor->output->scale;
+	cursor->height = cursor->surface->current->height * cursor->output->scale;
 
 	if (cursor->output->hardware_cursor != cursor) {
 		cursor->output->needs_swap = true;
@@ -580,8 +574,8 @@ void wlr_output_cursor_set_surface(struct wlr_output_cursor *cursor,
 		return;
 	}
 
-	cursor->hotspot_x = hotspot_x;
-	cursor->hotspot_y = hotspot_y;
+	cursor->hotspot_x = hotspot_x * cursor->output->scale;
+	cursor->hotspot_y = hotspot_y * cursor->output->scale;
 
 	if (surface && surface == cursor->surface) {
 		if (cursor->output->hardware_cursor == cursor &&

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -310,6 +310,9 @@ static void output_fullscreen_surface_render(struct wlr_output *output,
 	wlr_surface_send_frame_done(surface, when);
 }
 
+/**
+ * Returns the cursor box, scaled for its output.
+ */
 static void output_cursor_get_box(struct wlr_output_cursor *cursor,
 		struct wlr_box *box) {
 	box->x = cursor->x - cursor->hotspot_x;
@@ -318,8 +321,8 @@ static void output_cursor_get_box(struct wlr_output_cursor *cursor,
 	box->height = cursor->height;
 
 	if (cursor->surface != NULL) {
-		box->x += cursor->surface->current->sx;
-		box->y += cursor->surface->current->sy;
+		box->x += cursor->surface->current->sx * cursor->output->scale;
+		box->y += cursor->surface->current->sy * cursor->output->scale;
 	}
 }
 


### PR DESCRIPTION
Test plan: setup a scaled output, spawn `gnome-calculator`. Cursor should be scaled too (and not blurry).

`weston-terminal` doesn't send a scaled cursor, so its cursor is just scaled up (same behavior on Weston).

I changed rootston cursor size from 16 to 24 because the default theme doesn't have 16x16 cursors and fallbacks to 24x24 (that caused issues when loading the theme with a scale factor of 2).

Fixes #471