### PR TITLE
Add libdrm as dependency for wlr_backend

### DIFF
--- a/backend/meson.build
+++ b/backend/meson.build
@@ -45,5 +45,5 @@ lib_wlr_backend = static_library(
 	'wlr_backend',
 	backend_files,
 	include_directories: wlr_inc,
-	dependencies: [wayland_server, egl, gbm, libinput, systemd, elogind, wlr_render, wlr_protos],
+	dependencies: [wayland_server, egl, gbm, libinput, systemd, elogind, wlr_render, wlr_protos, drm],
 )


### PR DESCRIPTION
Without this patch I'm getting the following build error when building
with Nix. On other platforms it probably works because `libdrm` can be found anyway:

```
[34/160] Linking static target render/libwlr_render.a.
[35/160] Generating 'backend/wlr_backend@sta/xdg-shell-unstable-v6-protocol.h'.
[36/160] Generating 'backend/wlr_backend@sta/gamma-control-protocol.h'.
[37/160] Generating 'backend/wlr_backend@sta/screenshooter-protocol.h'.
[38/160] Generating 'backend/wlr_backend@sta/server-decoration-protocol.h'.
[39/160] Generating 'backend/wlr_backend@sta/xdg-shell-unstable-v6-client-protocol.h'.
[40/160] Generating 'backend/wlr_backend@sta/gamma-control-client-protocol.h'.
[41/160] Generating 'backend/wlr_backend@sta/screenshooter-client-protocol.h'.
[42/160] Generating 'backend/wlr_backend@sta/server-decoration-client-protocol.h'.
[43/160] Compiling C object 'backend/wlr_backend@sta/backend.c.o'.
[44/160] Compiling C object 'backend/wlr_backend@sta/session_direct-ipc.c.o'.
FAILED: backend/wlr_backend@sta/session_direct-ipc.c.o 
gcc  -Ibackend/wlr_backend@sta -Ibackend -I../backend -I../include -Irender -I/nix/store/8s4r1yl22a01vj5246khsiw3gn0qxf2s-wayland-1.14.0/include -I/nix/store/zqd5iqrnpiciz78kf4ifm2l0kmi5zhz1-mesa-noglu-17.2.7-dev/include -I/nix/store/spzp2vjc326srg26jxn8wyq57h7hy9r4-libinput-1.9.3-dev/include -I/nix/store/k9pch32rvxl10akhsq3apwl8v055ax4a-systemd-234-dev/include -I/tmp/nix-build-wlroots-unstable-2017-12-22.drv-0/source/build -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -std=c11 -O3 -Wno-unused-parameter '-DWLR_SRC_DIR="/tmp/nix-build-wlroots-unstable-2017-12-22.drv-0/source"' -DWL_HIDE_DEPRECATED -DHAS_XCB_ICCCM -DHAS_LIBCAP -DHAS_SYSTEMD -DHAS_XWAYLAND -fPIC -MMD -MQ 'backend/wlr_backend@sta/session_direct-ipc.c.o' -MF 'backend/wlr_backend@sta/session_direct-ipc.c.o.d' -o 'backend/wlr_backend@sta/session_direct-ipc.c.o' -c ../backend/session/direct-ipc.c
In file included from ../backend/session/direct-ipc.c:20:0:
/nix/store/9ac27wk5vh47p28gladbdfafpidrx9rh-libdrm-2.4.88-dev/include/xf86drm.h:40:17: fatal error: drm.h: No such file or directory
 #include <drm.h>
                 ^
compilation terminated.
ninja: build stopped: subcommand failed.
builder for ‘/nix/store/lnhwf239sl6zkmzxhf5mcvhpp6wp2ixh-wlroots-unstable-2017-12-22.drv’ failed with exit code 1
error: build of ‘/nix/store/lnhwf239sl6zkmzxhf5mcvhpp6wp2ixh-wlroots-unstable-2017-12-22.drv’ failed
```