### PR TITLE
xwayland: render children window in fullscreen

### DIFF
--- a/include/wlr/xwayland.h
+++ b/include/wlr/xwayland.h
@@ -98,8 +98,11 @@ struct wlr_xwayland_surface {
 	char *title;
 	char *class;
 	char *instance;
-	struct wlr_xwayland_surface *parent;
 	pid_t pid;
+
+	struct wl_list children; // wlr_xwayland_surface::parent_link
+	struct wlr_xwayland_surface *parent;
+	struct wl_list parent_link; // wlr_xwayland_surface::children
 
 	xcb_atom_t *window_type;
 	size_t window_type_len;

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -169,6 +169,19 @@ static void render_wl_shell_surface(struct wlr_wl_shell_surface *surface,
 	}
 }
 
+static void render_xwayland_children(struct wlr_xwayland_surface *surface,
+		struct roots_desktop *desktop, struct wlr_output *wlr_output,
+		struct timespec *when) {
+	struct wlr_xwayland_surface *child;
+	wl_list_for_each(child, &surface->children, parent_link) {
+		if (child->surface != NULL && child->added) {
+			render_surface(child->surface, desktop, wlr_output, when,
+				child->x, child->y, 0);
+		}
+		render_xwayland_children(child, desktop, wlr_output, when);
+	}
+}
+
 static void render_view(struct roots_view *view, struct roots_desktop *desktop,
 		struct wlr_output *wlr_output, struct timespec *when) {
 	switch (view->type) {
@@ -200,7 +213,7 @@ static bool has_standalone_surface(struct roots_view *view) {
 	case ROOTS_WL_SHELL_VIEW:
 		return wl_list_empty(&view->wl_shell_surface->popups);
 	case ROOTS_XWAYLAND_VIEW:
-		return true;
+		return wl_list_empty(&view->xwayland_surface->children);
 	}
 	return true;
 }
@@ -218,27 +231,36 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	wlr_renderer_begin(server->renderer, wlr_output);
 
 	if (output->fullscreen_view != NULL) {
+		struct roots_view *view = output->fullscreen_view;
+
 		// Make sure the view is centered on screen
 		const struct wlr_box *output_box =
 			wlr_output_layout_get_box(desktop->layout, wlr_output);
 		struct wlr_box view_box;
-		view_get_box(output->fullscreen_view, &view_box);
+		view_get_box(view, &view_box);
 		double view_x = (double)(output_box->width - view_box.width) / 2 +
 			output_box->x;
 		double view_y = (double)(output_box->height - view_box.height) / 2 +
 			output_box->y;
-		view_move(output->fullscreen_view, view_x, view_y);
+		view_move(view, view_x, view_y);
 
-		if (has_standalone_surface(output->fullscreen_view)) {
-			wlr_output_set_fullscreen_surface(wlr_output,
-				output->fullscreen_view->wlr_surface);
+		if (has_standalone_surface(view)) {
+			wlr_output_set_fullscreen_surface(wlr_output, view->wlr_surface);
 		} else {
 			wlr_output_set_fullscreen_surface(wlr_output, NULL);
 
 			glClearColor(0, 0, 0, 0);
 			glClear(GL_COLOR_BUFFER_BIT);
 
-			render_view(output->fullscreen_view, desktop, wlr_output, &now);
+			render_view(view, desktop, wlr_output, &now);
+
+			// During normal rendering the xwayland window tree isn't traversed
+			// because all windows are rendered. Here we only want to render
+			// the fullscreen window's children so we have to traverse the tree.
+			if (view->type == ROOTS_XWAYLAND_VIEW) {
+				render_xwayland_children(view->xwayland_surface, desktop,
+					wlr_output, &now);
+			}
 		}
 		wlr_renderer_end(server->renderer);
 		wlr_output_swap_buffers(wlr_output);


### PR DESCRIPTION
Test plan: open Firefox in fullscreen mode, the right click menu should show up.

Fixes #561