### PR TITLE
adds a configure_notify event to xwayland

### DIFF
--- a/include/wlr/xwayland.h
+++ b/include/wlr/xwayland.h
@@ -125,6 +125,7 @@ struct wlr_xwayland_surface {
 
 		struct wl_signal map_notify;
 		struct wl_signal unmap_notify;
+		struct wl_signal configure_notify;
 		struct wl_signal set_title;
 		struct wl_signal set_class;
 		struct wl_signal set_parent;

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -102,6 +102,7 @@ static struct wlr_xwayland_surface *wlr_xwayland_surface_create(
 	wl_signal_init(&surface->events.request_fullscreen);
 	wl_signal_init(&surface->events.map_notify);
 	wl_signal_init(&surface->events.unmap_notify);
+	wl_signal_init(&surface->events.configure_notify);
 	wl_signal_init(&surface->events.set_class);
 	wl_signal_init(&surface->events.set_title);
 	wl_signal_init(&surface->events.set_parent);
@@ -632,6 +633,22 @@ static void xwm_handle_configure_notify(struct wlr_xwm *xwm,
 	xsurface->y = ev->y;
 	xsurface->width = ev->width;
 	xsurface->height = ev->height;
+
+	struct wlr_xwayland_surface_configure_event *wlr_event =
+		calloc(1, sizeof(struct wlr_xwayland_surface_configure_event));
+	if (wlr_event == NULL) {
+		return;
+	}
+
+	wlr_event->surface = xsurface;
+	wlr_event->x = ev->x;
+	wlr_event->y = ev->y;
+	wlr_event->width = ev->width;
+	wlr_event->height = ev->height;
+
+	wl_signal_emit(&xsurface->events.request_configure, wlr_event);
+
+	free(wlr_event);
 }
 
 #define ICCCM_WITHDRAWN_STATE	0

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -622,6 +622,8 @@ static void xwm_handle_configure_request(struct wlr_xwm *xwm,
 
 static void xwm_handle_configure_notify(struct wlr_xwm *xwm,
 		xcb_configure_notify_event_t *ev) {
+	wlr_log(L_DEBUG, "XCB_CONFIGURE_NOTIFY (%u) [%ux%u+%d,%d]", ev->window,
+		ev->width, ev->height, ev->x, ev->y);
 	struct wlr_xwayland_surface *xsurface =
 		lookup_surface(xwm, ev->window);
 
@@ -634,21 +636,15 @@ static void xwm_handle_configure_notify(struct wlr_xwm *xwm,
 	xsurface->width = ev->width;
 	xsurface->height = ev->height;
 
-	struct wlr_xwayland_surface_configure_event *wlr_event =
-		calloc(1, sizeof(struct wlr_xwayland_surface_configure_event));
-	if (wlr_event == NULL) {
-		return;
-	}
+	struct wlr_xwayland_surface_configure_event wlr_event;
 
-	wlr_event->surface = xsurface;
-	wlr_event->x = ev->x;
-	wlr_event->y = ev->y;
-	wlr_event->width = ev->width;
-	wlr_event->height = ev->height;
+	wlr_event.surface = xsurface;
+	wlr_event.x = ev->x;
+	wlr_event.y = ev->y;
+	wlr_event.width = ev->width;
+	wlr_event.height = ev->height;
 
-	wl_signal_emit(&xsurface->events.request_configure, wlr_event);
-
-	free(wlr_event);
+	wl_signal_emit(&xsurface->events.configure_notify, &wlr_event);
 }
 
 #define ICCCM_WITHDRAWN_STATE	0


### PR DESCRIPTION
To know when a client reacts to a resize or other event we can listen to
the configure event on xdg_shell.
For xwayland the required event isn't exported so far.
This adds a signal to wlr_xwayland_surface that's fired whenever it
changes position or size.