### PR TITLE
Add wlr_output::enabled

### DIFF
--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -33,7 +33,6 @@ static bool atomic_end(int drm_fd, struct atomic *atom) {
 	}
 
 	uint32_t flags = DRM_MODE_ATOMIC_TEST_ONLY | DRM_MODE_ATOMIC_NONBLOCK;
-
 	if (drmModeAtomicCommit(drm_fd, atom->req, flags, NULL)) {
 		wlr_log_errno(L_ERROR, "Atomic test failed");
 		drmModeAtomicSetCursor(atom->req, atom->cursor);
@@ -44,12 +43,10 @@ static bool atomic_end(int drm_fd, struct atomic *atom) {
 }
 
 static bool atomic_commit(int drm_fd, struct atomic *atom,
-		struct wlr_drm_connector *conn, uint32_t flag, bool modeset) {
+		struct wlr_drm_connector *conn, uint32_t flags, bool modeset) {
 	if (atom->failed) {
 		return false;
 	}
-
-	uint32_t flags = DRM_MODE_PAGE_FLIP_EVENT | flag;
 
 	int ret = drmModeAtomicCommit(drm_fd, atom->req, flags, conn);
 	if (ret) {
@@ -59,7 +56,8 @@ static bool atomic_commit(int drm_fd, struct atomic *atom,
 		// Try to commit without new changes
 		drmModeAtomicSetCursor(atom->req, atom->cursor);
 		if (drmModeAtomicCommit(drm_fd, atom->req, flags, conn)) {
-			wlr_log_errno(L_ERROR, "%s: Atomic commit failed (%s)",
+			wlr_log_errno(L_ERROR,
+				"%s: Atomic commit without new changes failed (%s)",
 				conn->output.name, modeset ? "modeset" : "pageflip");
 		}
 	}
@@ -100,8 +98,8 @@ static bool atomic_crtc_pageflip(struct wlr_drm_backend *drm,
 		struct wlr_drm_connector *conn,
 		struct wlr_drm_crtc *crtc,
 		uint32_t fb_id, drmModeModeInfo *mode) {
-	if (mode) {
-		if (crtc->mode_id) {
+	if (mode != NULL) {
+		if (crtc->mode_id != 0) {
 			drmModeDestroyPropertyBlob(drm->fd, crtc->mode_id);
 		}
 
@@ -111,16 +109,20 @@ static bool atomic_crtc_pageflip(struct wlr_drm_backend *drm,
 		}
 	}
 
-	struct atomic atom;
+	uint32_t flags = DRM_MODE_PAGE_FLIP_EVENT;
+	if (mode != NULL) {
+		flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
+	} else {
+		flags |= DRM_MODE_ATOMIC_NONBLOCK;
+	}
 
+	struct atomic atom;
 	atomic_begin(crtc, &atom);
 	atomic_add(&atom, conn->id, conn->props.crtc_id, crtc->id);
 	atomic_add(&atom, crtc->id, crtc->props.mode_id, crtc->mode_id);
 	atomic_add(&atom, crtc->id, crtc->props.active, 1);
 	set_plane_props(&atom, crtc->primary, crtc->id, fb_id, true);
-	return atomic_commit(drm->fd, &atom, conn,
-		mode ? DRM_MODE_ATOMIC_ALLOW_MODESET : DRM_MODE_ATOMIC_NONBLOCK,
-		mode);
+	return atomic_commit(drm->fd, &atom, conn, flags, mode);
 }
 
 static bool atomic_conn_enable(struct wlr_drm_backend *drm,

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -252,7 +252,10 @@ static void wlr_drm_connector_enable(struct wlr_output *output, bool enable) {
 	}
 
 	struct wlr_drm_backend *drm = (struct wlr_drm_backend *)output->backend;
-	drm->iface->conn_enable(drm, conn, enable);
+	bool ok = drm->iface->conn_enable(drm, conn, enable);
+	if (!ok) {
+		return;
+	}
 
 	if (enable) {
 		wlr_drm_connector_start_renderer(conn);

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -257,6 +257,8 @@ static void wlr_drm_connector_enable(struct wlr_output *output, bool enable) {
 	if (enable) {
 		wlr_drm_connector_start_renderer(conn);
 	}
+
+	wlr_output_update_enabled(&conn->output, enable);
 }
 
 static void realloc_planes(struct wlr_drm_backend *drm, const uint32_t *crtc_in,
@@ -722,7 +724,8 @@ void wlr_drm_scan_connectors(struct wlr_drm_backend *drm) {
 				drmModeFreeConnector(drm_conn);
 				continue;
 			}
-			wlr_output_init(&wlr_conn->output, &drm->backend, &output_impl);
+			wlr_output_init(&wlr_conn->output, &drm->backend, &output_impl,
+				drm->display);
 
 			struct wl_event_loop *ev = wl_display_get_event_loop(drm->display);
 			wlr_conn->retry_pageflip = wl_event_loop_add_timer(ev, retry_pageflip,
@@ -792,7 +795,7 @@ void wlr_drm_scan_connectors(struct wlr_drm_backend *drm) {
 				wl_list_insert(&wlr_conn->output.modes, &mode->wlr_mode.link);
 			}
 
-			wlr_output_create_global(&wlr_conn->output, drm->display);
+			wlr_output_update_enabled(&wlr_conn->output, true);
 
 			wlr_conn->state = WLR_DRM_CONN_NEEDS_MODESET;
 			wlr_log(L_INFO, "Sending modesetting signal for '%s'",
@@ -802,7 +805,7 @@ void wlr_drm_scan_connectors(struct wlr_drm_backend *drm) {
 				drm_conn->connection != DRM_MODE_CONNECTED) {
 			wlr_log(L_INFO, "'%s' disconnected", wlr_conn->output.name);
 
-			wlr_output_destroy_global(&wlr_conn->output);
+			wlr_output_update_enabled(&wlr_conn->output, false);
 			wlr_drm_connector_cleanup(wlr_conn);
 		}
 

--- a/backend/drm/legacy.c
+++ b/backend/drm/legacy.c
@@ -25,10 +25,11 @@ static bool legacy_crtc_pageflip(struct wlr_drm_backend *drm,
 	return true;
 }
 
-static void legacy_conn_enable(struct wlr_drm_backend *drm,
+static bool legacy_conn_enable(struct wlr_drm_backend *drm,
 		struct wlr_drm_connector *conn, bool enable) {
-	drmModeConnectorSetProperty(drm->fd, conn->id, conn->props.dpms,
+	int ret = drmModeConnectorSetProperty(drm->fd, conn->id, conn->props.dpms,
 		enable ? DRM_MODE_DPMS_ON : DRM_MODE_DPMS_OFF);
+	return ret >= 0;
 }
 
 bool legacy_crtc_set_cursor(struct wlr_drm_backend *drm,

--- a/backend/headless/backend.c
+++ b/backend/headless/backend.c
@@ -15,7 +15,7 @@ static bool backend_start(struct wlr_backend *wlr_backend) {
 	struct wlr_headless_output *output;
 	wl_list_for_each(output, &backend->outputs, link) {
 		wl_event_source_timer_update(output->frame_timer, output->frame_delay);
-		wlr_output_create_global(&output->wlr_output, backend->display);
+		wlr_output_update_enabled(&output->wlr_output, true);
 		wl_signal_emit(&backend->backend.events.output_add,
 			&output->wlr_output);
 	}

--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -105,7 +105,8 @@ struct wlr_output *wlr_headless_add_output(struct wlr_backend *wlr_backend,
 		return NULL;
 	}
 	output->backend = backend;
-	wlr_output_init(&output->wlr_output, &backend->backend, &output_impl);
+	wlr_output_init(&output->wlr_output, &backend->backend, &output_impl,
+		backend->display);
 	struct wlr_output *wlr_output = &output->wlr_output;
 
 	output->egl_surface = egl_create_surface(&backend->egl, width, height);
@@ -138,7 +139,7 @@ struct wlr_output *wlr_headless_add_output(struct wlr_backend *wlr_backend,
 
 	if (backend->started) {
 		wl_event_source_timer_update(output->frame_timer, output->frame_delay);
-		wlr_output_create_global(wlr_output, backend->display);
+		wlr_output_update_enabled(wlr_output, true);
 		wl_signal_emit(&backend->backend.events.output_add, wlr_output);
 	}
 

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -261,7 +261,8 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *_backend) {
 		wlr_log(L_ERROR, "Failed to allocate wlr_wl_backend_output");
 		return NULL;
 	}
-	wlr_output_init(&output->wlr_output, &backend->backend, &output_impl);
+	wlr_output_init(&output->wlr_output, &backend->backend, &output_impl,
+		backend->local_display);
 	struct wlr_output *wlr_output = &output->wlr_output;
 
 	wlr_output_update_custom_mode(wlr_output, 1280, 720, 0);
@@ -325,7 +326,7 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *_backend) {
 	}
 
 	wl_list_insert(&backend->outputs, &output->link);
-	wlr_output_create_global(wlr_output, backend->local_display);
+	wlr_output_update_enabled(wlr_output, true);
 	wl_signal_emit(&backend->backend.events.output_add, wlr_output);
 	return wlr_output;
 

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -181,7 +181,8 @@ static int signal_frame(void *data) {
 
 static void init_atom(struct wlr_x11_backend *x11, struct wlr_x11_atom *atom,
 		uint8_t only_if_exists, const char *name) {
-	atom->cookie = xcb_intern_atom(x11->xcb_conn, only_if_exists, strlen(name), name);
+	atom->cookie = xcb_intern_atom(x11->xcb_conn, only_if_exists, strlen(name),
+		name);
 	atom->reply = xcb_intern_atom_reply(x11->xcb_conn, atom->cookie, NULL);
 }
 
@@ -201,7 +202,8 @@ static bool wlr_x11_backend_start(struct wlr_backend *backend) {
 
 	output->x11 = x11;
 
-	wlr_output_init(&output->wlr_output, &x11->backend, &output_impl);
+	wlr_output_init(&output->wlr_output, &x11->backend, &output_impl,
+		x11->wl_display);
 	snprintf(output->wlr_output.name, sizeof(output->wlr_output.name), "X11-1");
 
 	output->win = xcb_generate_id(x11->xcb_conn);
@@ -224,7 +226,7 @@ static bool wlr_x11_backend_start(struct wlr_backend *backend) {
 
 	xcb_map_window(x11->xcb_conn, output->win);
 	xcb_flush(x11->xcb_conn);
-	wlr_output_create_global(&output->wlr_output, x11->wl_display);
+	wlr_output_update_enabled(&output->wlr_output, true);
 
 	wl_signal_emit(&x11->backend.events.output_add, output);
 	wl_signal_emit(&x11->backend.events.input_add, &x11->keyboard_dev);

--- a/examples/support/shared.c
+++ b/examples/support/shared.c
@@ -425,7 +425,7 @@ static void output_add_notify(struct wl_listener *listener, void *data) {
 	ostate->frame.notify = output_frame_notify;
 	ostate->resolution.notify = output_resolution_notify;
 	wl_signal_add(&output->events.frame, &ostate->frame);
-	wl_signal_add(&output->events.resolution, &ostate->resolution);
+	wl_signal_add(&output->events.mode, &ostate->resolution);
 	wl_list_insert(&state->outputs, &ostate->link);
 	if (state->output_add_cb) {
 		state->output_add_cb(ostate);

--- a/include/backend/drm/iface.h
+++ b/include/backend/drm/iface.h
@@ -15,7 +15,7 @@ struct wlr_drm_crtc;
 // Used to provide atomic or legacy DRM functions
 struct wlr_drm_interface {
 	// Enable or disable DPMS for connector
-	void (*conn_enable)(struct wlr_drm_backend *drm,
+	bool (*conn_enable)(struct wlr_drm_backend *drm,
 		struct wlr_drm_connector *conn, bool enable);
 	// Pageflip on crtc. If mode is non-NULL perform a full modeset using it.
 	bool (*crtc_pageflip)(struct wlr_drm_backend *drm,

--- a/include/rootston/config.h
+++ b/include/rootston/config.h
@@ -7,6 +7,7 @@
 
 struct roots_output_config {
 	char *name;
+	bool enable;
 	enum wl_output_transform transform;
 	int x, y;
 	float scale;

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -26,14 +26,11 @@ struct wlr_output_impl {
 };
 
 void wlr_output_init(struct wlr_output *output, struct wlr_backend *backend,
-	const struct wlr_output_impl *impl);
-void wlr_output_free(struct wlr_output *output);
+	const struct wlr_output_impl *impl, struct wl_display *display);
 void wlr_output_update_mode(struct wlr_output *output,
 	struct wlr_output_mode *mode);
 void wlr_output_update_custom_mode(struct wlr_output *output, int32_t width,
 	int32_t height, int32_t refresh);
-struct wl_global *wlr_output_create_global(struct wlr_output *wlr_output,
-	struct wl_display *display);
-void wlr_output_destroy_global(struct wlr_output *wlr_output);
+void wlr_output_update_enabled(struct wlr_output *output, bool enabled);
 
 #endif

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -64,6 +64,7 @@ struct wlr_output {
 	struct {
 		struct wl_signal frame;
 		struct wl_signal swap_buffers;
+		struct wl_signal enable;
 		struct wl_signal resolution;
 		struct wl_signal scale;
 		struct wl_signal transform;

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -36,19 +36,19 @@ struct wlr_output_impl;
 struct wlr_output {
 	const struct wlr_output_impl *impl;
 	struct wlr_backend *backend;
+	struct wl_display *display;
 
 	struct wl_global *wl_global;
 	struct wl_list wl_resources;
 
-	uint32_t flags;
 	char name[16];
 	char make[48];
 	char model[16];
 	char serial[16];
-	float scale;
-	int32_t width, height;
-	int32_t refresh; // mHz
 	int32_t phys_width, phys_height; // mm
+
+	bool enabled;
+	float scale;
 	enum wl_output_subpixel subpixel;
 	enum wl_output_transform transform;
 	bool needs_swap;
@@ -58,6 +58,8 @@ struct wlr_output {
 	// Note: some backends may have zero modes
 	struct wl_list modes;
 	struct wlr_output_mode *current_mode;
+	int32_t width, height;
+	int32_t refresh; // mHz
 
 	struct {
 		struct wl_signal frame;

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -65,7 +65,7 @@ struct wlr_output {
 		struct wl_signal frame;
 		struct wl_signal swap_buffers;
 		struct wl_signal enable;
-		struct wl_signal resolution;
+		struct wl_signal mode;
 		struct wl_signal scale;
 		struct wl_signal transform;
 		struct wl_signal destroy;

--- a/rootston/config.c
+++ b/rootston/config.c
@@ -263,10 +263,19 @@ static int config_ini_handler(void *user, const char *section, const char *name,
 			oc->name = strdup(output_name);
 			oc->transform = WL_OUTPUT_TRANSFORM_NORMAL;
 			oc->scale = 1;
+			oc->enable = true;
 			wl_list_insert(&config->outputs, &oc->link);
 		}
 
-		if (strcmp(name, "x") == 0) {
+		if (strcmp(name, "enable") == 0) {
+			if (strcasecmp(value, "true") == 0) {
+				oc->enable = true;
+			} else if (strcasecmp(value, "false") == 0) {
+				oc->enable = false;
+			} else {
+				wlr_log(L_ERROR, "got invalid output enable value: %s", value);
+			}
+		} else if (strcmp(name, "x") == 0) {
 			oc->x = strtol(value, NULL, 10);
 		} else if (strcmp(name, "y") == 0) {
 			oc->y = strtol(value, NULL, 10);

--- a/rootston/keyboard.c
+++ b/rootston/keyboard.c
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <stdbool.h>
 #include <wayland-server.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_pointer.h>
@@ -85,6 +86,8 @@ static void pressed_keysyms_update(xkb_keysym_t *pressed_keysyms,
 
 static const char *exec_prefix = "exec ";
 
+static bool outputs_enabled = true;
+
 static void keyboard_binding_execute(struct roots_keyboard *keyboard,
 		const char *command) {
 	struct roots_seat *seat = keyboard->seat;
@@ -119,6 +122,12 @@ static void keyboard_binding_execute(struct roots_keyboard *keyboard,
 		}
 	} else if (strcmp(command, "nop") == 0) {
 		wlr_log(L_DEBUG, "nop command");
+	} else if (strcmp(command, "toggle_outputs") == 0) {
+		outputs_enabled = !outputs_enabled;
+		struct roots_output *output;
+		wl_list_for_each(output, &keyboard->input->server->desktop->outputs, link) {
+			wlr_output_enable(output->wlr_output, outputs_enabled);
+		}
 	} else {
 		wlr_log(L_ERROR, "unknown binding command: %s", command);
 	}

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -211,6 +211,10 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	struct roots_desktop *desktop = output->desktop;
 	struct roots_server *server = desktop->server;
 
+	if (!wlr_output->enabled) {
+		return;
+	}
+
 	struct timespec now;
 	clock_gettime(CLOCK_MONOTONIC, &now);
 

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -324,9 +324,10 @@ void output_add_notify(struct wl_listener *listener, void *data) {
 	wlr_log(L_DEBUG, "'%s %s %s' %"PRId32"mm x %"PRId32"mm", wlr_output->make,
 		wlr_output->model, wlr_output->serial, wlr_output->phys_width,
 		wlr_output->phys_height);
+
 	if (wl_list_length(&wlr_output->modes) > 0) {
-		struct wlr_output_mode *mode = NULL;
-		mode = wl_container_of((&wlr_output->modes)->prev, mode, link);
+		struct wlr_output_mode *mode =
+			wl_container_of((&wlr_output->modes)->prev, mode, link);
 		wlr_output_set_mode(wlr_output, mode);
 	}
 
@@ -341,13 +342,17 @@ void output_add_notify(struct wl_listener *listener, void *data) {
 	struct roots_output_config *output_config =
 		roots_config_get_output(config, wlr_output);
 	if (output_config) {
-		if (output_config->mode.width) {
-			set_mode(wlr_output, output_config);
+		if (output_config->enable) {
+			if (output_config->mode.width) {
+				set_mode(wlr_output, output_config);
+			}
+			wlr_output_set_scale(wlr_output, output_config->scale);
+			wlr_output_set_transform(wlr_output, output_config->transform);
+			wlr_output_layout_add(desktop->layout, wlr_output, output_config->x,
+				output_config->y);
+		} else {
+			wlr_output_enable(wlr_output, false);
 		}
-		wlr_output_set_scale(wlr_output, output_config->scale);
-		wlr_output_set_transform(wlr_output, output_config->transform);
-		wlr_output_layout_add(desktop->layout, wlr_output, output_config->x,
-			output_config->y);
 	} else {
 		wlr_output_layout_add_auto(desktop->layout, wlr_output);
 	}

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -202,7 +202,7 @@ void wlr_output_update_custom_mode(struct wlr_output *output, int32_t width,
 		wlr_output_send_current_mode_to_resource(resource);
 	}
 
-	wl_signal_emit(&output->events.resolution, output);
+	wl_signal_emit(&output->events.mode, output);
 }
 
 void wlr_output_set_transform(struct wlr_output *output,
@@ -270,8 +270,8 @@ void wlr_output_init(struct wlr_output *output, struct wlr_backend *backend,
 	wl_list_init(&output->wl_resources);
 	wl_signal_init(&output->events.frame);
 	wl_signal_init(&output->events.swap_buffers);
-	wl_signal_init(&output->events.resolution);
 	wl_signal_init(&output->events.enable);
+	wl_signal_init(&output->events.mode);
 	wl_signal_init(&output->events.scale);
 	wl_signal_init(&output->events.transform);
 	wl_signal_init(&output->events.destroy);

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -156,6 +156,10 @@ static void wlr_output_update_matrix(struct wlr_output *output) {
 }
 
 void wlr_output_enable(struct wlr_output *output, bool enable) {
+	if (output->enabled == enable) {
+		return;
+	}
+
 	if (output->impl->enable) {
 		output->impl->enable(output, enable);
 	}

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -146,6 +146,8 @@ void wlr_output_update_enabled(struct wlr_output *output, bool enabled) {
 	} else {
 		wlr_output_destroy_global(output);
 	}
+
+	wl_signal_emit(&output->events.enable, output);
 }
 
 static void wlr_output_update_matrix(struct wlr_output *output) {
@@ -269,6 +271,7 @@ void wlr_output_init(struct wlr_output *output, struct wlr_backend *backend,
 	wl_signal_init(&output->events.frame);
 	wl_signal_init(&output->events.swap_buffers);
 	wl_signal_init(&output->events.resolution);
+	wl_signal_init(&output->events.enable);
 	wl_signal_init(&output->events.scale);
 	wl_signal_init(&output->events.transform);
 	wl_signal_init(&output->events.destroy);

--- a/types/wlr_output_layout.c
+++ b/types/wlr_output_layout.c
@@ -19,7 +19,7 @@ struct wlr_output_layout_output_state {
 	bool auto_configured;
 
 	struct wl_listener enable;
-	struct wl_listener resolution;
+	struct wl_listener mode;
 	struct wl_listener scale;
 	struct wl_listener transform;
 	struct wl_listener output_destroy;
@@ -49,7 +49,7 @@ static void wlr_output_layout_output_destroy(
 		struct wlr_output_layout_output *l_output) {
 	wl_signal_emit(&l_output->events.destroy, l_output);
 	wl_list_remove(&l_output->state->enable.link);
-	wl_list_remove(&l_output->state->resolution.link);
+	wl_list_remove(&l_output->state->mode.link);
 	wl_list_remove(&l_output->state->scale.link);
 	wl_list_remove(&l_output->state->transform.link);
 	wl_list_remove(&l_output->state->output_destroy.link);
@@ -150,9 +150,9 @@ static void handle_output_enable(struct wl_listener *listener, void *data) {
 	wlr_output_layout_reconfigure(state->layout);
 }
 
-static void handle_output_resolution(struct wl_listener *listener, void *data) {
+static void handle_output_mode(struct wl_listener *listener, void *data) {
 	struct wlr_output_layout_output_state *state =
-		wl_container_of(listener, state, resolution);
+		wl_container_of(listener, state, mode);
 	wlr_output_layout_reconfigure(state->layout);
 }
 
@@ -196,8 +196,8 @@ static struct wlr_output_layout_output *wlr_output_layout_output_create(
 
 	wl_signal_add(&output->events.enable, &l_output->state->enable);
 	l_output->state->enable.notify = handle_output_enable;
-	wl_signal_add(&output->events.resolution, &l_output->state->resolution);
-	l_output->state->resolution.notify = handle_output_resolution;
+	wl_signal_add(&output->events.mode, &l_output->state->mode);
+	l_output->state->mode.notify = handle_output_mode;
 	wl_signal_add(&output->events.scale, &l_output->state->scale);
 	l_output->state->scale.notify = handle_output_scale;
 	wl_signal_add(&output->events.transform, &l_output->state->transform);


### PR DESCRIPTION
This un-exports `wlr_output_{create,destroy}_global`, since this is a protocol matter. This instead adds a `wlr_output_update_enabled` for backends.
  
This fixes disabled outputs with the DRM backend.

- [x] Fix cursor at (0, 0) when re-enabling an output. This happens because the output layout moves the cursor to (0, 0) when the output is disabled.
- [x] Fix failed pageflip. This happens when re-enabling the output, no idea how to fix it.

Test plan:

```ini
[bindings]
Logo+t = toggle_outputs
```

See @acrisci's comment for edge cases.

Related Weston patch: https://patchwork.freedesktop.org/patch/194357/