### PR TITLE
enabled libcap by default on arch buildpkg (arch default)

### DIFF
--- a/dist/archlinux/PKGBUILD
+++ b/dist/archlinux/PKGBUILD
@@ -1,5 +1,8 @@
+# Maintainer: Drew DeVault <sir@cmpwn.com>
+# Contributor: chrisaw <home@chrisaw.com>
+
 pkgname=wlroots
-pkgver=r600.d89272d
+pkgver=git
 pkgrel=1
 license=('MIT')
 pkgdesc='Wayland compositor library'
@@ -36,7 +39,7 @@ build() {
 		-Db_lto=True \
 		-Denable-systemd=True \
 		-Denable-elogind=False \
-		-Denable-libcap=False
+		-Denable-libcap=True
 
 	ninja -C build
 }


### PR DESCRIPTION
It looks like libcap needs to be enabled by default on ArchLinux since Arch pushes systemd and logind which require libcap to be enabled.

I may be missing something here though so happy to be corrected.