### PR TITLE
Fix building rootston without XWayland

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ compiler:
   - gcc
   - clang
 
+# Settings to try
+env:
+ matrix:
+  - OPTIONS="-Denable_libcap=true  -Denable_systemd=true  -Denable_elogind=false -Denable_xwayland=true"
+  - OPTIONS="-Denable_libcap=false -Denable_systemd=false -Denable_elogind=false -Denable_xwayland=false"
+
 arch:
   packages:
     - meson
@@ -19,7 +25,7 @@ arch:
     - xcb-util-image
     - libcap
   script:
-    - "meson build"
+    - "meson build $OPTIONS"
     - "ninja -C build"
 
 script:

--- a/backend/meson.build
+++ b/backend/meson.build
@@ -33,11 +33,11 @@ else
 	backend_files += files('session/direct.c')
 endif
 
-if systemd.found()
+if systemd.found() and get_option('enable_systemd')
 	backend_files += files('session/logind.c')
 endif
 
-if elogind.found()
+if elogind.found() and get_option('enable_elogind')
 	backend_files += files('session/logind.c')
 endif
 

--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -51,7 +51,9 @@ struct roots_xwayland_surface {
 enum roots_view_type {
 	ROOTS_WL_SHELL_VIEW,
 	ROOTS_XDG_SHELL_V6_VIEW,
+#ifdef WLR_HAS_XWAYLAND
 	ROOTS_XWAYLAND_VIEW,
+#endif
 };
 
 struct roots_view {

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -490,6 +490,7 @@ struct roots_desktop *desktop_create(struct roots_server *server,
 	desktop->server = server;
 	desktop->config = config;
 
+#ifdef WLR_HAS_XWAYLAND
 	const char *cursor_theme = NULL;
 	const char *cursor_default = ROOTS_XCURSOR_DEFAULT;
 	struct roots_cursor_config *cc =
@@ -509,6 +510,7 @@ struct roots_desktop *desktop_create(struct roots_server *server,
 		free(desktop);
 		return NULL;
 	}
+#endif
 
 	desktop->layout = wlr_output_layout_create();
 	desktop->layout_change.notify = handle_layout_change;

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -490,6 +490,23 @@ struct roots_desktop *desktop_create(struct roots_server *server,
 	desktop->server = server;
 	desktop->config = config;
 
+	desktop->layout = wlr_output_layout_create();
+	desktop->layout_change.notify = handle_layout_change;
+	wl_signal_add(&desktop->layout->events.change, &desktop->layout_change);
+
+	desktop->compositor = wlr_compositor_create(server->wl_display,
+		server->renderer);
+
+	desktop->xdg_shell_v6 = wlr_xdg_shell_v6_create(server->wl_display);
+	wl_signal_add(&desktop->xdg_shell_v6->events.new_surface,
+		&desktop->xdg_shell_v6_surface);
+	desktop->xdg_shell_v6_surface.notify = handle_xdg_shell_v6_surface;
+
+	desktop->wl_shell = wlr_wl_shell_create(server->wl_display);
+	wl_signal_add(&desktop->wl_shell->events.new_surface,
+		&desktop->wl_shell_surface);
+	desktop->wl_shell_surface.notify = handle_wl_shell_surface;
+
 #ifdef WLR_HAS_XWAYLAND
 	const char *cursor_theme = NULL;
 	const char *cursor_default = ROOTS_XCURSOR_DEFAULT;
@@ -510,26 +527,7 @@ struct roots_desktop *desktop_create(struct roots_server *server,
 		free(desktop);
 		return NULL;
 	}
-#endif
 
-	desktop->layout = wlr_output_layout_create();
-	desktop->layout_change.notify = handle_layout_change;
-	wl_signal_add(&desktop->layout->events.change, &desktop->layout_change);
-
-	desktop->compositor = wlr_compositor_create(server->wl_display,
-		server->renderer);
-
-	desktop->xdg_shell_v6 = wlr_xdg_shell_v6_create(server->wl_display);
-	wl_signal_add(&desktop->xdg_shell_v6->events.new_surface,
-		&desktop->xdg_shell_v6_surface);
-	desktop->xdg_shell_v6_surface.notify = handle_xdg_shell_v6_surface;
-
-	desktop->wl_shell = wlr_wl_shell_create(server->wl_display);
-	wl_signal_add(&desktop->wl_shell->events.new_surface,
-		&desktop->wl_shell_surface);
-	desktop->wl_shell_surface.notify = handle_wl_shell_surface;
-
-#ifdef WLR_HAS_XWAYLAND
 	if (config->xwayland) {
 		desktop->xwayland = wlr_xwayland_create(server->wl_display,
 			desktop->compositor);

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -137,6 +137,7 @@ static void render_wl_shell_surface(struct wlr_wl_shell_surface *surface,
 	}
 }
 
+#ifdef WLR_HAS_XWAYLAND
 static void render_xwayland_children(struct wlr_xwayland_surface *surface,
 		struct roots_desktop *desktop, struct wlr_output *wlr_output,
 		struct timespec *when) {
@@ -149,6 +150,7 @@ static void render_xwayland_children(struct wlr_xwayland_surface *surface,
 		render_xwayland_children(child, desktop, wlr_output, when);
 	}
 }
+#endif
 
 static void render_decorations(struct roots_view *view,
 		struct roots_desktop *desktop, struct wlr_output *output) {
@@ -198,10 +200,12 @@ static void render_view(struct roots_view *view, struct roots_desktop *desktop,
 		render_wl_shell_surface(view->wl_shell_surface, desktop, wlr_output,
 			when, view->x, view->y, view->rotation, false);
 		break;
+#ifdef WLR_HAS_XWAYLAND
 	case ROOTS_XWAYLAND_VIEW:
 		render_surface(view->wlr_surface, desktop, wlr_output, when,
 			view->x, view->y, view->rotation);
 		break;
+#endif
 	}
 }
 
@@ -215,8 +219,10 @@ static bool has_standalone_surface(struct roots_view *view) {
 		return wl_list_empty(&view->xdg_surface_v6->popups);
 	case ROOTS_WL_SHELL_VIEW:
 		return wl_list_empty(&view->wl_shell_surface->popups);
+#ifdef WLR_HAS_XWAYLAND
 	case ROOTS_XWAYLAND_VIEW:
 		return wl_list_empty(&view->xwayland_surface->children);
+#endif
 	}
 	return true;
 }
@@ -264,10 +270,12 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 			// During normal rendering the xwayland window tree isn't traversed
 			// because all windows are rendered. Here we only want to render
 			// the fullscreen window's children so we have to traverse the tree.
+#ifdef WLR_HAS_XWAYLAND
 			if (view->type == ROOTS_XWAYLAND_VIEW) {
 				render_xwayland_children(view->xwayland_surface, desktop,
 					wlr_output, &now);
 			}
+#endif
 		}
 		wlr_renderer_end(server->renderer);
 		wlr_output_swap_buffers(wlr_output);

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -651,10 +651,12 @@ void roots_seat_set_focus(struct roots_seat *seat, struct roots_view *view) {
 		return;
 	}
 
+#ifdef WLR_HAS_XWAYLAND
 	if (view && view->type == ROOTS_XWAYLAND_VIEW &&
 			view->xwayland_surface->override_redirect) {
 		return;
 	}
+#endif
 	struct roots_seat_view *seat_view = NULL;
 	if (view != NULL) {
 		seat_view = roots_seat_view_from_view(seat, view);


### PR DESCRIPTION
Just recently I tried compiling wlroots without XWayland support, which is obviously broken due to some missing #ifdefs. This problem is easy to fix by itself, but I went a little bit further to try and avoid such problems in the future by adding a second CI job to Travis. While the default job will continue to default to all build options being set to `true`, the second job will set everything to `false`. This should in theory allow wlroots to detect such issues much earlier in the future.

I don't know whether that change is desired by the project, but I think it should be worthwhile. Building wlroots is not really a long-running task, so having the CI build the project twice shouldn't take too long while the benefit is kind of obvious to me.

Anyway. If you feel like the second CI job is not welcome, you can just drop the last commit :)