### PR TITLE
rootston: hide cursor if seat has only keyboards

### DIFF
--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -313,6 +313,14 @@ static void seat_update_capabilities(struct roots_seat *seat) {
 		caps |= WL_SEAT_CAPABILITY_TOUCH;
 	}
 	wlr_seat_set_capabilities(seat->seat, caps);
+
+	// Hide cursor if seat doesn't have pointer capability
+	if ((caps & WL_SEAT_CAPABILITY_POINTER) == 0) {
+		wlr_cursor_set_image(seat->cursor->cursor, NULL, 0, 0, 0, 0, 0, 0);
+	} else {
+		wlr_xcursor_manager_set_cursor_image(seat->cursor->xcursor_manager,
+			seat->cursor->default_xcursor, seat->cursor->cursor);
+	}
 }
 
 static void seat_add_keyboard(struct roots_seat *seat,

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -293,17 +293,26 @@ struct roots_seat *roots_seat_create(struct roots_input *input, char *name) {
 		return NULL;
 	}
 
-	wlr_seat_set_capabilities(seat->seat,
-		WL_SEAT_CAPABILITY_KEYBOARD |
-		WL_SEAT_CAPABILITY_POINTER |
-		WL_SEAT_CAPABILITY_TOUCH);
-
 	wl_list_insert(&input->seats, &seat->link);
 
 	seat->seat_destroy.notify = roots_seat_handle_seat_destroy;
 	wl_signal_add(&seat->seat->events.destroy, &seat->seat_destroy);
 
 	return seat;
+}
+
+static void seat_update_capabilities(struct roots_seat *seat) {
+	uint32_t caps = 0;
+	if (!wl_list_empty(&seat->keyboards)) {
+		caps |= WL_SEAT_CAPABILITY_KEYBOARD;
+	}
+	if (!wl_list_empty(&seat->pointers) || !wl_list_empty(&seat->tablet_tools)) {
+		caps |= WL_SEAT_CAPABILITY_POINTER;
+	}
+	if (!wl_list_empty(&seat->touch)) {
+		caps |= WL_SEAT_CAPABILITY_TOUCH;
+	}
+	wlr_seat_set_capabilities(seat->seat, caps);
 }
 
 static void seat_add_keyboard(struct roots_seat *seat,
@@ -404,6 +413,8 @@ void roots_seat_add_device(struct roots_seat *seat,
 		seat_add_tablet_tool(seat, device);
 		break;
 	}
+
+	seat_update_capabilities(seat);
 }
 
 static void seat_remove_keyboard(struct roots_seat *seat,
@@ -480,6 +491,8 @@ void roots_seat_remove_device(struct roots_seat *seat,
 		seat_remove_tablet_tool(seat, device);
 		break;
 	}
+
+	seat_update_capabilities(seat);
 }
 
 void roots_seat_configure_xcursor(struct roots_seat *seat) {


### PR DESCRIPTION
Also set the real seat capabilities instead of always all of them.

Test plan: create a seat with a mouse and a keyboard. Unpluging the mouse should hide the pointer.

Updates https://github.com/swaywm/sway/issues/1568