### PR TITLE
config: Put all defines into config.h

### DIFF
--- a/backend/session/direct-ipc.c
+++ b/backend/session/direct-ipc.c
@@ -18,12 +18,13 @@
 #include <linux/major.h>
 #endif
 #include <xf86drm.h>
+#include "config.h"
 #include <wlr/util/log.h>
 #include "backend/session/direct-ipc.h"
 
 enum { DRM_MAJOR = 226 };
 
-#ifdef HAS_LIBCAP
+#ifdef WLR_HAS_LIBCAP
 #include <sys/capability.h>
 
 static bool have_permissions(void) {

--- a/backend/session/logind.c
+++ b/backend/session/logind.c
@@ -10,13 +10,14 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <wayland-server.h>
+#include "config.h"
 #include <wlr/backend/session/interface.h>
 #include <wlr/util/log.h>
 
-#ifdef HAS_SYSTEMD
+#ifdef WLR_HAS_SYSTEMD
 	#include <systemd/sd-bus.h>
 	#include <systemd/sd-login.h>
-#elif HAS_ELOGIND
+#elif WLR_HAS_ELOGIND
 	#include <elogind/sd-bus.h>
 	#include <elogind/sd-login.h> 
 #endif

--- a/backend/session/session.c
+++ b/backend/session/session.c
@@ -9,6 +9,7 @@
 #include <wayland-server.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
+#include "config.h"
 #include <wlr/backend/session.h>
 #include <wlr/backend/session/interface.h>
 #include <wlr/util/log.h>
@@ -17,9 +18,9 @@ extern const struct session_impl session_logind;
 extern const struct session_impl session_direct;
 
 static const struct session_impl *impls[] = {
-#ifdef HAS_SYSTEMD
+#ifdef WLR_HAS_SYSTEMD
 	&session_logind,
-#elif HAS_ELOGIND
+#elif WLR_HAS_ELOGIND
 	&session_logind,
 #endif
 	&session_direct,

--- a/examples/support/config.c
+++ b/examples/support/config.c
@@ -7,10 +7,10 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/param.h>
+#include "config.h"
 #include <wlr/util/log.h>
 #include <wlr/types/wlr_box.h>
 #include "shared.h"
-#include "config.h"
 #include "ini.h"
 
 static void usage(const char *name, int ret) {

--- a/include/rootston/desktop.h
+++ b/include/rootston/desktop.h
@@ -2,6 +2,7 @@
 #define _ROOTSTON_DESKTOP_H
 #include <time.h>
 #include <wayland-server.h>
+#include "config.h"
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_compositor.h>
@@ -50,7 +51,7 @@ struct roots_desktop {
 	struct wl_listener wl_shell_surface;
 	struct wl_listener decoration_new;
 
-#ifdef HAS_XWAYLAND
+#ifdef WLR_HAS_XWAYLAND
 	struct wlr_xwayland *xwayland;
 	struct wl_listener xwayland_surface;
 	struct wl_listener xwayland_ready;

--- a/include/rootston/server.h
+++ b/include/rootston/server.h
@@ -1,11 +1,12 @@
 #ifndef _ROOTSTON_SERVER_H
 #define _ROOTSTON_SERVER_H
 #include <wayland-server.h>
+#include "config.h"
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/render.h>
-#ifdef HAS_XWAYLAND
+#ifdef WLR_HAS_XWAYLAND
 #include <wlr/xwayland.h>
 #endif
 #include "rootston/config.h"

--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -2,6 +2,7 @@
 #define _ROOTSTON_VIEW_H
 
 #include <stdbool.h>
+#include "config.h"
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_surface.h>
 #include <wlr/types/wlr_xdg_shell_v6.h>
@@ -79,14 +80,14 @@ struct roots_view {
 	union {
 		struct wlr_wl_shell_surface *wl_shell_surface;
 		struct wlr_xdg_surface_v6 *xdg_surface_v6;
-#ifdef HAS_XWAYLAND
+#ifdef WLR_HAS_XWAYLAND
 		struct wlr_xwayland_surface *xwayland_surface;
 #endif
 	};
 	union {
 		struct roots_wl_shell_surface *roots_wl_shell_surface;
 		struct roots_xdg_surface_v6 *roots_xdg_surface_v6;
-#ifdef HAS_XWAYLAND
+#ifdef WLR_HAS_XWAYLAND
 		struct roots_xwayland_surface *roots_xwayland_surface;
 #endif
 	};

--- a/include/wlr/xwayland.h
+++ b/include/wlr/xwayland.h
@@ -3,11 +3,12 @@
 
 #include <time.h>
 #include <stdbool.h>
+#include "config.h"
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_seat.h>
 #include <xcb/xcb.h>
 
-#ifdef HAS_XCB_ICCCM
+#ifdef WLR_HAS_XCB_ICCCM
 	#include <xcb/xcb_icccm.h>
 #endif
 

--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,8 @@ add_project_link_arguments(
 	language: 'c',
 )
 
+conf_data = configuration_data()
+
 wlr_inc = include_directories('include')
 
 cc = meson.get_compiler('c')
@@ -63,26 +65,24 @@ elogind        = dependency('libelogind', required: false)
 math           = cc.find_library('m', required: false)
 
 if xcb_icccm.found()
-	add_project_arguments('-DHAS_XCB_ICCCM', language: 'c')
+	conf_data.set('WLR_HAS_XCB_ICCCM', true)
 endif
 
 if libcap.found() and get_option('enable_libcap')
-	add_project_arguments('-DHAS_LIBCAP', language: 'c')
+	conf_data.set('WLR_HAS_LIBCAP', true)
 endif
 
 if systemd.found() and get_option('enable_systemd')
-	add_project_arguments('-DHAS_SYSTEMD', language: 'c')
+	conf_data.set('WLR_HAS_SYSTEMD', true)
 endif
 
 if elogind.found() and get_option('enable_elogind')
-	add_project_arguments('-DHAS_ELOGIND', language: 'c')
+	conf_data.set('WLR_HAS_ELOGIND', true)
 endif
 
 exclude_files = []
 wlr_parts = []
-conf_data = configuration_data()
 if get_option('enable_xwayland')
-	add_project_arguments('-DHAS_XWAYLAND', language: 'c')
 	subdir('xwayland')
 	wlr_parts += [lib_wlr_xwayland]
 	conf_data.set('WLR_HAS_XWAYLAND', true)

--- a/rootston/config.c
+++ b/rootston/config.c
@@ -9,6 +9,7 @@
 #include <strings.h>
 #include <unistd.h>
 #include <sys/param.h>
+#include "config.h"
 #include <wlr/util/log.h>
 #include <wlr/types/wlr_box.h>
 #include "rootston/config.h"

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -3,6 +3,7 @@
 #include <time.h>
 #include <stdlib.h>
 #include <math.h>
+#include "config.h"
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_cursor.h>
@@ -440,7 +441,7 @@ struct roots_desktop *desktop_create(struct roots_server *server,
 		&desktop->wl_shell_surface);
 	desktop->wl_shell_surface.notify = handle_wl_shell_surface;
 
-#ifdef HAS_XWAYLAND
+#ifdef WLR_HAS_XWAYLAND
 	if (config->xwayland) {
 		desktop->xwayland = wlr_xwayland_create(server->wl_display,
 			desktop->compositor);

--- a/rootston/main.c
+++ b/rootston/main.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <wayland-server.h>
+#include "config.h"
 #include <wlr/backend.h>
 #include <wlr/backend/headless.h>
 #include <wlr/backend/multi.h>
@@ -64,7 +65,7 @@ int main(int argc, char **argv) {
 	}
 
 	setenv("WAYLAND_DISPLAY", socket, true);
-#ifndef HAS_XWAYLAND
+#ifndef WLR_HAS_XWAYLAND
 	ready(NULL, NULL);
 #else
 	if (server.desktop->xwayland != NULL) {

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <wayland-server.h>
+#include "config.h"
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/util/log.h>
 #include "rootston/xcursor.h"

--- a/rootston/xwayland.c
+++ b/rootston/xwayland.c
@@ -2,11 +2,12 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <wayland-server.h>
+#include "config.h"
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_surface.h>
 #include <wlr/xwayland.h>
 #include <wlr/util/log.h>
-#include "rootston/desktop.h"
+#include "rootston/server.h"
 #include "rootston/server.h"
 
 static void activate(struct roots_view *view, bool active) {

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <wayland-server.h>
+#include "config.h"
 #include <wlr/types/wlr_xdg_shell_v6.h>
 #include <wlr/types/wlr_surface.h>
 #include <wlr/types/wlr_seat.h>

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -7,6 +7,7 @@
 #include <xcb/xfixes.h>
 #include <xcb/xcb_image.h>
 #include <xcb/render.h>
+#include "config.h"
 #include "wlr/util/log.h"
 #include "wlr/util/edges.h"
 #include "wlr/types/wlr_surface.h"
@@ -14,7 +15,7 @@
 #include "wlr/xcursor.h"
 #include "wlr/xwm.h"
 
-#ifdef HAS_XCB_ICCCM
+#ifdef WLR_HAS_XCB_ICCCM
 	#include <xcb/xcb_icccm.h>
 #endif
 
@@ -365,7 +366,7 @@ static void read_surface_protocols(struct wlr_xwm *xwm,
 	wlr_log(L_DEBUG, "WM_PROTOCOLS (%zu)", atoms_len);
 }
 
-#ifdef HAS_XCB_ICCCM
+#ifdef WLR_HAS_XCB_ICCCM
 static void read_surface_hints(struct wlr_xwm *xwm,
 		struct wlr_xwayland_surface *xsurface,
 		xcb_get_property_reply_t *reply) {
@@ -396,7 +397,7 @@ static void read_surface_hints(struct wlr_xwm *xwm,
 }
 #endif
 
-#ifdef HAS_XCB_ICCCM
+#ifdef WLR_HAS_XCB_ICCCM
 static void read_surface_normal_hints(struct wlr_xwm *xwm,
 		struct wlr_xwayland_surface *xsurface,
 		xcb_get_property_reply_t *reply) {


### PR DESCRIPTION
This makes sense, given that there are installed header-files, which rely on some of those defines.