### PR TITLE
[wip] multibackend fixes

### DIFF
--- a/backend/backend.c
+++ b/backend/backend.c
@@ -18,6 +18,7 @@ void wlr_backend_init(struct wlr_backend *backend,
 		const struct wlr_backend_impl *impl) {
 	assert(backend);
 	backend->impl = impl;
+	wl_signal_init(&backend->events.destroy);
 	wl_signal_init(&backend->events.input_add);
 	wl_signal_init(&backend->events.input_remove);
 	wl_signal_init(&backend->events.output_add);
@@ -32,6 +33,7 @@ bool wlr_backend_start(struct wlr_backend *backend) {
 }
 
 void wlr_backend_destroy(struct wlr_backend *backend) {
+	wl_signal_emit(&backend->events.destroy, backend);
 	if (backend->impl && backend->impl->destroy) {
 		backend->impl->destroy(backend);
 	} else {

--- a/backend/backend.c
+++ b/backend/backend.c
@@ -93,7 +93,7 @@ struct wlr_backend *wlr_backend_autocreate(struct wl_display *display) {
 		return NULL;
 	}
 
-	backend = wlr_multi_backend_create(display, session);
+	backend = wlr_multi_backend_create(display);
 	if (!backend) {
 		goto error_session;
 	}

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -174,3 +174,8 @@ error_fd:
 	free(drm);
 	return NULL;
 }
+
+struct wlr_session *wlr_drm_backend_get_session(struct wlr_backend *backend) {
+	struct wlr_drm_backend *drm = (struct wlr_drm_backend *)backend;
+	return drm->session;
+}

--- a/backend/multi/backend.c
+++ b/backend/multi/backend.c
@@ -42,7 +42,6 @@ static void subbackend_state_destroy(struct subbackend_state *sub) {
 
 static void multi_backend_destroy(struct wlr_backend *wlr_backend) {
 	struct wlr_multi_backend *backend = (struct wlr_multi_backend *)wlr_backend;
-	wl_list_remove(&backend->display_destroy.link);
 	struct subbackend_state *sub, *next;
 	wl_list_for_each_safe(sub, next, &backend->backends, link) {
 		// XXX do we really want to take ownership over added backends?
@@ -189,4 +188,10 @@ struct wlr_session *wlr_multi_get_session(struct wlr_backend *_backend) {
 		}
 	}
 	return NULL;
+}
+
+bool wlr_multi_is_empty(struct wlr_backend *_backend) {
+	assert(wlr_backend_is_multi(_backend));
+	struct wlr_multi_backend *backend = (struct wlr_multi_backend *)_backend;
+	return wl_list_length(&backend->backends) < 1;
 }

--- a/backend/multi/backend.c
+++ b/backend/multi/backend.c
@@ -79,6 +79,9 @@ struct wlr_backend *wlr_multi_backend_create(struct wl_display *display) {
 	wl_list_init(&backend->backends);
 	wlr_backend_init(&backend->backend, &backend_impl);
 
+	wl_signal_init(&backend->events.backend_add);
+	wl_signal_init(&backend->events.backend_remove);
+
 	return &backend->backend;
 }
 
@@ -162,6 +165,8 @@ void wlr_multi_backend_add(struct wlr_backend *_multi,
 
 	wl_signal_add(&backend->events.output_remove, &sub->output_remove);
 	sub->output_remove.notify = output_remove_reemit;
+
+	wl_signal_emit(&multi->events.backend_add, backend);
 }
 
 void wlr_multi_backend_remove(struct wlr_backend *_multi,
@@ -173,6 +178,7 @@ void wlr_multi_backend_remove(struct wlr_backend *_multi,
 		multi_backend_get_subbackend(multi, backend);
 
 	if (sub) {
+		wl_signal_emit(&multi->events.backend_remove, backend);
 		subbackend_state_destroy(sub);
 	}
 }

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -143,4 +143,6 @@ int wlr_drm_event(int fd, uint32_t mask, void *data);
 
 void wlr_drm_connector_start_renderer(struct wlr_drm_connector *conn);
 
+struct wlr_session *wlr_drm_backend_get_session(struct wlr_backend *backend);
+
 #endif

--- a/include/backend/multi.h
+++ b/include/backend/multi.h
@@ -10,8 +10,6 @@ struct wlr_multi_backend {
 	struct wlr_backend backend;
 
 	struct wl_list backends;
-
-	struct wl_listener display_destroy;
 };
 
 #endif

--- a/include/backend/multi.h
+++ b/include/backend/multi.h
@@ -11,6 +11,8 @@ struct wlr_multi_backend {
 
 	struct wl_list backends;
 
+	struct wl_listener display_destroy;
+
 	struct {
 		struct wl_signal backend_add;
 		struct wl_signal backend_remove;

--- a/include/backend/multi.h
+++ b/include/backend/multi.h
@@ -9,7 +9,6 @@
 struct wlr_multi_backend {
 	struct wlr_backend backend;
 
-	struct wlr_session *session;
 	struct wl_list backends;
 
 	struct wl_listener display_destroy;

--- a/include/backend/multi.h
+++ b/include/backend/multi.h
@@ -10,6 +10,11 @@ struct wlr_multi_backend {
 	struct wlr_backend backend;
 
 	struct wl_list backends;
+
+	struct {
+		struct wl_signal backend_add;
+		struct wl_signal backend_remove;
+	} events;
 };
 
 #endif

--- a/include/wlr/backend.h
+++ b/include/wlr/backend.h
@@ -11,6 +11,7 @@ struct wlr_backend {
 	const struct wlr_backend_impl *impl;
 
 	struct {
+		struct wl_signal destroy;
 		struct wl_signal input_add;
 		struct wl_signal input_remove;
 		struct wl_signal output_add;

--- a/include/wlr/backend/multi.h
+++ b/include/wlr/backend/multi.h
@@ -9,6 +9,9 @@ struct wlr_backend *wlr_multi_backend_create(struct wl_display *display);
 void wlr_multi_backend_add(struct wlr_backend *multi,
 	struct wlr_backend *backend);
 
+void wlr_multi_backend_remove(struct wlr_backend *multi,
+	struct wlr_backend *backend);
+
 bool wlr_backend_is_multi(struct wlr_backend *backend);
 
 struct wlr_session *wlr_multi_get_session(struct wlr_backend *base);

--- a/include/wlr/backend/multi.h
+++ b/include/wlr/backend/multi.h
@@ -16,4 +16,6 @@ bool wlr_backend_is_multi(struct wlr_backend *backend);
 
 struct wlr_session *wlr_multi_get_session(struct wlr_backend *base);
 
+bool wlr_multi_is_empty(struct wlr_backend *backend);
+
 #endif

--- a/include/wlr/backend/multi.h
+++ b/include/wlr/backend/multi.h
@@ -4,8 +4,8 @@
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
 
-struct wlr_backend *wlr_multi_backend_create(struct wl_display *display,
-	struct wlr_session *session);
+struct wlr_backend *wlr_multi_backend_create(struct wl_display *display);
+
 void wlr_multi_backend_add(struct wlr_backend *multi,
 	struct wlr_backend *backend);
 

--- a/rootston/main.c
+++ b/rootston/main.c
@@ -5,6 +5,7 @@
 #include <wayland-server.h>
 #include <wlr/backend.h>
 #include <wlr/backend/headless.h>
+#include <wlr/backend/multi.h>
 #include <wlr/render.h>
 #include <wlr/render/gles2.h>
 #include <wlr/util/log.h>
@@ -31,6 +32,12 @@ int main(int argc, char **argv) {
 	assert(server.wl_event_loop = wl_display_get_event_loop(server.wl_display));
 
 	assert(server.backend = wlr_backend_autocreate(server.wl_display));
+
+	if (wlr_multi_is_empty(server.backend)) {
+		wlr_log(L_ERROR, "could not start backend");
+		wlr_backend_destroy(server.backend);
+		return 1;
+	}
 
 	assert(server.renderer = wlr_gles2_renderer_create(server.backend));
 	server.data_device_manager =

--- a/rootston/main.c
+++ b/rootston/main.c
@@ -31,9 +31,9 @@ int main(int argc, char **argv) {
 	assert(server.wl_display = wl_display_create());
 	assert(server.wl_event_loop = wl_display_get_event_loop(server.wl_display));
 
-	assert(server.backend = wlr_backend_autocreate(server.wl_display));
+	server.backend = wlr_backend_autocreate(server.wl_display);
 
-	if (wlr_multi_is_empty(server.backend)) {
+	if (server.backend == NULL) {
 		wlr_log(L_ERROR, "could not start backend");
 		wlr_backend_destroy(server.backend);
 		return 1;


### PR DESCRIPTION
Preparation for the multibackend features of sway outlined in [sway#1529](https://github.com/swaywm/sway/issues/1529).

Changes:

* [x] backend destroy event
* [x] remove assumption that the multibackend must have a session (drm backend can be destroyed/recreated and the multibackend lives on or multibackend on X11+Wayland only)
* [x] #503 - return multibackend from autocreate in a useful way
* [x] `wlr_multi_backend_remove()`
* [x] backend_add and backend_remove events

Open issues:

* Does the multibackend own the wlr-backend children? That is, do we really want to destroy the wlr-backends when the parent multi is destroyed?
* Current implementation will return an empty (non-NULL but no subbackends) wlr-multi-backend instead of NULL when no backends could be created
* When you add a backend to the multi, will it reemit all of the outputs and inputs on added multibackend for the newly added backend? (current solution: no, use the backend_add and backend_remove events to do this)