### PR TITLE
Multiple outputs with Wayland backend

### DIFF
--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <assert.h>
+#include <limits.h>
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #include <wayland-server.h>
@@ -115,6 +116,38 @@ struct wlr_wl_backend_output *wlr_wl_output_for_surface(
 		}
 	}
 	return NULL;
+}
+
+void wlr_wl_output_layout_get_box(struct wlr_wl_backend *backend,
+		struct wlr_box *box) {
+	int min_x = INT_MAX, min_y = INT_MAX;
+	int max_x = INT_MIN, max_y = INT_MIN;
+
+	struct wlr_wl_backend_output *output;
+	wl_list_for_each(output, &backend->outputs, link) {
+		struct wlr_output *wlr_output = &output->wlr_output;
+
+		int width, height;
+		wlr_output_effective_resolution(wlr_output, &width, &height);
+
+		if (wlr_output->lx < min_x) {
+			min_x = wlr_output->lx;
+		}
+		if (wlr_output->ly < min_y) {
+			min_y = wlr_output->ly;
+		}
+		if (wlr_output->lx + width > max_x) {
+			max_x = wlr_output->lx + width;
+		}
+		if (wlr_output->ly + height > max_y) {
+			max_y = wlr_output->ly + height;
+		}
+	}
+
+	box->x = min_x;
+	box->y = min_y;
+	box->width = max_x - min_x;
+	box->height = max_y - min_y;
 }
 
 struct wlr_backend *wlr_wl_backend_create(struct wl_display *display) {

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -154,6 +154,8 @@ static void wlr_wl_output_destroy(struct wlr_output *_output) {
 	wl_signal_emit(&output->backend->backend.events.output_remove,
 		&output->wlr_output);
 
+	wl_list_remove(&output->link);
+
 	if (output->cursor.buf_size != 0) {
 		assert(output->cursor.data);
 		assert(output->cursor.buffer);
@@ -171,6 +173,7 @@ static void wlr_wl_output_destroy(struct wlr_output *_output) {
 	if (output->frame_callback) {
 		wl_callback_destroy(output->frame_callback);
 	}
+
 	eglDestroySurface(output->backend->egl.display, output->surface);
 	wl_egl_window_destroy(output->egl_window);
 	zxdg_toplevel_v6_destroy(output->xdg_toplevel);
@@ -233,7 +236,7 @@ static void xdg_toplevel_handle_close(void *data, struct zxdg_toplevel_v6 *xdg_t
 	struct wlr_wl_backend_output *output = data;
 	assert(output && output->xdg_toplevel == xdg_toplevel);
 
-	wl_display_terminate(output->backend->local_display);
+	wlr_output_destroy((struct wlr_output *)output);
 }
 
 static struct zxdg_toplevel_v6_listener xdg_toplevel_listener = {

--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -21,7 +21,10 @@ static void pointer_handle_enter(void *data, struct wl_pointer *wl_pointer,
 	struct wlr_wl_pointer *wlr_wl_pointer = (struct wlr_wl_pointer *)dev->pointer;
 	struct wlr_wl_backend_output *output =
 		wlr_wl_output_for_surface(wlr_wl_dev->backend, surface);
-	assert(output);
+	if (!output) {
+		// GNOME sends a pointer enter when the surface is being destroyed
+		return;
+	}
 	wlr_wl_pointer->current_output = output;
 	output->enter_serial = serial;
 	wlr_wl_output_update_cursor(output);

--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -52,23 +52,28 @@ static void pointer_handle_motion(void *data, struct wl_pointer *wl_pointer,
 		return;
 	}
 
+	struct wlr_output *wlr_output = &wlr_wl_pointer->current_output->wlr_output;
+
 	struct wlr_box box;
 	wl_egl_window_get_attached_size(wlr_wl_pointer->current_output->egl_window,
 		&box.width, &box.height);
 	box.x = wl_fixed_to_int(surface_x);
 	box.y = wl_fixed_to_int(surface_y);
 	struct wlr_box transformed;
-	wlr_output_transform_apply_to_box(
-		wlr_wl_pointer->current_output->wlr_output.transform, &box,
-		&transformed);
+	wlr_output_transform_apply_to_box(wlr_output->transform, &box, &transformed);
+	box.x /= wlr_output->scale;
+	box.y /= wlr_output->scale;
+
+	struct wlr_box layout_box;
+	wlr_wl_output_layout_get_box(wlr_wl_pointer->current_output->backend, &layout_box);
 
 	struct wlr_event_pointer_motion_absolute wlr_event;
 	wlr_event.device = dev;
 	wlr_event.time_msec = time;
-	wlr_event.width_mm = transformed.width;
-	wlr_event.height_mm = transformed.height;
-	wlr_event.x_mm = transformed.x;
-	wlr_event.y_mm = transformed.y;
+	wlr_event.width_mm = layout_box.width;
+	wlr_event.height_mm = layout_box.height;
+	wlr_event.x_mm = transformed.x + wlr_output->lx + layout_box.x;
+	wlr_event.y_mm = transformed.y + wlr_output->ly + layout_box.y;
 	wl_signal_emit(&dev->pointer->events.motion_absolute, &wlr_event);
 }
 

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -7,6 +7,7 @@
 #include <wayland-egl.h>
 #include <wlr/render/egl.h>
 #include <wlr/backend/wayland.h>
+#include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wayland-util.h>
@@ -75,6 +76,8 @@ void wlr_wl_registry_poll(struct wlr_wl_backend *backend);
 void wlr_wl_output_update_cursor(struct wlr_wl_backend_output *output);
 struct wlr_wl_backend_output *wlr_wl_output_for_surface(
 		struct wlr_wl_backend *backend, struct wl_surface *surface);
+void wlr_wl_output_layout_get_box(struct wlr_wl_backend *backend,
+		struct wlr_box *box);
 
 extern const struct wl_seat_listener seat_listener;
 

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -272,9 +272,9 @@ void wlr_output_destroy(struct wlr_output *output) {
 
 	struct wlr_output_mode *mode, *tmp_mode;
 	wl_list_for_each_safe(mode, tmp_mode, &output->modes, link) {
+		wl_list_remove(&mode->link);
 		free(mode);
 	}
-	wl_list_remove(&output->modes);
 	if (output->impl && output->impl->destroy) {
 		output->impl->destroy(output);
 	} else {


### PR DESCRIPTION
- [x] Remove output instead of terminating display when a wayland backend view closed
- [x] Fix pointer events

Test plan: `env WLR_WL_OUTPUTS=2 build/rootston/rootston`, check with one output with scale=2 and rotate=90.