### PR TITLE
rootston: add arbitrary libinput config 'tap_enabled'

### DIFF
--- a/include/rootston/config.h
+++ b/include/rootston/config.h
@@ -21,6 +21,7 @@ struct roots_device_config {
 	char *name;
 	char *seat;
 	char *mapped_output;
+	bool tap_enabled;
 	struct wlr_box *mapped_box;
 	struct wl_list link;
 };

--- a/rootston/config.c
+++ b/rootston/config.c
@@ -342,6 +342,16 @@ static int config_ini_handler(void *user, const char *section, const char *name,
 		} else if (strcmp(name, "seat") == 0) {
 			free(dc->seat);
 			dc->seat = strdup(value);
+		} else if (strcmp(name, "tap_enabled") == 0) {
+			if (strcasecmp(value, "true") == 0) {
+				dc->tap_enabled = true;
+			} else if (strcasecmp(value, "false") == 0) {
+				dc->tap_enabled = false;
+			} else {
+				wlr_log(L_ERROR,
+					"got unknown tap_enabled value: %s",
+					value);
+			}
 		} else {
 			wlr_log(L_ERROR, "got unknown device config: %s", name);
 		}

--- a/rootston/input.c
+++ b/rootston/input.c
@@ -5,6 +5,7 @@
 #include <wlr/util/log.h>
 #include <wlr/xcursor.h>
 #include <wlr/xwayland.h>
+#include <wlr/backend/libinput.h>
 #include "rootston/server.h"
 #include "rootston/config.h"
 #include "rootston/input.h"
@@ -60,6 +61,17 @@ static void input_add_notify(struct wl_listener *listener, void *data) {
 			device->vendor, device->product, device_type(device->type), seat_name);
 
 	roots_seat_add_device(seat, device);
+
+	if (dc && wlr_input_device_is_libinput(device)) {
+		struct libinput_device *libinput_dev =
+			wlr_libinput_get_device_handle(device);
+
+		wlr_log(L_DEBUG, "input has config, tap_enabled: %d\n", dc->tap_enabled);
+		if (dc->tap_enabled) {
+			libinput_device_config_tap_set_enabled(libinput_dev,
+					LIBINPUT_CONFIG_TAP_ENABLED);
+		}
+	}
 }
 
 static void input_remove_notify(struct wl_listener *listener, void *data) {

--- a/rootston/rootston.ini.example
+++ b/rootston/rootston.ini.example
@@ -30,6 +30,7 @@ theme = default
 map-to-output = VGA-1
 # Restrict cursor movements for this mouse to concrete rectangle
 geometry = 2500x800
+# tap_enabled=true
 
 [keyboard]
 meta-key = Logo


### PR DESCRIPTION
This ought to be enough to serve as an example for other compsitors to use.

I've already done the sway config as well, so not sure this is actually strictly neeeded, but I guess it can't hurt?

One last reference to #497 to properly close it in my head :)