### PR TITLE
Don't destroy backend in compositor_fini

### DIFF
--- a/examples/support/shared.c
+++ b/examples/support/shared.c
@@ -494,6 +494,5 @@ void compositor_init(struct compositor_state *state) {
 }
 
 void compositor_fini(struct compositor_state *state) {
-	wlr_backend_destroy(state->backend);
 	wl_display_destroy(state->display);
 }


### PR DESCRIPTION
This is already done after the changes in #504, and now just causes a
segfault on closing the examples.