### PR TITLE
Destroy multi backend on display destroy

### DIFF
--- a/backend/backend.c
+++ b/backend/backend.c
@@ -91,7 +91,7 @@ struct wlr_backend *wlr_backend_autocreate(struct wl_display *display) {
 		return NULL;
 	}
 
-	backend = wlr_multi_backend_create(session);
+	backend = wlr_multi_backend_create(display, session);
 	if (!backend) {
 		goto error_session;
 	}

--- a/include/backend/multi.h
+++ b/include/backend/multi.h
@@ -11,6 +11,8 @@ struct wlr_multi_backend {
 
 	struct wlr_session *session;
 	struct wl_list backends;
+
+	struct wl_listener display_destroy;
 };
 
 #endif

--- a/include/wlr/backend/multi.h
+++ b/include/wlr/backend/multi.h
@@ -4,9 +4,10 @@
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
 
-struct wlr_backend *wlr_multi_backend_create(struct wlr_session *session);
+struct wlr_backend *wlr_multi_backend_create(struct wl_display *display,
+	struct wlr_session *session);
 void wlr_multi_backend_add(struct wlr_backend *multi,
-		struct wlr_backend *backend);
+	struct wlr_backend *backend);
 
 bool wlr_backend_is_multi(struct wlr_backend *backend);
 

--- a/rootston/main.c
+++ b/rootston/main.c
@@ -73,7 +73,6 @@ int main(int argc, char **argv) {
 #endif
 
 	wl_display_run(server.wl_display);
-	wlr_backend_destroy(server.backend);
 	wl_display_destroy(server.wl_display);
 	return 0;
 }


### PR DESCRIPTION
That allows to remove the `wlr_backend_destroy` call in `main.c`, because everything is cleaned up by the display destroy.