### PR TITLE
Output damage tracking

### DIFF
--- a/backend/backend.c
+++ b/backend/backend.c
@@ -37,7 +37,6 @@ void wlr_backend_destroy(struct wlr_backend *backend) {
 		return;
 	}
 
-	wl_signal_emit(&backend->events.destroy, backend);
 	if (backend->impl && backend->impl->destroy) {
 		backend->impl->destroy(backend);
 	} else {

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -34,6 +34,8 @@ static void wlr_drm_backend_destroy(struct wlr_backend *backend) {
 		wlr_output_destroy(&conn->output);
 	}
 
+	wl_signal_emit(&backend->events.destroy, backend);
+
 	wl_list_remove(&drm->display_destroy.link);
 	wl_list_remove(&drm->session_signal.link);
 	wl_list_remove(&drm->drm_invalidated.link);

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -91,6 +91,8 @@ static void session_signal(struct wl_listener *listener, void *data) {
 			struct wlr_drm_plane *plane = conn->crtc->cursor;
 			drm->iface->crtc_set_cursor(drm, conn->crtc,
 				(plane && plane->cursor_enabled) ? plane->cursor_bo : NULL);
+			drm->iface->crtc_move_cursor(drm, conn->crtc, conn->cursor_x,
+				conn->cursor_y);
 		}
 	} else {
 		wlr_log(L_INFO, "DRM fd paused");

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -192,6 +192,9 @@ static bool wlr_drm_connector_make_current(struct wlr_output *output,
 static bool wlr_drm_connector_swap_buffers(struct wlr_output *output) {
 	struct wlr_drm_connector *conn = (struct wlr_drm_connector *)output;
 	struct wlr_drm_backend *drm = (struct wlr_drm_backend *)output->backend;
+	if (!drm->session->active) {
+		return false;
+	}
 
 	struct wlr_drm_crtc *crtc = conn->crtc;
 	if (!crtc) {
@@ -516,6 +519,10 @@ static bool wlr_drm_connector_set_cursor(struct wlr_output *output,
 	struct wlr_drm_backend *drm = (struct wlr_drm_backend *)output->backend;
 	struct wlr_drm_renderer *renderer = &drm->renderer;
 
+	if (!drm->session->active) {
+		return false;
+	}
+
 	struct wlr_drm_crtc *crtc = conn->crtc;
 	if (!crtc) {
 		return false;
@@ -644,6 +651,9 @@ static bool wlr_drm_connector_move_cursor(struct wlr_output *output,
 		int x, int y) {
 	struct wlr_drm_connector *conn = (struct wlr_drm_connector *)output;
 	struct wlr_drm_backend *drm = (struct wlr_drm_backend *)output->backend;
+	if (!drm->session->active) {
+		return false;
+	}
 	if (!conn->crtc) {
 		return false;
 	}

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -881,7 +881,7 @@ static void page_flip_handler(int fd, unsigned seq,
 	}
 
 	if (drm->session->active) {
-		wl_signal_emit(&conn->output.events.frame, &conn->output);
+		wlr_output_send_frame(&conn->output);
 	}
 }
 

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -619,7 +619,11 @@ static bool wlr_drm_connector_set_cursor(struct wlr_output *output,
 
 	gbm_bo_unmap(bo, bo_data);
 
-	return drm->iface->crtc_set_cursor(drm, crtc, bo);
+	bool ok = drm->iface->crtc_set_cursor(drm, crtc, bo);
+	if (ok) {
+		wlr_output_update_needs_swap(output);
+	}
+	return ok;
 }
 
 static bool wlr_drm_connector_move_cursor(struct wlr_output *output,
@@ -643,8 +647,12 @@ static bool wlr_drm_connector_move_cursor(struct wlr_output *output,
 		transformed_box.y -= plane->cursor_hotspot_y;
 	}
 
-	return drm->iface->crtc_move_cursor(drm, conn->crtc, transformed_box.x,
+	bool ok = drm->iface->crtc_move_cursor(drm, conn->crtc, transformed_box.x,
 		transformed_box.y);
+	if (ok) {
+		wlr_output_update_needs_swap(output);
+	}
+	return ok;
 }
 
 static void wlr_drm_connector_destroy(struct wlr_output *output) {

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -581,15 +581,14 @@ static bool wlr_drm_connector_set_cursor(struct wlr_output *output,
 	}
 
 	struct wlr_box hotspot = {
-		.width = plane->surf.width,
-		.height = plane->surf.height,
 		.x = hotspot_x,
 		.y = hotspot_y,
 	};
 	enum wl_output_transform transform =
 		wlr_output_transform_invert(output->transform);
 	struct wlr_box transformed_hotspot;
-	wlr_box_transform(&hotspot, transform, &transformed_hotspot);
+	wlr_box_transform(&hotspot, transform,
+		plane->surf.width, plane->surf.height, &transformed_hotspot);
 	plane->cursor_hotspot_x = transformed_hotspot.x;
 	plane->cursor_hotspot_y = transformed_hotspot.y;
 
@@ -650,15 +649,15 @@ static bool wlr_drm_connector_move_cursor(struct wlr_output *output,
 	}
 	struct wlr_drm_plane *plane = conn->crtc->cursor;
 
-	struct wlr_box box;
-	box.x = x;
-	box.y = y;
-	wlr_output_effective_resolution(output, &box.width, &box.height);
+	struct wlr_box box = { .x = x, .y = y };
+
+	int width, height;
+	wlr_output_effective_resolution(output, &width, &height);
 
 	enum wl_output_transform transform =
 		wlr_output_transform_invert(output->transform);
 	struct wlr_box transformed_box;
-	wlr_box_transform(&box, transform, &transformed_box);
+	wlr_box_transform(&box, transform, width, height, &transformed_box);
 
 	if (plane != NULL) {
 		transformed_box.x -= plane->cursor_hotspot_x;

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -201,6 +201,11 @@ static void wlr_drm_connector_swap_buffers(struct wlr_output *output) {
 	}
 	uint32_t fb_id = get_fb_for_bo(bo);
 
+	if (conn->pageflip_pending) {
+		wlr_log(L_ERROR, "Skipping pageflip");
+		return;
+	}
+
 	if (drm->iface->crtc_pageflip(drm, conn, crtc, fb_id, NULL)) {
 		conn->pageflip_pending = true;
 	} else {

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -213,13 +213,11 @@ static bool wlr_drm_connector_swap_buffers(struct wlr_output *output) {
 		return false;
 	}
 
-	if (drm->iface->crtc_pageflip(drm, conn, crtc, fb_id, NULL)) {
-		conn->pageflip_pending = true;
-	} else {
-		wl_event_source_timer_update(conn->retry_pageflip,
-			1000000.0f / conn->output.current_mode->refresh);
+	if (!drm->iface->crtc_pageflip(drm, conn, crtc, fb_id, NULL)) {
+		return false;
 	}
 
+	conn->pageflip_pending = true;
 	return true;
 }
 

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -199,14 +199,13 @@ static void wlr_drm_connector_swap_buffers(struct wlr_output *output) {
 	if (drm->parent) {
 		bo = wlr_drm_surface_mgpu_copy(&plane->mgpu_surf, bo);
 	}
-
 	uint32_t fb_id = get_fb_for_bo(bo);
 
 	if (drm->iface->crtc_pageflip(drm, conn, crtc, fb_id, NULL)) {
 		conn->pageflip_pending = true;
 	} else {
 		wl_event_source_timer_update(conn->retry_pageflip,
-			1000.0f / conn->output.current_mode->refresh);
+			1000000.0f / conn->output.current_mode->refresh);
 	}
 }
 
@@ -241,7 +240,7 @@ void wlr_drm_connector_start_renderer(struct wlr_drm_connector *conn) {
 		conn->pageflip_pending = true;
 	} else {
 		wl_event_source_timer_update(conn->retry_pageflip,
-			1000.0f / conn->output.current_mode->refresh);
+			1000000.0f / conn->output.current_mode->refresh);
 	}
 }
 

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -210,7 +210,7 @@ static bool wlr_drm_connector_swap_buffers(struct wlr_output *output) {
 
 	if (conn->pageflip_pending) {
 		wlr_log(L_ERROR, "Skipping pageflip");
-		return true;
+		return false;
 	}
 
 	if (drm->iface->crtc_pageflip(drm, conn, crtc, fb_id, NULL)) {

--- a/backend/headless/backend.c
+++ b/backend/headless/backend.c
@@ -51,6 +51,8 @@ static void backend_destroy(struct wlr_backend *wlr_backend) {
 		wlr_input_device_destroy(&input_device->wlr_input_device);
 	}
 
+	wl_signal_emit(&wlr_backend->events.destroy, backend);
+
 	wlr_egl_finish(&backend->egl);
 	free(backend);
 }

--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -48,18 +48,15 @@ static void output_transform(struct wlr_output *wlr_output,
 	output->wlr_output.transform = transform;
 }
 
-static void output_make_current(struct wlr_output *wlr_output) {
+static bool output_make_current(struct wlr_output *wlr_output, int *buffer_age) {
 	struct wlr_headless_output *output =
 		(struct wlr_headless_output *)wlr_output;
-	if (!eglMakeCurrent(output->backend->egl.display,
-		output->egl_surface, output->egl_surface,
-		output->backend->egl.context)) {
-		wlr_log(L_ERROR, "eglMakeCurrent failed: %s", egl_error());
-	}
+	return wlr_egl_make_current(&output->backend->egl, output->egl_surface,
+		buffer_age);
 }
 
-static void output_swap_buffers(struct wlr_output *wlr_output) {
-	// No-op
+static bool output_swap_buffers(struct wlr_output *wlr_output) {
+	return true; // No-op
 }
 
 static void output_destroy(struct wlr_output *wlr_output) {

--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -62,8 +62,6 @@ static bool output_swap_buffers(struct wlr_output *wlr_output) {
 static void output_destroy(struct wlr_output *wlr_output) {
 	struct wlr_headless_output *output =
 		(struct wlr_headless_output *)wlr_output;
-	wl_signal_emit(&output->backend->backend.events.output_remove,
-		&output->wlr_output);
 
 	wl_list_remove(&output->link);
 

--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -85,7 +85,7 @@ bool wlr_output_is_headless(struct wlr_output *wlr_output) {
 
 static int signal_frame(void *data) {
 	struct wlr_headless_output *output = data;
-	wl_signal_emit(&output->wlr_output.events.frame, &output->wlr_output);
+	wlr_output_send_frame(&output->wlr_output);
 	wl_event_source_timer_update(output->frame_timer, output->frame_delay);
 	return 0;
 }

--- a/backend/libinput/backend.c
+++ b/backend/libinput/backend.c
@@ -95,12 +95,12 @@ static bool wlr_libinput_backend_start(struct wlr_backend *_backend) {
 	return true;
 }
 
-static void wlr_libinput_backend_destroy(struct wlr_backend *_backend) {
-	if (!_backend) {
+static void wlr_libinput_backend_destroy(struct wlr_backend *wlr_backend) {
+	if (!wlr_backend) {
 		return;
 	}
 	struct wlr_libinput_backend *backend =
-		(struct wlr_libinput_backend *)_backend;
+		(struct wlr_libinput_backend *)wlr_backend;
 
 	for (size_t i = 0; i < backend->wlr_device_lists.length; i++) {
 		struct wl_list *wlr_devices = backend->wlr_device_lists.items[i];
@@ -111,6 +111,8 @@ static void wlr_libinput_backend_destroy(struct wlr_backend *_backend) {
 		}
 		free(wlr_devices);
 	}
+
+	wl_signal_emit(&wlr_backend->events.destroy, wlr_backend);
 
 	wl_list_remove(&backend->display_destroy.link);
 	wl_list_remove(&backend->session_signal.link);

--- a/backend/multi/backend.c
+++ b/backend/multi/backend.c
@@ -42,11 +42,16 @@ static void subbackend_state_destroy(struct subbackend_state *sub) {
 
 static void multi_backend_destroy(struct wlr_backend *wlr_backend) {
 	struct wlr_multi_backend *backend = (struct wlr_multi_backend *)wlr_backend;
+
 	wl_list_remove(&backend->display_destroy.link);
+
 	struct subbackend_state *sub, *next;
 	wl_list_for_each_safe(sub, next, &backend->backends, link) {
 		wlr_backend_destroy(sub->backend);
 	}
+
+	// Destroy this backend only after removing all sub-backends
+	wl_signal_emit(&wlr_backend->events.destroy, backend);
 	free(backend);
 }
 

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -64,9 +64,9 @@ static bool wlr_wl_backend_start(struct wlr_backend *_backend) {
 	return true;
 }
 
-static void wlr_wl_backend_destroy(struct wlr_backend *_backend) {
-	struct wlr_wl_backend *backend = (struct wlr_wl_backend *)_backend;
-	if (!_backend) {
+static void wlr_wl_backend_destroy(struct wlr_backend *wlr_backend) {
+	struct wlr_wl_backend *backend = (struct wlr_wl_backend *)wlr_backend;
+	if (backend == NULL) {
 		return;
 	}
 
@@ -79,6 +79,8 @@ static void wlr_wl_backend_destroy(struct wlr_backend *_backend) {
 	wl_list_for_each_safe(input_device, tmp_input_device, &backend->devices, link) {
 		wlr_input_device_destroy(input_device);
 	}
+
+	wl_signal_emit(&wlr_backend->events.destroy, wlr_backend);
 
 	wl_list_remove(&backend->local_display_destroy.link);
 

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -17,11 +17,11 @@ int os_create_anonymous_file(off_t size);
 
 static struct wl_callback_listener frame_listener;
 
-static void surface_frame_callback(void *data, struct wl_callback *cb, uint32_t time) {
+static void surface_frame_callback(void *data, struct wl_callback *cb,
+		uint32_t time) {
 	struct wlr_wl_backend_output *output = data;
-	struct wlr_output *wlr_output = (struct wlr_output *)output;
-	assert(wlr_output);
-	wl_signal_emit(&wlr_output->events.frame, wlr_output);
+	assert(output);
+	wlr_output_send_frame(&output->wlr_output);
 	wl_callback_destroy(cb);
 	output->frame_callback = NULL;
 }

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -161,11 +161,12 @@ static bool wlr_wl_output_set_cursor(struct wlr_output *_output,
 	return true;
 }
 
-static void wlr_wl_output_destroy(struct wlr_output *_output) {
+static void wlr_wl_output_destroy(struct wlr_output *wlr_output) {
 	struct wlr_wl_backend_output *output =
-		(struct wlr_wl_backend_output *)_output;
-	wl_signal_emit(&output->backend->backend.events.output_remove,
-		&output->wlr_output);
+		(struct wlr_wl_backend_output *)wlr_output;
+	if (output == NULL) {
+		return;
+	}
 
 	wl_list_remove(&output->link);
 

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -21,9 +21,10 @@ static void surface_frame_callback(void *data, struct wl_callback *cb,
 		uint32_t time) {
 	struct wlr_wl_backend_output *output = data;
 	assert(output);
-	wlr_output_send_frame(&output->wlr_output);
 	wl_callback_destroy(cb);
 	output->frame_callback = NULL;
+
+	wlr_output_send_frame(&output->wlr_output);
 }
 
 static struct wl_callback_listener frame_listener = {
@@ -49,6 +50,11 @@ static bool wlr_wl_output_make_current(struct wlr_output *wlr_output,
 static bool wlr_wl_output_swap_buffers(struct wlr_output *wlr_output) {
 	struct wlr_wl_backend_output *output =
 		(struct wlr_wl_backend_output *)wlr_output;
+
+	if (output->frame_callback != NULL) {
+		wlr_log(L_ERROR, "Skipping buffer swap");
+		return false;
+	}
 
 	output->frame_callback = wl_surface_frame(output->surface);
 	wl_callback_add_listener(output->frame_callback, &frame_listener, output);

--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -54,14 +54,16 @@ static void pointer_handle_motion(void *data, struct wl_pointer *wl_pointer,
 
 	struct wlr_output *wlr_output = &wlr_wl_pointer->current_output->wlr_output;
 
-	struct wlr_box box;
+	int width, height;
 	wl_egl_window_get_attached_size(wlr_wl_pointer->current_output->egl_window,
-		&box.width, &box.height);
-	box.x = wl_fixed_to_int(surface_x);
-	box.y = wl_fixed_to_int(surface_y);
+		&width, &height);
 
+	struct wlr_box box = {
+		.x = wl_fixed_to_int(surface_x),
+		.y = wl_fixed_to_int(surface_y),
+	};
 	struct wlr_box transformed;
-	wlr_box_transform(&box, wlr_output->transform, &transformed);
+	wlr_box_transform(&box, wlr_output->transform, width, height, &transformed);
 	transformed.x /= wlr_output->scale;
 	transformed.y /= wlr_output->scale;
 

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -44,7 +44,7 @@ static bool handle_x11_event(struct wlr_x11_backend *x11, xcb_generic_event_t *e
 
 	switch (event->response_type) {
 	case XCB_EXPOSE: {
-		wl_signal_emit(&output->wlr_output.events.frame, output);
+		wlr_output_send_frame(&output->wlr_output);
 		break;
 	}
 	case XCB_KEY_PRESS:
@@ -174,7 +174,7 @@ static int x11_event(int fd, uint32_t mask, void *data) {
 
 static int signal_frame(void *data) {
 	struct wlr_x11_backend *x11 = data;
-	wl_signal_emit(&x11->output.wlr_output.events.frame, &x11->output);
+	wlr_output_send_frame(&x11->output.wlr_output);
 	wl_event_source_timer_update(x11->frame_timer, 16);
 	return 0;
 }

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -395,6 +395,12 @@ static void output_swap_buffers(struct wlr_output *wlr_output) {
 	if (!eglSwapBuffers(x11->egl.display, output->surf)) {
 		wlr_log(L_ERROR, "eglSwapBuffers failed: %s", egl_error());
 	}
+
+	// Damage the whole output
+	// TODO: use the buffer age extension
+	pixman_region32_union_rect(&wlr_output->damage, &wlr_output->damage,
+		0, 0, wlr_output->width, wlr_output->height);
+	wlr_output_update_needs_swap(wlr_output);
 }
 
 static struct wlr_output_impl output_impl = {

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -259,6 +259,8 @@ static void wlr_x11_backend_destroy(struct wlr_backend *backend) {
 		xkb_state_unref(x11->keyboard_dev.keyboard->xkb_state);
 	}
 
+	wl_signal_emit(&backend->events.destroy, backend);
+
 	wl_list_remove(&x11->display_destroy.link);
 
 	wl_event_source_remove(x11->frame_timer);

--- a/examples/multi-pointer.c
+++ b/examples/multi-pointer.c
@@ -56,7 +56,7 @@ static void handle_output_frame(struct output_state *output,
 	struct sample_state *sample = state->data;
 	struct wlr_output *wlr_output = output->output;
 
-	wlr_output_make_current(wlr_output);
+	wlr_output_make_current(wlr_output, NULL);
 
 	glClearColor(sample->clear_color[0], sample->clear_color[1],
 		sample->clear_color[2], sample->clear_color[3]);

--- a/examples/multi-pointer.c
+++ b/examples/multi-pointer.c
@@ -62,7 +62,7 @@ static void handle_output_frame(struct output_state *output,
 		sample->clear_color[2], sample->clear_color[3]);
 	glClear(GL_COLOR_BUFFER_BIT);
 
-	wlr_output_swap_buffers(wlr_output);
+	wlr_output_swap_buffers(wlr_output, NULL, NULL);
 }
 
 static void handle_output_add(struct output_state *ostate) {

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -102,7 +102,7 @@ static void handle_output_frame(struct output_state *output,
 
 	wlr_output_make_current(wlr_output, NULL);
 	wlr_renderer_begin(sample->renderer, wlr_output);
-	wlr_renderer_clear(sample->renderer, 0.25f, 0.25f, 0.25f, 1);
+	wlr_renderer_clear(sample->renderer, &(float[]){0.25f, 0.25f, 0.25f, 1});
 
 	animate_cat(sample, output->output);
 

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -100,7 +100,7 @@ static void handle_output_frame(struct output_state *output,
 	struct sample_state *sample = state->data;
 	struct wlr_output *wlr_output = output->output;
 
-	wlr_output_make_current(wlr_output);
+	wlr_output_make_current(wlr_output, NULL);
 	wlr_renderer_begin(sample->renderer, wlr_output);
 
 	animate_cat(sample, output->output);

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -102,6 +102,7 @@ static void handle_output_frame(struct output_state *output,
 
 	wlr_output_make_current(wlr_output, NULL);
 	wlr_renderer_begin(sample->renderer, wlr_output);
+	wlr_renderer_clear(sample->renderer, 0.25f, 0.25f, 0.25f, 1);
 
 	animate_cat(sample, output->output);
 

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -125,7 +125,7 @@ static void handle_output_frame(struct output_state *output,
 	}
 
 	wlr_renderer_end(sample->renderer);
-	wlr_output_swap_buffers(wlr_output);
+	wlr_output_swap_buffers(wlr_output, NULL, NULL);
 }
 
 static void handle_output_add(struct output_state *ostate) {

--- a/examples/pointer.c
+++ b/examples/pointer.c
@@ -91,7 +91,7 @@ static void handle_output_frame(struct output_state *output,
 		sample->clear_color[2], sample->clear_color[3]);
 	glClear(GL_COLOR_BUFFER_BIT);
 
-	wlr_output_swap_buffers(wlr_output);
+	wlr_output_swap_buffers(wlr_output, NULL, NULL);
 }
 
 static void handle_output_add(struct output_state *ostate) {

--- a/examples/pointer.c
+++ b/examples/pointer.c
@@ -85,7 +85,7 @@ static void handle_output_frame(struct output_state *output,
 	struct sample_state *sample = state->data;
 	struct wlr_output *wlr_output = output->output;
 
-	wlr_output_make_current(wlr_output);
+	wlr_output_make_current(wlr_output, NULL);
 
 	glClearColor(sample->clear_color[0], sample->clear_color[1],
 		sample->clear_color[2], sample->clear_color[3]);

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -44,6 +44,7 @@ static void handle_output_frame(struct output_state *output, struct timespec *ts
 
 	wlr_output_make_current(wlr_output, NULL);
 	wlr_renderer_begin(sample->renderer, wlr_output);
+	wlr_renderer_clear(sample->renderer, 0.25f, 0.25f, 0.25f, 1);
 
 	float matrix[16];
 	for (int y = -128 + (int)odata->y_offs; y < height; y += 128) {

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -56,7 +56,7 @@ static void handle_output_frame(struct output_state *output, struct timespec *ts
 	}
 
 	wlr_renderer_end(sample->renderer);
-	wlr_output_swap_buffers(wlr_output);
+	wlr_output_swap_buffers(wlr_output, NULL, NULL);
 
 	long ms = (ts->tv_sec - output->last_frame.tv_sec) * 1000 +
 		(ts->tv_nsec - output->last_frame.tv_nsec) / 1000000;

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -44,7 +44,7 @@ static void handle_output_frame(struct output_state *output, struct timespec *ts
 
 	wlr_output_make_current(wlr_output, NULL);
 	wlr_renderer_begin(sample->renderer, wlr_output);
-	wlr_renderer_clear(sample->renderer, 0.25f, 0.25f, 0.25f, 1);
+	wlr_renderer_clear(sample->renderer, &(float[]){0.25f, 0.25f, 0.25f, 1});
 
 	float matrix[16];
 	for (int y = -128 + (int)odata->y_offs; y < height; y += 128) {

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -42,7 +42,7 @@ static void handle_output_frame(struct output_state *output, struct timespec *ts
 	int32_t width, height;
 	wlr_output_effective_resolution(wlr_output, &width, &height);
 
-	wlr_output_make_current(wlr_output);
+	wlr_output_make_current(wlr_output, NULL);
 	wlr_renderer_begin(sample->renderer, wlr_output);
 
 	float matrix[16];

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -35,7 +35,7 @@ void handle_output_frame(struct output_state *output, struct timespec *ts) {
 		sample->dec = inc;
 	}
 
-	wlr_output_make_current(output->output);
+	wlr_output_make_current(output->output, NULL);
 
 	glClearColor(sample->color[0], sample->color[1], sample->color[2], 1.0);
 	glClear(GL_COLOR_BUFFER_BIT);

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -40,7 +40,7 @@ void handle_output_frame(struct output_state *output, struct timespec *ts) {
 	glClearColor(sample->color[0], sample->color[1], sample->color[2], 1.0);
 	glClear(GL_COLOR_BUFFER_BIT);
 
-	wlr_output_swap_buffers(output->output);
+	wlr_output_swap_buffers(output->output, NULL, NULL);
 }
 
 int main() {

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -76,7 +76,7 @@ static void handle_output_frame(struct output_state *output, struct timespec *ts
 	}
 
 	wlr_renderer_end(sample->renderer);
-	wlr_output_swap_buffers(wlr_output);
+	wlr_output_swap_buffers(wlr_output, NULL, NULL);
 }
 
 static void handle_tool_axis(struct tablet_tool_state *tstate,

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -42,7 +42,7 @@ static void handle_output_frame(struct output_state *output, struct timespec *ts
 	int32_t width, height;
 	wlr_output_effective_resolution(wlr_output, &width, &height);
 
-	wlr_output_make_current(wlr_output);
+	wlr_output_make_current(wlr_output, NULL);
 	wlr_renderer_begin(sample->renderer, wlr_output);
 
 	float matrix[16], view[16];

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -44,7 +44,7 @@ static void handle_output_frame(struct output_state *output, struct timespec *ts
 
 	wlr_output_make_current(wlr_output, NULL);
 	wlr_renderer_begin(sample->renderer, wlr_output);
-	wlr_renderer_clear(sample->renderer, 0.25f, 0.25f, 0.25f, 1);
+	wlr_renderer_clear(sample->renderer, &(float[]){0.25f, 0.25f, 0.25f, 1});
 
 	float matrix[16], view[16];
 	float distance = 0.8f * (1 - sample->distance);

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -44,6 +44,7 @@ static void handle_output_frame(struct output_state *output, struct timespec *ts
 
 	wlr_output_make_current(wlr_output, NULL);
 	wlr_renderer_begin(sample->renderer, wlr_output);
+	wlr_renderer_clear(sample->renderer, 0.25f, 0.25f, 0.25f, 1);
 
 	float matrix[16], view[16];
 	float distance = 0.8f * (1 - sample->distance);

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -56,7 +56,7 @@ static void handle_output_frame(struct output_state *output, struct timespec *ts
 	}
 
 	wlr_renderer_end(sample->renderer);
-	wlr_output_swap_buffers(wlr_output);
+	wlr_output_swap_buffers(wlr_output, NULL, NULL);
 }
 
 static void handle_touch_down(struct touch_state *tstate, int32_t touch_id,

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -41,7 +41,7 @@ static void handle_output_frame(struct output_state *output, struct timespec *ts
 	int32_t width, height;
 	wlr_output_effective_resolution(wlr_output, &width, &height);
 
-	wlr_output_make_current(wlr_output);
+	wlr_output_make_current(wlr_output, NULL);
 	wlr_renderer_begin(sample->renderer, wlr_output);
 
 	float matrix[16];

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -43,6 +43,7 @@ static void handle_output_frame(struct output_state *output, struct timespec *ts
 
 	wlr_output_make_current(wlr_output, NULL);
 	wlr_renderer_begin(sample->renderer, wlr_output);
+	wlr_renderer_clear(sample->renderer, 0.25f, 0.25f, 0.25f, 1);
 
 	float matrix[16];
 	struct touch_point *p;

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -43,7 +43,7 @@ static void handle_output_frame(struct output_state *output, struct timespec *ts
 
 	wlr_output_make_current(wlr_output, NULL);
 	wlr_renderer_begin(sample->renderer, wlr_output);
-	wlr_renderer_clear(sample->renderer, 0.25f, 0.25f, 0.25f, 1);
+	wlr_renderer_clear(sample->renderer, &(float[]){0.25f, 0.25f, 0.25f, 1});
 
 	float matrix[16];
 	struct touch_point *p;

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -123,8 +123,8 @@ struct wlr_drm_connector {
 
 	union wlr_drm_connector_props props;
 
-	uint32_t width;
-	uint32_t height;
+	uint32_t width, height;
+	int32_t cursor_x, cursor_y;
 
 	drmModeCrtc *old_crtc;
 

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -45,7 +45,7 @@ bool wlr_drm_plane_surfaces_init(struct wlr_drm_plane *plane, struct wlr_drm_bac
 		int32_t width, uint32_t height, uint32_t format);
 
 void wlr_drm_surface_finish(struct wlr_drm_surface *surf);
-void wlr_drm_surface_make_current(struct wlr_drm_surface *surf);
+bool wlr_drm_surface_make_current(struct wlr_drm_surface *surf, int *buffer_age);
 struct gbm_bo *wlr_drm_surface_swap_buffers(struct wlr_drm_surface *surf);
 struct gbm_bo *wlr_drm_surface_get_front(struct wlr_drm_surface *surf);
 void wlr_drm_surface_post(struct wlr_drm_surface *surf);

--- a/include/rootston/desktop.h
+++ b/include/rootston/desktop.h
@@ -64,7 +64,7 @@ struct roots_view *desktop_view_at(struct roots_desktop *desktop, double lx,
 	double ly, struct wlr_surface **surface, double *sx, double *sy);
 
 void view_init(struct roots_view *view, struct roots_desktop *desktop);
-void view_destroy(struct roots_view *view);
+void view_finish(struct roots_view *view);
 void view_activate(struct roots_view *view, bool activate);
 void view_apply_damage(struct roots_view *view);
 void view_damage_whole(struct roots_view *view);

--- a/include/rootston/desktop.h
+++ b/include/rootston/desktop.h
@@ -69,6 +69,7 @@ void view_activate(struct roots_view *view, bool activate);
 void view_apply_damage(struct roots_view *view);
 void view_damage_whole(struct roots_view *view);
 void view_update_position(struct roots_view *view, double x, double y);
+void view_update_size(struct roots_view *view, uint32_t width, uint32_t height);
 
 void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data);
 void handle_wl_shell_surface(struct wl_listener *listener, void *data);

--- a/include/rootston/output.h
+++ b/include/rootston/output.h
@@ -39,6 +39,7 @@ void output_remove_notify(struct wl_listener *listener, void *data);
 struct roots_view;
 struct roots_drag_icon;
 
+void output_damage_whole(struct roots_output *output);
 void output_damage_whole_view(struct roots_output *output,
 	struct roots_view *view);
 void output_damage_from_view(struct roots_output *output,

--- a/include/rootston/output.h
+++ b/include/rootston/output.h
@@ -16,10 +16,11 @@ struct roots_output {
 
 	struct timespec last_frame;
 	pixman_region32_t damage, previous_damage;
-	struct wl_event_source *repaint_timer;
+	bool frame_scheduled;
 
 	struct wl_listener frame;
 	struct wl_listener mode;
+	struct wl_listener damage_listener;
 };
 
 void output_add_notify(struct wl_listener *listener, void *data);

--- a/include/rootston/output.h
+++ b/include/rootston/output.h
@@ -14,10 +14,12 @@ struct roots_output {
 
 	struct roots_view *fullscreen_view;
 
-	struct wl_listener frame;
 	struct timespec last_frame;
 	pixman_region32_t damage, previous_damage;
 	struct wl_event_source *repaint_timer;
+
+	struct wl_listener frame;
+	struct wl_listener mode;
 };
 
 void output_add_notify(struct wl_listener *listener, void *data);

--- a/include/rootston/output.h
+++ b/include/rootston/output.h
@@ -5,6 +5,8 @@
 #include <pixman.h>
 #include <wayland-server.h>
 
+#define ROOTS_OUTPUT_PREVIOUS_DAMAGE_LEN 2
+
 struct roots_desktop;
 
 struct roots_output {
@@ -15,8 +17,11 @@ struct roots_output {
 	struct roots_view *fullscreen_view;
 
 	struct timespec last_frame;
-	pixman_region32_t damage, previous_damage;
+	pixman_region32_t damage;
 	bool frame_pending;
+
+	pixman_region32_t previous_damage[ROOTS_OUTPUT_PREVIOUS_DAMAGE_LEN];
+	size_t previous_damage_idx;
 
 	struct wl_listener frame;
 	struct wl_listener mode;

--- a/include/rootston/output.h
+++ b/include/rootston/output.h
@@ -5,6 +5,11 @@
 #include <pixman.h>
 #include <wayland-server.h>
 
+/**
+ * Damage tracking requires to keep track of previous frames' damage. To allow
+ * damage tracking to work with triple buffering, an history of two frames is
+ * required.
+ */
 #define ROOTS_OUTPUT_PREVIOUS_DAMAGE_LEN 2
 
 struct roots_desktop;
@@ -20,6 +25,7 @@ struct roots_output {
 	pixman_region32_t damage;
 	bool frame_pending;
 
+	// circular queue for previous damage
 	pixman_region32_t previous_damage[ROOTS_OUTPUT_PREVIOUS_DAMAGE_LEN];
 	size_t previous_damage_idx;
 

--- a/include/rootston/output.h
+++ b/include/rootston/output.h
@@ -23,7 +23,6 @@ struct roots_output {
 
 	struct timespec last_frame;
 	pixman_region32_t damage; // in ouput-local coordinates
-	bool frame_pending;
 
 	// circular queue for previous damage
 	pixman_region32_t previous_damage[ROOTS_OUTPUT_PREVIOUS_DAMAGE_LEN];

--- a/include/rootston/output.h
+++ b/include/rootston/output.h
@@ -16,11 +16,11 @@ struct roots_output {
 
 	struct timespec last_frame;
 	pixman_region32_t damage, previous_damage;
-	bool frame_scheduled;
+	bool frame_pending;
 
 	struct wl_listener frame;
 	struct wl_listener mode;
-	struct wl_listener damage_listener;
+	struct wl_listener needs_swap;
 };
 
 void output_add_notify(struct wl_listener *listener, void *data);

--- a/include/rootston/output.h
+++ b/include/rootston/output.h
@@ -7,7 +7,7 @@
 
 /**
  * Damage tracking requires to keep track of previous frames' damage. To allow
- * damage tracking to work with triple buffering, an history of two frames is
+ * damage tracking to work with triple buffering, a history of two frames is
  * required.
  */
 #define ROOTS_OUTPUT_PREVIOUS_DAMAGE_LEN 2
@@ -22,7 +22,7 @@ struct roots_output {
 	struct roots_view *fullscreen_view;
 
 	struct timespec last_frame;
-	pixman_region32_t damage;
+	pixman_region32_t damage; // in ouput-local coordinates
 	bool frame_pending;
 
 	// circular queue for previous damage

--- a/include/rootston/seat.h
+++ b/include/rootston/seat.h
@@ -17,12 +17,15 @@ struct roots_seat {
 	struct wl_list views; // roots_seat_view::link
 	bool has_focus;
 
+	struct wl_list drag_icons; // roots_drag_icon::link
+
 	struct wl_list keyboards;
 	struct wl_list pointers;
 	struct wl_list touch;
 	struct wl_list tablet_tools;
 
-	struct wl_listener seat_destroy;
+	struct wl_listener new_drag_icon;
+	struct wl_listener destroy;
 };
 
 struct roots_seat_view {
@@ -31,6 +34,16 @@ struct roots_seat_view {
 	struct wl_list link; // roots_seat::views
 
 	struct wl_listener view_destroy;
+};
+
+struct roots_drag_icon {
+	struct roots_seat *seat;
+	struct wlr_drag_icon *wlr_drag_icon;
+	struct wl_list link;
+
+	struct wl_listener surface_commit;
+	struct wl_listener map;
+	struct wl_listener destroy;
 };
 
 struct roots_pointer {

--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -91,7 +91,11 @@ struct roots_view {
 		struct roots_xwayland_surface *roots_xwayland_surface;
 #endif
 	};
+
 	struct wlr_surface *wlr_surface;
+	struct wl_list children; // roots_view_child::link
+
+	struct wl_listener new_subsurface;
 
 	struct {
 		struct wl_signal destroy;
@@ -112,6 +116,21 @@ struct roots_view {
 	void (*close)(struct roots_view *view);
 };
 
+struct roots_view_child {
+	struct roots_view *view;
+	struct wlr_surface *wlr_surface;
+	struct wl_list link;
+
+	struct wl_listener commit;
+	struct wl_listener new_subsurface;
+};
+
+struct roots_subsurface {
+	struct roots_view_child view_child;
+	struct wlr_subsurface *wlr_subsurface;
+	struct wl_listener destroy;
+};
+
 void view_get_box(const struct roots_view *view, struct wlr_box *box);
 void view_activate(struct roots_view *view, bool active);
 void view_move(struct roots_view *view, double x, double y);
@@ -125,5 +144,13 @@ void view_close(struct roots_view *view);
 bool view_center(struct roots_view *view);
 void view_setup(struct roots_view *view);
 void view_teardown(struct roots_view *view);
+
+void view_child_init(struct roots_view_child *child, struct roots_view *view,
+	struct wlr_surface *wlr_surface);
+void view_child_finish(struct roots_view_child *child);
+
+struct roots_subsurface *subsurface_create(struct roots_view *view,
+	struct wlr_subsurface *wlr_subsurface);
+void subsurface_destroy(struct roots_subsurface *subsurface);
 
 #endif

--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -23,12 +23,14 @@ struct roots_wl_shell_surface {
 struct roots_xdg_surface_v6 {
 	struct roots_view *view;
 
-	struct wl_listener commit;
 	struct wl_listener destroy;
+	struct wl_listener new_popup;
 	struct wl_listener request_move;
 	struct wl_listener request_resize;
 	struct wl_listener request_maximize;
 	struct wl_listener request_fullscreen;
+
+	struct wl_listener surface_commit;
 
 	uint32_t pending_move_resize_configure_serial;
 };
@@ -131,6 +133,13 @@ struct roots_subsurface {
 	struct roots_view_child view_child;
 	struct wlr_subsurface *wlr_subsurface;
 	struct wl_listener destroy;
+};
+
+struct roots_xdg_popup_v6 {
+	struct roots_view_child view_child;
+	struct wlr_xdg_popup_v6 *wlr_popup;
+	struct wl_listener destroy;
+	struct wl_listener new_popup;
 };
 
 void view_get_box(const struct roots_view *view, struct wlr_box *box);

--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -164,6 +164,7 @@ void view_move_resize(struct roots_view *view, double x, double y,
 void view_maximize(struct roots_view *view, bool maximized);
 void view_set_fullscreen(struct roots_view *view, bool fullscreen,
 	struct wlr_output *output);
+void view_rotate(struct roots_view *view, float rotation);
 void view_close(struct roots_view *view);
 bool view_center(struct roots_view *view);
 void view_setup(struct roots_view *view);

--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -123,6 +123,8 @@ struct roots_view_child {
 
 	struct wl_listener commit;
 	struct wl_listener new_subsurface;
+
+	void (*destroy)(struct roots_view_child *child);
 };
 
 struct roots_subsurface {
@@ -151,6 +153,5 @@ void view_child_finish(struct roots_view_child *child);
 
 struct roots_subsurface *subsurface_create(struct roots_view *view,
 	struct wlr_subsurface *wlr_subsurface);
-void subsurface_destroy(struct roots_subsurface *subsurface);
 
 #endif

--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -62,6 +62,7 @@ struct roots_view {
 	struct wl_list link; // roots_desktop::views
 
 	double x, y;
+	uint32_t width, height;
 	float rotation;
 
 	bool decorated;
@@ -108,11 +109,7 @@ struct roots_view {
 		struct wl_signal destroy;
 	} events;
 
-	// TODO: This would probably be better as a field that's updated on a
-	// configure event from the xdg_shell
-	// If not then this should follow the typical type/impl pattern we use
-	// elsewhere
-	void (*get_size)(const struct roots_view *view, struct wlr_box *box);
+	// TODO: this should follow the typical type/impl pattern we use elsewhere
 	void (*activate)(struct roots_view *view, bool active);
 	void (*move)(struct roots_view *view, double x, double y);
 	void (*resize)(struct roots_view *view, uint32_t width, uint32_t height);

--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -11,6 +11,7 @@ struct roots_wl_shell_surface {
 	struct roots_view *view;
 
 	struct wl_listener destroy;
+	struct wl_listener new_popup;
 	struct wl_listener request_move;
 	struct wl_listener request_resize;
 	struct wl_listener request_maximize;
@@ -133,6 +134,14 @@ struct roots_subsurface {
 	struct roots_view_child view_child;
 	struct wlr_subsurface *wlr_subsurface;
 	struct wl_listener destroy;
+};
+
+struct roots_wl_shell_popup {
+	struct roots_view_child view_child;
+	struct wlr_wl_shell_surface *wlr_wl_shell_surface;
+	struct wl_listener destroy;
+	struct wl_listener set_state;
+	struct wl_listener new_popup;
 };
 
 struct roots_xdg_popup_v6 {

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -32,5 +32,6 @@ void wlr_output_update_mode(struct wlr_output *output,
 void wlr_output_update_custom_mode(struct wlr_output *output, int32_t width,
 	int32_t height, int32_t refresh);
 void wlr_output_update_enabled(struct wlr_output *output, bool enabled);
+void wlr_output_update_needs_swap(struct wlr_output *output);
 
 #endif

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -18,8 +18,8 @@ struct wlr_output_impl {
 		int32_t hotspot_x, int32_t hotspot_y, bool update_pixels);
 	bool (*move_cursor)(struct wlr_output *output, int x, int y);
 	void (*destroy)(struct wlr_output *output);
-	void (*make_current)(struct wlr_output *output);
-	void (*swap_buffers)(struct wlr_output *output);
+	bool (*make_current)(struct wlr_output *output, int *buffer_age);
+	bool (*swap_buffers)(struct wlr_output *output);
 	void (*set_gamma)(struct wlr_output *output,
 		uint32_t size, uint16_t *r, uint16_t *g, uint16_t *b);
 	uint32_t (*get_gamma_size)(struct wlr_output *output);

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -33,5 +33,6 @@ void wlr_output_update_custom_mode(struct wlr_output *output, int32_t width,
 	int32_t height, int32_t refresh);
 void wlr_output_update_enabled(struct wlr_output *output, bool enabled);
 void wlr_output_update_needs_swap(struct wlr_output *output);
+void wlr_output_send_frame(struct wlr_output *output);
 
 #endif

--- a/include/wlr/render.h
+++ b/include/wlr/render.h
@@ -5,6 +5,7 @@
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #include <wayland-server-protocol.h>
+#include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_output.h>
 
 struct wlr_texture;
@@ -12,6 +13,9 @@ struct wlr_renderer;
 
 void wlr_renderer_begin(struct wlr_renderer *r, struct wlr_output *output);
 void wlr_renderer_end(struct wlr_renderer *r);
+void wlr_renderer_clear(struct wlr_renderer *r, float red, float green,
+	float blue, float alpha);
+void wlr_renderer_scissor(struct wlr_renderer *r, struct wlr_box *box);
 /**
  * Requests a texture handle from this renderer.
  */

--- a/include/wlr/render.h
+++ b/include/wlr/render.h
@@ -13,8 +13,7 @@ struct wlr_renderer;
 
 void wlr_renderer_begin(struct wlr_renderer *r, struct wlr_output *output);
 void wlr_renderer_end(struct wlr_renderer *r);
-void wlr_renderer_clear(struct wlr_renderer *r, float red, float green,
-	float blue, float alpha);
+void wlr_renderer_clear(struct wlr_renderer *r, const float (*color)[4]);
 /**
  * Defines a scissor box. Only pixels that lie within the scissor box can be
  * modified by drawing functions. Providing a NULL `box` disables the scissor

--- a/include/wlr/render.h
+++ b/include/wlr/render.h
@@ -15,6 +15,11 @@ void wlr_renderer_begin(struct wlr_renderer *r, struct wlr_output *output);
 void wlr_renderer_end(struct wlr_renderer *r);
 void wlr_renderer_clear(struct wlr_renderer *r, float red, float green,
 	float blue, float alpha);
+/**
+ * Defines a scissor box. Only pixels that lie within the scissor box can be
+ * modified by drawing functions. Providing a NULL `box` disables the scissor
+ * box.
+ */
 void wlr_renderer_scissor(struct wlr_renderer *r, struct wlr_box *box);
 /**
  * Requests a texture handle from this renderer.

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -11,8 +11,12 @@ struct wlr_egl {
 	EGLConfig config;
 	EGLContext context;
 
-	const char *egl_exts;
-	const char *gl_exts;
+	const char *egl_exts_str;
+	const char *gl_exts_str;
+
+	struct {
+		bool buffer_age;
+	} egl_exts;
 
 	struct wl_display *wl_display;
 };
@@ -64,5 +68,11 @@ bool wlr_egl_destroy_image(struct wlr_egl *egl, EGLImageKHR image);
  * Returns a string for the last error ocurred with egl.
  */
 const char *egl_error(void);
+
+bool wlr_egl_make_current(struct wlr_egl *egl, EGLSurface surface,
+	int *buffer_age);
+
+// TODO: remove
+int wlr_egl_get_buffer_age(struct wlr_egl *egl, EGLSurface surface);
 
 #endif

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -72,7 +72,4 @@ const char *egl_error(void);
 bool wlr_egl_make_current(struct wlr_egl *egl, EGLSurface surface,
 	int *buffer_age);
 
-// TODO: remove
-int wlr_egl_get_buffer_age(struct wlr_egl *egl, EGLSurface surface);
-
 #endif

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -18,8 +18,7 @@ struct wlr_renderer {
 struct wlr_renderer_impl {
 	void (*begin)(struct wlr_renderer *renderer, struct wlr_output *output);
 	void (*end)(struct wlr_renderer *renderer);
-	void (*clear)(struct wlr_renderer *renderer, float red, float green,
-		float blue, float alpha);
+	void (*clear)(struct wlr_renderer *renderer, const float (*color)[4]);
 	void (*scissor)(struct wlr_renderer *renderer, struct wlr_box *box);
 	struct wlr_texture *(*texture_create)(struct wlr_renderer *renderer);
 	bool (*render_with_matrix)(struct wlr_renderer *renderer,

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -6,6 +6,7 @@
 #include <EGL/eglext.h>
 #include <stdbool.h>
 #include <wlr/render.h>
+#include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_output.h>
 
 struct wlr_renderer_impl;
@@ -17,6 +18,9 @@ struct wlr_renderer {
 struct wlr_renderer_impl {
 	void (*begin)(struct wlr_renderer *renderer, struct wlr_output *output);
 	void (*end)(struct wlr_renderer *renderer);
+	void (*clear)(struct wlr_renderer *renderer, float red, float green,
+		float blue, float alpha);
+	void (*scissor)(struct wlr_renderer *renderer, struct wlr_box *box);
 	struct wlr_texture *(*texture_create)(struct wlr_renderer *renderer);
 	bool (*render_with_matrix)(struct wlr_renderer *renderer,
 		struct wlr_texture *texture, const float (*matrix)[16]);

--- a/include/wlr/types/wlr_box.h
+++ b/include/wlr/types/wlr_box.h
@@ -2,6 +2,7 @@
 #define WLR_TYPES_WLR_BOX_H
 
 #include <stdbool.h>
+#include <wayland-server.h>
 
 struct wlr_box {
 	int x, y;
@@ -18,8 +19,11 @@ bool wlr_box_contains_point(const struct wlr_box *box, double x, double y);
 
 bool wlr_box_empty(const struct wlr_box *box);
 
-enum wl_output_transform;
+/**
+ * Transforms a box inside a `width` x `height` box.
+ */
 void wlr_box_transform(const struct wlr_box *box,
-	enum wl_output_transform transform, struct wlr_box *dest);
+	enum wl_output_transform transform, int width, int height,
+	struct wlr_box *dest);
 
 #endif

--- a/include/wlr/types/wlr_box.h
+++ b/include/wlr/types/wlr_box.h
@@ -26,4 +26,10 @@ void wlr_box_transform(const struct wlr_box *box,
 	enum wl_output_transform transform, int width, int height,
 	struct wlr_box *dest);
 
+/**
+ * Creates the smallest box that contains a rotated box.
+ */
+void wlr_box_rotated_bounds(const struct wlr_box *box, float rotation,
+	struct wlr_box *dest);
+
 #endif

--- a/include/wlr/types/wlr_compositor.h
+++ b/include/wlr/types/wlr_compositor.h
@@ -13,7 +13,7 @@ struct wlr_compositor {
 	struct wl_listener display_destroy;
 
 	struct {
-		struct wl_signal create_surface;
+		struct wl_signal new_surface;
 	} events;
 };
 

--- a/include/wlr/types/wlr_data_device.h
+++ b/include/wlr/types/wlr_data_device.h
@@ -71,10 +71,10 @@ struct wlr_drag_icon {
 	bool is_pointer;
 	int32_t touch_id;
 
-	int32_t sx;
-	int32_t sy;
+	int32_t sx, sy;
 
 	struct {
+		struct wl_signal map; // emitted when mapped or unmapped
 		struct wl_signal destroy;
 	} events;
 

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -33,6 +33,8 @@ struct wlr_output_cursor {
 	struct wl_listener surface_destroy;
 };
 
+#define WLR_OUTPUT_PREVIOUS_DAMAGE_COUNT 2
+
 struct wlr_output_impl;
 
 struct wlr_output {
@@ -55,7 +57,7 @@ struct wlr_output {
 	enum wl_output_transform transform;
 
 	bool needs_swap;
-	pixman_region32_t damage, previous_damage;
+	pixman_region32_t damage;
 	float transform_matrix[16];
 
 	// Note: some backends may have zero modes
@@ -104,13 +106,19 @@ void wlr_output_set_scale(struct wlr_output *output, float scale);
 void wlr_output_destroy(struct wlr_output *output);
 void wlr_output_effective_resolution(struct wlr_output *output,
 	int *width, int *height);
-void wlr_output_make_current(struct wlr_output *output);
+/**
+ * Makes the output GL context current.
+ *
+ * `buffer_age` is set to the drawing buffer age in number of frames or -1 if
+ * unknown.
+ */
+bool wlr_output_make_current(struct wlr_output *output, int *buffer_age);
 /**
  * Swaps the output buffers. If the time of the frame isn't known, set `when` to
  * NULL. If the compositor doesn't support damage tracking, set `damage` to
  * NULL.
  */
-void wlr_output_swap_buffers(struct wlr_output *output, struct timespec *when,
+bool wlr_output_swap_buffers(struct wlr_output *output, struct timespec *when,
 	pixman_region32_t *damage);
 void wlr_output_set_gamma(struct wlr_output *output,
 	uint32_t size, uint16_t *r, uint16_t *g, uint16_t *b);

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -63,6 +63,7 @@ struct wlr_output {
 	bool needs_swap;
 	// damage for cursors and fullscreen surface, in output-local coordinates
 	pixman_region32_t damage;
+	bool frame_pending;
 	float transform_matrix[16];
 
 	struct {
@@ -123,6 +124,11 @@ bool wlr_output_make_current(struct wlr_output *output, int *buffer_age);
  */
 bool wlr_output_swap_buffers(struct wlr_output *output, struct timespec *when,
 	pixman_region32_t *damage);
+/**
+ * Manually schedules a `frame` event. If a `frame` event is already pending,
+ * it is a no-op.
+ */
+void wlr_output_schedule_frame(struct wlr_output *output);
 void wlr_output_set_gamma(struct wlr_output *output,
 	uint32_t size, uint16_t *r, uint16_t *g, uint16_t *b);
 uint32_t wlr_output_get_gamma_size(struct wlr_output *output);

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -106,6 +106,14 @@ void wlr_output_set_transform(struct wlr_output *output,
 void wlr_output_set_position(struct wlr_output *output, int32_t lx, int32_t ly);
 void wlr_output_set_scale(struct wlr_output *output, float scale);
 void wlr_output_destroy(struct wlr_output *output);
+/**
+ * Computes the transformed output resolution.
+ */
+void wlr_output_transformed_resolution(struct wlr_output *output,
+	int *width, int *height);
+/**
+ * Computes the transformed and scaled output resolution.
+ */
 void wlr_output_effective_resolution(struct wlr_output *output,
 	int *width, int *height);
 /**

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -53,7 +53,7 @@ struct wlr_output {
 	enum wl_output_subpixel subpixel;
 	enum wl_output_transform transform;
 
-	pixman_region32_t damage;
+	pixman_region32_t damage, previous_damage;
 	float transform_matrix[16];
 
 	// Note: some backends may have zero modes

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -77,6 +77,8 @@ struct wlr_output {
 		struct wl_signal destroy;
 	} events;
 
+	struct wl_event_source *idle_frame;
+
 	struct wlr_surface *fullscreen_surface;
 	struct wl_listener fullscreen_surface_commit;
 	struct wl_listener fullscreen_surface_destroy;

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -2,6 +2,7 @@
 #define WLR_TYPES_WLR_OUTPUT_H
 
 #include <stdbool.h>
+#include <time.h>
 #include <pixman.h>
 #include <wayland-util.h>
 #include <wayland-server.h>
@@ -103,7 +104,13 @@ void wlr_output_destroy(struct wlr_output *output);
 void wlr_output_effective_resolution(struct wlr_output *output,
 	int *width, int *height);
 void wlr_output_make_current(struct wlr_output *output);
-void wlr_output_swap_buffers(struct wlr_output *output);
+/**
+ * Swaps the output buffers. If the time of the frame isn't known, set `when` to
+ * NULL. If the compositor doesn't support damage tracking, set `damage` to
+ * NULL.
+ */
+void wlr_output_swap_buffers(struct wlr_output *output, struct timespec *when,
+	pixman_region32_t *damage);
 void wlr_output_set_gamma(struct wlr_output *output,
 	uint32_t size, uint16_t *r, uint16_t *g, uint16_t *b);
 uint32_t wlr_output_get_gamma_size(struct wlr_output *output);

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -82,6 +82,7 @@ struct wlr_output {
 	struct wlr_surface *fullscreen_surface;
 	struct wl_listener fullscreen_surface_commit;
 	struct wl_listener fullscreen_surface_destroy;
+	int fullscreen_width, fullscreen_height;
 
 	struct wl_list cursors; // wlr_output_cursor::link
 	struct wlr_output_cursor *hardware_cursor;

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -63,6 +63,7 @@ struct wlr_output {
 	int32_t refresh; // mHz
 
 	struct {
+		struct wl_signal damage;
 		struct wl_signal frame;
 		struct wl_signal swap_buffers;
 		struct wl_signal enable;

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -54,6 +54,7 @@ struct wlr_output {
 	enum wl_output_subpixel subpixel;
 	enum wl_output_transform transform;
 
+	bool needs_swap;
 	pixman_region32_t damage, previous_damage;
 	float transform_matrix[16];
 
@@ -64,8 +65,8 @@ struct wlr_output {
 	int32_t refresh; // mHz
 
 	struct {
-		struct wl_signal damage;
 		struct wl_signal frame;
+		struct wl_signal needs_swap;
 		struct wl_signal swap_buffers;
 		struct wl_signal enable;
 		struct wl_signal mode;

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -24,7 +24,6 @@ struct wlr_output_cursor {
 	struct wl_list link;
 
 	// only when using a software cursor without a surface
-	struct wlr_renderer *renderer;
 	struct wlr_texture *texture;
 
 	// only when using a cursor surface

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -61,7 +61,8 @@ struct wlr_output {
 	enum wl_output_transform transform;
 
 	bool needs_swap;
-	pixman_region32_t damage; // damage for cursors and fullscreen surface
+	// damage for cursors and fullscreen surface, in output-local coordinates
+	pixman_region32_t damage;
 	float transform_matrix[16];
 
 	struct {

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -209,6 +209,8 @@ struct wlr_seat {
 		struct wl_signal selection;
 		struct wl_signal primary_selection;
 
+		struct wl_signal new_drag_icon;
+
 		struct wl_signal destroy;
 	} events;
 

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -56,6 +56,10 @@ struct wlr_subsurface {
 	struct wl_list parent_pending_link;
 
 	struct wl_listener parent_destroy_listener;
+
+	struct {
+		struct wl_signal destroy;
+	} events;
 };
 
 struct wlr_surface {
@@ -70,6 +74,7 @@ struct wlr_surface {
 
 	struct {
 		struct wl_signal commit;
+		struct wl_signal new_subsurface;
 		struct wl_signal destroy;
 	} events;
 

--- a/include/wlr/types/wlr_wl_shell.h
+++ b/include/wlr/types/wlr_wl_shell.h
@@ -79,6 +79,7 @@ struct wlr_wl_shell_surface {
 	struct {
 		struct wl_signal destroy;
 		struct wl_signal ping_timeout;
+		struct wl_signal new_popup;
 
 		struct wl_signal request_move;
 		struct wl_signal request_resize;

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -34,6 +34,7 @@ struct wlr_xdg_client_v6 {
 
 struct wlr_xdg_popup_v6 {
 	struct wlr_xdg_surface_v6 *base;
+	struct wl_list link;
 
 	struct wl_resource *resource;
 	bool committed;
@@ -104,8 +105,7 @@ struct wlr_xdg_surface_v6 {
 		struct wlr_xdg_popup_v6 *popup_state;
 	};
 
-	struct wl_list popups;
-	struct wl_list popup_link;
+	struct wl_list popups; // wlr_xdg_popup_v6::link
 
 	bool configured;
 	bool added;
@@ -126,6 +126,7 @@ struct wlr_xdg_surface_v6 {
 	struct {
 		struct wl_signal destroy;
 		struct wl_signal ping_timeout;
+		struct wl_signal new_popup;
 
 		struct wl_signal request_maximize;
 		struct wl_signal request_fullscreen;

--- a/include/wlr/util/region.h
+++ b/include/wlr/util/region.h
@@ -3,6 +3,12 @@
 
 #include <pixman.h>
 
+/**
+ * Scales a region, ie. multiplies all its coordinates by `scale`.
+ *
+ * The resulting coordinates are rounded up or down so that the new region is
+ * at least as big as the original one.
+ */
 void wlr_region_scale(pixman_region32_t *dst, pixman_region32_t *src,
 	float scale);
 

--- a/include/wlr/util/region.h
+++ b/include/wlr/util/region.h
@@ -1,0 +1,9 @@
+#ifndef WLR_UTIL_REGION_H
+#define WLR_UTIL_REGION_H
+
+#include <pixman.h>
+
+void wlr_region_scale(pixman_region32_t *dst, pixman_region32_t *src,
+	float scale);
+
+#endif

--- a/include/wlr/util/region.h
+++ b/include/wlr/util/region.h
@@ -2,6 +2,7 @@
 #define WLR_UTIL_REGION_H
 
 #include <pixman.h>
+#include <wayland-server.h>
 
 /**
  * Scales a region, ie. multiplies all its coordinates by `scale`.
@@ -11,5 +12,11 @@
  */
 void wlr_region_scale(pixman_region32_t *dst, pixman_region32_t *src,
 	float scale);
+
+/**
+ * Applies a transform to a region inside a box of size `width` x `height`.
+ */
+void wlr_region_transform(pixman_region32_t *dst, pixman_region32_t *src,
+	enum wl_output_transform transform, int width, int height);
 
 #endif

--- a/include/wlr/util/region.h
+++ b/include/wlr/util/region.h
@@ -19,4 +19,11 @@ void wlr_region_scale(pixman_region32_t *dst, pixman_region32_t *src,
 void wlr_region_transform(pixman_region32_t *dst, pixman_region32_t *src,
 	enum wl_output_transform transform, int width, int height);
 
+/**
+ * Expands the region of `distance`. If `distance` is negative, it shrinks the
+ * region.
+ */
+void wlr_region_expand(pixman_region32_t *dst, pixman_region32_t *src,
+	int distance);
+
 #endif

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -107,9 +107,6 @@ static void init_globals() {
 
 static void wlr_gles2_begin(struct wlr_renderer *_renderer,
 		struct wlr_output *output) {
-	// TODO: let users customize the clear color?
-	//GL_CALL(glClearColor(0.25f, 0.25f, 0.25f, 1));
-	//GL_CALL(glClear(GL_COLOR_BUFFER_BIT));
 	GL_CALL(glViewport(0, 0, output->width, output->height));
 
 	// enable transparency

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -121,9 +121,9 @@ static void wlr_gles2_end(struct wlr_renderer *wlr_renderer) {
 	// no-op
 }
 
-static void wlr_gles2_clear(struct wlr_renderer *wlr_renderer, float red,
-		float green, float blue, float alpha) {
-	glClearColor(red, green, blue, alpha);
+static void wlr_gles2_clear(struct wlr_renderer *wlr_renderer,
+		const float (*color)[4]) {
+	glClearColor((*color)[0], (*color)[1], (*color)[2], (*color)[3]);
 	glClear(GL_COLOR_BUFFER_BIT);
 }
 

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -23,9 +23,8 @@ void wlr_renderer_end(struct wlr_renderer *r) {
 	r->impl->end(r);
 }
 
-void wlr_renderer_clear(struct wlr_renderer *r, float red, float green,
-		float blue, float alpha) {
-	r->impl->clear(r, red, green, blue, alpha);
+void wlr_renderer_clear(struct wlr_renderer *r, const float (*color)[4]) {
+	r->impl->clear(r, color);
 }
 
 void wlr_renderer_scissor(struct wlr_renderer *r, struct wlr_box *box) {

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -23,6 +23,15 @@ void wlr_renderer_end(struct wlr_renderer *r) {
 	r->impl->end(r);
 }
 
+void wlr_renderer_clear(struct wlr_renderer *r, float red, float green,
+		float blue, float alpha) {
+	r->impl->clear(r, red, green, blue, alpha);
+}
+
+void wlr_renderer_scissor(struct wlr_renderer *r, struct wlr_box *box) {
+	r->impl->scissor(r, box);
+}
+
 struct wlr_texture *wlr_render_texture_create(struct wlr_renderer *r) {
 	return r->impl->texture_create(r);
 }

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -203,7 +203,7 @@ static void roots_cursor_update_position(struct roots_cursor *cursor,
 			float angle = atan2(vx*uy - vy*ux, vx*ux + vy*uy);
 			int steps = 12;
 			angle = round(angle/M_PI*steps) / (steps/M_PI);
-			view->rotation = cursor->view_rotation + angle;
+			view_rotate(view, cursor->view_rotation + angle);
 		}
 		break;
 	}

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -243,6 +243,7 @@ void view_set_fullscreen(struct roots_view *view, bool fullscreen,
 
 		roots_output->fullscreen_view = view;
 		view->fullscreen_output = roots_output;
+		output_damage_whole(roots_output);
 	}
 
 	if (was_fullscreen && !fullscreen) {
@@ -250,6 +251,7 @@ void view_set_fullscreen(struct roots_view *view, bool fullscreen,
 			view->saved.height);
 		view_rotate(view, view->saved.rotation);
 
+		output_damage_whole(view->fullscreen_output);
 		view->fullscreen_output->fullscreen_view = NULL;
 		view->fullscreen_output = NULL;
 	}

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -200,7 +200,7 @@ void view_maximize(struct roots_view *view, bool maximized) {
 
 		view_move_resize(view, output_box->x, output_box->y, output_box->width,
 			output_box->height);
-		view->rotation = 0;
+		view_rotate(view, 0);
 	}
 
 	if (view->maximized && !maximized) {
@@ -208,7 +208,7 @@ void view_maximize(struct roots_view *view, bool maximized) {
 
 		view_move_resize(view, view->saved.x, view->saved.y, view->saved.width,
 			view->saved.height);
-		view->rotation = view->saved.rotation;
+		view_rotate(view, view->saved.rotation);
 	}
 }
 
@@ -249,7 +249,7 @@ void view_set_fullscreen(struct roots_view *view, bool fullscreen,
 			wlr_output_layout_get_box(view->desktop->layout, output);
 		view_move_resize(view, output_box->x, output_box->y, output_box->width,
 			output_box->height);
-		view->rotation = 0;
+		view_rotate(view, 0);
 
 		roots_output->fullscreen_view = view;
 		view->fullscreen_output = roots_output;
@@ -258,11 +258,21 @@ void view_set_fullscreen(struct roots_view *view, bool fullscreen,
 	if (was_fullscreen && !fullscreen) {
 		view_move_resize(view, view->saved.x, view->saved.y, view->saved.width,
 			view->saved.height);
-		view->rotation = view->saved.rotation;
+		view_rotate(view, view->saved.rotation);
 
 		view->fullscreen_output->fullscreen_view = NULL;
 		view->fullscreen_output = NULL;
 	}
+}
+
+void view_rotate(struct roots_view *view, float rotation) {
+	if (view->rotation == rotation) {
+		return;
+	}
+
+	view_damage_whole(view);
+	view->rotation = rotation;
+	view_damage_whole(view);
 }
 
 void view_close(struct roots_view *view) {

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -298,6 +298,10 @@ void view_damage_whole(struct roots_view *view) {
 }
 
 void view_update_position(struct roots_view *view, double x, double y) {
+	if (view->x == x && view->y == y) {
+		return;
+	}
+
 	view_damage_whole(view);
 	view->x = x;
 	view->y = y;

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -24,18 +24,8 @@
 void view_get_box(const struct roots_view *view, struct wlr_box *box) {
 	box->x = view->x;
 	box->y = view->y;
-	if (view->get_size) {
-		view->get_size(view, box);
-	} else {
-		if (view->wlr_surface == NULL) {
-			// View is unmapped
-			box->width = box->height = 0;
-			return;
-		}
-
-		box->width = view->wlr_surface->current->width;
-		box->height = view->wlr_surface->current->height;
-	}
+	box->width = view->width;
+	box->height = view->height;
 }
 
 void view_get_deco_box(const struct roots_view *view, struct wlr_box *box) {
@@ -466,6 +456,17 @@ void view_update_position(struct roots_view *view, double x, double y) {
 	view_damage_whole(view);
 	view->x = x;
 	view->y = y;
+	view_damage_whole(view);
+}
+
+void view_update_size(struct roots_view *view, uint32_t width, uint32_t height) {
+	if (view->width == width && view->height == height) {
+		return;
+	}
+
+	view_damage_whole(view);
+	view->width = width;
+	view->height = height;
 	view_damage_whole(view);
 }
 

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -493,7 +493,7 @@ static void output_handle_frame(struct wl_listener *listener, void *data) {
 	render_output(output);
 }
 
-static void output_damage_whole(struct roots_output *output) {
+void output_damage_whole(struct roots_output *output) {
 	int width, height;
 	wlr_output_transformed_resolution(output->wlr_output, &width, &height);
 

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -296,6 +296,8 @@ static void render_output(struct roots_output *output) {
 	pixman_region32_t damage;
 	pixman_region32_init(&damage);
 	pixman_region32_union(&damage, &output->damage, &output->previous_damage);
+	pixman_region32_intersect_rect(&damage, &damage, 0, 0, wlr_output->width,
+		wlr_output->height);
 
 	// TODO: fullscreen
 	if (!pixman_region32_not_empty(&damage)) {
@@ -404,10 +406,8 @@ static void schedule_render(struct roots_output *output) {
 }
 
 static void output_damage_whole(struct roots_output *output) {
-	int width, height;
-	wlr_output_effective_resolution(output->wlr_output, &width, &height);
 	pixman_region32_union_rect(&output->damage, &output->damage,
-		0, 0, width, height);
+		0, 0, output->wlr_output->width, output->wlr_output->height);
 
 	schedule_render(output);
 }

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -312,6 +312,12 @@ damage_finish:
 }
 
 static void render_view(struct roots_view *view, struct render_data *data) {
+	// Do not render views fullscreened on other outputs
+	if (view->fullscreen_output != NULL &&
+			view->fullscreen_output != data->output) {
+		return;
+	}
+
 	render_decorations(view, data);
 	view_for_each_surface(view, render_surface, data);
 }

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -175,17 +175,6 @@ static bool surface_intersect_output(struct wlr_surface *surface,
 	return wlr_output_layout_intersects(output_layout, wlr_output, &layout_box);
 }
 
-static void output_get_transformed_size(struct wlr_output *wlr_output,
-		int *width, int *height) {
-	if (wlr_output->transform % 2 == 0) {
-		*width = wlr_output->width;
-		*height = wlr_output->height;
-	} else {
-		*width = wlr_output->height;
-		*height = wlr_output->width;
-	}
-}
-
 static void scissor_output(struct roots_output *output, pixman_box32_t *rect) {
 	struct wlr_output *wlr_output = output->wlr_output;
 
@@ -197,7 +186,7 @@ static void scissor_output(struct roots_output *output, pixman_box32_t *rect) {
 	};
 
 	int ow, oh;
-	output_get_transformed_size(output->wlr_output, &ow, &oh);
+	wlr_output_transformed_resolution(output->wlr_output, &ow, &oh);
 
 	// Scissor is in renderer coordinates, ie. upside down
 	enum wl_output_transform transform = wlr_output_transform_compose(
@@ -392,7 +381,7 @@ static void render_output(struct roots_output *output) {
 	}
 
 	int width, height;
-	output_get_transformed_size(output->wlr_output, &width, &height);
+	wlr_output_transformed_resolution(output->wlr_output, &width, &height);
 
 	// Check if we can use damage tracking
 	pixman_region32_t damage;
@@ -506,7 +495,7 @@ static void output_handle_frame(struct wl_listener *listener, void *data) {
 
 static void output_damage_whole(struct roots_output *output) {
 	int width, height;
-	output_get_transformed_size(output->wlr_output, &width, &height);
+	wlr_output_transformed_resolution(output->wlr_output, &width, &height);
 
 	pixman_region32_union_rect(&output->damage, &output->damage, 0, 0,
 		width, height);

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -8,6 +8,7 @@
 #include <wlr/types/wlr_xdg_shell_v6.h>
 #include <wlr/render/matrix.h>
 #include <wlr/util/log.h>
+#include <wlr/util/region.h>
 #include "rootston/server.h"
 #include "rootston/output.h"
 #include "rootston/config.h"
@@ -186,7 +187,7 @@ static void render_surface(struct wlr_surface *surface, double lx, double ly,
 		return;
 	}
 
-	// TODO: output scale, output transform support
+	// TODO: output transform support
 	pixman_region32_t damage;
 	pixman_region32_init(&damage);
 	pixman_region32_union_rect(&damage, &damage, box.x, box.y,
@@ -257,7 +258,7 @@ static void render_decorations(struct roots_view *view,
 	struct wlr_box box;
 	get_decoration_box(view, output, &box);
 
-	// TODO: output scale, output transform support
+	// TODO: output transform support
 	pixman_region32_t damage;
 	pixman_region32_init(&damage);
 	pixman_region32_union_rect(&damage, &damage, box.x, box.y,
@@ -583,10 +584,11 @@ static void damage_from_surface(struct wlr_surface *surface,
 		return;
 	}
 
-	// TODO: output scale, output transform support
+	// TODO: output transform support
 	pixman_region32_t damage;
 	pixman_region32_init(&damage);
 	pixman_region32_copy(&damage, &surface->current->surface_damage);
+	wlr_region_scale(&damage, &damage, output->wlr_output->scale);
 	pixman_region32_translate(&damage, box.x, box.y);
 	pixman_region32_union(&output->damage, &output->damage, &damage);
 	pixman_region32_fini(&damage);

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -361,7 +361,7 @@ static void render_output(struct roots_output *output) {
 	struct timespec now;
 	clock_gettime(CLOCK_MONOTONIC, &now);
 
-	float clear_color[] = {0.25f, 0.25f, 0.25f};
+	float clear_color[] = {0.25f, 0.25f, 0.25f, 1.0f};
 
 	// Check if we can delegate the fullscreen surface to the output
 	if (output->fullscreen_view != NULL) {
@@ -438,8 +438,7 @@ static void render_output(struct roots_output *output) {
 	pixman_box32_t *rects = pixman_region32_rectangles(&damage, &nrects);
 	for (int i = 0; i < nrects; ++i) {
 		scissor_output(output, &rects[i]);
-		wlr_renderer_clear(renderer, clear_color[0], clear_color[1],
-			clear_color[2], 1);
+		wlr_renderer_clear(renderer, &clear_color);
 	}
 
 	// If a view is fullscreen on this output, render it

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -387,7 +387,9 @@ static void render_output(struct roots_output *output) {
 	}
 
 	int buffer_age = -1;
-	wlr_output_make_current(wlr_output, &buffer_age);
+	if (!wlr_output_make_current(wlr_output, &buffer_age)) {
+		return;
+	}
 
 	int width, height;
 	output_get_transformed_size(output->wlr_output, &width, &height);
@@ -482,7 +484,9 @@ static void render_output(struct roots_output *output) {
 renderer_end:
 	wlr_renderer_scissor(output->desktop->server->renderer, NULL);
 	wlr_renderer_end(server->renderer);
-	wlr_output_swap_buffers(wlr_output, &now, &damage);
+	if (!wlr_output_swap_buffers(wlr_output, &now, &damage)) {
+		goto damage_finish;
+	}
 	// same as decrementing, but works on unsigned integers
 	output->previous_damage_idx += ROOTS_OUTPUT_PREVIOUS_DAMAGE_LEN - 1;
 	output->previous_damage_idx %= ROOTS_OUTPUT_PREVIOUS_DAMAGE_LEN;

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -471,6 +471,11 @@ void output_damage_from_view(struct roots_output *output,
 	// TODO: subsurfaces, popups, etc
 }
 
+static void output_handle_mode(struct wl_listener *listener, void *data) {
+	struct roots_output *output = wl_container_of(listener, output, mode);
+	output_damage_whole(output);
+}
+
 static void set_mode(struct wlr_output *output,
 		struct roots_output_config *oc) {
 	int mhz = (int)(oc->mode.refresh_rate * 1000);
@@ -530,6 +535,8 @@ void output_add_notify(struct wl_listener *listener, void *data) {
 
 	output->frame.notify = output_handle_frame;
 	wl_signal_add(&wlr_output->events.frame, &output->frame);
+	output->mode.notify = output_handle_mode;
+	wl_signal_add(&wlr_output->events.mode, &output->mode);
 
 	struct roots_output_config *output_config =
 		roots_config_get_output(config, wlr_output);

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -518,6 +518,7 @@ static bool view_accept_damage(struct roots_output *output,
 	if (output->fullscreen_view == view) {
 		return true;
 	}
+#ifdef WLR_HAS_XWAYLAND
 	if (output->fullscreen_view->type == ROOTS_XWAYLAND_VIEW &&
 			view->type == ROOTS_XWAYLAND_VIEW) {
 		// Special case: accept damage from children
@@ -529,6 +530,7 @@ static bool view_accept_damage(struct roots_output *output,
 			xsurface = xsurface->parent;
 		}
 	}
+#endif
 	return false;
 }
 

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -549,12 +549,12 @@ static void damage_whole_surface(struct wlr_surface *surface,
 		return;
 	}
 
+	int ow, oh;
+	wlr_output_transformed_resolution(output->wlr_output, &ow, &oh);
+
 	struct wlr_box box;
-	bool intersects = surface_intersect_output(surface, output->desktop->layout,
+	surface_intersect_output(surface, output->desktop->layout,
 		output->wlr_output, lx, ly, rotation, &box);
-	if (!intersects) {
-		return;
-	}
 
 	// Take the surface damage and damage the whole surface
 	// The surface damage is still useful in case the surface got resized
@@ -564,6 +564,7 @@ static void damage_whole_surface(struct wlr_surface *surface,
 	wlr_region_scale(&damage, &damage, output->wlr_output->scale);
 	pixman_region32_union_rect(&damage, &damage, 0, 0, box.width, box.height);
 	pixman_region32_translate(&damage, box.x, box.y);
+	pixman_region32_intersect_rect(&damage, &damage, 0, 0, ow, oh);
 	pixman_box32_t *extents = pixman_region32_extents(&damage);
 	struct wlr_box extents_box = {
 		.x = extents->x1,
@@ -620,12 +621,12 @@ static void damage_from_surface(struct wlr_surface *surface,
 		return;
 	}
 
+	int ow, oh;
+	wlr_output_transformed_resolution(output->wlr_output, &ow, &oh);
+
 	struct wlr_box box;
-	bool intersects = surface_intersect_output(surface, output->desktop->layout,
+	surface_intersect_output(surface, output->desktop->layout,
 		output->wlr_output, lx, ly, rotation, &box);
-	if (!intersects) {
-		return;
-	}
 
 	pixman_region32_t damage;
 	pixman_region32_init(&damage);
@@ -638,6 +639,7 @@ static void damage_from_surface(struct wlr_surface *surface,
 			ceil(output->wlr_output->scale) - surface->current->scale);
 	}
 	pixman_region32_translate(&damage, box.x, box.y);
+	pixman_region32_intersect_rect(&damage, &damage, 0, 0, ow, oh);
 	pixman_region32_union(&output->damage, &output->damage, &damage);
 	pixman_region32_fini(&damage);
 

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -287,10 +287,13 @@ static void render_decorations(struct roots_view *view,
 	struct wlr_box box;
 	get_decoration_box(view, output, &box);
 
+	struct wlr_box rotated;
+	wlr_box_rotated_bounds(&box, -view->rotation, &rotated);
+
 	pixman_region32_t damage;
 	pixman_region32_init(&damage);
-	pixman_region32_union_rect(&damage, &damage, box.x, box.y,
-		box.width, box.height);
+	pixman_region32_union_rect(&damage, &damage, rotated.x, rotated.y,
+		rotated.width, rotated.height);
 	pixman_region32_intersect(&damage, &damage, data->damage);
 	bool damaged = pixman_region32_not_empty(&damage);
 	if (!damaged) {

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -374,7 +374,7 @@ static void render_output(struct roots_output *output) {
 renderer_end:
 	glDisable(GL_SCISSOR_TEST);
 	wlr_renderer_end(server->renderer);
-	wlr_output_swap_buffers(wlr_output);
+	wlr_output_swap_buffers(wlr_output, &now, &damage);
 	output->frame_scheduled = true;
 	pixman_region32_copy(&output->previous_damage, &output->damage);
 	pixman_region32_clear(&output->damage);

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -600,6 +600,12 @@ static void damage_from_surface(struct wlr_surface *surface,
 	pixman_region32_init(&damage);
 	pixman_region32_copy(&damage, &surface->current->surface_damage);
 	wlr_region_scale(&damage, &damage, output->wlr_output->scale);
+	if (ceil(output->wlr_output->scale) > surface->current->scale) {
+		// When scaling up a surface, it'll become blurry so we need to expand
+		// the damage region
+		wlr_region_expand(&damage, &damage,
+			ceil(output->wlr_output->scale) - surface->current->scale);
+	}
 	pixman_region32_translate(&damage, box.x, box.y);
 	pixman_region32_union(&output->damage, &output->damage, &damage);
 	pixman_region32_fini(&damage);

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -419,8 +419,6 @@ static void render_output(struct roots_output *output) {
 		goto renderer_end;
 	}
 
-	wlr_renderer_clear(output->desktop->server->renderer, 1, 1, 1, 1);
-
 	int nrects;
 	pixman_box32_t *rects = pixman_region32_rectangles(&damage, &nrects);
 	for (int i = 0; i < nrects; ++i) {

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -764,6 +764,8 @@ void roots_seat_set_focus(struct roots_seat *seat, struct roots_view *view) {
 	wl_list_remove(&seat_view->link);
 	wl_list_insert(&seat->views, &seat_view->link);
 
+	view_damage_whole(view);
+
 	struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(seat->seat);
 	if (keyboard != NULL) {
 		wlr_seat_keyboard_notify_enter(seat->seat, view->wlr_surface,

--- a/rootston/wl_shell.c
+++ b/rootston/wl_shell.c
@@ -147,6 +147,8 @@ static void handle_surface_commit(struct wl_listener *listener, void *data) {
 
 	int width = wlr_surface->current->width;
 	int height = wlr_surface->current->height;
+	view_update_size(view, width, height);
+
 	double x = view->x;
 	double y = view->y;
 	if (view->pending_move_resize.update_x) {
@@ -231,6 +233,8 @@ void handle_wl_shell_surface(struct wl_listener *listener, void *data) {
 		return;
 	}
 	view->type = ROOTS_WL_SHELL_VIEW;
+	view->width = surface->surface->current->width;
+	view->height = surface->surface->current->height;
 
 	view->wl_shell_surface = surface;
 	view->roots_wl_shell_surface = roots_surface;

--- a/rootston/wl_shell.c
+++ b/rootston/wl_shell.c
@@ -118,7 +118,8 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	wl_list_remove(&roots_surface->set_state.link);
 	wl_list_remove(&roots_surface->surface_commit.link);
 	wl_list_remove(&roots_surface->view->link);
-	view_destroy(roots_surface->view);
+	view_finish(roots_surface->view);
+	free(roots_surface->view);
 	free(roots_surface);
 }
 

--- a/rootston/wl_shell.c
+++ b/rootston/wl_shell.c
@@ -88,22 +88,23 @@ static void handle_surface_commit(struct wl_listener *listener, void *data) {
 	struct roots_view *view = roots_surface->view;
 	struct wlr_surface *wlr_surface = view->wlr_surface;
 
+	view_apply_damage(view);
+
 	int width = wlr_surface->current->width;
 	int height = wlr_surface->current->height;
+	double x = view->x;
+	double y = view->y;
 	if (view->pending_move_resize.update_x) {
-		double x = view->pending_move_resize.x +
-			view->pending_move_resize.width - width;
-		view_update_position(view, x, view->y);
+		x = view->pending_move_resize.x + view->pending_move_resize.width -
+			width;
 		view->pending_move_resize.update_x = false;
 	}
 	if (view->pending_move_resize.update_y) {
-		double y = view->pending_move_resize.y +
-			view->pending_move_resize.height - height;
-		view_update_position(view, view->x, y);
+		y = view->pending_move_resize.y + view->pending_move_resize.height -
+			height;
 		view->pending_move_resize.update_y = false;
 	}
-
-	view_apply_damage(view);
+	view_update_position(view, x, y);
 }
 
 static void handle_destroy(struct wl_listener *listener, void *data) {

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -197,29 +197,30 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	struct roots_view *view = roots_surface->view;
 	struct wlr_xdg_surface_v6 *surface = view->xdg_surface_v6;
 
+	view_apply_damage(view);
+
 	uint32_t pending_serial =
 		roots_surface->pending_move_resize_configure_serial;
 	if (pending_serial > 0 && pending_serial >= surface->configure_serial) {
 		struct wlr_box size;
 		get_size(view, &size);
 
+		double x = view->x;
+		double y = view->y;
 		if (view->pending_move_resize.update_x) {
-			double x = view->pending_move_resize.x +
-				view->pending_move_resize.width - size.width;
-			view_update_position(view, x, view->y);
+			x = view->pending_move_resize.x + view->pending_move_resize.width -
+				size.width;
 		}
 		if (view->pending_move_resize.update_y) {
-			double y = view->pending_move_resize.y +
-				view->pending_move_resize.height - size.height;
-			view_update_position(view, view->x, y);
+			y = view->pending_move_resize.y + view->pending_move_resize.height -
+				size.height;
 		}
+		view_update_position(view, x, y);
 
 		if (pending_serial == surface->configure_serial) {
 			roots_surface->pending_move_resize_configure_serial = 0;
 		}
 	}
-
-	view_apply_damage(view);
 }
 
 static void handle_destroy(struct wl_listener *listener, void *data) {

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -231,7 +231,8 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	wl_list_remove(&roots_xdg_surface->request_move.link);
 	wl_list_remove(&roots_xdg_surface->request_resize.link);
 	wl_list_remove(&roots_xdg_surface->view->link);
-	view_destroy(roots_xdg_surface->view);
+	view_finish(roots_xdg_surface->view);
+	free(roots_xdg_surface->view);
 	free(roots_xdg_surface);
 }
 

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -10,6 +10,52 @@
 #include "rootston/server.h"
 #include "rootston/input.h"
 
+static void popup_destroy(struct roots_view_child *child) {
+	assert(child->destroy == popup_destroy);
+	struct roots_xdg_popup_v6 *popup = (struct roots_xdg_popup_v6 *)child;
+	if (popup == NULL) {
+		return;
+	}
+	wl_list_remove(&popup->destroy.link);
+	wl_list_remove(&popup->new_popup.link);
+	view_child_finish(&popup->view_child);
+	free(popup);
+}
+
+static void popup_handle_destroy(struct wl_listener *listener, void *data) {
+	struct roots_xdg_popup_v6 *popup =
+		wl_container_of(listener, popup, destroy);
+	popup_destroy((struct roots_view_child *)popup);
+}
+
+static struct roots_xdg_popup_v6 *popup_create(struct roots_view *view,
+	struct wlr_xdg_popup_v6 *wlr_popup);
+
+static void popup_handle_new_popup(struct wl_listener *listener, void *data) {
+	struct roots_xdg_popup_v6 *popup =
+		wl_container_of(listener, popup, new_popup);
+	struct wlr_xdg_popup_v6 *wlr_popup = data;
+	popup_create(popup->view_child.view, wlr_popup);
+}
+
+static struct roots_xdg_popup_v6 *popup_create(struct roots_view *view,
+		struct wlr_xdg_popup_v6 *wlr_popup) {
+	struct roots_xdg_popup_v6 *popup =
+		calloc(1, sizeof(struct roots_xdg_popup_v6));
+	if (popup == NULL) {
+		return NULL;
+	}
+	popup->wlr_popup = wlr_popup;
+	popup->view_child.destroy = popup_destroy;
+	view_child_init(&popup->view_child, view, wlr_popup->base->surface);
+	popup->destroy.notify = popup_handle_destroy;
+	wl_signal_add(&wlr_popup->base->events.destroy, &popup->destroy);
+	popup->new_popup.notify = popup_handle_new_popup;
+	wl_signal_add(&wlr_popup->base->events.new_popup, &popup->new_popup);
+	return popup;
+}
+
+
 static void get_size(const struct roots_view *view, struct wlr_box *box) {
 	assert(view->type == ROOTS_XDG_SHELL_V6_VIEW);
 	struct wlr_xdg_surface_v6 *surface = view->xdg_surface_v6;
@@ -191,9 +237,9 @@ static void handle_request_fullscreen(struct wl_listener *listener,
 	view_set_fullscreen(view, e->fullscreen, e->output);
 }
 
-static void handle_commit(struct wl_listener *listener, void *data) {
+static void handle_surface_commit(struct wl_listener *listener, void *data) {
 	struct roots_xdg_surface_v6 *roots_surface =
-		wl_container_of(listener, roots_surface, commit);
+		wl_container_of(listener, roots_surface, surface_commit);
 	struct roots_view *view = roots_surface->view;
 	struct wlr_xdg_surface_v6 *surface = view->xdg_surface_v6;
 
@@ -223,13 +269,23 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	}
 }
 
+static void handle_new_popup(struct wl_listener *listener, void *data) {
+	struct roots_xdg_surface_v6 *roots_xdg_surface =
+		wl_container_of(listener, roots_xdg_surface, new_popup);
+	struct wlr_xdg_popup_v6 *wlr_popup = data;
+	popup_create(roots_xdg_surface->view, wlr_popup);
+}
+
 static void handle_destroy(struct wl_listener *listener, void *data) {
 	struct roots_xdg_surface_v6 *roots_xdg_surface =
 		wl_container_of(listener, roots_xdg_surface, destroy);
-	wl_list_remove(&roots_xdg_surface->commit.link);
+	wl_list_remove(&roots_xdg_surface->surface_commit.link);
 	wl_list_remove(&roots_xdg_surface->destroy.link);
+	wl_list_remove(&roots_xdg_surface->new_popup.link);
 	wl_list_remove(&roots_xdg_surface->request_move.link);
 	wl_list_remove(&roots_xdg_surface->request_resize.link);
+	wl_list_remove(&roots_xdg_surface->request_maximize.link);
+	wl_list_remove(&roots_xdg_surface->request_fullscreen.link);
 	wl_list_remove(&roots_xdg_surface->view->link);
 	view_finish(roots_xdg_surface->view);
 	free(roots_xdg_surface->view);
@@ -257,8 +313,9 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	if (!roots_surface) {
 		return;
 	}
-	roots_surface->commit.notify = handle_commit;
-	wl_signal_add(&surface->surface->events.commit, &roots_surface->commit);
+	roots_surface->surface_commit.notify = handle_surface_commit;
+	wl_signal_add(&surface->surface->events.commit,
+		&roots_surface->surface_commit);
 	roots_surface->destroy.notify = handle_destroy;
 	wl_signal_add(&surface->events.destroy, &roots_surface->destroy);
 	roots_surface->request_move.notify = handle_request_move;
@@ -272,6 +329,8 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	roots_surface->request_fullscreen.notify = handle_request_fullscreen;
 	wl_signal_add(&surface->events.request_fullscreen,
 		&roots_surface->request_fullscreen);
+	roots_surface->new_popup.notify = handle_new_popup;
+	wl_signal_add(&surface->events.new_popup, &roots_surface->new_popup);
 
 	struct roots_view *view = calloc(1, sizeof(struct roots_view));
 	if (!view) {

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -245,12 +245,13 @@ static void handle_surface_commit(struct wl_listener *listener, void *data) {
 
 	view_apply_damage(view);
 
+	struct wlr_box size;
+	get_size(view, &size);
+	view_update_size(view, size.width, size.height);
+
 	uint32_t pending_serial =
 		roots_surface->pending_move_resize_configure_serial;
 	if (pending_serial > 0 && pending_serial >= surface->configure_serial) {
-		struct wlr_box size;
-		get_size(view, &size);
-
 		double x = view->x;
 		double y = view->y;
 		if (view->pending_move_resize.update_x) {
@@ -338,10 +339,10 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 		return;
 	}
 	view->type = ROOTS_XDG_SHELL_V6_VIEW;
+
 	view->xdg_surface_v6 = surface;
 	view->roots_xdg_surface_v6 = roots_surface;
 	view->wlr_surface = surface->surface;
-	view->get_size = get_size;
 	view->activate = activate;
 	view->resize = resize;
 	view->move_resize = move_resize;
@@ -349,6 +350,12 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	view->set_fullscreen = set_fullscreen;
 	view->close = close;
 	roots_surface->view = view;
+
+	struct wlr_box box;
+	get_size(view, &box);
+	view->width = box.width;
+	view->height = box.height;
+
 	view_init(view, desktop);
 	wl_list_insert(&desktop->views, &view->link);
 

--- a/rootston/xwayland.c
+++ b/rootston/xwayland.c
@@ -236,6 +236,12 @@ static void handle_map_notify(struct wl_listener *listener, void *data) {
 	view->y = xsurface->y;
 	wl_list_insert(&desktop->views, &view->link);
 
+	struct wlr_subsurface *subsurface;
+	wl_list_for_each(subsurface, &view->wlr_surface->subsurface_list,
+			parent_link) {
+		subsurface_create(view, subsurface);
+	}
+
 	view_damage_whole(view);
 
 	roots_surface->surface_commit.notify = handle_surface_commit;
@@ -251,6 +257,11 @@ static void handle_unmap_notify(struct wl_listener *listener, void *data) {
 	wl_list_remove(&roots_surface->surface_commit.link);
 
 	view_damage_whole(view);
+
+	struct roots_view_child *child, *tmp;
+	wl_list_for_each_safe(child, tmp, &view->children, link) {
+		child->destroy(child);
+	}
 
 	view->wlr_surface = NULL;
 	wl_list_remove(&view->link);

--- a/rootston/xwayland.c
+++ b/rootston/xwayland.c
@@ -209,6 +209,8 @@ static void handle_surface_commit(struct wl_listener *listener, void *data) {
 
 	int width = wlr_surface->current->width;
 	int height = wlr_surface->current->height;
+	view_update_size(view, width, height);
+
 	double x = view->x;
 	double y = view->y;
 	if (view->pending_move_resize.update_x) {
@@ -234,6 +236,8 @@ static void handle_map_notify(struct wl_listener *listener, void *data) {
 	view->wlr_surface = xsurface->surface;
 	view->x = xsurface->x;
 	view->y = xsurface->y;
+	view->width = xsurface->surface->current->width;
+	view->height = xsurface->surface->current->height;
 	wl_list_insert(&desktop->views, &view->link);
 
 	struct wlr_subsurface *subsurface;
@@ -264,6 +268,7 @@ static void handle_unmap_notify(struct wl_listener *listener, void *data) {
 	}
 
 	view->wlr_surface = NULL;
+	view->width = view->height = 0;
 	wl_list_remove(&view->link);
 }
 
@@ -314,6 +319,8 @@ void handle_xwayland_surface(struct wl_listener *listener, void *data) {
 	view->type = ROOTS_XWAYLAND_VIEW;
 	view->x = (double)surface->x;
 	view->y = (double)surface->y;
+	view->width = surface->surface->current->width;
+	view->height = surface->surface->current->height;
 
 	view->xwayland_surface = surface;
 	view->roots_xwayland_surface = roots_surface;

--- a/rootston/xwayland.c
+++ b/rootston/xwayland.c
@@ -204,23 +204,23 @@ static void handle_surface_commit(struct wl_listener *listener, void *data) {
 	struct roots_view *view = roots_surface->view;
 	struct wlr_surface *wlr_surface = view->wlr_surface;
 
+	view_apply_damage(view);
+
 	int width = wlr_surface->current->width;
 	int height = wlr_surface->current->height;
-
+	double x = view->x;
+	double y = view->y;
 	if (view->pending_move_resize.update_x) {
-		double x = view->pending_move_resize.x +
-			view->pending_move_resize.width - width;
-		view_update_position(view, x, view->y);
+		x = view->pending_move_resize.x + view->pending_move_resize.width -
+			width;
 		view->pending_move_resize.update_x = false;
 	}
 	if (view->pending_move_resize.update_y) {
-		double y = view->pending_move_resize.y +
-			view->pending_move_resize.height - height;
-		view_update_position(view, view->x, y);
+		y = view->pending_move_resize.y + view->pending_move_resize.height -
+			height;
 		view->pending_move_resize.update_y = false;
 	}
-
-	view_apply_damage(view);
+	view_update_position(view, x, y);
 }
 
 static void handle_map_notify(struct wl_listener *listener, void *data) {

--- a/rootston/xwayland.c
+++ b/rootston/xwayland.c
@@ -267,6 +267,12 @@ static void handle_unmap_notify(struct wl_listener *listener, void *data) {
 		child->destroy(child);
 	}
 
+	if (view->fullscreen_output != NULL) {
+		output_damage_whole(view->fullscreen_output);
+		view->fullscreen_output->fullscreen_view = NULL;
+		view->fullscreen_output = NULL;
+	}
+
 	view->wlr_surface = NULL;
 	view->width = view->height = 0;
 	wl_list_remove(&view->link);

--- a/types/wlr_box.c
+++ b/types/wlr_box.c
@@ -67,47 +67,50 @@ bool wlr_box_contains_point(const struct wlr_box *box, double x, double y) {
 }
 
 void wlr_box_transform(const struct wlr_box *box,
-		enum wl_output_transform transform, struct wlr_box *dest) {
+		enum wl_output_transform transform, int width, int height,
+		struct wlr_box *dest) {
+	struct wlr_box src = *box;
+
 	if (transform % 2 == 0) {
-		dest->width = box->width;
-		dest->height = box->height;
+		dest->width = src.width;
+		dest->height = src.height;
 	} else {
-		dest->width = box->height;
-		dest->height = box->width;
+		dest->width = src.height;
+		dest->height = src.width;
 	}
 
 	switch (transform) {
 	case WL_OUTPUT_TRANSFORM_NORMAL:
-		dest->x = box->x;
-		dest->y = box->y;
+		dest->x = src.x;
+		dest->y = src.y;
 		break;
 	case WL_OUTPUT_TRANSFORM_90:
-		dest->x = box->y;
-		dest->y = box->width - box->x;
+		dest->x = src.y;
+		dest->y = width - src.x - src.width;
 		break;
 	case WL_OUTPUT_TRANSFORM_180:
-		dest->x = box->width - box->x;
-		dest->y = box->height - box->y;
+		dest->x = width - src.x - src.width;
+		dest->y = height - src.y - src.height;
 		break;
 	case WL_OUTPUT_TRANSFORM_270:
-		dest->x = box->height - box->y;
-		dest->y = box->x;
+		dest->x = height - src.y - src.height;
+		dest->y = src.x;
 		break;
 	case WL_OUTPUT_TRANSFORM_FLIPPED:
-		dest->x = box->width - box->x;
-		dest->y = box->y;
+		dest->x = width - src.x - src.width;
+		dest->y = src.y;
 		break;
 	case WL_OUTPUT_TRANSFORM_FLIPPED_90:
-		dest->x = box->height - box->y;
-		dest->y = box->width - box->x;
+		dest->x = height - src.y - src.height;
+		dest->y = width - src.x - src.width;
 		break;
 	case WL_OUTPUT_TRANSFORM_FLIPPED_180:
-		dest->x = box->x;
-		dest->y = box->height - box->y;
+		dest->x = src.x;
+		dest->y = height - src.y - src.height;
 		break;
 	case WL_OUTPUT_TRANSFORM_FLIPPED_270:
-		dest->x = box->y;
-		dest->y = box->x;
+		dest->x = src.y;
+		dest->y = src.x;
 		break;
 	}
 }

--- a/types/wlr_box.c
+++ b/types/wlr_box.c
@@ -138,8 +138,8 @@ void wlr_box_rotated_bounds(const struct wlr_box *box, float rotation,
 		(box->x + box->width - ox) * s +
 		(box->y + box->height - oy) * c;
 
-	dest->x = fmin(x1, x2);
-	dest->width = fmax(x1, x2) - fmin(x1, x2);
-	dest->y = fmin(y1, y2);
-	dest->height = fmax(y1, y2) - fmin(y1, y2);
+	dest->x = floor(fmin(x1, x2));
+	dest->width = ceil(fmax(x1, x2) - fmin(x1, x2));
+	dest->y = floor(fmin(y1, y2));
+	dest->height = ceil(fmax(y1, y2) - fmin(y1, y2));
 }

--- a/types/wlr_box.c
+++ b/types/wlr_box.c
@@ -114,3 +114,32 @@ void wlr_box_transform(const struct wlr_box *box,
 		break;
 	}
 }
+
+void wlr_box_rotated_bounds(const struct wlr_box *box, float rotation,
+		struct wlr_box *dest) {
+	if (rotation == 0) {
+		*dest = *box;
+		return;
+	}
+
+	double ox = box->x + (double)box->width/2;
+	double oy = box->y + (double)box->height/2;
+
+	double c = fabs(cos(rotation));
+	double s = fabs(sin(rotation));
+
+	double x1 = ox + (box->x - ox) * c + (box->y - oy) * s;
+	double x2 = ox +
+		(box->x + box->width - ox) * c +
+		(box->y + box->height - oy) * s;
+
+	double y1 = oy + (box->x - ox) * s + (box->y - oy) * c;
+	double y2 = oy +
+		(box->x + box->width - ox) * s +
+		(box->y + box->height - oy) * c;
+
+	dest->x = fmin(x1, x2);
+	dest->width = fmax(x1, x2) - fmin(x1, x2);
+	dest->y = fmin(y1, y2);
+	dest->height = fmax(y1, y2) - fmin(y1, y2);
+}

--- a/types/wlr_compositor.c
+++ b/types/wlr_compositor.c
@@ -35,7 +35,7 @@ static void wl_compositor_create_surface(struct wl_client *client,
 
 	wl_list_insert(&compositor->surfaces,
 		wl_resource_get_link(surface_resource));
-	wl_signal_emit(&compositor->events.create_surface, surface);
+	wl_signal_emit(&compositor->events.new_surface, surface);
 }
 
 static void wl_compositor_create_region(struct wl_client *client,
@@ -185,7 +185,7 @@ struct wlr_compositor *wlr_compositor_create(struct wl_display *display,
 
 	wl_list_init(&compositor->wl_resources);
 	wl_list_init(&compositor->surfaces);
-	wl_signal_init(&compositor->events.create_surface);
+	wl_signal_init(&compositor->events.new_surface);
 
 	compositor->display_destroy.notify = handle_display_destroy;
 	wl_display_add_destroy_listener(display, &compositor->display_destroy);

--- a/types/wlr_data_device.c
+++ b/types/wlr_data_device.c
@@ -454,6 +454,7 @@ static void wlr_drag_end(struct wlr_drag *drag) {
 		if (drag->icon) {
 			drag->icon->mapped = false;
 			wl_list_remove(&drag->icon_destroy.link);
+			wl_signal_emit(&drag->icon->events.map, drag->icon);
 		}
 
 		free(drag);
@@ -673,8 +674,8 @@ static struct wlr_drag_icon *wlr_drag_icon_create(
 	icon->is_pointer = is_pointer;
 	icon->touch_id = touch_id;
 	icon->mapped = true;
-	wl_list_insert(&client->seat->drag_icons, &icon->link);
 
+	wl_signal_init(&icon->events.map);
 	wl_signal_init(&icon->events.destroy);
 
 	wl_signal_add(&icon->surface->events.destroy, &icon->surface_destroy);
@@ -685,6 +686,9 @@ static struct wlr_drag_icon *wlr_drag_icon_create(
 
 	wl_signal_add(&client->events.destroy, &icon->seat_client_destroy);
 	icon->seat_client_destroy.notify = handle_drag_icon_seat_client_destroy;
+
+	wl_list_insert(&client->seat->drag_icons, &icon->link);
+	wl_signal_emit(&client->seat->events.new_drag_icon, icon);
 
 	return icon;
 }

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -286,6 +286,7 @@ void wlr_output_destroy(struct wlr_output *output) {
 	wlr_output_destroy_global(output);
 	wlr_output_set_fullscreen_surface(output, NULL);
 
+	wl_signal_emit(&output->backend->events.output_remove, output);
 	wl_signal_emit(&output->events.destroy, output);
 
 	struct wlr_output_mode *mode, *tmp_mode;

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -563,8 +563,11 @@ void wlr_output_update_needs_swap(struct wlr_output *output) {
 }
 
 static void output_damage_whole(struct wlr_output *output) {
+	int width, height;
+	wlr_output_effective_resolution(output, &width, &height);
+
 	pixman_region32_union_rect(&output->damage, &output->damage, 0, 0,
-		output->width, output->height);
+		width, height);
 	wlr_output_update_needs_swap(output);
 }
 

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -594,6 +594,14 @@ static void output_fullscreen_surface_handle_commit(
 		fullscreen_surface_commit);
 	struct wlr_surface *surface = output->fullscreen_surface;
 
+	if (output->fullscreen_width != surface->current->width ||
+			output->fullscreen_height != surface->current->height) {
+		output->fullscreen_width = surface->current->width;
+		output->fullscreen_height = surface->current->height;
+		output_damage_whole(output);
+		return;
+	}
+
 	struct wlr_box box;
 	output_fullscreen_surface_get_box(output, surface, &box);
 

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -14,6 +14,7 @@
 #include <wlr/render/matrix.h>
 #include <wlr/render/gles2.h>
 #include <wlr/render.h>
+#include <wlr/util/region.h>
 
 static void wl_output_send_to_resource(struct wl_resource *resource) {
 	assert(resource);
@@ -554,6 +555,7 @@ static void output_fullscreen_surface_handle_commit(
 	pixman_region32_t damage;
 	pixman_region32_init(&damage);
 	pixman_region32_copy(&damage, &surface->current->surface_damage);
+	wlr_region_scale(&damage, &damage, output->scale);
 	pixman_region32_translate(&damage, box.x, box.y);
 	pixman_region32_union(&output->damage, &output->damage, &damage);
 	pixman_region32_fini(&damage);

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -184,11 +184,6 @@ void wlr_output_update_mode(struct wlr_output *output,
 
 void wlr_output_update_custom_mode(struct wlr_output *output, int32_t width,
 		int32_t height, int32_t refresh) {
-	if (output->width == width && output->height == height &&
-			output->refresh == refresh) {
-		return;
-	}
-
 	output->width = width;
 	output->height = height;
 	wlr_output_update_matrix(output);

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -272,6 +272,7 @@ void wlr_output_init(struct wlr_output *output, struct wlr_backend *backend,
 	output->scale = 1;
 	wl_list_init(&output->cursors);
 	wl_list_init(&output->wl_resources);
+	wl_signal_init(&output->events.damage);
 	wl_signal_init(&output->events.frame);
 	wl_signal_init(&output->events.swap_buffers);
 	wl_signal_init(&output->events.enable);
@@ -494,6 +495,7 @@ uint32_t wlr_output_get_gamma_size(struct wlr_output *output) {
 static void output_damage_whole(struct wlr_output *output) {
 	pixman_region32_union_rect(&output->damage, &output->damage, 0, 0,
 		output->width, output->height);
+	wl_signal_emit(&output->events.damage, output);
 }
 
 static void output_fullscreen_surface_reset(struct wlr_output *output) {
@@ -520,6 +522,8 @@ static void output_fullscreen_surface_handle_commit(
 	pixman_region32_translate(&damage, box.x, box.y);
 	pixman_region32_union(&output->damage, &output->damage, &damage);
 	pixman_region32_fini(&damage);
+
+	wl_signal_emit(&output->events.damage, output);
 }
 
 static void output_fullscreen_surface_handle_destroy(
@@ -561,6 +565,7 @@ static void output_cursor_damage_whole(struct wlr_output_cursor *cursor) {
 	output_cursor_get_box(cursor, &box);
 	pixman_region32_union_rect(&cursor->output->damage, &cursor->output->damage,
 		box.x, box.y, box.width, box.height);
+	wl_signal_emit(&cursor->output->events.damage, cursor->output);
 }
 
 static void output_cursor_reset(struct wlr_output_cursor *cursor) {

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -572,7 +572,7 @@ void wlr_output_update_needs_swap(struct wlr_output *output) {
 
 static void output_damage_whole(struct wlr_output *output) {
 	int width, height;
-	wlr_output_effective_resolution(output, &width, &height);
+	wlr_output_transformed_resolution(output, &width, &height);
 
 	pixman_region32_union_rect(&output->damage, &output->damage, 0, 0,
 		width, height);
@@ -714,10 +714,8 @@ bool wlr_output_cursor_set_image(struct wlr_output_cursor *cursor,
 static void output_cursor_update_visible(struct wlr_output_cursor *cursor) {
 	struct wlr_box output_box;
 	output_box.x = output_box.y = 0;
-	wlr_output_effective_resolution(cursor->output, &output_box.width,
+	wlr_output_transformed_resolution(cursor->output, &output_box.width,
 		&output_box.height);
-	output_box.width *= cursor->output->scale;
-	output_box.height *= cursor->output->scale;
 
 	struct wlr_box cursor_box;
 	output_cursor_get_box(cursor, &cursor_box);

--- a/types/wlr_screenshooter.c
+++ b/types/wlr_screenshooter.c
@@ -47,7 +47,6 @@ static void output_frame_notify(struct wl_listener *listener, void *_data) {
 	struct wlr_renderer *renderer = state->screenshot->screenshooter->renderer;
 	struct wlr_output *output = state->screenshot->output;
 
-	wlr_output_make_current(output);
 	wlr_renderer_read_pixels(renderer, 0, 0, output->width, output->height,
 		state->pixels);
 

--- a/types/wlr_screenshooter.c
+++ b/types/wlr_screenshooter.c
@@ -138,6 +138,10 @@ static void screenshooter_shoot(struct wl_client *client,
 	state->screenshot = screenshot;
 	state->frame_listener.notify = output_frame_notify;
 	wl_signal_add(&output->events.swap_buffers, &state->frame_listener);
+
+	// Schedule a buffer swap
+	output->needs_swap = true;
+	wlr_output_schedule_frame(output);
 }
 
 static struct orbital_screenshooter_interface screenshooter_impl = {

--- a/types/wlr_seat.c
+++ b/types/wlr_seat.c
@@ -454,7 +454,10 @@ struct wlr_seat *wlr_seat_create(struct wl_display *display, const char *name) {
 	wl_list_init(&wlr_seat->clients);
 	wl_list_init(&wlr_seat->drag_icons);
 
+	wl_signal_init(&wlr_seat->events.new_drag_icon);
+
 	wl_signal_init(&wlr_seat->events.request_set_cursor);
+
 	wl_signal_init(&wlr_seat->events.selection);
 	wl_signal_init(&wlr_seat->events.primary_selection);
 

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -169,14 +169,13 @@ static bool wlr_surface_update_size(struct wlr_surface *surface,
 	wl_list_init(&state->frame_callback_list);
 
 	bool update_damage = false;
-	if (width < state->width) {
-		pixman_region32_union_rect(&state->surface_damage, &state->surface_damage,
-			width, 0, state->width - width, state->height);
-		update_damage = true;
-	}
-	if (height < state->height) {
-		pixman_region32_union_rect(&state->surface_damage, &state->surface_damage,
-			0, height, state->width, state->height - height);
+	if (width != state->width || height != state->height) {
+		// Damage the whole surface on resize
+		// This isn't in the spec, but Weston does it and QT expects it
+		pixman_region32_union_rect(&state->surface_damage,
+			&state->surface_damage, 0, 0, state->width, state->height);
+		pixman_region32_union_rect(&state->surface_damage,
+			&state->surface_damage, 0, 0, width, height);
 		update_damage = true;
 	}
 

--- a/types/wlr_wl_shell.c
+++ b/types/wlr_wl_shell.c
@@ -221,6 +221,7 @@ static void shell_surface_popup_set_parent(struct wlr_wl_shell_surface *surface,
 	if (parent) {
 		wl_list_remove(&surface->popup_link);
 		wl_list_insert(&parent->popups, &surface->popup_link);
+		wl_signal_emit(&parent->events.new_popup, surface);
 	}
 }
 
@@ -519,6 +520,7 @@ static void shell_protocol_get_shell_surface(struct wl_client *client,
 
 	wl_signal_init(&wl_surface->events.destroy);
 	wl_signal_init(&wl_surface->events.ping_timeout);
+	wl_signal_init(&wl_surface->events.new_popup);
 	wl_signal_init(&wl_surface->events.request_move);
 	wl_signal_init(&wl_surface->events.request_resize);
 	wl_signal_init(&wl_surface->events.request_fullscreen);

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -203,7 +203,7 @@ static void xdg_surface_destroy(struct wlr_xdg_surface_v6 *surface) {
 			}
 		}
 
-		wl_list_remove(&surface->popup_link);
+		wl_list_remove(&surface->popup_state->link);
 		free(surface->popup_state);
 	}
 
@@ -502,12 +502,13 @@ static void xdg_surface_get_popup(struct wl_client *client,
 	surface->popup_state->parent = parent;
 	surface->popup_state->geometry =
 		xdg_positioner_get_geometry(positioner, surface, parent);
-	wl_list_insert(&surface->popup_state->parent->popups,
-		&surface->popup_link);
+	wl_list_insert(&parent->popups, &surface->popup_state->link);
 
 	wl_resource_set_implementation(surface->popup_state->resource,
 		&zxdg_popup_v6_implementation, surface,
 		xdg_popup_resource_destroy);
+
+	wl_signal_emit(&parent->events.new_popup, surface->popup_state);
 }
 
 
@@ -1184,6 +1185,7 @@ static void xdg_shell_get_xdg_surface(struct wl_client *wl_client,
 	wl_signal_init(&surface->events.request_show_window_menu);
 	wl_signal_init(&surface->events.destroy);
 	wl_signal_init(&surface->events.ping_timeout);
+	wl_signal_init(&surface->events.new_popup);
 
 	wl_signal_add(&surface->surface->events.destroy,
 		&surface->surface_destroy_listener);
@@ -1401,14 +1403,16 @@ struct wlr_xdg_surface_v6 *wlr_xdg_surface_v6_popup_at(
 	// XXX: I think this is so complicated because we're mixing geometry
 	// coordinates with surface coordinates. Input handling should only deal
 	// with surface coordinates.
-	struct wlr_xdg_surface_v6 *popup;
-	wl_list_for_each(popup, &surface->popups, popup_link) {
+	struct wlr_xdg_popup_v6 *popup_state;
+	wl_list_for_each(popup_state, &surface->popups, link) {
+		struct wlr_xdg_surface_v6 *popup = popup_state->base;
+
 		double _popup_sx =
-			surface->geometry->x + popup->popup_state->geometry.x;
+			surface->geometry->x + popup_state->geometry.x;
 		double _popup_sy =
-			surface->geometry->y + popup->popup_state->geometry.y;
-		int popup_width =  popup->popup_state->geometry.width;
-		int popup_height =  popup->popup_state->geometry.height;
+			surface->geometry->y + popup_state->geometry.y;
+		int popup_width =  popup_state->geometry.width;
+		int popup_height =  popup_state->geometry.height;
 
 		struct wlr_xdg_surface_v6 *_popup =
 			wlr_xdg_surface_v6_popup_at(popup,

--- a/util/meson.build
+++ b/util/meson.build
@@ -6,5 +6,5 @@ lib_wlr_util = static_library(
 		'region.c',
 	),
 	include_directories: wlr_inc,
-	dependencies: [pixman],
+	dependencies: [wayland_server, pixman],
 )

--- a/util/meson.build
+++ b/util/meson.build
@@ -3,6 +3,8 @@ lib_wlr_util = static_library(
 	files(
 		'log.c',
 		'os-compatibility.c',
+		'region.c',
 	),
 	include_directories: wlr_inc,
+	dependencies: [pixman],
 )

--- a/util/region.c
+++ b/util/region.c
@@ -1,0 +1,29 @@
+#include <stdlib.h>
+#include <math.h>
+#include <wlr/util/region.h>
+
+void wlr_region_scale(pixman_region32_t *dst, pixman_region32_t *src,
+		float scale) {
+	if (scale == 1) {
+		pixman_region32_copy(dst, src);
+		return;
+	}
+
+	int nrects;
+	pixman_box32_t *src_rects = pixman_region32_rectangles(src, &nrects);
+
+	pixman_box32_t *dst_rects = malloc(nrects * sizeof(pixman_box32_t));
+	if (dst_rects == NULL) {
+		return;
+	}
+
+	for (int i = 0; i < nrects; ++i) {
+		dst_rects[i].x1 = floor(src_rects[i].x1 * scale);
+		dst_rects[i].x2 = ceil(src_rects[i].x2 * scale);
+		dst_rects[i].y1 = floor(src_rects[i].y1 * scale);
+		dst_rects[i].y2 = ceil(src_rects[i].y2 * scale);
+	}
+
+	pixman_region32_fini(dst);
+	pixman_region32_init_rects(dst, dst_rects, nrects);
+}

--- a/util/region.c
+++ b/util/region.c
@@ -101,3 +101,30 @@ void wlr_region_transform(pixman_region32_t *dst, pixman_region32_t *src,
 	pixman_region32_init_rects(dst, dst_rects, nrects);
 	free(dst_rects);
 }
+
+void wlr_region_expand(pixman_region32_t *dst, pixman_region32_t *src,
+		int distance) {
+	if (distance == 0) {
+		pixman_region32_copy(dst, src);
+		return;
+	}
+
+	int nrects;
+	pixman_box32_t *src_rects = pixman_region32_rectangles(src, &nrects);
+
+	pixman_box32_t *dst_rects = malloc(nrects * sizeof(pixman_box32_t));
+	if (dst_rects == NULL) {
+		return;
+	}
+
+	for (int i = 0; i < nrects; ++i) {
+		dst_rects[i].x1 = src_rects[i].x1 - distance;
+		dst_rects[i].x2 = src_rects[i].x2 + distance;
+		dst_rects[i].y1 = src_rects[i].y1 - distance;
+		dst_rects[i].y2 = src_rects[i].y2 + distance;
+	}
+
+	pixman_region32_fini(dst);
+	pixman_region32_init_rects(dst, dst_rects, nrects);
+	free(dst_rects);
+}

--- a/util/region.c
+++ b/util/region.c
@@ -26,4 +26,78 @@ void wlr_region_scale(pixman_region32_t *dst, pixman_region32_t *src,
 
 	pixman_region32_fini(dst);
 	pixman_region32_init_rects(dst, dst_rects, nrects);
+	free(dst_rects);
+}
+
+void wlr_region_transform(pixman_region32_t *dst, pixman_region32_t *src,
+		enum wl_output_transform transform, int width, int height) {
+	if (transform == WL_OUTPUT_TRANSFORM_NORMAL) {
+		pixman_region32_copy(dst, src);
+		return;
+	}
+
+	int nrects;
+	pixman_box32_t *src_rects = pixman_region32_rectangles(src, &nrects);
+
+	pixman_box32_t *dst_rects = malloc(nrects * sizeof(pixman_box32_t));
+	if (dst_rects == NULL) {
+		return;
+	}
+
+	for (int i = 0; i < nrects; ++i) {
+		switch (transform) {
+		case WL_OUTPUT_TRANSFORM_NORMAL:
+			dst_rects[i].x1 = src_rects[i].x1;
+			dst_rects[i].y1 = src_rects[i].y1;
+			dst_rects[i].x2 = src_rects[i].x2;
+			dst_rects[i].y2 = src_rects[i].y2;
+			break;
+		case WL_OUTPUT_TRANSFORM_90:
+			dst_rects[i].x1 = src_rects[i].y1;
+			dst_rects[i].y1 = width - src_rects[i].x2;
+			dst_rects[i].x2 = src_rects[i].y2;
+			dst_rects[i].y2 = width - src_rects[i].x1;
+			break;
+		case WL_OUTPUT_TRANSFORM_180:
+			dst_rects[i].x1 = width - src_rects[i].x2;
+			dst_rects[i].y1 = height - src_rects[i].y2;
+			dst_rects[i].x2 = width - src_rects[i].x1;
+			dst_rects[i].y2 = height - src_rects[i].y1;
+			break;
+		case WL_OUTPUT_TRANSFORM_270:
+			dst_rects[i].x1 = height - src_rects[i].y2;
+			dst_rects[i].y1 = src_rects[i].x1;
+			dst_rects[i].x2 = height - src_rects[i].y1;
+			dst_rects[i].y2 = src_rects[i].x2;
+			break;
+		case WL_OUTPUT_TRANSFORM_FLIPPED:
+			dst_rects[i].x1 = width - src_rects[i].x2;
+			dst_rects[i].y1 = src_rects[i].y1;
+			dst_rects[i].x2 = width - src_rects[i].x1;
+			dst_rects[i].y2 = src_rects[i].y2;
+			break;
+		case WL_OUTPUT_TRANSFORM_FLIPPED_90:
+			dst_rects[i].x1 = height - src_rects[i].y2;
+			dst_rects[i].y1 = width - src_rects[i].x2;
+			dst_rects[i].x2 = height - src_rects[i].y1;
+			dst_rects[i].y2 = width - src_rects[i].x1;
+			break;
+		case WL_OUTPUT_TRANSFORM_FLIPPED_180:
+			dst_rects[i].x1 = src_rects[i].x1;
+			dst_rects[i].y1 = height - src_rects[i].y2;
+			dst_rects[i].x2 = src_rects[i].x2;
+			dst_rects[i].y2 = height - src_rects[i].y1;
+			break;
+		case WL_OUTPUT_TRANSFORM_FLIPPED_270:
+			dst_rects[i].x1 = src_rects[i].y1;
+			dst_rects[i].y1 = src_rects[i].x1;
+			dst_rects[i].x2 = src_rects[i].y2;
+			dst_rects[i].y2 = src_rects[i].x2;
+			break;
+		}
+	}
+
+	pixman_region32_fini(dst);
+	pixman_region32_init_rects(dst, dst_rects, nrects);
+	free(dst_rects);
 }

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -1406,7 +1406,7 @@ struct wlr_xwm *xwm_create(struct wlr_xwayland *wlr_xwayland) {
 	xwm_selection_init(xwm);
 
 	xwm->compositor_surface_create.notify = handle_compositor_surface_create;
-	wl_signal_add(&wlr_xwayland->compositor->events.create_surface,
+	wl_signal_add(&wlr_xwayland->compositor->events.new_surface,
 		&xwm->compositor_surface_create);
 
 	xwm_create_wm_window(xwm);

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -315,7 +315,7 @@ static void read_surface_parent(struct wlr_xwm *xwm,
 		wl_list_init(&xsurface->parent_link);
 	}
 
-	wlr_log(L_DEBUG, "XCB_ATOM_WM_TRANSIENT_FOR: %p", xid);
+	wlr_log(L_DEBUG, "XCB_ATOM_WM_TRANSIENT_FOR: %p", xsurface->parent);
 	wl_signal_emit(&xsurface->events.set_parent, xsurface);
 }
 


### PR DESCRIPTION
Roadmap:

- [x] Do not actually swap buffers when nothing changed - sleep and retry later
- [x] Use surface damage to populate output damage
- [x] Only draw affected regions
- [x] Don't render the whole output when software cursor moves (#572)
- [x] Double buffering artifacts
- [x] Software cursor artifacts when changing cursor image (try chromium, evince on borders or over text)
- [x] Shadow artifacts when resizing a window (try weston-terminal, also happens when un-maximizing a view)
- [x] Listen to subsurface commit event
- [x] Listen to xdg popup commit event
- [x] Listen to wl popup commit event
- [x] subsurface artifacts when animated (try gnome-calculator)
- [x] Fullscreen views
- [x] Xwayland popups not visible in fullscreen
- [x] Damage whole output on mode change (try resizing wayland backend window)
- [x] Fix software cursors being drawn multiple times outside the damage zone
- [x] Fix hardware cursor not moving when not swapping buffers in DRM backend (with atomic interface)
- [x] Fix buffers too old in X11 backend
- [x] Handle drag icons
- [x] Fix decorations when resizing views
- [x] Fix QT decorations (try qtcreator)
- [x] Output scale
- [x] Output transforms
- [x] View rotation
- [x] Wait for damage before trying to render (with rate limiting)
- [x] Use `EGL_EXT_buffer_age` to make sure we can re-use old buffers (if not, damage the whole output) and to support triple buffering
- [x] Wrap GL calls in the renderer
- [x] Update examples
- [x] Fix the screenshooter blocking when there's no damage
- [x] When switching to another tty and back, one of the buffers gets cleared to black
- [x] Fix DRM with multiple outputs
- [x] Fix mpv not refreshing video when moving software cursor on Wayland backend
- [x] Fix DRM modesetting glitches (maybe remove `retry_pageflip`?)
- [x] Changing views z-index doesn't damage them
- [x] Fix urxvt carret damage on output with scale=2
- [x] Fix artifacts when unmaximizing/leaving fullscreen for rotated views
- [x] Fix artifacts when entering fullscreen for mpv between two outputs
- [ ] Consider integrating some rootston stuff into wlroots

If you want to show which parts of the screen are repainted by damage tracking, add this in `rootston/output.c` on line 421:

```c
wlr_renderer_clear(output->desktop->server->renderer, 1, 1, 1, 1);
```

Test plan: this is a test matrix
* Try all backends
* Try all output transforms and change output scale (integral, fractional)
* Try all shells
* Try subsurfaces, popups, drag icons
* Try cursors
* Try fullscreen surfaces
* Try view rotation

Future work:
- When damaging a whole view child, do not damage the whole parent
- Use opaque regions to do not always draw the full stack of views (#277)
- Provide damage to backend when swapping buffers, and use `EGL_EXT_swap_buffers_with_damage`/`EGL_KHR_swap_buffers_with_damage` instead of `eglSwapBuffers` if available
- When resuming rendering, figure out where we are in the vblank cycle (see Weston's `start_repaint_loop`). To do so, request a frame event from the backend/output.

Fixes #192
Fixes #572 