### PR TITLE
relases gbm buffers on init

### DIFF
--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -66,6 +66,17 @@ bool wlr_drm_surface_init(struct wlr_drm_surface *surf,
 	surf->width = width;
 	surf->height = height;
 
+	if (surf->gbm) {
+		if (surf->front) {
+			gbm_surface_release_buffer(surf->gbm, surf->front);
+			surf->front = NULL;
+		}
+		if (surf->back) {
+			gbm_surface_release_buffer(surf->gbm, surf->back);
+			surf->back = NULL;
+		}
+	}
+
 	surf->gbm = gbm_surface_create(renderer->gbm, width, height,
 		format, GBM_BO_USE_RENDERING | flags);
 	if (!surf->gbm) {

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -75,6 +75,10 @@ bool wlr_drm_surface_init(struct wlr_drm_surface *surf,
 			gbm_surface_release_buffer(surf->gbm, surf->back);
 			surf->back = NULL;
 		}
+		gbm_surface_destroy(surf->gbm);
+	}
+	if (surf->egl) {
+		eglDestroySurface(surf->renderer->egl.display, surf->egl);
 	}
 
 	surf->gbm = gbm_surface_create(renderer->gbm, width, height,


### PR DESCRIPTION
The wlr_drm_surface_init function is called (upon others) when the drm
mode is changed.
When the surface was used previously this replaced the gbm_surface, but
did not replace the gbm buffers (front/back).
With this, wlr_drm_surface_get_from never set up the new buffers with
the new glViewport because surf->front existed.

This frees the buffers to get new buffers on the new surface with the
new viewport.


This fixes https://github.com/swaywm/wlroots/issues/593

Testplan: I should rebase the test-code mentioned in the issue, then use that branch with the keybind.