### PR TITLE
adds remote argument to wayland backend create

### DIFF
--- a/backend/backend.c
+++ b/backend/backend.c
@@ -53,7 +53,7 @@ struct wlr_egl *wlr_backend_get_egl(struct wlr_backend *backend) {
 }
 
 static struct wlr_backend *attempt_wl_backend(struct wl_display *display) {
-	struct wlr_backend *backend = wlr_wl_backend_create(display);
+	struct wlr_backend *backend = wlr_wl_backend_create(display, NULL);
 	if (backend) {
 		int outputs = 1;
 		const char *_outputs = getenv("WLR_WL_OUTPUTS");

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -158,7 +158,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	wlr_wl_backend_destroy(&backend->backend);
 }
 
-struct wlr_backend *wlr_wl_backend_create(struct wl_display *display) {
+struct wlr_backend *wlr_wl_backend_create(struct wl_display *display, const char *remote) {
 	wlr_log(L_INFO, "Creating wayland backend");
 
 	struct wlr_wl_backend *backend = calloc(1, sizeof(struct wlr_wl_backend));
@@ -173,7 +173,7 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display) {
 
 	backend->local_display = display;
 
-	backend->remote_display = wl_display_connect(NULL);
+	backend->remote_display = wl_display_connect(remote);
 	if (!backend->remote_display) {
 		wlr_log_errno(L_ERROR, "Could not connect to remote display");
 		return false;

--- a/include/wlr/backend/wayland.h
+++ b/include/wlr/backend/wayland.h
@@ -12,7 +12,7 @@
  * Creates a new wlr_wl_backend. This backend will be created with no outputs;
  * you must use wlr_wl_output_create to add them.
  */
-struct wlr_backend *wlr_wl_backend_create(struct wl_display *display);
+struct wlr_backend *wlr_wl_backend_create(struct wl_display *display, const char *remote);
 
 /**
  * Adds a new output to this backend. You may remove outputs by destroying them.


### PR DESCRIPTION
Add a remote display name argument to wlr_wl_backend_create.
If NULL is passed to the wayland backend at all times, creating a
wayland backend *after* the compositor was started up, would require
changing the WAYLAND_DISPLAY environment variable.