### PR TITLE
Wrap wl_resource_get_user_data into safer helper functions

### DIFF
--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -157,6 +157,7 @@ void wlr_output_set_gamma(struct wlr_output *output,
 uint32_t wlr_output_get_gamma_size(struct wlr_output *output);
 void wlr_output_set_fullscreen_surface(struct wlr_output *output,
 	struct wlr_surface *surface);
+struct wlr_output *wlr_output_from_resource(struct wl_resource *resource);
 
 
 struct wlr_output_cursor *wlr_output_cursor_create(struct wlr_output *output);

--- a/include/wlr/types/wlr_region.h
+++ b/include/wlr/types/wlr_region.h
@@ -1,13 +1,16 @@
 #ifndef WLR_TYPES_WLR_REGION_H
 #define WLR_TYPES_WLR_REGION_H
 
+#include <pixman.h>
+
 struct wl_resource;
 
 /*
  * Implements the given resource as region.
- * Sets the associated pixman_region32_t as userdata.
  */
 void wlr_region_create(struct wl_client *client, struct wl_resource *res,
-		uint32_t id);
+	uint32_t id);
+
+pixman_region32_t *wlr_region_from_resource(struct wl_resource *resource);
 
 #endif

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -530,4 +530,6 @@ bool wlr_seat_touch_has_grab(struct wlr_seat *seat);
  */
 bool wlr_seat_validate_grab_serial(struct wlr_seat *seat, uint32_t serial);
 
+struct wlr_seat_client *wlr_seat_client_from_resource(struct wl_resource *resource);
+
 #endif

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -164,4 +164,6 @@ void wlr_surface_set_role_committed(struct wlr_surface *surface,
 		void (*role_committed)(struct wlr_surface *surface, void *role_data),
 		void *role_data);
 
+struct wlr_surface *wlr_surface_from_resource(struct wl_resource *resource);
+
 #endif

--- a/types/wlr_data_device.c
+++ b/types/wlr_data_device.c
@@ -14,6 +14,24 @@
 		WL_DATA_DEVICE_MANAGER_DND_ACTION_MOVE | \
 		WL_DATA_DEVICE_MANAGER_DND_ACTION_ASK)
 
