### PR TITLE
rootston: revert to auto backend

### DIFF
--- a/rootston/main.c
+++ b/rootston/main.c
@@ -30,11 +30,7 @@ int main(int argc, char **argv) {
 	assert(server.wl_display = wl_display_create());
 	assert(server.wl_event_loop = wl_display_get_event_loop(server.wl_display));
 
-	//assert(server.backend = wlr_backend_autocreate(server.wl_display));
-	assert(server.backend = wlr_headless_backend_create(server.wl_display));
-	wlr_headless_add_output(server.backend, 1280, 720);
-	wlr_headless_add_input_device(server.backend, WLR_INPUT_DEVICE_KEYBOARD);
-	wlr_headless_add_input_device(server.backend, WLR_INPUT_DEVICE_POINTER);
+	assert(server.backend = wlr_backend_autocreate(server.wl_display));
 
 	assert(server.renderer = wlr_gles2_renderer_create(server.backend));
 	server.data_device_manager =


### PR DESCRIPTION
It's my fault not making it more obvious that this needed to be reverted before merging #496.

>Since backends are not configurable in rootston, there are some changes in main.c that'll need to be reverted before merge.