### PR TITLE
Send mode info on DRM refresh only once

### DIFF
--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -163,16 +163,7 @@ bool wlr_output_set_mode(struct wlr_output *output,
 	if (!output->impl || !output->impl->set_mode) {
 		return false;
 	}
-	bool result = output->impl->set_mode(output, mode);
-	if (result) {
-		wlr_output_update_matrix(output);
-
-		struct wl_resource *resource;
-		wl_resource_for_each(resource, &output->wl_resources) {
-			wlr_output_send_current_mode_to_resource(resource);
-		}
-	}
-	return result;
+	return output->impl->set_mode(output, mode);
 }
 
 bool wlr_output_set_custom_mode(struct wlr_output *output, int32_t width,

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -171,16 +171,7 @@ bool wlr_output_set_custom_mode(struct wlr_output *output, int32_t width,
 	if (!output->impl || !output->impl->set_custom_mode) {
 		return false;
 	}
-	bool result = output->impl->set_custom_mode(output, width, height, refresh);
-	if (result) {
-		wlr_output_update_matrix(output);
-
-		struct wl_resource *resource;
-		wl_resource_for_each(resource, &output->wl_resources) {
-			wlr_output_send_current_mode_to_resource(resource);
-		}
-	}
-	return result;
+	return output->impl->set_custom_mode(output, width, height, refresh);
 }
 
 void wlr_output_update_mode(struct wlr_output *output,


### PR DESCRIPTION
When DRM refreshed, `wlr_output_set_mode` is called. It would then call
the DRM `set_mode` callback which sends the updated matrix and mode info.

However once that call completed it would then immediately send the
information again. This is handled poorly by xwayland, causing it to
scale up the clients twice.

I'm only half sure my reasoning is correct, so if someone with more knowledge on DRM / intricacies of the output part of the Wayland protocol wants to chime in that would be great.