### PR TITLE
Make pointer button release outside window still count down the button_count

### DIFF
--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -261,7 +261,9 @@ static void roots_cursor_press_button(struct roots_cursor *cursor,
 		}
 	}
 
-	if (view && surface) {
+	if ((view && surface) ||
+		(state == WLR_BUTTON_RELEASED &&
+		 seat->seat->pointer_state.button_count != 0)) {
 		if (!is_touch) {
 			wlr_seat_pointer_notify_button(seat->seat, time, button, state);
 		}


### PR DESCRIPTION
I am just starting contributions to wlroots, so I may have misunderstood everything. But hunting for bugs is always a good way of getting into a codebase.

When double-clicking a maximized window title, so that the windows size is restored and the mouse pointer ends up _outside_ the window it becomes impossible to move windows.
The reason is that the button_count variable is not counted down if the mouse button is released outside the window, so the button_count remains incremented even after the button is released.
This patch adds a call to wlr_seat_pointer_notify_button if the mouse button is released outside the window.

Is this fix the right way to fix the problem? Are there any undesirable side-effects? I don't quite understand the view and surface concepts.