### PR TITLE
Abstract data sources

### DIFF
--- a/include/wlr/types/wlr_data_device.h
+++ b/include/wlr/types/wlr_data_device.h
@@ -23,33 +23,39 @@ struct wlr_data_offer {
 	struct wl_resource *resource;
 	struct wlr_data_source *source;
 
-	uint32_t dnd_actions;
-	enum wl_data_device_manager_dnd_action preferred_dnd_action;
+	uint32_t actions;
+	enum wl_data_device_manager_dnd_action preferred_action;
 	bool in_ask;
 
 	struct wl_listener source_destroy;
 };
 
 struct wlr_data_source {
-	struct wl_resource *resource;
+	// source metadata
+	struct wl_array mime_types;
+	int32_t actions;
+
+	// source implementation
+	void (*send)(struct wlr_data_source *source, const char *mime_type,
+		int32_t fd);
+	void (*accept)(struct wlr_data_source *source, uint32_t serial,
+		const char *mime_type);
+	void (*cancel)(struct wlr_data_source *source);
+
+	// drag'n'drop implementation
+	void (*dnd_drop)(struct wlr_data_source *source);
+	void (*dnd_finish)(struct wlr_data_source *source);
+	void (*dnd_action)(struct wlr_data_source *source,
+		enum wl_data_device_manager_dnd_action action);
+
+	// source status
+	bool accepted;
 	struct wlr_data_offer *offer;
 	struct wlr_seat_client *seat_client;
 
-	struct wl_array mime_types;
-
-	bool accepted;
-
-	// drag and drop
+	// drag'n'drop status
 	enum wl_data_device_manager_dnd_action current_dnd_action;
-	uint32_t dnd_actions;
 	uint32_t compositor_action;
-	bool actions_set;
-
-	void (*accept)(struct wlr_data_source *source, uint32_t serial,
-			const char *mime_type);
-	void (*send)(struct wlr_data_source *source, const char *mime_type,
-			int32_t fd);
-	void (*cancel)(struct wlr_data_source *source);
 
 	struct {
 		struct wl_signal destroy;

--- a/include/wlr/types/wlr_primary_selection.h
+++ b/include/wlr/types/wlr_primary_selection.h
@@ -15,15 +15,17 @@ struct wlr_primary_selection_device_manager {
 struct wlr_primary_selection_offer;
 
 struct wlr_primary_selection_source {
-	struct wl_resource *resource;
-	struct wlr_primary_selection_offer *offer;
-	struct wlr_seat_client *seat_client;
-
+	// source metadata
 	struct wl_array mime_types;
 
+	// source implementation
 	void (*send)(struct wlr_primary_selection_source *source,
 		const char *mime_type, int32_t fd);
 	void (*cancel)(struct wlr_primary_selection_source *source);
+
+	// source status
+	struct wlr_primary_selection_offer *offer;
+	struct wlr_seat_client *seat_client;
 
 	struct {
 		struct wl_signal destroy;

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -178,8 +178,7 @@ struct wlr_seat {
 	uint32_t capabilities;
 	struct timespec last_event;
 
-	struct wlr_data_device *data_device; // TODO needed?
-	struct wlr_data_source *selection_source;
+	struct wlr_data_source *selection_data_source;
 	uint32_t selection_serial;
 
 	struct wlr_primary_selection_source *primary_selection_source;

--- a/types/wlr_data_device.c
+++ b/types/wlr_data_device.c
@@ -173,6 +173,8 @@ static void data_offer_resource_destroy(struct wl_resource *resource) {
 		goto out;
 	}
 
+	offer->source->offer = NULL;
+
 	// If the drag destination has version < 3, wl_data_offer.finish
 	// won't be called, so do this here as a safety net, because
 	// we still want the version >= 3 drag source to be happy.
@@ -183,7 +185,6 @@ static void data_offer_resource_destroy(struct wl_resource *resource) {
 		offer->source->cancel(offer->source);
 	}
 
-	offer->source->offer = NULL;
 out:
 	free(offer);
 }

--- a/types/wlr_data_device.c
+++ b/types/wlr_data_device.c
@@ -339,7 +339,6 @@ static void data_device_set_selection(struct wl_client *client,
 	struct wlr_seat_client *seat_client =
 		wl_resource_get_user_data(dd_resource);
 
-	// TODO: store serial and check against incoming serial here
 	struct wlr_data_source *wlr_source = (struct wlr_data_source *)source;
 	wlr_seat_set_selection(seat_client->seat, wlr_source, serial);
 }

--- a/types/wlr_data_device.c
+++ b/types/wlr_data_device.c
@@ -253,9 +253,9 @@ void wlr_seat_client_send_selection(struct wlr_seat_client *seat_client) {
 		return;
 	}
 
-	if (seat_client->seat->selection_source) {
+	if (seat_client->seat->selection_data_source) {
 		struct wlr_data_offer *offer = wlr_data_source_send_offer(
-			seat_client->seat->selection_source, seat_client);
+			seat_client->seat->selection_data_source, seat_client);
 		if (offer == NULL) {
 			return;
 		}
@@ -285,7 +285,7 @@ static void seat_client_selection_data_source_destroy(
 		}
 	}
 
-	seat->selection_source = NULL;
+	seat->selection_data_source = NULL;
 
 	wl_signal_emit(&seat->events.selection, seat);
 }
@@ -297,18 +297,18 @@ void wlr_seat_set_selection(struct wlr_seat *seat,
 		assert(source->cancel);
 	}
 
-	if (seat->selection_source &&
+	if (seat->selection_data_source &&
 			seat->selection_serial - serial < UINT32_MAX / 2) {
 		return;
 	}
 
-	if (seat->selection_source) {
-		seat->selection_source->cancel(seat->selection_source);
-		seat->selection_source = NULL;
+	if (seat->selection_data_source) {
+		seat->selection_data_source->cancel(seat->selection_data_source);
+		seat->selection_data_source = NULL;
 		wl_list_remove(&seat->selection_data_source_destroy.link);
 	}
 
-	seat->selection_source = source;
+	seat->selection_data_source = source;
 	seat->selection_serial = serial;
 
 	struct wlr_seat_client *focused_client =

--- a/types/wlr_primary_selection.c
+++ b/types/wlr_primary_selection.c
@@ -246,7 +246,6 @@ static void device_handle_set_selection(struct wl_client *client,
 	struct wlr_seat_client *seat_client =
 		wl_resource_get_user_data(resource);
 
-	// TODO: store serial and check against incoming serial here
 	struct wlr_primary_selection_source *wlr_source =
 		(struct wlr_primary_selection_source *)source;
 	wlr_seat_set_primary_selection(seat_client->seat, wlr_source, serial);

--- a/types/wlr_primary_selection.c
+++ b/types/wlr_primary_selection.c
@@ -44,11 +44,8 @@ static void offer_resource_handle_destroy(struct wl_resource *resource) {
 		goto out;
 	}
 
-	if (offer->source->cancel) {
-		offer->source->cancel(offer->source);
-	}
-
 	offer->source->offer = NULL;
+
 out:
 	free(offer);
 }

--- a/types/wlr_seat.c
+++ b/types/wlr_seat.c
@@ -352,9 +352,9 @@ void wlr_seat_destroy(struct wlr_seat *seat) {
 
 	wl_list_remove(&seat->display_destroy.link);
 
-	if (seat->selection_source) {
-		seat->selection_source->cancel(seat->selection_source);
-		seat->selection_source = NULL;
+	if (seat->selection_data_source) {
+		seat->selection_data_source->cancel(seat->selection_data_source);
+		seat->selection_data_source = NULL;
 		wl_list_remove(&seat->selection_data_source_destroy.link);
 	}
 	if (seat->primary_selection_source) {
@@ -373,7 +373,6 @@ void wlr_seat_destroy(struct wlr_seat *seat) {
 	free(seat->pointer_state.default_grab);
 	free(seat->keyboard_state.default_grab);
 	free(seat->touch_state.default_grab);
-	free(seat->data_device);
 	free(seat->name);
 	free(seat);
 }

--- a/types/wlr_seat.c
+++ b/types/wlr_seat.c
@@ -343,28 +343,39 @@ static const struct wlr_touch_grab_interface default_touch_grab_impl = {
 };
 
 
-void wlr_seat_destroy(struct wlr_seat *wlr_seat) {
-	if (!wlr_seat) {
+void wlr_seat_destroy(struct wlr_seat *seat) {
+	if (!seat) {
 		return;
 	}
 
-	wl_signal_emit(&wlr_seat->events.destroy, wlr_seat);
+	wl_signal_emit(&seat->events.destroy, seat);
 
-	wl_list_remove(&wlr_seat->display_destroy.link);
+	wl_list_remove(&seat->display_destroy.link);
+
+	if (seat->selection_source) {
+		seat->selection_source->cancel(seat->selection_source);
+		seat->selection_source = NULL;
+		wl_list_remove(&seat->selection_data_source_destroy.link);
+	}
+	if (seat->primary_selection_source) {
+		seat->primary_selection_source->cancel(seat->primary_selection_source);
+		seat->primary_selection_source = NULL;
+		wl_list_remove(&seat->primary_selection_source_destroy.link);
+	}
 
 	struct wlr_seat_client *client, *tmp;
-	wl_list_for_each_safe(client, tmp, &wlr_seat->clients, link) {
+	wl_list_for_each_safe(client, tmp, &seat->clients, link) {
 		// will destroy other resources as well
 		wl_resource_destroy(client->wl_resource);
 	}
 
-	wl_global_destroy(wlr_seat->wl_global);
-	free(wlr_seat->pointer_state.default_grab);
-	free(wlr_seat->keyboard_state.default_grab);
-	free(wlr_seat->touch_state.default_grab);
-	free(wlr_seat->data_device);
-	free(wlr_seat->name);
-	free(wlr_seat);
+	wl_global_destroy(seat->wl_global);
+	free(seat->pointer_state.default_grab);
+	free(seat->keyboard_state.default_grab);
+	free(seat->touch_state.default_grab);
+	free(seat->data_device);
+	free(seat->name);
+	free(seat);
 }
 
 static void handle_display_destroy(struct wl_listener *listener, void *data) {

--- a/xwayland/selection.c
+++ b/xwayland/selection.c
@@ -153,7 +153,8 @@ error_out:
 static void xwm_selection_source_send(struct wlr_xwm_selection *selection,
 		const char *mime_type, int32_t fd) {
 	if (selection == &selection->xwm->clipboard_selection) {
-		struct wlr_data_source *source = selection->xwm->seat->selection_source;
+		struct wlr_data_source *source =
+			selection->xwm->seat->selection_data_source;
 		if (source != NULL) {
 			source->send(source, mime_type, fd);
 			return;
@@ -214,7 +215,8 @@ static void xwm_selection_send_timestamp(struct wlr_xwm_selection *selection) {
 static struct wl_array *xwm_selection_source_get_mime_types(
 		struct wlr_xwm_selection *selection) {
 	if (selection == &selection->xwm->clipboard_selection) {
-		struct wlr_data_source *source = selection->xwm->seat->selection_source;
+		struct wlr_data_source *source =
+			selection->xwm->seat->selection_data_source;
 		if (source != NULL) {
 			return &source->mime_types;
 		}
@@ -834,8 +836,8 @@ void xwm_selection_finish(struct wlr_xwm *xwm) {
 		xcb_destroy_window(xwm->xcb_conn, xwm->selection_window);
 	}
 	if (xwm->seat) {
-		if (xwm->seat->selection_source &&
-				xwm->seat->selection_source->cancel == data_source_cancel) {
+		if (xwm->seat->selection_data_source &&
+				xwm->seat->selection_data_source->cancel == data_source_cancel) {
 			wlr_seat_set_selection(xwm->seat, NULL,
 					wl_display_next_serial(xwm->xwayland->wl_display));
 		}
@@ -871,7 +873,7 @@ static void seat_handle_selection(struct wl_listener *listener,
 	struct wlr_seat *seat = data;
 	struct wlr_xwm *xwm =
 		wl_container_of(listener, xwm, seat_selection);
-	struct wlr_data_source *source = seat->selection_source;
+	struct wlr_data_source *source = seat->selection_data_source;
 
 	if (source != NULL && source->send == data_source_send) {
 		return;


### PR DESCRIPTION
- [x] Abstract `wlr_data_source`
- [x] Abstract `wlr_primary_selection_source`

This refactors `wlr_data_source` and adds a new `struct client_data_source`. The `resource` field, only populated when the source comes from a Wayland client, is removed from the abstracted struct. Some new drag'n'drop-related callbacks are added, they'll be useful for the xwayland sync implementation.

Test plan:
* Check that clipboard still works: wayland <-> wayland, xwayland <-> wayland, xwayland <-> xwayland
* Same for primary selection
* Check that drag'n'drop still works (wayland <-> wayland only): `weston-flower`, dragging text

Fixes #528