### PR TITLE
meson: fix include path in generated .pc

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -159,7 +159,6 @@ subdir('examples')
 pkgconfig = import('pkgconfig')
 pkgconfig.generate(
 	libraries: lib_wlr,
-	subdirs: '@0@'.format(meson.project_name()),
 	version: meson.project_version(),
 	filebase: meson.project_name(),
 	name: meson.project_name(),


### PR DESCRIPTION
The generated .pc still contained -I${prefix}/wlroots, this is no longer
needed at all as the prefix is now 'wlr' and all includes are 'wlr/foo'
  