### PR TITLE
Serial validation for grab requests

### DIFF
--- a/include/rootston/cursor.h
+++ b/include/rootston/cursor.h
@@ -10,12 +10,6 @@ enum roots_cursor_mode {
 	ROOTS_CURSOR_ROTATE = 3,
 };
 
-struct roots_input_event {
-	uint32_t serial;
-	struct wlr_cursor *cursor;
-	struct wlr_input_device *device;
-};
-
 struct roots_cursor {
 	struct roots_seat *seat;
 	struct wlr_cursor *cursor;
@@ -32,9 +26,6 @@ struct roots_cursor {
 	int view_x, view_y, view_width, view_height;
 	float view_rotation;
 	uint32_t resize_edges;
-	// Ring buffer of input events that could trigger move/resize/rotate
-	int input_events_idx;
-	struct roots_input_event input_events[16];
 
 	struct wl_listener motion;
 	struct wl_listener motion_absolute;

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -509,4 +509,10 @@ int wlr_seat_touch_num_points(struct wlr_seat *seat);
  */
 bool wlr_seat_touch_has_grab(struct wlr_seat *seat);
 
+/**
+ * Check whether this serial is valid to start a grab action such as an
+ * interactive move or resize.
+ */
+bool wlr_seat_validate_grab_serial(struct wlr_seat *seat, uint32_t serial);
+
 #endif

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -174,15 +174,10 @@ static void roots_cursor_press_button(struct roots_cursor *cursor,
 		}
 	}
 
-	uint32_t serial;
-	if (is_touch) {
-		serial = wl_display_get_serial(desktop->server->wl_display);
-	} else {
-		serial =
-			wlr_seat_pointer_notify_button(seat->seat, time, button, state);
+	if (!is_touch) {
+		wlr_seat_pointer_notify_button(seat->seat, time, button, state);
 	}
 
-	int i;
 	switch (state) {
 	case WLR_BUTTON_RELEASED:
 		if (!is_touch) {
@@ -190,12 +185,6 @@ static void roots_cursor_press_button(struct roots_cursor *cursor,
 		}
 		break;
 	case WLR_BUTTON_PRESSED:
-		i = cursor->input_events_idx;
-		cursor->input_events[i].serial = serial;
-		cursor->input_events[i].cursor = cursor->cursor;
-		cursor->input_events[i].device = device;
-		cursor->input_events_idx = (i + 1)
-			% (sizeof(cursor->input_events) / sizeof(cursor->input_events[0]));
 		roots_seat_set_focus(seat, view);
 		break;
 	}

--- a/rootston/wl_shell.c
+++ b/rootston/wl_shell.c
@@ -43,7 +43,6 @@ static void handle_request_resize(struct wl_listener *listener, void *data) {
 	struct roots_input *input = view->desktop->server->input;
 	struct wlr_wl_shell_surface_resize_event *e = data;
 	struct roots_seat *seat = input_seat_from_wlr_seat(input, e->seat->seat);
-	// TODO verify input event
 	if (!seat || seat->cursor->mode != ROOTS_CURSOR_PASSTHROUGH) {
 		return;
 	}

--- a/types/wlr_seat.c
+++ b/types/wlr_seat.c
@@ -1216,3 +1216,8 @@ int wlr_seat_touch_num_points(struct wlr_seat *seat) {
 bool wlr_seat_touch_has_grab(struct wlr_seat *seat) {
 	return seat->touch_state.grab->interface != &default_touch_grab_impl;
 }
+
+bool wlr_seat_validate_grab_serial(struct wlr_seat *seat, uint32_t serial) {
+	return serial == seat->pointer_state.grab_serial ||
+		serial == seat->touch_state.grab_serial;
+}

--- a/types/wlr_wl_shell.c
+++ b/types/wlr_wl_shell.c
@@ -112,6 +112,11 @@ static void shell_surface_protocol_move(struct wl_client *client,
 	struct wlr_seat_client *seat =
 		wl_resource_get_user_data(seat_resource);
 
+	if (!wlr_seat_validate_grab_serial(seat->seat, serial)) {
+		wlr_log(L_DEBUG, "invalid serial for grab");
+		return;
+	}
+
 	struct wlr_wl_shell_surface_move_event event = {
 		.surface = surface,
 		.seat = seat,
@@ -169,6 +174,11 @@ static void shell_surface_protocol_resize(struct wl_client *client,
 	struct wlr_wl_shell_surface *surface = wl_resource_get_user_data(resource);
 	struct wlr_seat_client *seat =
 		wl_resource_get_user_data(seat_resource);
+
+	if (!wlr_seat_validate_grab_serial(seat->seat, serial)) {
+		wlr_log(L_DEBUG, "invalid serial for grab");
+		return;
+	}
 
 	struct wlr_wl_shell_surface_resize_event event = {
 		.surface = surface,

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -565,6 +565,11 @@ static void xdg_toplevel_protocol_show_window_menu(struct wl_client *client,
 		return;
 	}
 
+	if (!wlr_seat_validate_grab_serial(seat->seat, serial)) {
+		wlr_log(L_DEBUG, "invalid serial for grab");
+		return;
+	}
+
 	struct wlr_xdg_toplevel_v6_show_window_menu_event event = {
 		.surface = surface,
 		.seat = seat,
@@ -590,6 +595,11 @@ static void xdg_toplevel_protocol_move(struct wl_client *client,
 		return;
 	}
 
+	if (!wlr_seat_validate_grab_serial(seat->seat, serial)) {
+		wlr_log(L_DEBUG, "invalid serial for grab");
+		return;
+	}
+
 	struct wlr_xdg_toplevel_v6_move_event event = {
 		.surface = surface,
 		.seat = seat,
@@ -610,6 +620,11 @@ static void xdg_toplevel_protocol_resize(struct wl_client *client,
 		wl_resource_post_error(surface->toplevel_state->resource,
 			ZXDG_SURFACE_V6_ERROR_NOT_CONSTRUCTED,
 			"surface has not been configured yet");
+		return;
+	}
+
+	if (!wlr_seat_validate_grab_serial(seat->seat, serial)) {
+		wlr_log(L_DEBUG, "invalid serial for grab");
 		return;
 	}
 


### PR DESCRIPTION
Add serial validation for grab requests.

Grab requests handled:

* xdg-shell move,resize
* wl-shell move,resize

Xwayland shell events cannot be validated because there is no serial information.

We thought serial validation was necessary for setting selections, but the the protocol doesn't specify how to validate these serials and Weston does no serial validation, so we won't do any validation of those after all.

fixes #511 