### PR TITLE
Meson option enhancements

### DIFF
--- a/backend/meson.build
+++ b/backend/meson.build
@@ -27,6 +27,17 @@ backend_files = files(
 	'x11/backend.c',
 )
 
+backend_deps = [
+	wayland_server,
+	egl,
+	gbm,
+	libinput,
+	wlr_render,
+	wlr_protos,
+	drm,
+	pixman,
+]
+
 if host_machine.system().startswith('freebsd')
 	backend_files += files('session/direct-freebsd.c')
 else
@@ -35,26 +46,17 @@ endif
 
 if conf_data.get('WLR_HAS_SYSTEMD', false)
 	backend_files += files('session/logind.c')
+	backend_deps += systemd
 endif
 
 if conf_data.get('WLR_HAS_ELOGIND', false)
 	backend_files += files('session/logind.c')
+	backend_deps += elogind
 endif
 
 lib_wlr_backend = static_library(
 	'wlr_backend',
 	backend_files,
 	include_directories: wlr_inc,
-	dependencies: [
-		wayland_server,
-		egl,
-		gbm,
-		libinput,
-		systemd,
-		elogind,
-		wlr_render,
-		wlr_protos,
-		drm,
-		pixman,
-	],
+	dependencies: backend_deps,
 )

--- a/backend/meson.build
+++ b/backend/meson.build
@@ -33,11 +33,11 @@ else
 	backend_files += files('session/direct.c')
 endif
 
-if systemd.found() and get_option('enable_systemd')
+if conf_data.get('WLR_HAS_SYSTEMD', false)
 	backend_files += files('session/logind.c')
 endif
 
-if elogind.found() and get_option('enable_elogind')
+if conf_data.get('WLR_HAS_ELOGIND', false)
 	backend_files += files('session/logind.c')
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -70,24 +70,28 @@ systemd        = dependency('libsystemd', required: get_option('enable_systemd')
 elogind        = dependency('libelogind', required: get_option('enable_elogind') == 'true')
 math           = cc.find_library('m', required: false)
 
+exclude_headers = []
+wlr_parts = []
+wlr_deps = []
+
 if xcb_icccm.found()
 	conf_data.set('WLR_HAS_XCB_ICCCM', true)
 endif
 
 if libcap.found() and get_option('enable_libcap') != 'false'
 	conf_data.set('WLR_HAS_LIBCAP', true)
+	wlr_deps += libcap
 endif
 
 if systemd.found() and get_option('enable_systemd') != 'false'
 	conf_data.set('WLR_HAS_SYSTEMD', true)
+	wlr_deps += systemd
 endif
 
 if elogind.found() and get_option('enable_elogind') != 'false'
 	conf_data.set('WLR_HAS_ELOGIND', true)
 endif
 
-exclude_headers = []
-wlr_parts = []
 if get_option('enable_xwayland')
 	subdir('xwayland')
 	wlr_parts += [lib_wlr_xwayland]
@@ -117,7 +121,7 @@ wlr_parts += [
 	lib_wlr_xcursor,
 ]
 
-wlr_deps = [
+wlr_deps += [
 	wayland_server,
 	wayland_client,
 	wayland_egl,
@@ -133,8 +137,6 @@ wlr_deps = [
 	xcb,
 	xcb_composite,
 	x11_xcb,
-	libcap,
-	systemd,
 	math,
 ]
 

--- a/meson.build
+++ b/meson.build
@@ -65,24 +65,24 @@ xcb_image      = dependency('xcb-image')
 xcb_render     = dependency('xcb-render')
 xcb_icccm      = dependency('xcb-icccm', required: false)
 x11_xcb        = dependency('x11-xcb')
-libcap         = dependency('libcap', required: false)
-systemd        = dependency('libsystemd', required: false)
-elogind        = dependency('libelogind', required: false)
+libcap         = dependency('libcap', required: get_option('enable_libcap') == 'true')
+systemd        = dependency('libsystemd', required: get_option('enable_systemd') == 'true')
+elogind        = dependency('libelogind', required: get_option('enable_elogind') == 'true')
 math           = cc.find_library('m', required: false)
 
 if xcb_icccm.found()
 	conf_data.set('WLR_HAS_XCB_ICCCM', true)
 endif
 
-if libcap.found() and get_option('enable_libcap')
+if libcap.found() and get_option('enable_libcap') != 'false'
 	conf_data.set('WLR_HAS_LIBCAP', true)
 endif
 
-if systemd.found() and get_option('enable_systemd')
+if systemd.found() and get_option('enable_systemd') != 'false'
 	conf_data.set('WLR_HAS_SYSTEMD', true)
 endif
 
-if elogind.found() and get_option('enable_elogind')
+if elogind.found() and get_option('enable_elogind') != 'false'
 	conf_data.set('WLR_HAS_ELOGIND', true)
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -159,10 +159,10 @@ summary = [
   '----------------',
   'wlroots @0@'.format(meson.project_version()),
   '',
-  '   libcap: @0@'.format(get_option('enable_libcap')),
-  '  systemd: @0@'.format(get_option('enable_systemd')),
-  '  elogind: @0@'.format(get_option('enable_elogind')),
-  ' xwayland: @0@'.format(get_option('enable_xwayland')),
+  '   libcap: @0@'.format(conf_data.get('WLR_HAS_LIBCAP', false)),
+  '  systemd: @0@'.format(conf_data.get('WLR_HAS_SYSTEMD', false)),
+  '  elogind: @0@'.format(conf_data.get('WLR_HAS_ELOGIND', false)),
+  ' xwayland: @0@'.format(conf_data.get('WLR_HAS_XWAYLAND', false)),
   '----------------',
   ''
 ]

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,4 @@
-option('enable_libcap', type: 'boolean', value: true, description: 'Enable support for capabilities')
-option('enable_systemd', type: 'boolean', value: true, description: 'Enable support for logind')
-option('enable_elogind', type: 'boolean', value: true, description: 'Enable support for logind')
+option('enable_libcap', type: 'combo', choices: ['auto', 'true', 'false'], value: 'auto', description: 'Enable support for capabilities')
+option('enable_systemd', type: 'combo', choices: ['auto', 'true', 'false'], value: 'auto', description: 'Enable support for logind')
+option('enable_elogind', type: 'combo', choices: ['auto', 'true', 'false'], value: 'auto', description: 'Enable support for logind')
 option('enable_xwayland', type: 'boolean', value: true, description: 'Enable support X11 applications')


### PR DESCRIPTION
The two commits are fairly independant, but under the same theme:
 - first commit makes the message printed at meson time to reflect what is actually built, rather than the option default values (been annoying me for a while to have elogind = true in that message when I don't have elogind...)
 - second commit implements some sort of auto/true/false mechanism, that by default tries to build whatever we have, but if someone explicitely sets meson -Denable_foo=true will fail when foo is not found.
This should not break either default (true was technically auto before) nor explicit configs as -Denable_foo=false is the same syntax.
Happy to remove this commit if it is not welcome but this usually makes sense to do.