### PR TITLE
Fix some typos

### DIFF
--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -119,7 +119,7 @@ struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
 
 	char *name = drmGetDeviceNameFromFd2(gpu_fd);
 	drmVersion *version = drmGetVersion(gpu_fd);
-	wlr_log(L_INFO, "Initalizing DRM backend for %s (%s)", name, version->name);
+	wlr_log(L_INFO, "Initializing DRM backend for %s (%s)", name, version->name);
 	free(name);
 	drmFreeVersion(version);
 

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -469,7 +469,7 @@ static bool wlr_drm_connector_set_mode(struct wlr_output *output,
 	wlr_output_update_mode(&conn->output, mode);
 
 	// Since realloc_crtcs can deallocate planes on OTHER outputs,
-	// we actually need to reinitalise any than has changed
+	// we actually need to reinitialize any than has changed
 	ssize_t output_index = -1;
 	wl_list_for_each(conn, &drm->outputs, link) {
 		output_index += 1;
@@ -483,7 +483,7 @@ static bool wlr_drm_connector_set_mode(struct wlr_output *output,
 
 		if (!wlr_drm_plane_surfaces_init(crtc->primary, drm,
 				mode->width, mode->height, GBM_FORMAT_XRGB8888)) {
-			wlr_log(L_ERROR, "Failed to initalise renderer for plane");
+			wlr_log(L_ERROR, "Failed to initialize renderer for plane");
 			goto error_conn;
 		}
 
@@ -949,7 +949,7 @@ void wlr_drm_connector_cleanup(struct wlr_drm_connector *conn) {
 		conn->possible_crtc = 0;
 		/* Fallthrough */
 	case WLR_DRM_CONN_NEEDS_MODESET:
-		wlr_log(L_INFO, "Emmiting destruction signal for '%s'",
+		wlr_log(L_INFO, "Emitting destruction signal for '%s'",
 				conn->output.name);
 		wl_signal_emit(&drm->backend.events.output_remove, &conn->output);
 		break;

--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,7 @@ wlr_inc = include_directories('include')
 
 cc = meson.get_compiler('c')
 
-# Clang complains about some zeroed initialiser lists (= {0}), even though they
+# Clang complains about some zeroed initializer lists (= {0}), even though they
 # are valid
 if cc.get_id() == 'clang'
 	add_project_arguments('-Wno-missing-field-initializers', language: 'c')


### PR DESCRIPTION
Prefer initialize over initialise since used more often in the sources.

Debian's lintian tripped on these.