### PR TITLE
[old/reference] Roots decoration manager

### DIFF
--- a/include/rootston/config.h
+++ b/include/rootston/config.h
@@ -2,6 +2,7 @@
 #define _ROOTSTON_CONFIG_H
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_input_device.h>
+#include <wlr/types/wlr_server_decoration.h>
 
 #define ROOTS_CONFIG_DEFAULT_SEAT_NAME "seat0"
 
@@ -59,6 +60,7 @@ struct roots_cursor_config {
 
 struct roots_config {
 	bool xwayland;
+	enum wlr_server_decoration_manager_mode deco_mode;
 
 	struct wl_list outputs;
 	struct wl_list devices;

--- a/include/rootston/desktop.h
+++ b/include/rootston/desktop.h
@@ -74,6 +74,7 @@ struct roots_view *desktop_view_at(struct roots_desktop *desktop, double lx,
 void view_init(struct roots_view *view, struct roots_desktop *desktop);
 void view_destroy(struct roots_view *view);
 void view_activate(struct roots_view *view, bool activate);
+bool view_get_activated(struct roots_view *view);
 
 void output_add_notify(struct wl_listener *listener, void *data);
 void output_remove_notify(struct wl_listener *listener, void *data);

--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -6,6 +6,10 @@
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_surface.h>
 #include <wlr/types/wlr_xdg_shell_v6.h>
+#include <wlr/types/wlr_server_decoration.h>
+
+#define ROOTS_BORDER_WIDTH 4
+#define ROOTS_TITLEBAR_HEIGHT 12;
 
 struct roots_wl_shell_surface {
 	struct roots_view *view;
@@ -101,6 +105,11 @@ struct roots_view {
 		struct wl_signal destroy;
 	} events;
 
+	// kde decoration protocol
+	struct wlr_server_decoration *server_decoration;
+	struct wl_listener decoration_destroy;
+	struct wl_listener decoration_mode;
+
 	// TODO: This would probably be better as a field that's updated on a
 	// configure event from the xdg_shell
 	// If not then this should follow the typical type/impl pattern we use
@@ -143,5 +152,10 @@ enum roots_deco_part {
 };
 
 enum roots_deco_part view_get_deco_part(struct roots_view *view, double sx, double sy);
+
+void view_set_decorated(struct roots_view *view, bool decorated);
+
+void view_set_server_decoration(struct roots_view *view,
+		struct wlr_server_decoration *deco);
 
 #endif

--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -107,6 +107,7 @@ struct roots_view {
 	// elsewhere
 	void (*get_size)(const struct roots_view *view, struct wlr_box *box);
 	void (*activate)(struct roots_view *view, bool active);
+	bool (*get_activated)(struct roots_view *view);
 	void (*move)(struct roots_view *view, double x, double y);
 	void (*resize)(struct roots_view *view, uint32_t width, uint32_t height);
 	void (*move_resize)(struct roots_view *view, double x, double y,

--- a/rootston/config.c
+++ b/rootston/config.c
@@ -243,6 +243,16 @@ static int config_ini_handler(void *user, const char *section, const char *name,
 			} else {
 				wlr_log(L_ERROR, "got unknown xwayland value: %s", value);
 			}
+		} else if (strcmp(name, "decoration-mode") == 0) {
+			if (strcasecmp(value, "server") == 0) {
+				config->deco_mode = WLR_SERVER_DECORATION_MANAGER_MODE_SERVER;
+			} else if (strcmp(value, "client") == 0) {
+				config->deco_mode = WLR_SERVER_DECORATION_MANAGER_MODE_CLIENT;
+			} else if (strcmp(value, "none") == 0) {
+				config->deco_mode = WLR_SERVER_DECORATION_MANAGER_MODE_NONE;
+			} else {
+				wlr_log(L_ERROR, "got unknown decoration mode: %s", value);
+			}
 		} else {
 			wlr_log(L_ERROR, "got unknown core config: %s", name);
 		}
@@ -387,6 +397,7 @@ struct roots_config *roots_config_create_from_args(int argc, char *argv[]) {
 	}
 
 	config->xwayland = true;
+	config->deco_mode = WLR_SERVER_DECORATION_MANAGER_MODE_CLIENT;
 	wl_list_init(&config->outputs);
 	wl_list_init(&config->devices);
 	wl_list_init(&config->keyboards);

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -81,6 +81,54 @@ enum roots_deco_part view_get_deco_part(struct roots_view *view, double sx, doub
 	return parts;
 }
 
+void view_set_decorated(struct roots_view *view, bool decorated) {
+	if (decorated) {
+		view->decorated = true;
+		view->border_width = ROOTS_BORDER_WIDTH;
+		view->titlebar_height = ROOTS_TITLEBAR_HEIGHT;
+	} else {
+		view->decorated = false;
+	}
+}
+
+static void view_update_server_decorations(struct roots_view *view) {
+	bool decorated = (view->server_decoration &&
+			view->server_decoration->mode ==
+			WLR_SERVER_DECORATION_MANAGER_MODE_SERVER);
+
+	view_set_decorated(view, decorated);
+}
+
+void handle_server_decoration_destroy(struct wl_listener *listener,
+		void *data) {
+	struct roots_view *view = wl_container_of(listener, view, decoration_destroy);
+	view_set_server_decoration(view, NULL);
+}
+
+void handle_server_decoration_mode(struct wl_listener *listener, void *data) {
+	struct roots_view *view = wl_container_of(listener, view, decoration_destroy);
+	view_update_server_decorations(view);
+}
+
+void view_set_server_decoration(struct roots_view *view,
+		struct wlr_server_decoration *deco) {
+	if (view->server_decoration) {
+		wl_list_remove(&view->decoration_destroy.link);
+		wl_list_remove(&view->decoration_mode.link);
+		view->server_decoration = NULL;
+	}
+
+	if (deco) {
+		wl_signal_add(&deco->events.destroy, &view->decoration_destroy);
+		view->decoration_destroy.notify = handle_server_decoration_destroy;
+		wl_signal_add(&deco->events.mode, &view->decoration_mode);
+		view->decoration_mode.notify = handle_server_decoration_mode;
+		view->server_decoration = deco;
+	}
+
+	view_update_server_decorations(view);
+}
+
 static void view_update_output(const struct roots_view *view,
 		const struct wlr_box *before) {
 	struct roots_desktop *desktop = view->desktop;
@@ -319,6 +367,8 @@ void view_destroy(struct roots_view *view) {
 		view->fullscreen_output->fullscreen_view = NULL;
 	}
 
+	view_set_server_decoration(view, NULL);
+
 	free(view);
 }
 
@@ -337,6 +387,16 @@ void view_setup(struct roots_view *view) {
 
 	view_center(view);
 	view_update_output(view, NULL);
+
+	struct wlr_server_decoration *deco = NULL;
+	wl_list_for_each(deco,
+		&view->desktop->server_decoration_manager->decorations, link) {
+		if (deco->surface == view->wlr_surface) {
+			view_set_server_decoration(view, deco);
+			break;
+		}
+	}
+
 }
 
 static bool view_at(struct roots_view *view, double lx, double ly,
@@ -476,6 +536,20 @@ static void handle_layout_change(struct wl_listener *listener, void *data) {
 	}
 }
 
+static void handle_new_decoration(struct wl_listener *listener, void *data) {
+	struct roots_desktop *desktop = wl_container_of(listener, desktop, decoration_new);
+	struct wlr_server_decoration *deco = data;
+
+	// find the view for this decoration
+	struct roots_view *view = NULL;
+	wl_list_for_each(view, &desktop->views, link) {
+		if (deco->surface == view->wlr_surface) {
+			view_set_server_decoration(view, deco);
+			return;
+		}
+	}
+}
+
 struct roots_desktop *desktop_create(struct roots_server *server,
 		struct roots_config *config) {
 	wlr_log(L_DEBUG, "Initializing roots desktop");
@@ -560,11 +634,16 @@ struct roots_desktop *desktop_create(struct roots_server *server,
 		server->wl_display);
 	desktop->screenshooter = wlr_screenshooter_create(server->wl_display,
 		server->renderer);
+
 	desktop->server_decoration_manager =
 		wlr_server_decoration_manager_create(server->wl_display);
 	wlr_server_decoration_manager_set_default_mode(
-		desktop->server_decoration_manager,
-		config->deco_mode);
+		desktop->server_decoration_manager, config->deco_mode);
+
+	wl_signal_add(&desktop->server_decoration_manager->events.new_decoration,
+		&desktop->decoration_new);
+	desktop->decoration_new.notify = handle_new_decoration;
+
 	desktop->primary_selection_device_manager =
 		wlr_primary_selection_device_manager_create(server->wl_display);
 	desktop->idle = wlr_idle_create(server->wl_display);

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -564,7 +564,7 @@ struct roots_desktop *desktop_create(struct roots_server *server,
 		wlr_server_decoration_manager_create(server->wl_display);
 	wlr_server_decoration_manager_set_default_mode(
 		desktop->server_decoration_manager,
-		WLR_SERVER_DECORATION_MANAGER_MODE_CLIENT);
+		config->deco_mode);
 	desktop->primary_selection_device_manager =
 		wlr_primary_selection_device_manager_create(server->wl_display);
 	desktop->idle = wlr_idle_create(server->wl_display);

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -123,6 +123,13 @@ void view_activate(struct roots_view *view, bool activate) {
 	}
 }
 
+bool view_get_activated(struct roots_view *view) {
+	if (view->get_activated) {
+		return view->get_activated(view);
+	}
+	return input_view_has_focus(view->desktop->server->input, view);
+}
+
 void view_resize(struct roots_view *view, uint32_t width, uint32_t height) {
 	struct wlr_box before;
 	view_get_box(view, &before);

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -179,7 +179,13 @@ static void render_decorations(struct roots_view *view,
 	float matrix[16];
 	wlr_matrix_project_box(&matrix, &project_box, WL_OUTPUT_TRANSFORM_NORMAL,
 		view->rotation, &output->transform_matrix);
-	float color[4] = { 0.2, 0.2, 0.2, 1 };
+	float color[4]	= { 0.2, 0.2, 0.2, 1 };
+	if (view_get_activated(view)) {
+		color[0] = 0.09804;
+		color[1] = 0.09804;
+		color[2] = 0.43921;
+	}
+
 	wlr_render_colored_quad(desktop->server->renderer, &color, &matrix);
 }
 

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -296,19 +296,6 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	view->close = close;
 	roots_surface->view = view;
 
-	struct wlr_server_decoration *deco = NULL;
-	wl_list_for_each(deco, &desktop->server_decoration_manager->decorations,
-		link) {
-		if (deco->surface == view->wlr_surface) {
-			if (deco->mode == WLR_SERVER_DECORATION_MANAGER_MODE_SERVER) {
-				view->decorated = true;
-				view->border_width = 4;
-				view->titlebar_height = 12;
-				break;
-			}
-		}
-	}
-
 	view_init(view, desktop);
 	wl_list_insert(&desktop->views, &view->link);
 

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -295,6 +295,20 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	view->set_fullscreen = set_fullscreen;
 	view->close = close;
 	roots_surface->view = view;
+
+	struct wlr_server_decoration *deco = NULL;
+	wl_list_for_each(deco, &desktop->server_decoration_manager->decorations,
+		link) {
+		if (deco->surface == view->wlr_surface) {
+			if (deco->mode == WLR_SERVER_DECORATION_MANAGER_MODE_SERVER) {
+				view->decorated = true;
+				view->border_width = 4;
+				view->titlebar_height = 12;
+				break;
+			}
+		}
+	}
+
 	view_init(view, desktop);
 	wl_list_insert(&desktop->views, &view->link);
 

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -31,6 +31,15 @@ static void activate(struct roots_view *view, bool active) {
 	}
 }
 
+static bool get_activated(struct roots_view *view) {
+	assert(view->type == ROOTS_XDG_SHELL_V6_VIEW);
+	struct wlr_xdg_surface_v6 *surface = view->xdg_surface_v6;
+	if (surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL) {
+		return surface->toplevel_state->current.activated;
+	}
+	return false;
+}
+
 static void apply_size_constraints(struct wlr_xdg_surface_v6 *surface,
 		uint32_t width, uint32_t height, uint32_t *dest_width,
 		uint32_t *dest_height) {
@@ -279,6 +288,7 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	view->wlr_surface = surface->surface;
 	view->get_size = get_size;
 	view->activate = activate;
+	view->get_activated = get_activated;
 	view->resize = resize;
 	view->move_resize = move_resize;
 	view->maximize = maximize;

--- a/rootston/xwayland.c
+++ b/rootston/xwayland.c
@@ -6,6 +6,7 @@
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_surface.h>
 #include <wlr/xwayland.h>
+#include <wlr/xwm.h>
 #include <wlr/util/log.h>
 #include "rootston/server.h"
 #include "rootston/server.h"
@@ -13,6 +14,12 @@
 static void activate(struct roots_view *view, bool active) {
 	assert(view->type == ROOTS_XWAYLAND_VIEW);
 	wlr_xwayland_surface_activate(view->xwayland_surface, active);
+}
+
+static bool get_activated(struct roots_view *view) {
+	assert(view->type == ROOTS_XWAYLAND_VIEW);
+	struct wlr_xwm *xwm = view->xwayland_surface->xwm;
+	return view->xwayland_surface == xwm->focus_surface;
 }
 
 static void move(struct roots_view *view, double x, double y) {
@@ -301,6 +308,7 @@ void handle_xwayland_surface(struct wl_listener *listener, void *data) {
 	view->roots_xwayland_surface = roots_surface;
 	view->wlr_surface = surface->surface;
 	view->activate = activate;
+	view->get_activated = get_activated;
 	view->resize = resize;
 	view->move = move;
 	view->move_resize = move_resize;

--- a/rootston/xwayland.c
+++ b/rootston/xwayland.c
@@ -321,9 +321,7 @@ void handle_xwayland_surface(struct wl_listener *listener, void *data) {
 
 	if (!surface->override_redirect) {
 		if (surface->decorations == WLR_XWAYLAND_SURFACE_DECORATIONS_ALL) {
-			view->decorated = true;
-			view->border_width = 4;
-			view->titlebar_height = 12;
+			view_set_decorated(view, true);
 		}
 
 		view_setup(view);


### PR DESCRIPTION
Implement the decoration manager into rootston.

To enable ssd:

```ini
[core]
decoration-mode=server
#decoration-mode=client
#decoration-mode=none
```

TODO:

* [ ] find some program that implements the protocol correctly for testing

Support status:

Surprisingly not supported by qt apps on my system (tried konsole, qgit, qtcreator, kcalc on fedora 27).

gnome-terminal supports it but support is not correct. It never actually creates the decoration protcol object. It checks the default mode and uses that but never tells us what mode it's using.

gnome-calendar gives us a decoration protocol object but then tells us it wants client decorations.