### PR TITLE
rootston: allow scale < 1 as well

### DIFF
--- a/rootston/config.c
+++ b/rootston/config.c
@@ -281,7 +281,7 @@ static int config_ini_handler(void *user, const char *section, const char *name,
 			oc->y = strtol(value, NULL, 10);
 		} else if (strcmp(name, "scale") == 0) {
 			oc->scale = strtof(value, NULL);
-			assert(oc->scale >= 1);
+			assert(oc->scale > 0);
 		} else if (strcmp(name, "rotate") == 0) {
 			if (strcmp(value, "normal") == 0) {
 				oc->transform = WL_OUTPUT_TRANSFORM_NORMAL;


### PR DESCRIPTION
Since we support fractional scale, having scale=0.5 can make sense
(and, as far as I can tell, works fine)