### PR TITLE
compositor modifier hooks

### DIFF
--- a/include/wlr/types/wlr_keyboard.h
+++ b/include/wlr/types/wlr_keyboard.h
@@ -52,7 +52,7 @@ struct wlr_keyboard {
 
 	uint32_t keycodes[WLR_KEYBOARD_KEYS_CAP];
 	size_t num_keycodes;
-	struct wlr_keyboard_modifiers *modifiers;
+	struct wlr_keyboard_modifiers modifiers;
 
 	struct {
 		int32_t rate;

--- a/include/wlr/types/wlr_keyboard.h
+++ b/include/wlr/types/wlr_keyboard.h
@@ -32,6 +32,13 @@ enum wlr_keyboard_modifier {
 
 struct wlr_keyboard_impl;
 
+struct wlr_keyboard_modifiers {
+	xkb_mod_mask_t depressed;
+	xkb_mod_mask_t latched;
+	xkb_mod_mask_t locked;
+	xkb_mod_mask_t group;
+};
+
 struct wlr_keyboard {
 	struct wlr_keyboard_impl *impl;
 	// TODO: Should this store key repeat info too?
@@ -45,12 +52,7 @@ struct wlr_keyboard {
 
 	uint32_t keycodes[WLR_KEYBOARD_KEYS_CAP];
 	size_t num_keycodes;
-	struct {
-		xkb_mod_mask_t depressed;
-		xkb_mod_mask_t latched;
-		xkb_mod_mask_t locked;
-		xkb_mod_mask_t group;
-	} modifiers;
+	struct wlr_keyboard_modifiers *modifiers;
 
 	struct {
 		int32_t rate;

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -71,7 +71,8 @@ struct wlr_keyboard_grab_interface {
 			struct wlr_surface *surface);
 	void (*key)(struct wlr_seat_keyboard_grab *grab, uint32_t time,
 			uint32_t key, uint32_t state);
-	void (*modifiers)(struct wlr_seat_keyboard_grab *grab);
+	void (*modifiers)(struct wlr_seat_keyboard_grab *grab,
+			struct wlr_keyboard_modifiers *modifiers);
 	void (*cancel)(struct wlr_seat_keyboard_grab *grab);
 };
 
@@ -345,6 +346,11 @@ bool wlr_seat_pointer_has_grab(struct wlr_seat *seat);
 void wlr_seat_set_keyboard(struct wlr_seat *seat, struct wlr_input_device *dev);
 
 /**
+ * Get the active keyboard for the seat.
+ */
+struct wlr_keyboard *wlr_seat_get_keyboard(struct wlr_seat *seat);
+
+/**
  * Start a grab of the keyboard of this seat. The grabber is responsible for
  * handling all keyboard events until the grab ends.
  */
@@ -375,13 +381,15 @@ void wlr_seat_keyboard_notify_key(struct wlr_seat *seat, uint32_t time,
  * Send the modifier state to focused keyboard resources. Compositors should use
  * `wlr_seat_keyboard_notify_modifiers()` to respect any keyboard grabs.
  */
-void wlr_seat_keyboard_send_modifiers(struct wlr_seat *seat);
+void wlr_seat_keyboard_send_modifiers(struct wlr_seat *seat,
+		struct wlr_keyboard_modifiers *modifiers);
 
 /**
  * Notify the seat that the modifiers for the keyboard have changed. Defers to
  * any keyboard grabs.
  */
-void wlr_seat_keyboard_notify_modifiers(struct wlr_seat *seat);
+void wlr_seat_keyboard_notify_modifiers(struct wlr_seat *seat,
+		struct wlr_keyboard_modifiers *modifiers);
 
 /**
  * Notify the seat that the keyboard focus has changed and request it to be the

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -68,7 +68,8 @@ struct wlr_seat_keyboard_grab;
 
 struct wlr_keyboard_grab_interface {
 	void (*enter)(struct wlr_seat_keyboard_grab *grab,
-			struct wlr_surface *surface);
+			struct wlr_surface *surface, uint32_t keycodes[],
+			size_t num_keycodes, struct wlr_keyboard_modifiers *modifiers);
 	void (*key)(struct wlr_seat_keyboard_grab *grab, uint32_t time,
 			uint32_t key, uint32_t state);
 	void (*modifiers)(struct wlr_seat_keyboard_grab *grab,
@@ -396,8 +397,9 @@ void wlr_seat_keyboard_notify_modifiers(struct wlr_seat *seat,
  * focused surface for this keyboard. Defers to any current grab of the seat's
  * keyboard.
  */
-void wlr_seat_keyboard_notify_enter(struct wlr_seat *wlr_seat,
-		struct wlr_surface *surface);
+void wlr_seat_keyboard_notify_enter(struct wlr_seat *seat,
+		struct wlr_surface *surface, uint32_t keycodes[], size_t num_keycodes,
+		struct wlr_keyboard_modifiers *modifiers);
 
 /**
  * Send a keyboard enter event to the given surface and consider it to be the
@@ -406,8 +408,9 @@ void wlr_seat_keyboard_notify_enter(struct wlr_seat *wlr_seat,
  * `wlr_seat_keyboard_notify_enter()` to change keyboard focus to respect
  * keyboard grabs.
  */
-void wlr_seat_keyboard_enter(struct wlr_seat *wlr_seat,
-		struct wlr_surface *surface);
+void wlr_seat_keyboard_enter(struct wlr_seat *seat,
+		struct wlr_surface *surface, uint32_t keycodes[], size_t num_keycodes,
+		struct wlr_keyboard_modifiers *modifiers);
 
 /**
  * Clear the focused surface for the keyboard and leave all entered surfaces.

--- a/rootston/keyboard.c
+++ b/rootston/keyboard.c
@@ -279,7 +279,8 @@ void roots_keyboard_handle_key(struct roots_keyboard *keyboard,
 void roots_keyboard_handle_modifiers(struct roots_keyboard *r_keyboard) {
 	struct wlr_seat *seat = r_keyboard->seat->seat;
 	wlr_seat_set_keyboard(seat, r_keyboard->device);
-	wlr_seat_keyboard_notify_modifiers(seat);
+	wlr_seat_keyboard_notify_modifiers(seat,
+		r_keyboard->device->keyboard->modifiers);
 }
 
 static void keyboard_config_merge(struct roots_keyboard_config *config,

--- a/rootston/keyboard.c
+++ b/rootston/keyboard.c
@@ -289,7 +289,7 @@ void roots_keyboard_handle_modifiers(struct roots_keyboard *r_keyboard) {
 	struct wlr_seat *seat = r_keyboard->seat->seat;
 	wlr_seat_set_keyboard(seat, r_keyboard->device);
 	wlr_seat_keyboard_notify_modifiers(seat,
-		r_keyboard->device->keyboard->modifiers);
+		&r_keyboard->device->keyboard->modifiers);
 }
 
 static void keyboard_config_merge(struct roots_keyboard_config *config,

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -667,7 +667,7 @@ void roots_seat_set_focus(struct roots_seat *seat, struct roots_view *view) {
 	if (keyboard != NULL) {
 		wlr_seat_keyboard_notify_enter(seat->seat, view->wlr_surface,
 			keyboard->keycodes, keyboard->num_keycodes,
-			keyboard->modifiers);
+			&keyboard->modifiers);
 	} else {
 		wlr_seat_keyboard_notify_enter(seat->seat, view->wlr_surface,
 			NULL, 0, NULL);

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -616,7 +616,16 @@ void roots_seat_set_focus(struct roots_seat *seat, struct roots_view *view) {
 	seat->has_focus = true;
 	wl_list_remove(&seat_view->link);
 	wl_list_insert(&seat->views, &seat_view->link);
-	wlr_seat_keyboard_notify_enter(seat->seat, view->wlr_surface);
+
+	struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(seat->seat);
+	if (keyboard != NULL) {
+		wlr_seat_keyboard_notify_enter(seat->seat, view->wlr_surface,
+			keyboard->keycodes, keyboard->num_keycodes,
+			keyboard->modifiers);
+	} else {
+		wlr_seat_keyboard_notify_enter(seat->seat, view->wlr_surface,
+			NULL, 0, NULL);
+	}
 }
 
 void roots_seat_cycle_focus(struct roots_seat *seat) {

--- a/types/wlr_data_device.c
+++ b/types/wlr_data_device.c
@@ -594,7 +594,8 @@ static void keyboard_drag_key(struct wlr_seat_keyboard_grab *grab,
 	// no keyboard input during drags
 }
 
-static void keyboard_drag_modifiers(struct wlr_seat_keyboard_grab *grab) {
+static void keyboard_drag_modifiers(struct wlr_seat_keyboard_grab *grab,
+		struct wlr_keyboard_modifiers *modifiers) {
 	//struct wlr_keyboard *keyboard = grab->seat->keyboard_state.keyboard;
 	// TODO change the dnd action based on what modifier is pressed on the
 	// keyboard

--- a/types/wlr_data_device.c
+++ b/types/wlr_data_device.c
@@ -585,7 +585,8 @@ const struct wlr_touch_grab_interface wlr_data_device_touch_drag_interface = {
 };
 
 static void keyboard_drag_enter(struct wlr_seat_keyboard_grab *grab,
-		struct wlr_surface *surface) {
+		struct wlr_surface *surface, uint32_t keycodes[], size_t num_keycodes,
+		struct wlr_keyboard_modifiers *modifiers) {
 	// nothing has keyboard focus during drags
 }
 

--- a/types/wlr_keyboard.c
+++ b/types/wlr_keyboard.c
@@ -30,17 +30,17 @@ static void keyboard_modifier_update(struct wlr_keyboard *keyboard) {
 		XKB_STATE_MODS_LOCKED);
 	xkb_mod_mask_t group = xkb_state_serialize_layout(keyboard->xkb_state,
 		XKB_STATE_LAYOUT_EFFECTIVE);
-	if (depressed == keyboard->modifiers.depressed &&
-			latched == keyboard->modifiers.latched &&
-			locked == keyboard->modifiers.locked &&
-			group == keyboard->modifiers.group) {
+	if (depressed == keyboard->modifiers->depressed &&
+			latched == keyboard->modifiers->latched &&
+			locked == keyboard->modifiers->locked &&
+			group == keyboard->modifiers->group) {
 		return;
 	}
 
-	keyboard->modifiers.depressed = depressed;
-	keyboard->modifiers.latched = latched;
-	keyboard->modifiers.locked = locked;
-	keyboard->modifiers.group = group;
+	keyboard->modifiers->depressed = depressed;
+	keyboard->modifiers->latched = latched;
+	keyboard->modifiers->locked = locked;
+	keyboard->modifiers->group = group;
 
 	wl_signal_emit(&keyboard->events.modifiers, keyboard);
 }
@@ -117,6 +117,7 @@ void wlr_keyboard_notify_key(struct wlr_keyboard *keyboard,
 void wlr_keyboard_init(struct wlr_keyboard *kb,
 		struct wlr_keyboard_impl *impl) {
 	kb->impl = impl;
+	kb->modifiers = calloc(1, sizeof(struct wlr_keyboard_modifiers));
 	wl_signal_init(&kb->events.key);
 	wl_signal_init(&kb->events.modifiers);
 	wl_signal_init(&kb->events.keymap);
@@ -139,6 +140,7 @@ void wlr_keyboard_destroy(struct wlr_keyboard *kb) {
 	xkb_state_unref(kb->xkb_state);
 	xkb_keymap_unref(kb->keymap);
 	close(kb->keymap_fd);
+	free(kb->modifiers);
 	free(kb);
 }
 
@@ -222,7 +224,7 @@ void wlr_keyboard_set_repeat_info(struct wlr_keyboard *kb, int32_t rate,
 }
 
 uint32_t wlr_keyboard_get_modifiers(struct wlr_keyboard *kb) {
-	xkb_mod_mask_t mask = kb->modifiers.depressed | kb->modifiers.latched;
+	xkb_mod_mask_t mask = kb->modifiers->depressed | kb->modifiers->latched;
 	uint32_t modifiers = 0;
 	for (size_t i = 0; i < WLR_MODIFIER_COUNT; ++i) {
 		if (kb->mod_indexes[i] != XKB_MOD_INVALID &&

--- a/types/wlr_keyboard.c
+++ b/types/wlr_keyboard.c
@@ -42,17 +42,17 @@ static bool keyboard_modifier_update(struct wlr_keyboard *keyboard) {
 		XKB_STATE_MODS_LOCKED);
 	xkb_mod_mask_t group = xkb_state_serialize_layout(keyboard->xkb_state,
 		XKB_STATE_LAYOUT_EFFECTIVE);
-	if (depressed == keyboard->modifiers->depressed &&
-			latched == keyboard->modifiers->latched &&
-			locked == keyboard->modifiers->locked &&
-			group == keyboard->modifiers->group) {
+	if (depressed == keyboard->modifiers.depressed &&
+			latched == keyboard->modifiers.latched &&
+			locked == keyboard->modifiers.locked &&
+			group == keyboard->modifiers.group) {
 		return false;
 	}
 
-	keyboard->modifiers->depressed = depressed;
-	keyboard->modifiers->latched = latched;
-	keyboard->modifiers->locked = locked;
-	keyboard->modifiers->group = group;
+	keyboard->modifiers.depressed = depressed;
+	keyboard->modifiers.latched = latched;
+	keyboard->modifiers.locked = locked;
+	keyboard->modifiers.group = group;
 
 	return true;
 }
@@ -138,7 +138,6 @@ void wlr_keyboard_notify_key(struct wlr_keyboard *keyboard,
 void wlr_keyboard_init(struct wlr_keyboard *kb,
 		struct wlr_keyboard_impl *impl) {
 	kb->impl = impl;
-	kb->modifiers = calloc(1, sizeof(struct wlr_keyboard_modifiers));
 	wl_signal_init(&kb->events.key);
 	wl_signal_init(&kb->events.modifiers);
 	wl_signal_init(&kb->events.keymap);
@@ -161,7 +160,6 @@ void wlr_keyboard_destroy(struct wlr_keyboard *kb) {
 	xkb_state_unref(kb->xkb_state);
 	xkb_keymap_unref(kb->keymap);
 	close(kb->keymap_fd);
-	free(kb->modifiers);
 	free(kb);
 }
 
@@ -259,7 +257,7 @@ void wlr_keyboard_set_repeat_info(struct wlr_keyboard *kb, int32_t rate,
 }
 
 uint32_t wlr_keyboard_get_modifiers(struct wlr_keyboard *kb) {
-	xkb_mod_mask_t mask = kb->modifiers->depressed | kb->modifiers->latched;
+	xkb_mod_mask_t mask = kb->modifiers.depressed | kb->modifiers.latched;
 	uint32_t modifiers = 0;
 	for (size_t i = 0; i < WLR_MODIFIER_COUNT; ++i) {
 		if (kb->mod_indexes[i] != XKB_MOD_INVALID &&

--- a/types/wlr_seat.c
+++ b/types/wlr_seat.c
@@ -774,6 +774,7 @@ void wlr_seat_set_keyboard(struct wlr_seat *seat,
 
 	if (keyboard) {
 		assert(device->type == WLR_INPUT_DEVICE_KEYBOARD);
+		seat->keyboard_state.keyboard = keyboard;
 
 		wl_signal_add(&device->events.destroy,
 			&seat->keyboard_state.keyboard_destroy);
@@ -788,14 +789,14 @@ void wlr_seat_set_keyboard(struct wlr_seat *seat,
 
 		struct wlr_seat_client *client;
 		wl_list_for_each(client, &seat->clients, link) {
-			seat_client_send_keymap(client, device->keyboard);
-			seat_client_send_repeat_info(client, device->keyboard);
+			seat_client_send_keymap(client, keyboard);
+			seat_client_send_repeat_info(client, keyboard);
 		}
 
+		wlr_seat_keyboard_send_modifiers(seat, keyboard->modifiers);
+	} else {
+		seat->keyboard_state.keyboard = NULL;
 	}
-
-	seat->keyboard_state.keyboard = keyboard;
-	wlr_seat_keyboard_send_modifiers(seat);
 }
 
 struct wlr_keyboard *wlr_seat_get_keyboard(struct wlr_seat *seat) {

--- a/types/wlr_seat.c
+++ b/types/wlr_seat.c
@@ -794,7 +794,7 @@ void wlr_seat_set_keyboard(struct wlr_seat *seat,
 			seat_client_send_repeat_info(client, keyboard);
 		}
 
-		wlr_seat_keyboard_send_modifiers(seat, keyboard->modifiers);
+		wlr_seat_keyboard_send_modifiers(seat, &keyboard->modifiers);
 	} else {
 		seat->keyboard_state.keyboard = NULL;
 	}

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -112,8 +112,9 @@ static void xdg_keyboard_grab_key(struct wlr_seat_keyboard_grab *grab, uint32_t 
 	wlr_seat_keyboard_send_key(grab->seat, time, key, state);
 }
 
-static void xdg_keyboard_grab_modifiers(struct wlr_seat_keyboard_grab *grab) {
-	wlr_seat_keyboard_send_modifiers(grab->seat);
+static void xdg_keyboard_grab_modifiers(struct wlr_seat_keyboard_grab *grab,
+		struct wlr_keyboard_modifiers *modifiers) {
+	wlr_seat_keyboard_send_modifiers(grab->seat, modifiers);
 }
 
 static void xdg_keyboard_grab_cancel(struct wlr_seat_keyboard_grab *grab) {

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -103,7 +103,9 @@ static const struct wlr_pointer_grab_interface xdg_pointer_grab_impl = {
 	.axis = xdg_pointer_grab_axis,
 };
 
-static void xdg_keyboard_grab_enter(struct wlr_seat_keyboard_grab *grab, struct wlr_surface *surface) {
+static void xdg_keyboard_grab_enter(struct wlr_seat_keyboard_grab *grab,
+		struct wlr_surface *surface, uint32_t keycodes[], size_t num_keycodes,
+		struct wlr_keyboard_modifiers *modifiers) {
 	// keyboard focus should remain on the popup
 }
 


### PR DESCRIPTION
Add the ability to change modifiers in flight with `wlr_seat_keyboard_notify_modifiers()` by giving the compositor control over what modifiers are sent to clients. Further decouples the device from the seat and makes it more consistent with the rest of the interface.