### PR TITLE
Set default cursor image in rootston

### DIFF
--- a/include/rootston/config.h
+++ b/include/rootston/config.h
@@ -51,6 +51,7 @@ struct roots_cursor_config {
 	char *mapped_output;
 	struct wlr_box *mapped_box;
 	char *theme;
+	char *default_image;
 	struct wl_list link;
 };
 

--- a/include/rootston/cursor.h
+++ b/include/rootston/cursor.h
@@ -20,6 +20,8 @@ struct roots_cursor {
 	struct roots_seat *seat;
 	struct wlr_cursor *cursor;
 
+	const char *default_xcursor;
+
 	enum roots_cursor_mode mode;
 
 	// state from input (review if this is necessary)

--- a/rootston/config.c
+++ b/rootston/config.c
@@ -176,6 +176,9 @@ static void config_handle_cursor(struct roots_config *config,
 	} else if (strcmp(name, "theme") == 0) {
 		free(cc->theme);
 		cc->theme = strdup(value);
+	} else if (strcmp(name, "default-image") == 0) {
+		free(cc->default_image);
+		cc->default_image = strdup(value);
 	} else {
 		wlr_log(L_ERROR, "got unknown cursor config: %s", name);
 	}
@@ -454,6 +457,7 @@ void roots_config_destroy(struct roots_config *config) {
 		free(cc->mapped_output);
 		free(cc->mapped_box);
 		free(cc->theme);
+		free(cc->default_image);
 		free(cc);
 	}
 

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -22,6 +22,7 @@ struct roots_cursor *roots_cursor_create(struct roots_seat *seat) {
 		free(cursor);
 		return NULL;
 	}
+	cursor->default_xcursor = ROOTS_XCURSOR_DEFAULT;
 	return cursor;
 }
 
@@ -48,7 +49,7 @@ static void roots_cursor_update_position(struct roots_cursor *cursor,
 		}
 		if (set_compositor_cursor) {
 			wlr_xcursor_manager_set_cursor_image(cursor->xcursor_manager,
-				ROOTS_XCURSOR_DEFAULT, cursor->cursor);
+				cursor->default_xcursor, cursor->cursor);
 			cursor->cursor_client = NULL;
 		}
 		if (view) {

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -408,10 +408,14 @@ struct roots_desktop *desktop_create(struct roots_server *server,
 	desktop->config = config;
 
 	const char *cursor_theme = NULL;
+	const char *cursor_default = ROOTS_XCURSOR_DEFAULT;
 	struct roots_cursor_config *cc =
 		roots_config_get_cursor(config, ROOTS_CONFIG_DEFAULT_SEAT_NAME);
 	if (cc != NULL) {
 		cursor_theme = cc->theme;
+		if (cc->default_image != NULL) {
+			cursor_default = cc->default_image;
+		}
 	}
 
 	desktop->xcursor_manager = wlr_xcursor_manager_create(cursor_theme,
@@ -449,7 +453,7 @@ struct roots_desktop *desktop_create(struct roots_server *server,
 			wlr_log(L_ERROR, "Cannot load XWayland XCursor theme");
 		}
 		struct wlr_xcursor *xcursor = wlr_xcursor_manager_get_xcursor(
-			desktop->xcursor_manager, ROOTS_XCURSOR_DEFAULT, 1);
+			desktop->xcursor_manager, cursor_default, 1);
 		if (xcursor != NULL) {
 			struct wlr_xcursor_image *image = xcursor->images[0];
 			wlr_xwayland_set_cursor(desktop->xwayland, image->buffer,

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -442,6 +442,9 @@ void roots_seat_configure_xcursor(struct roots_seat *seat) {
 		roots_config_get_cursor(seat->input->config, seat->seat->name);
 	if (cc != NULL) {
 		cursor_theme = cc->theme;
+		if (cc->default_image != NULL) {
+			seat->cursor->default_xcursor = cc->default_image;
+		}
 	}
 
 	if (!seat->cursor->xcursor_manager) {
@@ -465,7 +468,7 @@ void roots_seat_configure_xcursor(struct roots_seat *seat) {
 	}
 
 	wlr_xcursor_manager_set_cursor_image(seat->cursor->xcursor_manager,
-		ROOTS_XCURSOR_DEFAULT, seat->cursor->cursor);
+		seat->cursor->default_xcursor, seat->cursor->cursor);
 	wlr_cursor_warp(seat->cursor->cursor, NULL, seat->cursor->cursor->x,
 		seat->cursor->cursor->y);
 }


### PR DESCRIPTION
Test plan: setup two seats, and use this config:

```ini
[cursor:seat1]
default-image = crosshair
```