### PR TITLE
Fix build without systemd

### DIFF
--- a/backend/session/logind.c
+++ b/backend/session/logind.c
@@ -17,7 +17,7 @@
 #ifdef WLR_HAS_SYSTEMD
 	#include <systemd/sd-bus.h>
 	#include <systemd/sd-login.h>
-#elif WLR_HAS_ELOGIND
+#elif defined(WLR_HAS_ELOGIND)
 	#include <elogind/sd-bus.h>
 	#include <elogind/sd-login.h> 
 #endif

--- a/backend/session/session.c
+++ b/backend/session/session.c
@@ -20,7 +20,7 @@ extern const struct session_impl session_direct;
 static const struct session_impl *impls[] = {
 #ifdef WLR_HAS_SYSTEMD
 	&session_logind,
-#elif WLR_HAS_ELOGIND
+#elif defined(WLR_HAS_ELOGIND)
 	&session_logind,
 #endif
 	&session_direct,


### PR DESCRIPTION
`WLR_HAS_ELOGIND` isn't a valid preprocessor expression, so the build fails (but only if `WLR_HAS_SYSTEMD` isn't defined).