### PR TITLE
Remove WL_HIDE_DEPRECATED

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -43,9 +43,6 @@ if cc.get_id() == 'clang'
 	add_project_arguments('-Wno-missing-braces', language: 'c')
 endif
 
-# Avoid wl_buffer deprecation warnings
-add_project_arguments('-DWL_HIDE_DEPRECATED', language: 'c')
-
 wayland_server = dependency('wayland-server')
 wayland_client = dependency('wayland-client')
 wayland_egl    = dependency('wayland-egl')


### PR DESCRIPTION
From the wayland-devel mailing list: _[RFC wayland] wayland-server: Finally remove deprecated struct wl_buffer definition_

We don't use it anyway, so we should remove WL_HIDE_DEPRECATED from the build options.