### PR TITLE
Fixed logging for examples

### DIFF
--- a/examples/idle.c
+++ b/examples/idle.c
@@ -7,6 +7,7 @@
 #include <wayland-client.h>
 #include <wayland-client-protocol.h>
 #include <idle-client-protocol.h>
+#include <wlr/util/log.h>
 
 static struct org_kde_kwin_idle *idle_manager = NULL;
 static struct wl_seat *seat = NULL;
@@ -108,6 +109,7 @@ void *main_loop(void *data) {
 }
 
 int main(int argc, char *argv[]) {
+	wlr_log_init(L_DEBUG, NULL);
 
 	if (parse_args(argc, argv) != 0) {
 		return -1;

--- a/examples/multi-pointer.c
+++ b/examples/multi-pointer.c
@@ -176,6 +176,7 @@ static void handle_input_remove(struct compositor_state *state,
 }
 
 int main(int argc, char *argv[]) {
+	wlr_log_init(L_DEBUG, NULL);
 	struct sample_state state = {
 		.default_color = { 0.25f, 0.25f, 0.25f, 1 },
 		.clear_color = { 0.25f, 0.25f, 0.25f, 1 },

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -181,6 +181,7 @@ static void handle_keyboard_key(struct keyboard_state *kbstate,
 }
 
 int main(int argc, char *argv[]) {
+	wlr_log_init(L_DEBUG, NULL);
 	struct sample_state state = {0};
 
 	state.x_vel = 500;

--- a/examples/pointer.c
+++ b/examples/pointer.c
@@ -257,6 +257,7 @@ static void handle_tablet_tool_axis(struct wl_listener *listener, void *data) {
 }
 
 int main(int argc, char *argv[]) {
+	wlr_log_init(L_DEBUG, NULL);
 	struct sample_state state = {
 		.default_color = { 0.25f, 0.25f, 0.25f, 1 },
 		.clear_color = { 0.25f, 0.25f, 0.25f, 1 },

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -123,6 +123,7 @@ static void handle_keyboard_key(struct keyboard_state *kbstate,
 }
 
 int main(int argc, char *argv[]) {
+	wlr_log_init(L_DEBUG, NULL);
 	struct sample_state state = {0};
 	state.config = parse_args(argc, argv);
 

--- a/examples/screenshot.c
+++ b/examples/screenshot.c
@@ -36,6 +36,7 @@
 #include <sys/param.h>
 #include <screenshooter-client-protocol.h>
 #include "util/os-compatibility.h"
+#include <wlr/util/log.h>
 
 static struct wl_shm *shm = NULL;
 static struct orbital_screenshooter *screenshooter = NULL;
@@ -242,6 +243,7 @@ static int set_buffer_size(int *width, int *height) {
 }
 
 int main(int argc, char *argv[]) {
+	wlr_log_init(L_DEBUG, NULL);
 	struct wl_display * display = wl_display_connect(NULL);
 	if (display == NULL) {
 		fprintf(stderr, "failed to create display: %m\n");

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -44,6 +44,7 @@ void handle_output_frame(struct output_state *output, struct timespec *ts) {
 }
 
 int main() {
+	wlr_log_init(L_DEBUG, NULL);
 	struct sample_state state = {
 		.color = { 1.0, 0.0, 0.0 },
 		.dec = 0,

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -139,6 +139,7 @@ static void handle_pad_button(struct tablet_pad_state *pstate,
 }
 
 int main(int argc, char *argv[]) {
+	wlr_log_init(L_DEBUG, NULL);
 	struct sample_state state = {
 		.tool_color = { 1, 1, 1, 1 },
 		.pad_color = { 0.75, 0.75, 0.75, 1.0 }

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -94,6 +94,7 @@ static void handle_touch_motion(struct touch_state *tstate, int32_t touch_id,
 }
 
 int main(int argc, char *argv[]) {
+	wlr_log_init(L_DEBUG, NULL);
 	struct sample_state state;
 	wl_list_init(&state.touch_points);
 


### PR DESCRIPTION
Recent change means you need to call `wlr_log_init`, which wasn't being done in the examples.