### PR TITLE
add nop command

### DIFF
--- a/rootston/keyboard.c
+++ b/rootston/keyboard.c
@@ -117,6 +117,8 @@ static void keyboard_binding_execute(struct roots_keyboard *keyboard,
 		if (focus != NULL) {
 			view_maximize(focus, !focus->maximized);
 		}
+	} else if (strcmp(command, "nop") == 0) {
+		wlr_log(L_DEBUG, "nop command");
 	} else {
 		wlr_log(L_ERROR, "unknown binding command: %s", command);
 	}


### PR DESCRIPTION
The `nop` command can be used by developers to test things at runtime. Arbitrary code can be put in the nop command handler and shared with diffs to demonstrate issues in bug reports.