### PR TITLE
Fixes for multiple outputs

### DIFF
--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -74,8 +74,8 @@ static void pointer_handle_motion(void *data, struct wl_pointer *wl_pointer,
 	wlr_event.time_msec = time;
 	wlr_event.width_mm = layout_box.width;
 	wlr_event.height_mm = layout_box.height;
-	wlr_event.x_mm = transformed.x + wlr_output->lx + layout_box.x;
-	wlr_event.y_mm = transformed.y + wlr_output->ly + layout_box.y;
+	wlr_event.x_mm = transformed.x + wlr_output->lx - layout_box.x;
+	wlr_event.y_mm = transformed.y + wlr_output->ly - layout_box.y;
 	wl_signal_emit(&dev->pointer->events.motion_absolute, &wlr_event);
 }
 

--- a/examples/screenshot.c
+++ b/examples/screenshot.c
@@ -220,16 +220,10 @@ static void write_image(const char *filename, int width, int height) {
 }
 
 static int set_buffer_size(int *width, int *height) {
-	struct screenshooter_output *output;
 	min_x = min_y = INT_MAX;
 	max_x = max_y = INT_MIN;
-	int position = 0;
 
-	wl_list_for_each_reverse(output, &output_list, link) {
-		output->offset_x = position;
-		position += output->width;
-	}
-
+	struct screenshooter_output *output;
 	wl_list_for_each(output, &output_list, link) {
 		min_x = MIN(min_x, output->offset_x);
 		min_y = MIN(min_y, output->offset_y);


### PR DESCRIPTION
* Fixes output positions in screenshots
* Fixes Wayland backend pointer events when output layout doesn't start at (0, 0)

Test plan:

```ini
[output:WL-1]
x = -500
y = -200

[output:WL-2]
x = 100
y = 50
```

Run `env WLR_WL_OUTPUTS=2 build/rootston/rootston`. Open some windows. Check that pointer events are at the right position. Put some windows between the two outputs, take a screenshot, check that outputs and windows are displayed correctly on the screenshot.

Fixes #392