### PR TITLE
[wip] Role committed

### DIFF
--- a/include/wlr/types/wlr_data_device.h
+++ b/include/wlr/types/wlr_data_device.h
@@ -72,7 +72,6 @@ struct wlr_drag_icon {
 	} events;
 
 	struct wl_listener surface_destroy;
-	struct wl_listener surface_commit;
 	struct wl_listener seat_client_destroy;
 };
 

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -77,6 +77,10 @@ struct wlr_surface {
 	struct wl_listener compositor_listener;
 	void *compositor_data;
 
+	// surface commit callback for the role that runs before all others
+	void (*role_committed)(struct wlr_surface *surface, void *role_data);
+	void *role_data;
+
 	// subsurface properties
 	struct wlr_subsurface *subsurface;
 	struct wl_list subsurface_list; // wlr_subsurface::parent_link
@@ -145,5 +149,13 @@ void wlr_surface_send_leave(struct wlr_surface *surface,
 
 void wlr_surface_send_frame_done(struct wlr_surface *surface,
 		const struct timespec *when);
+
+/**
+ * Set a callback for surface commit that runs before all the other callbacks.
+ * This is intended for use by the surface role.
+ */
+void wlr_surface_set_role_committed(struct wlr_surface *surface,
+		void (*role_committed)(struct wlr_surface *surface, void *role_data),
+		void *role_data);
 
 #endif

--- a/include/wlr/types/wlr_wl_shell.h
+++ b/include/wlr/types/wlr_wl_shell.h
@@ -70,7 +70,6 @@ struct wlr_wl_shell_surface {
 	char *class;
 
 	struct wl_listener surface_destroy_listener;
-	struct wl_listener surface_commit_listener;
 
 	struct wlr_wl_shell_surface *parent;
 	struct wl_list popup_link;
@@ -79,7 +78,6 @@ struct wlr_wl_shell_surface {
 
 	struct {
 		struct wl_signal destroy;
-		struct wl_signal commit;
 		struct wl_signal ping_timeout;
 
 		struct wl_signal request_move;

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -122,10 +122,8 @@ struct wlr_xdg_surface_v6 {
 	struct wlr_box *geometry;
 
 	struct wl_listener surface_destroy_listener;
-	struct wl_listener surface_commit_listener;
 
 	struct {
-		struct wl_signal commit;
 		struct wl_signal destroy;
 		struct wl_signal ping_timeout;
 

--- a/include/wlr/xwayland.h
+++ b/include/wlr/xwayland.h
@@ -133,7 +133,6 @@ struct wlr_xwayland_surface {
 	} events;
 
 	struct wl_listener surface_destroy;
-	struct wl_listener surface_commit;
 
 	void *data;
 };

--- a/rootston/wl_shell.c
+++ b/rootston/wl_shell.c
@@ -150,7 +150,7 @@ void handle_wl_shell_surface(struct wl_listener *listener, void *data) {
 	roots_surface->set_state.notify = handle_set_state;
 	wl_signal_add(&surface->events.set_state, &roots_surface->set_state);
 	roots_surface->surface_commit.notify = handle_surface_commit;
-	wl_signal_add(&surface->events.commit, &roots_surface->surface_commit);
+	wl_signal_add(&surface->surface->events.commit, &roots_surface->surface_commit);
 
 	struct roots_view *view = calloc(1, sizeof(struct roots_view));
 	if (!view) {

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -253,7 +253,7 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 		return;
 	}
 	roots_surface->commit.notify = handle_commit;
-	wl_signal_add(&surface->events.commit, &roots_surface->commit);
+	wl_signal_add(&surface->surface->events.commit, &roots_surface->commit);
 	roots_surface->destroy.notify = handle_destroy;
 	wl_signal_add(&surface->events.destroy, &roots_surface->destroy);
 	roots_surface->request_move.notify = handle_request_move;

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -428,6 +428,10 @@ static void wlr_surface_commit_pending(struct wlr_surface *surface) {
 		}
 	}
 
+	if (surface->role_committed) {
+		surface->role_committed(surface, surface->role_data);
+	}
+
 	// TODO: add the invalid bitfield to this callback
 	wl_signal_emit(&surface->events.commit, surface);
 }
@@ -942,4 +946,11 @@ void wlr_surface_send_frame_done(struct wlr_surface *surface,
 		wl_callback_send_done(cb->resource, timespec_to_msec(when));
 		wl_resource_destroy(cb->resource);
 	}
+}
+
+void wlr_surface_set_role_committed(struct wlr_surface *surface,
+		void (*role_committed)(struct wlr_surface *surface, void *role_data),
+		void *role_data) {
+	surface->role_committed = role_committed;
+	surface->role_data = role_data;
 }

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -220,7 +220,7 @@ static void wlr_xwayland_surface_destroy(
 
 	if (xsurface->surface) {
 		wl_list_remove(&xsurface->surface_destroy.link);
-		wl_list_remove(&xsurface->surface_commit.link);
+		wlr_surface_set_role_committed(xsurface->surface, NULL, NULL);
 	}
 
 	free(xsurface->title);
@@ -515,9 +515,9 @@ static void read_surface_property(struct wlr_xwm *xwm,
 	free(reply);
 }
 
-static void handle_surface_commit(struct wl_listener *listener, void *data) {
-	struct wlr_xwayland_surface *xsurface =
-		wl_container_of(listener, xsurface, surface_commit);
+static void handle_surface_commit(struct wlr_surface *wlr_surface,
+		void *role_data) {
+	struct wlr_xwayland_surface *xsurface = role_data;
 
 	if (!xsurface->added &&
 			wlr_surface_has_buffer(xsurface->surface) &&
@@ -558,8 +558,8 @@ static void xwm_map_shell_surface(struct wlr_xwm *xwm,
 		read_surface_property(xwm, xsurface, props[i]);
 	}
 
-	xsurface->surface_commit.notify = handle_surface_commit;
-	wl_signal_add(&surface->events.commit, &xsurface->surface_commit);
+	wlr_surface_set_role_committed(xsurface->surface, handle_surface_commit,
+		xsurface);
 
 	xsurface->surface_destroy.notify = handle_surface_destroy;
 	wl_signal_add(&surface->events.destroy, &xsurface->surface_destroy);
@@ -690,7 +690,7 @@ static void xwm_handle_unmap_notify(struct wlr_xwm *xwm,
 	}
 
 	if (xsurface->surface) {
-		wl_list_remove(&xsurface->surface_commit.link);
+		wlr_surface_set_role_committed(xsurface->surface, NULL, NULL);
 		wl_list_remove(&xsurface->surface_destroy.link);
 	}
 	xsurface->surface = NULL;


### PR DESCRIPTION
Add a private role-committed func to wlr-surface to ensure the role commit handler always runs before all the other handlers. This simplifies the api by removing the need for a commit event on the role types.

Role call:

* [x] xdg-shell
* [x] wl-shell
* [x] wl_pointer-cursor (no committed func)
* [x] wl_data_device-icon
* [x] wl_subsurface (no committed func)
* [x] xwayland