### PR TITLE
Add wlr_input_device_is_foo and wlr_output_is_bar functions

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -658,6 +658,10 @@ static struct wlr_output_impl output_impl = {
 	.get_gamma_size = wlr_drm_connector_get_gamma_size,
 };
 
+bool wlr_output_is_drm(struct wlr_output *output) {
+	return output->impl == &output_impl;
+}
+
 static int retry_pageflip(void *data) {
 	struct wlr_drm_connector *conn = data;
 	wlr_log(L_INFO, "%s: Retrying pageflip", conn->output.name);

--- a/backend/headless/input_device.c
+++ b/backend/headless/input_device.c
@@ -19,6 +19,10 @@ static struct wlr_input_device_impl input_device_impl = {
 	.destroy = input_device_destroy,
 };
 
+bool wlr_input_device_is_headless(struct wlr_input_device *wlr_dev) {
+	return wlr_dev->impl == &input_device_impl;
+}
+
 struct wlr_input_device *wlr_headless_add_input_device(
 		struct wlr_backend *wlr_backend, enum wlr_input_device_type type) {
 	struct wlr_headless_backend *backend =

--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -82,6 +82,10 @@ static const struct wlr_output_impl output_impl = {
 	.swap_buffers = output_swap_buffers,
 };
 
+bool wlr_output_is_headless(struct wlr_output *wlr_output) {
+	return wlr_output->impl == &output_impl;
+}
+
 static int signal_frame(void *data) {
 	struct wlr_headless_output *output = data;
 	wl_signal_emit(&output->wlr_output.events.frame, &output->wlr_output);

--- a/backend/libinput/events.c
+++ b/backend/libinput/events.c
@@ -53,6 +53,10 @@ static struct wlr_input_device *allocate_device(
 	return wlr_dev;
 }
 
+bool wlr_input_device_is_libinput(struct wlr_input_device *wlr_dev) {
+        return wlr_dev->impl == &input_device_impl;
+}
+
 static void handle_device_added(struct wlr_libinput_backend *backend,
 		struct libinput_device *libinput_dev) {
 	assert(backend && libinput_dev);

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -205,6 +205,10 @@ static struct wlr_output_impl output_impl = {
 	.move_cursor = wlr_wl_output_move_cursor,
 };
 
+bool wlr_output_is_wl(struct wlr_output *wlr_output) {
+	return wlr_output->impl == &output_impl;
+}
+
 static void xdg_surface_handle_configure(void *data, struct zxdg_surface_v6 *xdg_surface,
 		uint32_t serial) {
 	struct wlr_wl_backend_output *output = data;

--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -203,6 +203,10 @@ static struct wlr_input_device_impl input_device_impl = {
 	.destroy = input_device_destroy
 };
 
+bool wlr_input_device_is_wl(struct wlr_input_device *dev) {
+	return dev->impl == &input_device_impl;
+}
+
 static struct wlr_input_device *allocate_device(struct wlr_wl_backend *backend,
 		enum wlr_input_device_type type) {
 	struct wlr_wl_input_device *wlr_wl_dev;

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -401,3 +401,7 @@ static struct wlr_output_impl output_impl = {
 	.make_current = output_make_current,
 	.swap_buffers = output_swap_buffers,
 };
+
+bool wlr_output_is_x11(struct wlr_output *wlr_output) {
+	return wlr_output->impl == &output_impl;
+}

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -25,6 +25,7 @@
 
 static struct wlr_backend_impl backend_impl;
 static struct wlr_output_impl output_impl;
+static struct wlr_input_device_impl input_device_impl = { 0 };
 
 static uint32_t xcb_button_to_wl(uint32_t button) {
 	switch (button) {
@@ -328,12 +329,12 @@ struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
 	}
 
 	wlr_input_device_init(&x11->keyboard_dev, WLR_INPUT_DEVICE_KEYBOARD,
-		NULL, "X11 keyboard", 0, 0);
+		&input_device_impl, "X11 keyboard", 0, 0);
 	wlr_keyboard_init(&x11->keyboard, NULL);
 	x11->keyboard_dev.keyboard = &x11->keyboard;
 
 	wlr_input_device_init(&x11->pointer_dev, WLR_INPUT_DEVICE_POINTER,
-		NULL, "X11 pointer", 0, 0);
+		&input_device_impl, "X11 pointer", 0, 0);
 	wlr_pointer_init(&x11->pointer, NULL);
 	x11->pointer_dev.pointer = &x11->pointer;
 
@@ -404,4 +405,8 @@ static struct wlr_output_impl output_impl = {
 
 bool wlr_output_is_x11(struct wlr_output *wlr_output) {
 	return wlr_output->impl == &output_impl;
+}
+
+bool wlr_input_device_is_x11(struct wlr_input_device *wlr_dev) {
+	return wlr_dev->impl == &input_device_impl;
 }

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -12,7 +12,6 @@
 
 #include <wlr/backend/session.h>
 #include <wlr/backend/drm.h>
-#include <wlr/types/wlr_output.h>
 #include <wlr/render/egl.h>
 
 #include "iface.h"

--- a/include/backend/headless.h
+++ b/include/backend/headless.h
@@ -3,7 +3,6 @@
 
 #include <wlr/backend/interface.h>
 #include <wlr/backend/headless.h>
-#include <wlr/types/wlr_output.h>
 
 struct wlr_headless_backend {
 	struct wlr_backend backend;

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -8,7 +8,6 @@
 #include <wlr/render/egl.h>
 #include <wlr/backend/wayland.h>
 #include <wlr/types/wlr_box.h>
-#include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wayland-util.h>
 

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -8,7 +8,6 @@
 #include <wlr/render/egl.h>
 #include <wlr/backend/wayland.h>
 #include <wlr/types/wlr_box.h>
-#include <wlr/types/wlr_input_device.h>
 #include <wayland-util.h>
 
 struct wlr_wl_backend {

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -6,7 +6,6 @@
 #include <X11/Xlib-xcb.h>
 #include <wayland-server.h>
 #include <wlr/render/egl.h>
-#include <wlr/types/wlr_input_device.h>
 
 struct wlr_x11_backend;
 

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -6,7 +6,6 @@
 #include <X11/Xlib-xcb.h>
 #include <wayland-server.h>
 #include <wlr/render/egl.h>
-#include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_input_device.h>
 
 struct wlr_x11_backend;

--- a/include/wlr/backend/drm.h
+++ b/include/wlr/backend/drm.h
@@ -4,10 +4,12 @@
 #include <wayland-server.h>
 #include <wlr/backend/session.h>
 #include <wlr/backend.h>
+#include <wlr/types/wlr_output.h>
 
 struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
 	struct wlr_session *session, int gpu_fd, struct wlr_backend *parent);
 
 bool wlr_backend_is_drm(struct wlr_backend *backend);
+bool wlr_output_is_drm(struct wlr_output *output);
 
 #endif

--- a/include/wlr/backend/headless.h
+++ b/include/wlr/backend/headless.h
@@ -10,5 +10,6 @@ struct wlr_output *wlr_headless_add_output(struct wlr_backend *backend,
 struct wlr_input_device *wlr_headless_add_input_device(
 	struct wlr_backend *backend, enum wlr_input_device_type type);
 bool wlr_backend_is_headless(struct wlr_backend *backend);
+bool wlr_input_device_is_headless(struct wlr_input_device *device);
 
 #endif

--- a/include/wlr/backend/headless.h
+++ b/include/wlr/backend/headless.h
@@ -3,6 +3,7 @@
 
 #include <wlr/backend.h>
 #include <wlr/types/wlr_input_device.h>
+#include <wlr/types/wlr_output.h>
 
 struct wlr_backend *wlr_headless_backend_create(struct wl_display *display);
 struct wlr_output *wlr_headless_add_output(struct wlr_backend *backend,
@@ -11,5 +12,6 @@ struct wlr_input_device *wlr_headless_add_input_device(
 	struct wlr_backend *backend, enum wlr_input_device_type type);
 bool wlr_backend_is_headless(struct wlr_backend *backend);
 bool wlr_input_device_is_headless(struct wlr_input_device *device);
+bool wlr_output_is_headless(struct wlr_output *output);
 
 #endif

--- a/include/wlr/backend/libinput.h
+++ b/include/wlr/backend/libinput.h
@@ -12,5 +12,6 @@ struct wlr_backend *wlr_libinput_backend_create(struct wl_display *display,
 struct libinput_device *wlr_libinput_get_device_handle(struct wlr_input_device *dev);
 
 bool wlr_backend_is_libinput(struct wlr_backend *backend);
+bool wlr_input_device_is_libinput(struct wlr_input_device *device);
 
 #endif

--- a/include/wlr/backend/wayland.h
+++ b/include/wlr/backend/wayland.h
@@ -4,6 +4,7 @@
 #include <wayland-client.h>
 #include <wayland-server.h>
 #include <wlr/backend.h>
+#include <wlr/types/wlr_output.h>
 #include <stdbool.h>
 
 /**
@@ -11,6 +12,7 @@
  * you must use wlr_wl_output_create to add them.
  */
 struct wlr_backend *wlr_wl_backend_create(struct wl_display *display);
+
 /**
  * Adds a new output to this backend. You may remove outputs by destroying them.
  * Note that if called before initializing the backend, this will return NULL
@@ -18,9 +20,15 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display);
  * the output_add signal).
  */
 struct wlr_output *wlr_wl_output_create(struct wlr_backend *backend);
+
 /**
  * True if the given backend is a wlr_wl_backend.
  */
 bool wlr_backend_is_wl(struct wlr_backend *backend);
+
+/**
+ * True if the given output is a wlr_wl_backend_output.
+ */
+bool wlr_output_is_wl(struct wlr_output *output);
 
 #endif

--- a/include/wlr/backend/wayland.h
+++ b/include/wlr/backend/wayland.h
@@ -4,6 +4,7 @@
 #include <wayland-client.h>
 #include <wayland-server.h>
 #include <wlr/backend.h>
+#include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_output.h>
 #include <stdbool.h>
 
@@ -25,6 +26,11 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *backend);
  * True if the given backend is a wlr_wl_backend.
  */
 bool wlr_backend_is_wl(struct wlr_backend *backend);
+
+/**
+ * True if the given input device is a wlr_wl_input_device.
+ */
+bool wlr_input_device_is_wl(struct wlr_input_device *device);
 
 /**
  * True if the given output is a wlr_wl_backend_output.

--- a/include/wlr/backend/x11.h
+++ b/include/wlr/backend/x11.h
@@ -4,12 +4,14 @@
 #include <stdbool.h>
 #include <wayland-server.h>
 #include <wlr/backend.h>
+#include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_output.h>
 
 struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
 	const char *x11_display);
 
 bool wlr_backend_is_x11(struct wlr_backend *backend);
+bool wlr_input_device_is_x11(struct wlr_input_device *device);
 bool wlr_output_is_x11(struct wlr_output *output);
 
 #endif

--- a/include/wlr/backend/x11.h
+++ b/include/wlr/backend/x11.h
@@ -4,10 +4,12 @@
 #include <stdbool.h>
 #include <wayland-server.h>
 #include <wlr/backend.h>
+#include <wlr/types/wlr_output.h>
 
 struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
 	const char *x11_display);
 
 bool wlr_backend_is_x11(struct wlr_backend *backend);
+bool wlr_output_is_x11(struct wlr_output *output);
 
 #endif


### PR DESCRIPTION
This adds all the variants of wlr_input_device and wlr_output that I could find **that have and impl**.

This last point is important, because X11 has wlr_input_devices with a NULL implem, so we can't use that to check as we have done with backends.
I've considered creating a dummy impl initialized to 0 to use that just for check, should I?

Closes #482.
Reopens #497. (I'm not sure that's legit, but these really are two separate issues. I doubt I'll forget but feels cleaner with the issue open)