### PR TITLE
Do not segfault when loading an unknown keymap

### DIFF
--- a/rootston/keyboard.c
+++ b/rootston/keyboard.c
@@ -354,8 +354,16 @@ struct roots_keyboard *roots_keyboard_create(struct wlr_input_device *device,
 		wlr_log(L_ERROR, "Cannot create XKB context");
 		return NULL;
 	}
-	wlr_keyboard_set_keymap(device->keyboard, xkb_map_new_from_names(context,
-		&rules, XKB_KEYMAP_COMPILE_NO_FLAGS));
+
+	struct xkb_keymap *keymap = xkb_map_new_from_names(context, &rules,
+		XKB_KEYMAP_COMPILE_NO_FLAGS);
+	if (keymap == NULL) {
+		xkb_context_unref(context);
+		wlr_log(L_ERROR, "Cannot create XKB keymap");
+		return NULL;
+	}
+
+	wlr_keyboard_set_keymap(device->keyboard, keymap);
 	xkb_context_unref(context);
 
 	int repeat_rate = (config->repeat_rate > 0) ? config->repeat_rate : 25;

--- a/types/wlr_keyboard.c
+++ b/types/wlr_keyboard.c
@@ -1,4 +1,3 @@
-#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
@@ -132,9 +131,12 @@ void wlr_keyboard_led_update(struct wlr_keyboard *kb, uint32_t leds) {
 
 void wlr_keyboard_set_keymap(struct wlr_keyboard *kb,
 		struct xkb_keymap *keymap) {
-	wlr_log(L_DEBUG, "Keymap set");
+	kb->xkb_state = xkb_state_new(kb->keymap);
+	if (kb->xkb_state == NULL) {
+		wlr_log(L_ERROR, "Failed to create XKB state");
+		return;
+	}
 	kb->keymap = keymap;
-	assert(kb->xkb_state = xkb_state_new(kb->keymap));
 
 	const char *led_names[WLR_LED_COUNT] = {
 		XKB_LED_NAME_NUM,


### PR DESCRIPTION
Test plan:

```ini
[keyboard]
layout = en
```