### PR TITLE
Fix jitter when quickly resizing windows

### DIFF
--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -101,7 +101,7 @@ static void move_resize(struct roots_view *view, double x, double y,
 		constrained_height);
 	if (serial > 0) {
 		roots_surface->pending_move_resize_configure_serial = serial;
-	} else if(roots_surface->pending_move_resize_configure_serial == 0) {
+	} else if (roots_surface->pending_move_resize_configure_serial == 0) {
 		view->x = x;
 		view->y = y;
 	}

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -101,7 +101,7 @@ static void move_resize(struct roots_view *view, double x, double y,
 		constrained_height);
 	if (serial > 0) {
 		roots_surface->pending_move_resize_configure_serial = serial;
-	} else {
+	} else if(roots_surface->pending_move_resize_configure_serial == 0) {
 		view->x = x;
 		view->y = y;
 	}


### PR DESCRIPTION
Surfaces and views get resized only on commit, therefore we may only
change the position of a window if there are no pending commits.