### PR TITLE
Fix xwayland restart... and add wlr_seat destroy listener.

### DIFF
--- a/include/rootston/seat.h
+++ b/include/rootston/seat.h
@@ -21,6 +21,8 @@ struct roots_seat {
 	struct wl_list pointers;
 	struct wl_list touch;
 	struct wl_list tablet_tools;
+
+	struct wl_listener seat_destroy;
 };
 
 struct roots_seat_view {

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -207,6 +207,8 @@ struct wlr_seat {
 
 		struct wl_signal selection;
 		struct wl_signal primary_selection;
+
+		struct wl_signal destroy;
 	} events;
 
 	void *data;

--- a/include/wlr/xwayland.h
+++ b/include/wlr/xwayland.h
@@ -22,15 +22,17 @@ struct wlr_xwayland {
 	struct wl_client *client;
 	struct wl_display *wl_display;
 	struct wlr_compositor *compositor;
-	struct wlr_seat *seat;
 	time_t server_start;
 
 	struct wl_event_source *sigusr1_source;
 	struct wl_listener client_destroy;
 	struct wl_listener display_destroy;
-	struct wl_listener seat_destroy;
 	struct wlr_xwm *xwm;
 	struct wlr_xwayland_cursor *cursor;
+
+	/* Anything above seat is reset on Xwayland restart, rest is conserved */
+	struct wlr_seat *seat;
+	struct wl_listener seat_destroy;
 
 	struct {
 		struct wl_signal ready;

--- a/include/wlr/xwayland.h
+++ b/include/wlr/xwayland.h
@@ -28,6 +28,7 @@ struct wlr_xwayland {
 	struct wl_event_source *sigusr1_source;
 	struct wl_listener client_destroy;
 	struct wl_listener display_destroy;
+	struct wl_listener seat_destroy;
 	struct wlr_xwm *xwm;
 	struct wlr_xwayland_cursor *cursor;
 

--- a/include/wlr/xwm.h
+++ b/include/wlr/xwm.h
@@ -108,6 +108,7 @@ void xwm_set_cursor(struct wlr_xwm *xwm, const uint8_t *pixels, uint32_t stride,
 int xwm_handle_selection_event(struct wlr_xwm *xwm, xcb_generic_event_t *event);
 
 void xwm_selection_init(struct wlr_xwm *xwm);
+void xwm_selection_finish(struct wlr_xwm *xwm);
 
 void xwm_set_seat(struct wlr_xwm *xwm, struct wlr_seat *seat);
 

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -222,23 +222,23 @@ static void roots_seat_init_cursor(struct roots_seat *seat) {
 
 static void seat_view_destroy(struct roots_seat_view *seat_view);
 
-void roots_seat_destroy(struct roots_seat *seat) {
-	struct roots_seat_view *view, *nview;
-
-	// TODO: probably more to be freed here
-
-	wl_list_for_each_safe(view, nview, &seat->views, link) {
-		seat_view_destroy(view);
-	}
-	// Can be called from seat_destroy handler, so don't destroy seat
-}
-
 static void roots_seat_handle_seat_destroy(struct wl_listener *listener,
 		void *data) {
 	struct roots_seat *seat =
 		wl_container_of(listener, seat, seat_destroy);
 
-	roots_seat_destroy(seat);
+	// TODO: probably more to be freed here
+	wl_list_remove(&seat->seat_destroy.link);
+
+	struct roots_seat_view *view, *nview;
+	wl_list_for_each_safe(view, nview, &seat->views, link) {
+		seat_view_destroy(view);
+	}
+}
+
+void roots_seat_destroy(struct roots_seat *seat) {
+	roots_seat_handle_seat_destroy(&seat->seat_destroy, seat->seat);
+	wlr_seat_destroy(seat->seat);
 }
 
 struct roots_seat *roots_seat_create(struct roots_input *input, char *name) {

--- a/types/wlr_seat.c
+++ b/types/wlr_seat.c
@@ -348,7 +348,7 @@ void wlr_seat_destroy(struct wlr_seat *wlr_seat) {
 		return;
 	}
 
-	wl_signal_emit(&wlr_seat->events.destroy, NULL);
+	wl_signal_emit(&wlr_seat->events.destroy, wlr_seat);
 
 	wl_list_remove(&wlr_seat->display_destroy.link);
 

--- a/types/wlr_seat.c
+++ b/types/wlr_seat.c
@@ -348,6 +348,8 @@ void wlr_seat_destroy(struct wlr_seat *wlr_seat) {
 		return;
 	}
 
+	wl_signal_emit(&wlr_seat->events.destroy, NULL);
+
 	wl_list_remove(&wlr_seat->display_destroy.link);
 
 	struct wlr_seat_client *client, *tmp;
@@ -452,6 +454,8 @@ struct wlr_seat *wlr_seat_create(struct wl_display *display, const char *name) {
 
 	wl_signal_init(&wlr_seat->events.touch_grab_begin);
 	wl_signal_init(&wlr_seat->events.touch_grab_end);
+
+	wl_signal_init(&wlr_seat->events.destroy);
 
 	wlr_seat->display_destroy.notify = handle_display_destroy;
 	wl_display_add_destroy_listener(display, &wlr_seat->display_destroy);

--- a/xwayland/selection.c
+++ b/xwayland/selection.c
@@ -826,6 +826,30 @@ void xwm_selection_init(struct wlr_xwm *xwm) {
 	selection_init(xwm, &xwm->primary_selection, xwm->atoms[PRIMARY]);
 }
 
+void xwm_selection_finish(struct wlr_xwm *xwm) {
+	if (!xwm) {
+		return;
+	}
+	if (xwm->selection_window) {
+		xcb_destroy_window(xwm->xcb_conn, xwm->selection_window);
+	}
+	if (xwm->seat) {
+		if (xwm->seat->selection_source &&
+				xwm->seat->selection_source->cancel == data_source_cancel) {
+			wlr_seat_set_selection(xwm->seat, NULL,
+					wl_display_next_serial(xwm->xwayland->wl_display));
+		}
+		if (xwm->seat->primary_selection_source &&
+				xwm->seat->primary_selection_source->cancel == primary_selection_source_cancel) {
+			wlr_seat_set_primary_selection(xwm->seat, NULL,
+					wl_display_next_serial(xwm->xwayland->wl_display));
+		}
+		wl_list_remove(&xwm->seat_selection.link);
+		wl_list_remove(&xwm->seat_primary_selection.link);
+	}
+
+}
+
 static void xwm_selection_set_owner(struct wlr_xwm_selection *selection,
 		bool set) {
 	if (set) {

--- a/xwayland/selection.c
+++ b/xwayland/selection.c
@@ -844,8 +844,7 @@ void xwm_selection_finish(struct wlr_xwm *xwm) {
 			wlr_seat_set_primary_selection(xwm->seat, NULL,
 					wl_display_next_serial(xwm->xwayland->wl_display));
 		}
-		wl_list_remove(&xwm->seat_selection.link);
-		wl_list_remove(&xwm->seat_primary_selection.link);
+		wlr_xwayland_set_seat(xwm->xwayland, NULL);
 	}
 
 }

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -1114,6 +1114,10 @@ void xwm_destroy(struct wlr_xwm *xwm) {
 	wl_list_for_each_safe(xsurface, tmp, &xwm->unpaired_surfaces, link) {
 		wlr_xwayland_surface_destroy(xsurface);
 	}
+	if (xwm->seat) {
+		wl_list_remove(&xwm->seat_selection.link);
+		wl_list_remove(&xwm->seat_primary_selection.link);
+	}
 	wl_list_remove(&xwm->compositor_surface_create.link);
 	xcb_disconnect(xwm->xcb_conn);
 

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -1254,6 +1254,10 @@ static void xwm_get_render_format(struct wlr_xwm *xwm) {
 		xcb_render_query_pict_formats(xwm->xcb_conn);
 	xcb_render_query_pict_formats_reply_t *reply =
 		xcb_render_query_pict_formats_reply(xwm->xcb_conn, cookie, NULL);
+	if (!reply) {
+		wlr_log(L_ERROR, "Did not get any reply from xcb_rrender_query_pict_formats");
+		return;
+	}
 	xcb_render_pictforminfo_iterator_t iter =
 		xcb_render_query_pict_formats_formats_iterator(reply);
 	xcb_render_pictforminfo_t *format = NULL;

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -1255,7 +1255,7 @@ static void xwm_get_render_format(struct wlr_xwm *xwm) {
 	xcb_render_query_pict_formats_reply_t *reply =
 		xcb_render_query_pict_formats_reply(xwm->xcb_conn, cookie, NULL);
 	if (!reply) {
-		wlr_log(L_ERROR, "Did not get any reply from xcb_rrender_query_pict_formats");
+		wlr_log(L_ERROR, "Did not get any reply from xcb_render_query_pict_formats");
 		return;
 	}
 	xcb_render_pictforminfo_iterator_t iter =

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -1092,9 +1092,7 @@ void xwm_destroy(struct wlr_xwm *xwm) {
 	if (!xwm) {
 		return;
 	}
-	if (xwm->selection_window) {
-		xcb_destroy_window(xwm->xcb_conn, xwm->selection_window);
-	}
+	xwm_selection_finish(xwm);
 	if (xwm->cursor) {
 		xcb_free_cursor(xwm->xcb_conn, xwm->cursor);
 	}
@@ -1113,10 +1111,6 @@ void xwm_destroy(struct wlr_xwm *xwm) {
 	}
 	wl_list_for_each_safe(xsurface, tmp, &xwm->unpaired_surfaces, link) {
 		wlr_xwayland_surface_destroy(xsurface);
-	}
-	if (xwm->seat) {
-		wl_list_remove(&xwm->seat_selection.link);
-		wl_list_remove(&xwm->seat_primary_selection.link);
 	}
 	wl_list_remove(&xwm->compositor_surface_create.link);
 	xcb_disconnect(xwm->xcb_conn);

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -1274,10 +1274,12 @@ static void xwm_get_render_format(struct wlr_xwm *xwm) {
 
 	if (format == NULL) {
 		wlr_log(L_DEBUG, "No 32 bit render format");
+		free(reply);
 		return;
 	}
 
 	xwm->render_format_id = format->id;
+	free(reply);
 }
 
 void xwm_set_cursor(struct wlr_xwm *xwm, const uint8_t *pixels, uint32_t stride,


### PR DESCRIPTION
This started as a "simple" kludge to restore rootston hooks when xwayland restarts, ~~I'm still not quite happy with that part so comments more than welcome: basically, I'm just copying over listeners as a list + seat from old struct to new struct and it's not very pretty and quite fragile.
I think there needs to be some work to have a wlr_xwayland_reinit() function instead of using init() that doesn't memset(0) the whole struct as blindly as I used to do. Happy to do that either in this PR or in another one.~~ Done here.

The rest is quite good though:
 - some small xwm leak (there's tons left when I switch VT, but it's hard to tell where it comes from)
 - on restart, the shutdown happens in a different order to shutdown was completly broken, so added an event for when wlr_seat destroys itself that others can listen on.
 - Rootston apparently needed that event too because I kept crashing on shutdown after adding that event.

At this point, this works with no crash for me, so test plan:
 - start some Xwaylands stuff / wayland stuff
 - pkill Xwayland, Xwayland windows die (make sure there's been at least 5s since start or previous pkill)
 - start some new Xwayland window, they should appear (didn't previously, the last time this worked was on example compositor pre-rootston)
 - shutdown rootston, this shouldn't crash either.