### PR TITLE
Fix rootston seat button count

### DIFF
--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -166,6 +166,13 @@ static void roots_cursor_press_button(struct roots_cursor *cursor,
 		}
 		return;
 	}
+	if (state == WLR_BUTTON_RELEASED &&
+			cursor->mode != ROOTS_CURSOR_PASSTHROUGH) {
+		cursor->mode = ROOTS_CURSOR_PASSTHROUGH;
+		if (seat->seat->pointer_state.button_count == 0) {
+			return;
+		}
+	}
 
 	uint32_t serial;
 	if (is_touch) {
@@ -178,7 +185,6 @@ static void roots_cursor_press_button(struct roots_cursor *cursor,
 	int i;
 	switch (state) {
 	case WLR_BUTTON_RELEASED:
-		seat->cursor->mode = ROOTS_CURSOR_PASSTHROUGH;
 		if (!is_touch) {
 			roots_cursor_update_position(cursor, time);
 		}


### PR DESCRIPTION
When we're moving a window, this can be:
* Because the client has sent a move request, in which case the client got the button press, and we need to send the button released event to the seat
* Because of a keybinding, in which case we don't send the button pressed event to the seat, and we have not to send the button released event to the seat

Test plan: open `weston-dnd`, move the window with the titlebar and with rootston keybindings, try to drag some flowers.

Fixes #493