+static const struct wl_data_offer_interface data_offer_impl;
+
+static struct wlr_data_offer *data_offer_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &wl_data_offer_interface,
+		&data_offer_impl));
+	return wl_resource_get_user_data(resource);
+}
+
+static const struct wl_data_source_interface data_source_impl;
+
+static struct client_data_source *client_data_source_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &wl_data_source_interface,
+		&data_source_impl));
+	return wl_resource_get_user_data(resource);
+}
+
 static uint32_t data_offer_choose_action(struct wlr_data_offer *offer) {
 	uint32_t offer_actions, preferred_action = 0;
 	if (wl_resource_get_version(offer->resource) >=
@@ -78,7 +96,7 @@ static void data_offer_update_action(struct wlr_data_offer *offer) {
 
 static void data_offer_accept(struct wl_client *client,
 		struct wl_resource *resource, uint32_t serial, const char *mime_type) {
-	struct wlr_data_offer *offer = wl_resource_get_user_data(resource);
+	struct wlr_data_offer *offer = data_offer_from_resource(resource);
 
 	if (!offer->source || offer != offer->source->offer) {
 		return;
@@ -94,7 +112,7 @@ static void data_offer_accept(struct wl_client *client,
 
 static void data_offer_receive(struct wl_client *client,
 		struct wl_resource *resource, const char *mime_type, int32_t fd) {
-	struct wlr_data_offer *offer = wl_resource_get_user_data(resource);
+	struct wlr_data_offer *offer = data_offer_from_resource(resource);
 
 	if (offer->source && offer == offer->source->offer) {
 		offer->source->send(offer->source, mime_type, fd);
@@ -126,7 +144,7 @@ static void data_source_notify_finish(struct wlr_data_source *source) {
 
 static void data_offer_finish(struct wl_client *client,
 		struct wl_resource *resource) {
-	struct wlr_data_offer *offer = wl_resource_get_user_data(resource);
+	struct wlr_data_offer *offer = data_offer_from_resource(resource);
 
 	if (!offer->source || offer->source->offer != offer) {
 		return;
@@ -138,7 +156,7 @@ static void data_offer_finish(struct wl_client *client,
 static void data_offer_set_actions(struct wl_client *client,
 		struct wl_resource *resource, uint32_t actions,
 		uint32_t preferred_action) {
-	struct wlr_data_offer *offer = wl_resource_get_user_data(resource);
+	struct wlr_data_offer *offer = data_offer_from_resource(resource);
 
 	if (actions & ~ALL_ACTIONS) {
 		wl_resource_post_error(offer->resource,
@@ -162,7 +180,7 @@ static void data_offer_set_actions(struct wl_client *client,
 }
 
 static void data_offer_resource_destroy(struct wl_resource *resource) {
-	struct wlr_data_offer *offer = wl_resource_get_user_data(resource);
+	struct wlr_data_offer *offer = data_offer_from_resource(resource);
 
 	if (!offer->source) {
 		goto out;
@@ -332,16 +350,25 @@ void wlr_seat_set_selection(struct wlr_seat *seat,
 	}
 }
 
+static const struct wl_data_device_interface data_device_impl;
+
+static struct wlr_seat_client *seat_client_from_data_device_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &wl_data_device_interface,
+		&data_device_impl));
+	return wl_resource_get_user_data(resource);
+}
+
 static void data_device_set_selection(struct wl_client *client,
-		struct wl_resource *dd_resource, struct wl_resource *source_resource,
-		uint32_t serial) {
+		struct wl_resource *device_resource,
+		struct wl_resource *source_resource, uint32_t serial) {
 	struct client_data_source *source = NULL;
 	if (source_resource != NULL) {
-		source = wl_resource_get_user_data(source_resource);
+		source = client_data_source_from_resource(source_resource);
 	}
 
 	struct wlr_seat_client *seat_client =
-		wl_resource_get_user_data(dd_resource);
+		seat_client_from_data_device_resource(device_resource);
 
 	struct wlr_data_source *wlr_source = (struct wlr_data_source *)source;
 	wlr_seat_set_selection(seat_client->seat, wlr_source, serial);
@@ -783,17 +810,19 @@ static void data_device_start_drag(struct wl_client *client,
 		struct wl_resource *origin_resource, struct wl_resource *icon_resource,
 		uint32_t serial) {
 	struct wlr_seat_client *seat_client =
-		wl_resource_get_user_data(device_resource);
-	struct wlr_surface *origin = wl_resource_get_user_data(origin_resource);
+		seat_client_from_data_device_resource(device_resource);
+	struct wlr_surface *origin = wlr_surface_from_resource(origin_resource);
 	struct wlr_data_source *source = NULL;
 	struct wlr_surface *icon = NULL;
 
 	if (source_resource) {
-		source = wl_resource_get_user_data(source_resource);
+		struct client_data_source *client_source =
+			client_data_source_from_resource(source_resource);
+		source = (struct wlr_data_source *)client_source;
 	}
 
 	if (icon_resource) {
-		icon = wl_resource_get_user_data(icon_resource);
+		icon = wlr_surface_from_resource(icon_resource);
 	}
 	if (icon) {
 		if (wlr_surface_set_role(icon, "wl_data_device-icon",
@@ -876,7 +905,7 @@ static void data_source_destroy(struct wl_client *client,
 static void data_source_set_actions(struct wl_client *client,
 		struct wl_resource *resource, uint32_t dnd_actions) {
 	struct client_data_source *source =
-		wl_resource_get_user_data(resource);
+		client_data_source_from_resource(resource);
 
 	if (source->source.actions >= 0) {
 		wl_resource_post_error(source->resource,
@@ -905,7 +934,8 @@ static void data_source_set_actions(struct wl_client *client,
 
 static void data_source_offer(struct wl_client *client,
 		struct wl_resource *resource, const char *mime_type) {
-	struct client_data_source *source = wl_resource_get_user_data(resource);
+	struct client_data_source *source =
+		client_data_source_from_resource(resource);
 
 	char **p = wl_array_add(&source->source.mime_types, sizeof(*p));
 	if (p) {
@@ -919,14 +949,15 @@ static void data_source_offer(struct wl_client *client,
 	}
 }
 
-static struct wl_data_source_interface data_source_impl = {
+static const struct wl_data_source_interface data_source_impl = {
 	.offer = data_source_offer,
 	.destroy = data_source_destroy,
 	.set_actions = data_source_set_actions,
 };
 
 static void data_source_resource_handle_destroy(struct wl_resource *resource) {
-	struct client_data_source *source = wl_resource_get_user_data(resource);
+	struct client_data_source *source =
+		client_data_source_from_resource(resource);
 	wlr_data_source_finish(&source->source);
 	free(source);
 }
@@ -956,7 +987,7 @@ void data_device_manager_get_data_device(struct wl_client *client,
 		struct wl_resource *manager_resource, uint32_t id,
 		struct wl_resource *seat_resource) {
 	struct wlr_seat_client *seat_client =
-		wl_resource_get_user_data(seat_resource);
+		wlr_seat_client_from_resource(seat_resource);
 
 	struct wl_resource *resource = wl_resource_create(client,
 		&wl_data_device_interface, wl_resource_get_version(manager_resource),

--- a/types/wlr_gamma_control.c
+++ b/types/wlr_gamma_control.c
@@ -23,9 +23,18 @@ static void gamma_control_destroy(struct wlr_gamma_control *gamma_control) {
 	free(gamma_control);
 }
 
+static const struct gamma_control_interface gamma_control_impl;
+
+struct wlr_gamma_control *gamma_control_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &gamma_control_interface,
+		&gamma_control_impl));
+	return wl_resource_get_user_data(resource);
+}
+
 static void gamma_control_destroy_resource(struct wl_resource *resource) {
 	struct wlr_gamma_control *gamma_control =
-		wl_resource_get_user_data(resource);
+		gamma_control_from_resource(resource);
 	gamma_control_destroy(gamma_control);
 }
 
@@ -40,7 +49,7 @@ static void gamma_control_set_gamma(struct wl_client *client,
 		struct wl_resource *gamma_control_resource, struct wl_array *red,
 		struct wl_array *green, struct wl_array *blue) {
 	struct wlr_gamma_control *gamma_control =
-		wl_resource_get_user_data(gamma_control_resource);
+		gamma_control_from_resource(gamma_control_resource);
 
 	if (red->size != green->size || red->size != blue->size) {
 		wl_resource_post_error(gamma_control_resource,
@@ -68,12 +77,21 @@ static const struct gamma_control_interface gamma_control_impl = {
 	.reset_gamma = gamma_control_reset_gamma,
 };
 
+static const struct gamma_control_manager_interface gamma_control_manager_impl;
+
+struct wlr_gamma_control_manager *gamma_control_manager_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &gamma_control_manager_interface,
+		&gamma_control_manager_impl));
+	return wl_resource_get_user_data(resource);
+}
+
 static void gamma_control_manager_get_gamma_control(struct wl_client *client,
 		struct wl_resource *gamma_control_manager_resource, uint32_t id,
 		struct wl_resource *output_resource) {
 	struct wlr_gamma_control_manager *manager =
-		wl_resource_get_user_data(gamma_control_manager_resource);
-	struct wlr_output *output = wl_resource_get_user_data(output_resource);
+		gamma_control_manager_from_resource(gamma_control_manager_resource);
+	struct wlr_output *output = wlr_output_from_resource(output_resource);
 
 	struct wlr_gamma_control *gamma_control =
 		calloc(1, sizeof(struct wlr_gamma_control));
@@ -109,7 +127,7 @@ static void gamma_control_manager_get_gamma_control(struct wl_client *client,
 		wlr_output_get_gamma_size(output));
 }
 
-static struct gamma_control_manager_interface gamma_control_manager_impl = {
+static const struct gamma_control_manager_interface gamma_control_manager_impl = {
 	.get_gamma_control = gamma_control_manager_get_gamma_control,
 };
 

--- a/types/wlr_idle.c
+++ b/types/wlr_idle.c
@@ -7,6 +7,15 @@
 #include "idle-protocol.h"
 #include "util/signal.h"
 
+static const struct org_kde_kwin_idle_timeout_interface idle_timeout_impl;
+
+static struct wlr_idle_timeout *idle_timeout_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource,
+		&org_kde_kwin_idle_timeout_interface, &idle_timeout_impl));
+	return wl_resource_get_user_data(resource);
+}
+
 static void idle_timeout_destroy(struct wlr_idle_timeout *timer) {
 	wl_list_remove(&timer->input_listener.link);
 	wl_list_remove(&timer->seat_destroy.link);
@@ -34,7 +43,7 @@ static void handle_activity(struct wlr_idle_timeout *timer) {
 }
 
 static void handle_timer_resource_destroy(struct wl_resource *timer_resource) {
-	struct wlr_idle_timeout *timer = wl_resource_get_user_data(timer_resource);
+	struct wlr_idle_timeout *timer = idle_timeout_from_resource(timer_resource);
 	if (timer != NULL) {
 		idle_timeout_destroy(timer);
 	}
@@ -54,17 +63,27 @@ static void release_idle_timeout(struct wl_client *client,
 
 static void simulate_activity(struct wl_client *client,
 		struct wl_resource *resource){
-	struct wlr_idle_timeout *timer = wl_resource_get_user_data(resource);
+	struct wlr_idle_timeout *timer = idle_timeout_from_resource(resource);
 	handle_activity(timer);
 }
 
-static struct org_kde_kwin_idle_timeout_interface idle_timeout_impl = {
+static const struct org_kde_kwin_idle_timeout_interface idle_timeout_impl = {
 	.release = release_idle_timeout,
 	.simulate_user_activity = simulate_activity,
 };
 
+static const struct org_kde_kwin_idle_interface idle_impl;
+
+static struct wlr_idle *idle_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &org_kde_kwin_idle_interface,
+		&idle_impl));
+	return wl_resource_get_user_data(resource);
+}
+
 static void handle_input_notification(struct wl_listener *listener, void *data) {
-	struct wlr_idle_timeout *timer = wl_container_of(listener, timer, input_listener);
+	struct wlr_idle_timeout *timer =
+		wl_container_of(listener, timer, input_listener);
 	struct wlr_seat *seat = data;
 	if (timer->seat == seat) {
 		handle_activity(timer);
@@ -72,13 +91,11 @@ static void handle_input_notification(struct wl_listener *listener, void *data) 
 }
 
 static void create_idle_timer(struct wl_client *client,
-		struct wl_resource *idle_resource,
-		uint32_t id,
-		struct wl_resource *seat_resource,
-		uint32_t timeout) {
-	struct wlr_idle *idle = wl_resource_get_user_data(idle_resource);
+		struct wl_resource *idle_resource, uint32_t id,
+		struct wl_resource *seat_resource, uint32_t timeout) {
+	struct wlr_idle *idle = idle_from_resource(idle_resource);
 	struct wlr_seat_client *client_seat =
-		wl_resource_get_user_data(seat_resource);
+		wlr_seat_client_from_resource(seat_resource);
 
 	struct wlr_idle_timeout *timer =
 		calloc(1, sizeof(struct wlr_idle_timeout));
@@ -122,7 +139,7 @@ static void create_idle_timer(struct wl_client *client,
 	wl_event_source_timer_update(timer->idle_source, timer->timeout);
 }
 
-static struct org_kde_kwin_idle_interface idle_impl = {
+static const struct org_kde_kwin_idle_interface idle_impl = {
 	.get_idle_timeout = create_idle_timer,
 };
 

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -17,7 +17,7 @@
 
 static void wl_output_send_to_resource(struct wl_resource *resource) {
 	assert(resource);
-	struct wlr_output *output = wl_resource_get_user_data(resource);
+	struct wlr_output *output = wlr_output_from_resource(resource);
 	assert(output);
 	const uint32_t version = wl_resource_get_version(resource);
 	if (version >= WL_OUTPUT_GEOMETRY_SINCE_VERSION) {
@@ -53,7 +53,7 @@ static void wl_output_send_to_resource(struct wl_resource *resource) {
 static void wlr_output_send_current_mode_to_resource(
 		struct wl_resource *resource) {
 	assert(resource);
-	struct wlr_output *output = wl_resource_get_user_data(resource);
+	struct wlr_output *output = wlr_output_from_resource(resource);
 	assert(output);
 	const uint32_t version = wl_resource_get_version(resource);
 	if (version < WL_OUTPUT_MODE_SINCE_VERSION) {
@@ -75,7 +75,7 @@ static void wlr_output_send_current_mode_to_resource(
 }
 
 static void wl_output_destroy(struct wl_resource *resource) {
-	struct wlr_output *output = wl_resource_get_user_data(resource);
+	struct wlr_output *output = wlr_output_from_resource(resource);
 	struct wl_resource *_resource = NULL;
 	wl_resource_for_each(_resource, &output->wl_resources) {
 		if (_resource == resource) {
@@ -646,6 +646,12 @@ void wlr_output_set_fullscreen_surface(struct wlr_output *output,
 		output_fullscreen_surface_handle_destroy;
 	wl_signal_add(&surface->events.destroy,
 		&output->fullscreen_surface_destroy);
+}
+
+struct wlr_output *wlr_output_from_resource(struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &wl_output_interface,
+		&wl_output_impl));
+	return wl_resource_get_user_data(resource);
 }
 
 

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -223,9 +223,19 @@ static void xdg_surface_destroy(struct wlr_xdg_surface_v6 *surface) {
 }
 
 
+static const struct zxdg_positioner_v6_interface
+	zxdg_positioner_v6_implementation;
+
+static struct wlr_xdg_positioner_v6 *xdg_positioner_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &zxdg_positioner_v6_interface,
+		&zxdg_positioner_v6_implementation));
+	return wl_resource_get_user_data(resource);
+}
+
 static void xdg_positioner_destroy(struct wl_resource *resource) {
 	struct wlr_xdg_positioner_v6 *positioner =
-		wl_resource_get_user_data(resource);
+		xdg_positioner_from_resource(resource);
 	free(positioner);
 
 }
@@ -233,7 +243,7 @@ static void xdg_positioner_destroy(struct wl_resource *resource) {
 static void xdg_positioner_protocol_set_size(struct wl_client *client,
 		struct wl_resource *resource, int32_t width, int32_t height) {
 	struct wlr_xdg_positioner_v6 *positioner =
-		wl_resource_get_user_data(resource);
+		xdg_positioner_from_resource(resource);
 
 	if (width < 1 || height < 1) {
 		wl_resource_post_error(resource,
@@ -250,7 +260,7 @@ static void xdg_positioner_protocol_set_anchor_rect(struct wl_client *client,
 		struct wl_resource *resource, int32_t x, int32_t y, int32_t width,
 		int32_t height) {
 	struct wlr_xdg_positioner_v6 *positioner =
-		wl_resource_get_user_data(resource);
+		xdg_positioner_from_resource(resource);
 
 	if (width < 1 || height < 1) {
 		wl_resource_post_error(resource,
@@ -268,7 +278,7 @@ static void xdg_positioner_protocol_set_anchor_rect(struct wl_client *client,
 static void xdg_positioner_protocol_set_anchor(struct wl_client *client,
 		struct wl_resource *resource, uint32_t anchor) {
 	struct wlr_xdg_positioner_v6 *positioner =
-		wl_resource_get_user_data(resource);
+		xdg_positioner_from_resource(resource);
 
 	if (((anchor & ZXDG_POSITIONER_V6_ANCHOR_TOP ) &&
 				(anchor & ZXDG_POSITIONER_V6_ANCHOR_BOTTOM)) ||
@@ -286,7 +296,7 @@ static void xdg_positioner_protocol_set_anchor(struct wl_client *client,
 static void xdg_positioner_protocol_set_gravity(struct wl_client *client,
 		struct wl_resource *resource, uint32_t gravity) {
 	struct wlr_xdg_positioner_v6 *positioner =
-		wl_resource_get_user_data(resource);
+		xdg_positioner_from_resource(resource);
 
 	if (((gravity & ZXDG_POSITIONER_V6_GRAVITY_TOP) &&
 				(gravity & ZXDG_POSITIONER_V6_GRAVITY_BOTTOM)) ||
@@ -305,7 +315,7 @@ static void xdg_positioner_protocol_set_constraint_adjustment(
 		struct wl_client *client, struct wl_resource *resource,
 		uint32_t constraint_adjustment) {
 	struct wlr_xdg_positioner_v6 *positioner =
-		wl_resource_get_user_data(resource);
+		xdg_positioner_from_resource(resource);
 
 	positioner->constraint_adjustment = constraint_adjustment;
 }
@@ -313,7 +323,7 @@ static void xdg_positioner_protocol_set_constraint_adjustment(
 static void xdg_positioner_protocol_set_offset(struct wl_client *client,
 		struct wl_resource *resource, int32_t x, int32_t y) {
 	struct wlr_xdg_positioner_v6 *positioner =
-		wl_resource_get_user_data(resource);
+		xdg_positioner_from_resource(resource);
 
 	positioner->offset.x = x;
 	positioner->offset.y = y;
@@ -354,52 +364,6 @@ static void xdg_shell_create_positioner(struct wl_client *wl_client,
 		&zxdg_positioner_v6_implementation,
 		positioner, xdg_positioner_destroy);
 }
-
-static void xdg_popup_protocol_grab(struct wl_client *client,
-		struct wl_resource *resource, struct wl_resource *seat_resource,
-		uint32_t serial) {
-	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
-	struct wlr_seat_client *seat_client = wl_resource_get_user_data(seat_resource);
-
-	if (surface->popup_state->committed) {
-		wl_resource_post_error(surface->popup_state->resource,
-			ZXDG_POPUP_V6_ERROR_INVALID_GRAB,
-			"xdg_popup is already mapped");
-		return;
-	}
-
-	struct wlr_xdg_popup_grab_v6 *popup_grab =
-		xdg_shell_popup_grab_from_seat(surface->client->shell,
-			seat_client->seat);
-
-	struct wlr_xdg_surface_v6 *topmost = xdg_popup_grab_get_topmost(popup_grab);
-	bool parent_is_toplevel =
-		surface->popup_state->parent->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL;
-
-	if ((topmost == NULL && !parent_is_toplevel) ||
-			(topmost != NULL && topmost != surface->popup_state->parent)) {
-		wl_resource_post_error(surface->client->resource,
-			ZXDG_SHELL_V6_ERROR_NOT_THE_TOPMOST_POPUP,
-			"xdg_popup was not created on the topmost popup");
-		return;
-	}
-
-	popup_grab->client = surface->client->client;
-	surface->popup_state->seat = seat_client->seat;
-
-	wl_list_insert(&popup_grab->popups, &surface->popup_state->grab_link);
-
-	wlr_seat_pointer_start_grab(seat_client->seat,
-		&popup_grab->pointer_grab);
-	wlr_seat_keyboard_start_grab(seat_client->seat,
-		&popup_grab->keyboard_grab);
-}
-
-static const struct zxdg_popup_v6_interface zxdg_popup_v6_implementation = {
-	.destroy = resource_destroy,
-	.grab = xdg_popup_protocol_grab,
-};
-
 
 static struct wlr_box xdg_positioner_get_geometry(
 		struct wlr_xdg_positioner_v6 *positioner,
@@ -456,11 +420,77 @@ static struct wlr_box xdg_positioner_get_geometry(
 	return geometry;
 }
 
+
+static const struct zxdg_popup_v6_interface zxdg_popup_v6_implementation;
+
+static struct wlr_xdg_surface_v6 *xdg_surface_from_xdg_popup_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &zxdg_popup_v6_interface,
+		&zxdg_popup_v6_implementation));
+	return wl_resource_get_user_data(resource);
+}
+
+static void xdg_popup_protocol_grab(struct wl_client *client,
+		struct wl_resource *resource, struct wl_resource *seat_resource,
+		uint32_t serial) {
+	struct wlr_xdg_surface_v6 *surface =
+		xdg_surface_from_xdg_popup_resource(resource);
+	struct wlr_seat_client *seat_client =
+		wlr_seat_client_from_resource(seat_resource);
+
+	if (surface->popup_state->committed) {
+		wl_resource_post_error(surface->popup_state->resource,
+			ZXDG_POPUP_V6_ERROR_INVALID_GRAB,
+			"xdg_popup is already mapped");
+		return;
+	}
+
+	struct wlr_xdg_popup_grab_v6 *popup_grab =
+		xdg_shell_popup_grab_from_seat(surface->client->shell,
+			seat_client->seat);
+
+	struct wlr_xdg_surface_v6 *topmost = xdg_popup_grab_get_topmost(popup_grab);
+	bool parent_is_toplevel =
+		surface->popup_state->parent->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL;
+
+	if ((topmost == NULL && !parent_is_toplevel) ||
+			(topmost != NULL && topmost != surface->popup_state->parent)) {
+		wl_resource_post_error(surface->client->resource,
+			ZXDG_SHELL_V6_ERROR_NOT_THE_TOPMOST_POPUP,
+			"xdg_popup was not created on the topmost popup");
+		return;
+	}
+
+	popup_grab->client = surface->client->client;
+	surface->popup_state->seat = seat_client->seat;
+
+	wl_list_insert(&popup_grab->popups, &surface->popup_state->grab_link);
+
+	wlr_seat_pointer_start_grab(seat_client->seat,
+		&popup_grab->pointer_grab);
+	wlr_seat_keyboard_start_grab(seat_client->seat,
+		&popup_grab->keyboard_grab);
+}
+
+static const struct zxdg_popup_v6_interface zxdg_popup_v6_implementation = {
+	.destroy = resource_destroy,
+	.grab = xdg_popup_protocol_grab,
+};
+
 static void xdg_popup_resource_destroy(struct wl_resource *resource) {
-	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
+	struct wlr_xdg_surface_v6 *surface =
+		xdg_surface_from_xdg_popup_resource(resource);
 	if (surface != NULL) {
 		xdg_surface_destroy(surface);
 	}
+}
+
+static const struct zxdg_surface_v6_interface zxdg_surface_v6_implementation;
+
+static struct wlr_xdg_surface_v6 *xdg_surface_from_resource(struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &zxdg_surface_v6_interface,
+		&zxdg_surface_v6_implementation));
+	return wl_resource_get_user_data(resource);
 }
 
 static void xdg_surface_get_popup(struct wl_client *client,
@@ -468,11 +498,11 @@ static void xdg_surface_get_popup(struct wl_client *client,
 		struct wl_resource *parent_resource,
 		struct wl_resource *positioner_resource) {
 	struct wlr_xdg_surface_v6 *surface =
-		wl_resource_get_user_data(resource);
+		xdg_surface_from_resource(resource);
 	struct wlr_xdg_surface_v6 *parent =
-		wl_resource_get_user_data(parent_resource);
+		xdg_surface_from_resource(parent_resource);
 	struct wlr_xdg_positioner_v6 *positioner =
-		wl_resource_get_user_data(positioner_resource);
+		xdg_positioner_from_resource(positioner_resource);
 
 	if (positioner->size.width == 0 || positioner->anchor_rect.width == 0) {
 		wl_resource_post_error(resource,
@@ -516,13 +546,23 @@ static void xdg_surface_get_popup(struct wl_client *client,
 }
 
 
+static const struct zxdg_toplevel_v6_interface zxdg_toplevel_v6_implementation;
+
+static struct wlr_xdg_surface_v6 *xdg_surface_from_xdg_toplevel_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &zxdg_toplevel_v6_interface,
+		&zxdg_toplevel_v6_implementation));
+	return wl_resource_get_user_data(resource);
+}
+
 static void xdg_toplevel_protocol_set_parent(struct wl_client *client,
 		struct wl_resource *resource, struct wl_resource *parent_resource) {
-	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
-	struct wlr_xdg_surface_v6 *parent = NULL;
+	struct wlr_xdg_surface_v6 *surface =
+		xdg_surface_from_xdg_toplevel_resource(resource);
 
+	struct wlr_xdg_surface_v6 *parent = NULL;
 	if (parent_resource != NULL) {
-		parent = wl_resource_get_user_data(parent_resource);
+		parent = xdg_surface_from_xdg_toplevel_resource(parent_resource);
 	}
 
 	surface->toplevel_state->parent = parent;
@@ -530,10 +570,10 @@ static void xdg_toplevel_protocol_set_parent(struct wl_client *client,
 
 static void xdg_toplevel_protocol_set_title(struct wl_client *client,
 		struct wl_resource *resource, const char *title) {
-	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
-	char *tmp;
+	struct wlr_xdg_surface_v6 *surface =
+		xdg_surface_from_xdg_toplevel_resource(resource);
 
-	tmp = strdup(title);
+	char *tmp = strdup(title);
 	if (tmp == NULL) {
 		return;
 	}
@@ -544,10 +584,10 @@ static void xdg_toplevel_protocol_set_title(struct wl_client *client,
 
 static void xdg_toplevel_protocol_set_app_id(struct wl_client *client,
 		struct wl_resource *resource, const char *app_id) {
-	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
-	char *tmp;
+	struct wlr_xdg_surface_v6 *surface =
+		xdg_surface_from_xdg_toplevel_resource(resource);
 
-	tmp = strdup(app_id);
+	char *tmp = strdup(app_id);
 	if (tmp == NULL) {
 		return;
 	}
@@ -559,9 +599,10 @@ static void xdg_toplevel_protocol_set_app_id(struct wl_client *client,
 static void xdg_toplevel_protocol_show_window_menu(struct wl_client *client,
 		struct wl_resource *resource, struct wl_resource *seat_resource,
 		uint32_t serial, int32_t x, int32_t y) {
-	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
+	struct wlr_xdg_surface_v6 *surface =
+		xdg_surface_from_xdg_toplevel_resource(resource);
 	struct wlr_seat_client *seat =
-		wl_resource_get_user_data(seat_resource);
+		wlr_seat_client_from_resource(seat_resource);
 
 	if (!surface->configured) {
 		wl_resource_post_error(surface->toplevel_state->resource,
@@ -589,9 +630,10 @@ static void xdg_toplevel_protocol_show_window_menu(struct wl_client *client,
 static void xdg_toplevel_protocol_move(struct wl_client *client,
 		struct wl_resource *resource, struct wl_resource *seat_resource,
 		uint32_t serial) {
-	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
+	struct wlr_xdg_surface_v6 *surface =
+		xdg_surface_from_xdg_toplevel_resource(resource);
 	struct wlr_seat_client *seat =
-		wl_resource_get_user_data(seat_resource);
+		wlr_seat_client_from_resource(seat_resource);
 
 	if (!surface->configured) {
 		wl_resource_post_error(surface->toplevel_state->resource,
@@ -617,9 +659,10 @@ static void xdg_toplevel_protocol_move(struct wl_client *client,
 static void xdg_toplevel_protocol_resize(struct wl_client *client,
 		struct wl_resource *resource, struct wl_resource *seat_resource,
 		uint32_t serial, uint32_t edges) {
-	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
+	struct wlr_xdg_surface_v6 *surface =
+		xdg_surface_from_xdg_toplevel_resource(resource);
 	struct wlr_seat_client *seat =
-		wl_resource_get_user_data(seat_resource);
+		wlr_seat_client_from_resource(seat_resource);
 
 	if (!surface->configured) {
 		wl_resource_post_error(surface->toplevel_state->resource,
@@ -645,39 +688,44 @@ static void xdg_toplevel_protocol_resize(struct wl_client *client,
 
 static void xdg_toplevel_protocol_set_max_size(struct wl_client *client,
 		struct wl_resource *resource, int32_t width, int32_t height) {
-	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
+	struct wlr_xdg_surface_v6 *surface =
+		xdg_surface_from_xdg_toplevel_resource(resource);
 	surface->toplevel_state->next.max_width = width;
 	surface->toplevel_state->next.max_height = height;
 }
 
 static void xdg_toplevel_protocol_set_min_size(struct wl_client *client,
 		struct wl_resource *resource, int32_t width, int32_t height) {
-	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
+	struct wlr_xdg_surface_v6 *surface =
+		xdg_surface_from_xdg_toplevel_resource(resource);
 	surface->toplevel_state->next.min_width = width;
 	surface->toplevel_state->next.min_height = height;
 }
 
 static void xdg_toplevel_protocol_set_maximized(struct wl_client *client,
 		struct wl_resource *resource) {
-	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
+	struct wlr_xdg_surface_v6 *surface =
+		xdg_surface_from_xdg_toplevel_resource(resource);
 	surface->toplevel_state->next.maximized = true;
 	wlr_signal_emit_safe(&surface->events.request_maximize, surface);
 }
 
 static void xdg_toplevel_protocol_unset_maximized(struct wl_client *client,
 		struct wl_resource *resource) {
-	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
+	struct wlr_xdg_surface_v6 *surface =
+		xdg_surface_from_xdg_toplevel_resource(resource);
 	surface->toplevel_state->next.maximized = false;
 	wlr_signal_emit_safe(&surface->events.request_maximize, surface);
 }
 
 static void xdg_toplevel_protocol_set_fullscreen(struct wl_client *client,
 		struct wl_resource *resource, struct wl_resource *output_resource) {
-	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
+	struct wlr_xdg_surface_v6 *surface =
+		xdg_surface_from_xdg_toplevel_resource(resource);
 
 	struct wlr_output *output = NULL;
 	if (output_resource != NULL) {
-		output = wl_resource_get_user_data(output_resource);
+		output = wlr_output_from_resource(output_resource);
 	}
 
 	surface->toplevel_state->next.fullscreen = true;
@@ -693,7 +741,8 @@ static void xdg_toplevel_protocol_set_fullscreen(struct wl_client *client,
 
 static void xdg_toplevel_protocol_unset_fullscreen(struct wl_client *client,
 		struct wl_resource *resource) {
-	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
+	struct wlr_xdg_surface_v6 *surface =
+		xdg_surface_from_xdg_toplevel_resource(resource);
 
 	surface->toplevel_state->next.fullscreen = false;
 
@@ -708,7 +757,8 @@ static void xdg_toplevel_protocol_unset_fullscreen(struct wl_client *client,
 
 static void xdg_toplevel_protocol_set_minimized(struct wl_client *client,
 		struct wl_resource *resource) {
-	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
+	struct wlr_xdg_surface_v6 *surface =
+		xdg_surface_from_xdg_toplevel_resource(resource);
 	wlr_signal_emit_safe(&surface->events.request_minimize, surface);
 }
 
@@ -731,14 +781,15 @@ static const struct zxdg_toplevel_v6_interface zxdg_toplevel_v6_implementation =
 };
 
 static void xdg_surface_resource_destroy(struct wl_resource *resource) {
-	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
+	struct wlr_xdg_surface_v6 *surface = xdg_surface_from_resource(resource);
 	if (surface != NULL) {
 		xdg_surface_destroy(surface);
 	}
 }
 
 static void xdg_toplevel_resource_destroy(struct wl_resource *resource) {
-	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
+	struct wlr_xdg_surface_v6 *surface =
+		xdg_surface_from_xdg_toplevel_resource(resource);
 	if (surface != NULL) {
 		xdg_surface_destroy(surface);
 	}
@@ -746,7 +797,7 @@ static void xdg_toplevel_resource_destroy(struct wl_resource *resource) {
 
 static void xdg_surface_get_toplevel(struct wl_client *client,
 		struct wl_resource *resource, uint32_t id) {
-	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
+	struct wlr_xdg_surface_v6 *surface = xdg_surface_from_resource(resource);
 
 	if (wlr_surface_set_role(surface->surface, wlr_desktop_xdg_toplevel_role,
 			resource, ZXDG_SHELL_V6_ERROR_ROLE)) {
@@ -788,7 +839,7 @@ static void wlr_xdg_toplevel_v6_ack_configure(
 
 static void xdg_surface_ack_configure(struct wl_client *client,
 		struct wl_resource *resource, uint32_t serial) {
-	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
+	struct wlr_xdg_surface_v6 *surface = xdg_surface_from_resource(resource);
 
 	if (surface->role == WLR_XDG_SURFACE_V6_ROLE_NONE) {
 		wl_resource_post_error(surface->resource,
@@ -838,7 +889,7 @@ static void xdg_surface_ack_configure(struct wl_client *client,
 static void xdg_surface_set_window_geometry(struct wl_client *client,
 		struct wl_resource *resource, int32_t x, int32_t y, int32_t width,
 		int32_t height) {
-	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
+	struct wlr_xdg_surface_v6 *surface = xdg_surface_from_resource(resource);
 
 	if (surface->role == WLR_XDG_SURFACE_V6_ROLE_NONE) {
 		wl_resource_post_error(surface->resource,
@@ -1128,11 +1179,20 @@ static void handle_wlr_surface_committed(struct wlr_surface *wlr_surface,
 	}
 }
 
+static const struct zxdg_shell_v6_interface xdg_shell_impl;
+
+static struct wlr_xdg_client_v6 *xdg_client_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &zxdg_shell_v6_interface,
+		&xdg_shell_impl));
+	return wl_resource_get_user_data(resource);
+}
+
 static void xdg_shell_get_xdg_surface(struct wl_client *wl_client,
 		struct wl_resource *client_resource, uint32_t id,
 		struct wl_resource *surface_resource) {
 	struct wlr_xdg_client_v6 *client =
-		wl_resource_get_user_data(client_resource);
+		xdg_client_from_resource(client_resource);
 
 	struct wlr_xdg_surface_v6 *surface;
 	if (!(surface = calloc(1, sizeof(struct wlr_xdg_surface_v6)))) {
@@ -1155,7 +1215,7 @@ static void xdg_shell_get_xdg_surface(struct wl_client *wl_client,
 
 	surface->client = client;
 	surface->role = WLR_XDG_SURFACE_V6_ROLE_NONE;
-	surface->surface = wl_resource_get_user_data(surface_resource);
+	surface->surface = wlr_surface_from_resource(surface_resource);
 	surface->resource = wl_resource_create(wl_client,
 		&zxdg_surface_v6_interface, wl_resource_get_version(client_resource),
 		id);
@@ -1206,7 +1266,7 @@ static void xdg_shell_get_xdg_surface(struct wl_client *wl_client,
 
 static void xdg_shell_pong(struct wl_client *wl_client,
 		struct wl_resource *resource, uint32_t serial) {
-	struct wlr_xdg_client_v6 *client = wl_resource_get_user_data(resource);
+	struct wlr_xdg_client_v6 *client = xdg_client_from_resource(resource);
 
 	if (client->ping_serial != serial) {
 		return;
@@ -1216,7 +1276,7 @@ static void xdg_shell_pong(struct wl_client *wl_client,
 	client->ping_serial = 0;
 }
 
-static struct zxdg_shell_v6_interface xdg_shell_impl = {
+static const struct zxdg_shell_v6_interface xdg_shell_impl = {
 	.destroy = resource_destroy,
 	.create_positioner = xdg_shell_create_positioner,
 	.get_xdg_surface = xdg_shell_get_xdg_surface,
@@ -1224,7 +1284,7 @@ static struct zxdg_shell_v6_interface xdg_shell_impl = {
 };
 
 static void wlr_xdg_client_v6_destroy(struct wl_resource *resource) {
-	struct wlr_xdg_client_v6 *client = wl_resource_get_user_data(resource);
+	struct wlr_xdg_client_v6 *client = xdg_client_from_resource(resource);
 
 	struct wlr_xdg_surface_v6 *surface, *tmp = NULL;
 	wl_list_for_each_safe(surface, tmp, &client->surfaces, link) {

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -742,7 +742,7 @@ static void xwm_handle_surface_id_message(struct wlr_xwm *xwm,
 	struct wl_resource *resource =
 		wl_client_get_object(xwm->xwayland->client, id);
 	if (resource) {
-		struct wlr_surface *surface = wl_resource_get_user_data(resource);
+		struct wlr_surface *surface = wlr_surface_from_resource(resource);
 		xsurface->surface_id = 0;
 		xwm_map_shell_surface(xwm, xsurface, surface);
 	} else {


### PR DESCRIPTION
This ensures we're not incorrectly casting a resource.

Fixes #628