### PR TITLE
sends the modifiers on wlr_seat_set_keyboard

### DIFF
--- a/types/wlr_seat.c
+++ b/types/wlr_seat.c
@@ -794,6 +794,7 @@ void wlr_seat_set_keyboard(struct wlr_seat *seat,
 	}
 
 	seat->keyboard_state.keyboard = keyboard;
+	wlr_seat_keyboard_send_modifiers(seat);
 }
 
 void wlr_seat_keyboard_start_grab(struct wlr_seat *wlr_seat,


### PR DESCRIPTION
Without this, a client will lose modifiers for one keyboard, when a key
is pressed on the other.
With this the client will always use the modifiers tate of the keyboard
the key was pressed on.

Testplan:
Connect 2 keyboard to the same seat, focus a window (I tested with weston-terminal).
Hold shift on one keyboard and press a character key, this should input capital letters.
Keep shift pressed, press a key on the other keyboard.
Press the key on the first keyboard again.
With this patch it should insert capital letters, without lower case.