### PR TITLE
Fix cursor on transformed output with DRM backend

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -543,10 +543,11 @@ static bool wlr_drm_connector_set_cursor(struct wlr_output *output,
 
 		// OpenGL will read the pixels out upside down,
 		// so we need to flip the image vertically
+		enum wl_output_transform transform = wlr_output_transform_compose(
+			wlr_output_transform_invert(output->transform),
+			WL_OUTPUT_TRANSFORM_FLIPPED_180);
 		wlr_matrix_texture(plane->matrix, plane->surf.width, plane->surf.height,
-			conn->output.transform ^ WL_OUTPUT_TRANSFORM_FLIPPED_180);
-
-		// TODO the image needs to be rotated depending on the output rotation
+			transform);
 
 		plane->wlr_tex =
 			wlr_render_texture_create(plane->surf.renderer->wlr_rend);

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -118,6 +118,9 @@ bool wlr_output_cursor_move(struct wlr_output_cursor *cursor,
 	double x, double y);
 void wlr_output_cursor_destroy(struct wlr_output_cursor *cursor);
 
-enum wl_output_transform wlr_output_transform_invert(enum wl_output_transform);
+enum wl_output_transform wlr_output_transform_invert(
+	enum wl_output_transform tr);
+enum wl_output_transform wlr_output_transform_compose(
+	enum wl_output_transform tr_a, enum wl_output_transform tr_b);
 
 #endif

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -118,8 +118,18 @@ bool wlr_output_cursor_move(struct wlr_output_cursor *cursor,
 	double x, double y);
 void wlr_output_cursor_destroy(struct wlr_output_cursor *cursor);
 
+
+/**
+ * Returns the transform that, when composed with `tr`, gives
+ * `WL_OUTPUT_TRANSFORM_NORMAL`.
+ */
 enum wl_output_transform wlr_output_transform_invert(
 	enum wl_output_transform tr);
+
+/**
+ * Returns a transform that, when applied, has the same effect as applying
+ * sequentially `tr_a` and `tr_b`.
+ */
 enum wl_output_transform wlr_output_transform_compose(
 	enum wl_output_transform tr_a, enum wl_output_transform tr_b);
 

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -726,11 +726,22 @@ void wlr_output_cursor_destroy(struct wlr_output_cursor *cursor) {
 	free(cursor);
 }
 
+
 enum wl_output_transform wlr_output_transform_invert(
-		enum wl_output_transform transform) {
-	if ((transform & WL_OUTPUT_TRANSFORM_90) &&
-			!(transform & WL_OUTPUT_TRANSFORM_FLIPPED)) {
-		transform ^= WL_OUTPUT_TRANSFORM_180;
+		enum wl_output_transform tr) {
+	if ((tr & WL_OUTPUT_TRANSFORM_90) && !(tr & WL_OUTPUT_TRANSFORM_FLIPPED)) {
+		tr ^= WL_OUTPUT_TRANSFORM_180;
 	}
-	return transform;
+	return tr;
+}
+
+enum wl_output_transform wlr_output_transform_compose(
+		enum wl_output_transform tr_a, enum wl_output_transform tr_b) {
+	uint32_t flipped = (tr_a ^ tr_b) & WL_OUTPUT_TRANSFORM_FLIPPED;
+	uint32_t rotated =
+		(tr_a + tr_b) & (WL_OUTPUT_TRANSFORM_90 | WL_OUTPUT_TRANSFORM_180);
+	if ((tr_a & WL_OUTPUT_TRANSFORM_FLIPPED) && (tr_b & WL_OUTPUT_TRANSFORM_FLIPPED)) {
+		rotated = wlr_output_transform_invert(rotated);
+	}
+	return flipped | rotated;
 }


### PR DESCRIPTION
This PR aims to fix issues with cursor on transformed outputs with the DRM backend. For some output transforms, the hardware cursor was not transformed or not at the correct position. I think these issues have been introduced when fixing flipped-90 and flipped-270 transforms in the surface transforms PR.

This PR aims to fix output transforms and check for any corner case issue.

Test plan:
* For the Wayland and DRM backends
* Configure the output transform to normal, 90, 180, 270, flipped, flipped-90, flipped-180, flipped-270 (90 and flipped-90 are the more important ones, because they're tricky)
* Spawn `weston-terminal` (has a surface transform) and `gnome-calculator` (doesn't have a surface transform), check that both have the same orientation
* Move the mouse over these two windows, check that the hardware cursor position agrees with the software cursor position (by checking that the cursor doesn't jump when entering the window)
* Try to move a window and check that the window moves in the same way as the cursor

Fixes #517