### PR TITLE
Add idle-inhibit implementation

### DIFF
--- a/examples/idle-inhibit.c
+++ b/examples/idle-inhibit.c
@@ -96,8 +96,15 @@ static void xdg_toplevel_handle_configure(void *data,
 	height = h;
 }
 
+static void xdg_toplevel_handle_close(void *data,
+		struct xdg_toplevel *xdg_toplevel) {
+	exit(EXIT_SUCCESS);
+}
+
+
 static const struct xdg_toplevel_listener xdg_toplevel_listener = {
 	.configure = xdg_toplevel_handle_configure,
+	.close = xdg_toplevel_handle_close,
 };
 
 // static const struct zxdg_toplevel_decoration_v1_listener decoration_listener = {

--- a/examples/idle-inhibit.c
+++ b/examples/idle-inhibit.c
@@ -1,0 +1,203 @@
+#include <GLES2/gl2.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wayland-client.h>
+#include <wayland-egl.h>
+#include <wlr/render/egl.h>
+#include "xdg-shell-client-protocol.h"
+#include "idle-inhibit-unstable-v1-client-protocol.h"
+
+#include <linux/input-event-codes.h>
+
+/**
+ * Usage: toplevel-decoration [mode]
+ * Creates a xdg-toplevel supporting decoration negotiation. If `mode` is
+ * specified, the client will prefer this decoration mode.
+ */
+
+static int width = 500, height = 300;
+
+static struct wl_compositor *compositor = NULL;
+static struct wl_seat *seat = NULL;
+static struct xdg_wm_base *wm_base = NULL;
+static struct zwp_idle_inhibit_manager_v1 *idle_inhibit_manager = NULL;
+static struct zwp_idle_inhibitor_v1 *idle_inhibitor = NULL;
+
+struct wlr_egl egl;
+struct wl_egl_window *egl_window;
+struct wlr_egl_surface *egl_surface;
+
+static void draw(void);
+
+static void pointer_handle_button(void *data, struct wl_pointer *pointer, uint32_t serial,
+		uint32_t time, uint32_t button, uint32_t state_w) {
+	struct wl_surface *surface = data;
+
+	if (button == BTN_LEFT && state_w == WL_POINTER_BUTTON_STATE_PRESSED) {
+		if (idle_inhibitor) {
+			zwp_idle_inhibitor_v1_destroy(idle_inhibitor);
+			idle_inhibitor = NULL;
+		} else {
+			idle_inhibitor =
+				zwp_idle_inhibit_manager_v1_create_inhibitor(
+					idle_inhibit_manager,
+					surface);
+		}
+	}
+
+	draw();
+}
+
+static void noop () {}
+
+static const struct wl_pointer_listener pointer_listener = {
+	.enter = noop,
+	.leave = noop,
+	.motion = noop,
+	.button = pointer_handle_button,
+	.axis = noop,
+	.frame = noop,
+	.axis_source = noop,
+	.axis_stop = noop,
+	.axis_discrete = noop,
+};
+
+static void draw(void) {
+	eglMakeCurrent(egl.display, egl_surface, egl_surface, egl.context);
+
+	float color[] = {1.0, 1.0, 0.0, 1.0};
+	if (idle_inhibitor) {
+		color[0] = 0.0;
+	}
+
+	glViewport(0, 0, width, height);
+	glClearColor(color[0], color[1], color[2], 1.0);
+	glClear(GL_COLOR_BUFFER_BIT);
+
+	eglSwapBuffers(egl.display, egl_surface);
+}
+
+static void xdg_surface_handle_configure(void *data,
+		struct xdg_surface *xdg_surface, uint32_t serial) {
+	xdg_surface_ack_configure(xdg_surface, serial);
+	wl_egl_window_resize(egl_window, width, height, 0, 0);
+	draw();
+}
+
+static const struct xdg_surface_listener xdg_surface_listener = {
+	.configure = xdg_surface_handle_configure,
+};
+
+static void xdg_toplevel_handle_configure(void *data,
+		struct xdg_toplevel *xdg_toplevel, int32_t w, int32_t h,
+		struct wl_array *states) {
+	width = w;
+	height = h;
+}
+
+static const struct xdg_toplevel_listener xdg_toplevel_listener = {
+	.configure = xdg_toplevel_handle_configure,
+};
+
+// static const struct zxdg_toplevel_decoration_v1_listener decoration_listener = {
+// 	.preferred_mode = decoration_handle_preferred_mode,
+// 	.configure = decoration_handle_configure,
+// };
+
+static void handle_global(void *data, struct wl_registry *registry,
+		uint32_t name, const char *interface, uint32_t version) {
+	if (strcmp(interface, "wl_compositor") == 0) {
+		compositor = wl_registry_bind(registry, name, &wl_compositor_interface,
+			1);
+	} else if (strcmp(interface, xdg_wm_base_interface.name) == 0) {
+		wm_base = wl_registry_bind(registry, name, &xdg_wm_base_interface, 1);
+	} else if (strcmp(interface, zwp_idle_inhibit_manager_v1_interface.name) == 0) {
+		idle_inhibit_manager = wl_registry_bind(registry, name,
+			&zwp_idle_inhibit_manager_v1_interface, 1);
+	} else if (strcmp(interface, wl_seat_interface.name) == 0) {
+		seat = wl_registry_bind(registry, name, &wl_seat_interface, version);
+	}
+}
+
+static void handle_global_remove(void *data, struct wl_registry *registry,
+		uint32_t name) {
+	// TODO
+}
+
+static const struct wl_registry_listener registry_listener = {
+	.global = handle_global,
+	.global_remove = handle_global_remove,
+};
+
+int main(int argc, char **argv) {
+//	if (argc == 2) {
+//		char *mode = argv[1];
+//		if (strcmp(mode, "client") == 0) {
+//			decoration_mode = ZXDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT;
+//		} else if (strcmp(mode, "server") == 0) {
+//			decoration_mode = ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER;
+//		} else {
+//			fprintf(stderr, "Invalid decoration mode\n");
+//			return EXIT_FAILURE;
+//		}
+//	}
+
+	struct wl_display *display = wl_display_connect(NULL);
+	if (display == NULL) {
+		fprintf(stderr, "Failed to create display\n");
+		return EXIT_FAILURE;
+	}
+
+	struct wl_registry *registry = wl_display_get_registry(display);
+	wl_registry_add_listener(registry, &registry_listener, NULL);
+	wl_display_dispatch(display);
+	wl_display_roundtrip(display);
+
+	if (compositor == NULL) {
+		fprintf(stderr, "wl-compositor not available\n");
+		return EXIT_FAILURE;
+	}
+	if (wm_base == NULL) {
+		fprintf(stderr, "xdg-shell not available\n");
+		return EXIT_FAILURE;
+	}
+	if (idle_inhibit_manager == NULL) {
+		fprintf(stderr, "idle-inhibit not available\n");
+		return EXIT_FAILURE;
+	}
+
+	wlr_egl_init(&egl, EGL_PLATFORM_WAYLAND_EXT, display, NULL,
+		WL_SHM_FORMAT_ARGB8888);
+
+	struct wl_surface *surface = wl_compositor_create_surface(compositor);
+	struct xdg_surface *xdg_surface =
+		xdg_wm_base_get_xdg_surface(wm_base, surface);
+	struct xdg_toplevel *xdg_toplevel = xdg_surface_get_toplevel(xdg_surface);
+
+	idle_inhibitor =
+		zwp_idle_inhibit_manager_v1_create_inhibitor(idle_inhibit_manager,
+		surface);
+
+	struct wl_pointer *pointer = wl_seat_get_pointer(seat);
+	wl_pointer_add_listener(pointer, &pointer_listener, surface);
+
+
+	xdg_surface_add_listener(xdg_surface, &xdg_surface_listener, NULL);
+	xdg_toplevel_add_listener(xdg_toplevel, &xdg_toplevel_listener, NULL);
+
+	wl_surface_commit(surface);
+
+	egl_window = wl_egl_window_create(surface, width, height);
+	egl_surface = wlr_egl_create_surface(&egl, egl_window);
+
+	wl_display_roundtrip(display);
+
+	draw();
+
+	while (wl_display_dispatch(display) != -1) {
+		// No-op
+	}
+
+	return EXIT_SUCCESS;
+}

--- a/examples/idle-inhibit.c
+++ b/examples/idle-inhibit.c
@@ -68,41 +68,41 @@ static void pointer_handle_button(void *data, struct wl_pointer *pointer, uint32
 static void pointer_handle_enter(void *data, struct wl_pointer *wl_pointer,
 		uint32_t serial, struct wl_surface *surface,
 		wl_fixed_t surface_x, wl_fixed_t surface_y) {
-	/* NOOP: ignore event */
+	// This space intentionally left blank
 }
 
 static void pointer_handle_leave(void *data, struct wl_pointer *wl_pointer,
 		uint32_t serial, struct wl_surface *surface) {
-	/* NOOP: ignore event */
+	// This space intentionally left blank
 }
 
 static void pointer_handle_motion(void *data, struct wl_pointer *wl_pointer,
 		uint32_t time, wl_fixed_t surface_x, wl_fixed_t surface_y) {
-	/* NOOP: ignore event */
+	// This space intentionally left blank
 }
 
 static void pointer_handle_axis(void *data, struct wl_pointer *wl_pointer,
 		uint32_t time, uint32_t axis, wl_fixed_t value) {
-	/* NOOP: ignore event */
+	// This space intentionally left blank
 }
 
 static void pointer_handle_frame(void *data, struct wl_pointer *wl_pointer) {
-	/* NOOP: ignore event */
+	// This space intentionally left blank
 }
 
 static void pointer_handle_axis_source(void *data,
 		struct wl_pointer *wl_pointer, uint32_t axis_source) {
-	/* NOOP: ignore event */
+	// This space intentionally left blank
 }
 
 static void pointer_handle_axis_stop(void *data,
 		struct wl_pointer *wl_pointer, uint32_t time, uint32_t axis) {
-	/* NOOP: ignore event */
+	// This space intentionally left blank
 }
 
 static void pointer_handle_axis_discrete(void *data,
 		struct wl_pointer *wl_pointer, uint32_t axis, int32_t discrete) {
-	/* NOOP: ignore event */
+	// This space intentionally left blank
 }
 
 static const struct wl_pointer_listener pointer_listener = {
@@ -225,7 +225,7 @@ int main(int argc, char **argv) {
 	draw();
 
 	while (wl_display_dispatch(display) != -1) {
-		/** Do Nothing */
+		// This space intentionally left blank
 	}
 
 	return EXIT_SUCCESS;

--- a/examples/idle-inhibit.c
+++ b/examples/idle-inhibit.c
@@ -11,9 +11,12 @@
 #include <linux/input-event-codes.h>
 
 /**
- * Usage: toplevel-decoration [mode]
- * Creates a xdg-toplevel supporting decoration negotiation. If `mode` is
- * specified, the client will prefer this decoration mode.
+ * Usage: idle-inhibit
+ * Creates a xdg-toplevel using the idle-inhibit protocol.
+ * It will be solid green, when it has an idle inhibitor, and solid yellow if
+ * it does not.
+ * Left click with a pointer will toggle this state. (Touch is not supported
+ * for now).
  */
 
 static int width = 500, height = 300;
@@ -49,7 +52,12 @@ static void pointer_handle_button(void *data, struct wl_pointer *pointer, uint32
 	draw();
 }
 
-static void noop () {}
+/* Function that just does nothing.
+ * When it is noop(void) (like draw) the compiler complains about type
+ * mismatches in the listener struct.
+ * Without any arguments, it can be implicitly casted
+ */
+static void noop() {}
 
 static const struct wl_pointer_listener pointer_listener = {
 	.enter = noop,
@@ -107,11 +115,6 @@ static const struct xdg_toplevel_listener xdg_toplevel_listener = {
 	.close = xdg_toplevel_handle_close,
 };
 
-// static const struct zxdg_toplevel_decoration_v1_listener decoration_listener = {
-// 	.preferred_mode = decoration_handle_preferred_mode,
-// 	.configure = decoration_handle_configure,
-// };
-
 static void handle_global(void *data, struct wl_registry *registry,
 		uint32_t name, const char *interface, uint32_t version) {
 	if (strcmp(interface, "wl_compositor") == 0) {
@@ -138,18 +141,6 @@ static const struct wl_registry_listener registry_listener = {
 };
 
 int main(int argc, char **argv) {
-//	if (argc == 2) {
-//		char *mode = argv[1];
-//		if (strcmp(mode, "client") == 0) {
-//			decoration_mode = ZXDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT;
-//		} else if (strcmp(mode, "server") == 0) {
-//			decoration_mode = ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER;
-//		} else {
-//			fprintf(stderr, "Invalid decoration mode\n");
-//			return EXIT_FAILURE;
-//		}
-//	}
-
 	struct wl_display *display = wl_display_connect(NULL);
 	if (display == NULL) {
 		fprintf(stderr, "Failed to create display\n");

--- a/examples/idle-inhibit.c
+++ b/examples/idle-inhibit.c
@@ -31,7 +31,20 @@ struct wlr_egl egl;
 struct wl_egl_window *egl_window;
 struct wlr_egl_surface *egl_surface;
 
-static void draw(void);
+static void draw(void) {
+	eglMakeCurrent(egl.display, egl_surface, egl_surface, egl.context);
+
+	float color[] = {1.0, 1.0, 0.0, 1.0};
+	if (idle_inhibitor) {
+		color[0] = 0.0;
+	}
+
+	glViewport(0, 0, width, height);
+	glClearColor(color[0], color[1], color[2], 1.0);
+	glClear(GL_COLOR_BUFFER_BIT);
+
+	eglSwapBuffers(egl.display, egl_surface);
+}
 
 static void pointer_handle_button(void *data, struct wl_pointer *pointer, uint32_t serial,
 		uint32_t time, uint32_t button, uint32_t state_w) {
@@ -52,39 +65,57 @@ static void pointer_handle_button(void *data, struct wl_pointer *pointer, uint32
 	draw();
 }
 
-/* Function that just does nothing.
- * When it is noop(void) (like draw) the compiler complains about type
- * mismatches in the listener struct.
- * Without any arguments, it can be implicitly casted
- */
-static void noop() {}
+static void pointer_handle_enter(void *data, struct wl_pointer *wl_pointer,
+		uint32_t serial, struct wl_surface *surface,
+		wl_fixed_t surface_x, wl_fixed_t surface_y) {
+	/* NOOP: ignore event */
+}
+
+static void pointer_handle_leave(void *data, struct wl_pointer *wl_pointer,
+		uint32_t serial, struct wl_surface *surface) {
+	/* NOOP: ignore event */
+}
+
+static void pointer_handle_motion(void *data, struct wl_pointer *wl_pointer,
+		uint32_t time, wl_fixed_t surface_x, wl_fixed_t surface_y) {
+	/* NOOP: ignore event */
+}
+
+static void pointer_handle_axis(void *data, struct wl_pointer *wl_pointer,
+		uint32_t time, uint32_t axis, wl_fixed_t value) {
+	/* NOOP: ignore event */
+}
+
+static void pointer_handle_frame(void *data, struct wl_pointer *wl_pointer) {
+	/* NOOP: ignore event */
+}
+
+static void pointer_handle_axis_source(void *data,
+		struct wl_pointer *wl_pointer, uint32_t axis_source) {
+	/* NOOP: ignore event */
+}
+
+static void pointer_handle_axis_stop(void *data,
+		struct wl_pointer *wl_pointer, uint32_t time, uint32_t axis) {
+	/* NOOP: ignore event */
+}
+
+static void pointer_handle_axis_discrete(void *data,
+		struct wl_pointer *wl_pointer, uint32_t axis, int32_t discrete) {
+	/* NOOP: ignore event */
+}
 
 static const struct wl_pointer_listener pointer_listener = {
-	.enter = noop,
-	.leave = noop,
-	.motion = noop,
+	.enter = pointer_handle_enter,
+	.leave = pointer_handle_leave,
+	.motion = pointer_handle_motion,
 	.button = pointer_handle_button,
-	.axis = noop,
-	.frame = noop,
-	.axis_source = noop,
-	.axis_stop = noop,
-	.axis_discrete = noop,
+	.axis = pointer_handle_axis,
+	.frame = pointer_handle_frame,
+	.axis_source = pointer_handle_axis_source,
+	.axis_stop = pointer_handle_axis_stop,
+	.axis_discrete = pointer_handle_axis_discrete,
 };
-
-static void draw(void) {
-	eglMakeCurrent(egl.display, egl_surface, egl_surface, egl.context);
-
-	float color[] = {1.0, 1.0, 0.0, 1.0};
-	if (idle_inhibitor) {
-		color[0] = 0.0;
-	}
-
-	glViewport(0, 0, width, height);
-	glClearColor(color[0], color[1], color[2], 1.0);
-	glClear(GL_COLOR_BUFFER_BIT);
-
-	eglSwapBuffers(egl.display, egl_surface);
-}
 
 static void xdg_surface_handle_configure(void *data,
 		struct xdg_surface *xdg_surface, uint32_t serial) {
@@ -118,8 +149,8 @@ static const struct xdg_toplevel_listener xdg_toplevel_listener = {
 static void handle_global(void *data, struct wl_registry *registry,
 		uint32_t name, const char *interface, uint32_t version) {
 	if (strcmp(interface, "wl_compositor") == 0) {
-		compositor = wl_registry_bind(registry, name, &wl_compositor_interface,
-			1);
+		compositor = wl_registry_bind(registry, name,
+			&wl_compositor_interface, 1);
 	} else if (strcmp(interface, xdg_wm_base_interface.name) == 0) {
 		wm_base = wl_registry_bind(registry, name, &xdg_wm_base_interface, 1);
 	} else if (strcmp(interface, zwp_idle_inhibit_manager_v1_interface.name) == 0) {
@@ -132,7 +163,7 @@ static void handle_global(void *data, struct wl_registry *registry,
 
 static void handle_global_remove(void *data, struct wl_registry *registry,
 		uint32_t name) {
-	// TODO
+	// who cares
 }
 
 static const struct wl_registry_listener registry_listener = {
@@ -194,7 +225,7 @@ int main(int argc, char **argv) {
 	draw();
 
 	while (wl_display_dispatch(display) != -1) {
-		// No-op
+		/** Do Nothing */
 	}
 
 	return EXIT_SUCCESS;

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -41,3 +41,10 @@ executable(
 	dependencies: [wayland_client, wlr_protos, wlroots, threads],
 	link_with: lib_shared,
 )
+
+executable(
+	'idle-inhibit',
+	'idle-inhibit.c',
+	dependencies: [wayland_client, wlr_protos, wlroots, threads],
+	link_with: lib_shared,
+)

--- a/include/rootston/desktop.h
+++ b/include/rootston/desktop.h
@@ -45,7 +45,7 @@ struct roots_desktop {
 	struct wlr_server_decoration_manager *server_decoration_manager;
 	struct wlr_primary_selection_device_manager *primary_selection_device_manager;
 	struct wlr_idle *idle;
-	struct wlr_idle_inhibit_v1 *idle_inhibit;
+	struct wlr_idle_inhibit_manager_v1 *idle_inhibit;
 
 	struct wl_listener new_output;
 	struct wl_listener layout_change;

--- a/include/rootston/desktop.h
+++ b/include/rootston/desktop.h
@@ -16,6 +16,10 @@
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/types/wlr_xdg_shell_v6.h>
 #include <wlr/types/wlr_xdg_shell.h>
+#include <wlr/types/wlr_list.h>
+#include <wlr/types/wlr_idle.h>
+#include <wlr/types/wlr_idle_inhibit_v1.h>
+#include "rootston/view.h"
 #include "rootston/config.h"
 #include "rootston/output.h"
 #include "rootston/view.h"
@@ -41,6 +45,7 @@ struct roots_desktop {
 	struct wlr_server_decoration_manager *server_decoration_manager;
 	struct wlr_primary_selection_device_manager *primary_selection_device_manager;
 	struct wlr_idle *idle;
+	struct wlr_idle_inhibit_v1 *idle_inhibit;
 
 	struct wl_listener new_output;
 	struct wl_listener layout_change;

--- a/include/wlr/types/wlr_idle_inhibit_v1.h
+++ b/include/wlr/types/wlr_idle_inhibit_v1.h
@@ -1,0 +1,27 @@
+#ifndef WLR_TYPES_WLR_IDLE_INHIBIT_V1_H
+#define WLR_TYPES_WLR_IDLE_INHIBIT_V1_H
+
+#include <wayland-server.h>
+
+struct wlr_idle_inhibit_v1 {
+	struct wl_list clients;
+	struct wl_global *global;
+	
+	struct wl_listener display_destroy;
+	struct wl_signal new_inhibitor;
+};
+
+struct wlr_idle_inhibit_inhibitor_v1 {
+	struct wlr_surface *surface;
+	struct wl_resource *resource;
+	struct wl_listener surface_destroy;
+
+	struct wl_list link; // wlr_idle_inhibit_manager::inhibitors;
+
+	struct wl_signal destroy;
+};
+
+struct wlr_idle_inhibit_v1 *wlr_idle_inhibit_v1_create(struct wl_display *display);
+void wlr_idle_inhibit_v1_destroy(struct wlr_idle_inhibit_v1 *idle_inhibit);
+
+#endif

--- a/include/wlr/types/wlr_idle_inhibit_v1.h
+++ b/include/wlr/types/wlr_idle_inhibit_v1.h
@@ -15,7 +15,7 @@ struct wlr_idle_inhibit_manager_v1 {
 	} events;
 };
 
-struct wlr_idle_inhibit_inhibitor_v1 {
+struct wlr_idle_inhibitor_v1 {
 	struct wlr_surface *surface;
 	struct wl_resource *resource;
 	struct wl_listener surface_destroy;

--- a/include/wlr/types/wlr_idle_inhibit_v1.h
+++ b/include/wlr/types/wlr_idle_inhibit_v1.h
@@ -3,12 +3,16 @@
 
 #include <wayland-server.h>
 
-struct wlr_idle_inhibit_v1 {
-	struct wl_list clients;
+struct wlr_idle_inhibit_manager_v1 {
+	struct wl_list wl_resources; // wl_resource_get_link
+	struct wl_list inhibitors; // wlr_idle_inhibit_inhibitor_v1::link
 	struct wl_global *global;
 	
 	struct wl_listener display_destroy;
-	struct wl_signal new_inhibitor;
+
+	struct {
+		struct wl_signal new_inhibitor;
+	} events;
 };
 
 struct wlr_idle_inhibit_inhibitor_v1 {
@@ -16,12 +20,14 @@ struct wlr_idle_inhibit_inhibitor_v1 {
 	struct wl_resource *resource;
 	struct wl_listener surface_destroy;
 
-	struct wl_list link; // wlr_idle_inhibit_manager::inhibitors;
+	struct wl_list link; // wlr_idle_inhibit_manager_v1::inhibitors;
 
-	struct wl_signal destroy;
+	struct {
+		struct wl_signal destroy;
+	} events;
 };
 
-struct wlr_idle_inhibit_v1 *wlr_idle_inhibit_v1_create(struct wl_display *display);
-void wlr_idle_inhibit_v1_destroy(struct wlr_idle_inhibit_v1 *idle_inhibit);
+struct wlr_idle_inhibit_manager_v1 *wlr_idle_inhibit_v1_create(struct wl_display *display);
+void wlr_idle_inhibit_v1_destroy(struct wlr_idle_inhibit_manager_v1 *idle_inhibit);
 
 #endif

--- a/include/wlr/types/wlr_idle_inhibit_v1.h
+++ b/include/wlr/types/wlr_idle_inhibit_v1.h
@@ -3,6 +3,18 @@
 
 #include <wayland-server.h>
 
+/* This interface permits clients to inhibit the idle behavior such as
+ * screenblanking, locking, and screensaving.
+ *
+ * This allows clients to ensure they stay visible instead of being hidden by
+ * power-saving.
+ *
+ * Inhibitors are created for surfaces. They should only be in effect, while
+ * this surface is visible.
+ * The effect could also be limited to outputs it is displayed on (e.g.
+ * dimm/dpms off outputs, except the one a video is displayed on).
+ */
+
 struct wlr_idle_inhibit_manager_v1 {
 	struct wl_list wl_resources; // wl_resource_get_link
 	struct wl_list inhibitors; // wlr_idle_inhibit_inhibitor_v1::link

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -33,6 +33,7 @@ protocols = [
 
 client_protocols = [
 	[wl_protocol_dir, 'unstable/xdg-shell/xdg-shell-unstable-v6.xml'],
+	[wl_protocol_dir, 'stable/xdg-shell/xdg-shell.xml'],
 	[wl_protocol_dir, 'unstable/idle-inhibit/idle-inhibit-unstable-v1.xml'],
 	'gamma-control.xml',
 	'gtk-primary-selection.xml',

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -39,7 +39,6 @@ client_protocols = [
 	'gtk-primary-selection.xml',
 	'idle.xml',
 	'screenshooter.xml',
-	'server-decoration.xml',
 ]
 
 wl_protos_src = []

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -23,6 +23,7 @@ wayland_scanner_client = generator(
 protocols = [
 	[wl_protocol_dir, 'unstable/xdg-shell/xdg-shell-unstable-v6.xml'],
 	[wl_protocol_dir, 'stable/xdg-shell/xdg-shell.xml'],
+	[wl_protocol_dir, 'unstable/idle-inhibit/idle-inhibit-unstable-v1.xml'],
 	'gamma-control.xml',
 	'gtk-primary-selection.xml',
 	'idle.xml',
@@ -32,8 +33,12 @@ protocols = [
 
 client_protocols = [
 	[wl_protocol_dir, 'unstable/xdg-shell/xdg-shell-unstable-v6.xml'],
+	[wl_protocol_dir, 'unstable/idle-inhibit/idle-inhibit-unstable-v1.xml'],
+	'gamma-control.xml',
+	'gtk-primary-selection.xml',
 	'idle.xml',
 	'screenshooter.xml',
+	'server-decoration.xml',
 ]
 
 wl_protos_src = []

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -35,8 +35,6 @@ client_protocols = [
 	[wl_protocol_dir, 'unstable/xdg-shell/xdg-shell-unstable-v6.xml'],
 	[wl_protocol_dir, 'stable/xdg-shell/xdg-shell.xml'],
 	[wl_protocol_dir, 'unstable/idle-inhibit/idle-inhibit-unstable-v1.xml'],
-	'gamma-control.xml',
-	'gtk-primary-selection.xml',
 	'idle.xml',
 	'screenshooter.xml',
 ]

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -10,6 +10,7 @@
 #include <wlr/types/wlr_gamma_control.h>
 #include <wlr/types/wlr_idle.h>
 #include <wlr/types/wlr_output_layout.h>
+#include <wlr/types/wlr_idle_inhibit_v1.h>
 #include <wlr/types/wlr_primary_selection.h>
 #include <wlr/types/wlr_server_decoration.h>
 #include <wlr/types/wlr_wl_shell.h>
@@ -703,6 +704,7 @@ struct roots_desktop *desktop_create(struct roots_server *server,
 	desktop->primary_selection_device_manager =
 		wlr_primary_selection_device_manager_create(server->wl_display);
 	desktop->idle = wlr_idle_create(server->wl_display);
+	desktop->idle_inhibit = wlr_idle_inhibit_v1_create(server->wl_display);
 
 	return desktop;
 }

--- a/types/meson.build
+++ b/types/meson.build
@@ -27,6 +27,7 @@ lib_wlr_types = static_library(
 		'wlr_xcursor_manager.c',
 		'wlr_xdg_shell_v6.c',
 		'wlr_xdg_shell.c',
+		'wlr_idle_inhibit_v1.c',
 	),
 	include_directories: wlr_inc,
 	dependencies: [pixman, xkbcommon, wayland_server, wlr_protos],

--- a/types/wlr_idle_inhibit_v1.c
+++ b/types/wlr_idle_inhibit_v1.c
@@ -12,14 +12,14 @@ static struct zwp_idle_inhibit_manager_v1_interface idle_inhibit_impl;
 
 static struct zwp_idle_inhibitor_v1_interface idle_inhibitor_impl;
 
-struct wlr_idle_inhibit_manager_v1 *
+static struct wlr_idle_inhibit_manager_v1 *
 wlr_idle_inhibit_manager_v1_from_resource(struct wl_resource *resource) {
 	assert(wl_resource_instance_of(resource, &zwp_idle_inhibit_manager_v1_interface,
 		&idle_inhibit_impl));
 	return wl_resource_get_user_data(resource);
 }
 
-struct wlr_idle_inhibitor_v1 *
+static struct wlr_idle_inhibitor_v1 *
 wlr_idle_inhibitor_v1_from_resource(struct wl_resource *resource) {
 	assert(wl_resource_instance_of(resource, &zwp_idle_inhibitor_v1_interface,
 		&idle_inhibitor_impl));

--- a/types/wlr_idle_inhibit_v1.c
+++ b/types/wlr_idle_inhibit_v1.c
@@ -1,0 +1,191 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <wlr/util/log.h>
+#include <wlr/types/wlr_surface.h>
+#include <wlr/types/wlr_idle_inhibit_v1.h>
+#include "wayland-util.h"
+#include "wayland-server.h"
+#include "idle-inhibit-unstable-v1-protocol.h"
+
+struct wlr_idle_inhibit_manager {
+	struct wlr_idle_inhibit_v1 *wlr_idle_inhibit;
+	struct wl_resource *resource;
+
+	struct wl_list link; // wlr_idle_inhibit_v1::clients
+
+	struct wl_list inhibitors;
+};
+
+static void idle_inhibit_inhibitor_destroy(struct wl_resource *resource) {
+	struct wlr_idle_inhibit_inhibitor_v1 *inhibitor = wl_resource_get_user_data(resource);
+	assert(inhibitor);
+
+	wl_signal_emit(&inhibitor->destroy, inhibitor->surface);
+
+	wl_list_remove(&inhibitor->link);
+	wl_list_remove(&inhibitor->surface_destroy.link);
+	free(inhibitor);
+}
+
+static void idle_inhibit_inhibitor_handle_surface_destroy(struct wl_listener *listener,
+		void *data) {
+	assert(listener);
+	struct wlr_idle_inhibit_inhibitor_v1 *inhibitor =
+		wl_container_of(listener, inhibitor, surface_destroy);
+
+	wl_resource_destroy(inhibitor->resource);
+}
+
+static void idle_inhibit_inhibitor_v1_handle_destroy(struct wl_client *client,
+		struct wl_resource *manager_resource) {
+	wl_resource_destroy(manager_resource);
+}
+
+static struct zwp_idle_inhibitor_v1_interface idle_inhibitor_impl = {
+	.destroy = idle_inhibit_inhibitor_v1_handle_destroy,
+};
+
+static void wlr_create_inhibitor(struct wl_client *client,
+		struct wl_resource *resource, uint32_t id,
+		struct wl_resource *surface_resource) {
+	struct wlr_surface *surface = wl_resource_get_user_data(surface_resource);
+	struct wlr_idle_inhibit_manager *manager = wl_resource_get_user_data(resource);
+	assert(surface && manager);
+
+	struct wlr_idle_inhibit_inhibitor_v1 *inhibitor = calloc(1, sizeof(struct wlr_idle_inhibit_inhibitor_v1));
+	if (!inhibitor) {
+		wl_client_post_no_memory(client);
+		return;
+	}
+
+	struct wl_resource *wl_resource = wl_resource_create(client,
+		&zwp_idle_inhibitor_v1_interface, 1, id);
+	if (!wl_resource) {
+		wl_client_post_no_memory(client);
+		free(inhibitor);
+		return;
+	}
+
+	inhibitor->resource = wl_resource;
+	inhibitor->surface = surface;
+	wl_signal_init(&inhibitor->destroy);
+
+	inhibitor->surface_destroy.notify = idle_inhibit_inhibitor_handle_surface_destroy;
+	wl_signal_add(&surface->events.destroy, &inhibitor->surface_destroy);
+
+
+	wl_resource_set_implementation(wl_resource, &idle_inhibitor_impl,
+		inhibitor, idle_inhibit_inhibitor_destroy);
+
+	wl_list_insert(&manager->inhibitors, &inhibitor->link);
+	wl_signal_emit(&manager->wlr_idle_inhibit->new_inhibitor, inhibitor);
+}
+
+
+static void idle_inhibit_manager_destroy(struct wl_resource *resource) {
+	struct wlr_idle_inhibit_manager *manager = wl_resource_get_user_data(resource);
+	assert(manager);
+
+	wl_list_remove(&manager->link);
+
+	struct wlr_idle_inhibit_inhibitor_v1 *inhibitor;
+	struct wlr_idle_inhibit_inhibitor_v1 *tmp;
+	wl_list_for_each_safe(inhibitor, tmp, &manager->inhibitors, link) {
+		wl_resource_destroy(inhibitor->resource);
+	}
+}
+
+static void idle_inhibit_manager_handle_destroy(struct wl_client *client,
+		struct wl_resource *manager_resource) {
+	wl_resource_destroy(manager_resource);
+}
+
+static struct zwp_idle_inhibit_manager_v1_interface idle_inhibit_impl = {
+	.destroy = idle_inhibit_manager_handle_destroy,
+	.create_inhibitor = wlr_create_inhibitor,
+};
+
+void wlr_idle_inhibit_v1_destroy(struct wlr_idle_inhibit_v1 *idle_inhibit);
+
+
+static void handle_display_destroy(struct wl_listener *listener, void *data) {
+	struct wlr_idle_inhibit_v1 *idle_inhibit =
+		wl_container_of(listener, idle_inhibit, display_destroy);
+
+	wlr_idle_inhibit_v1_destroy(idle_inhibit);
+}
+
+static void idle_inhibit_bind(struct wl_client *wl_client, void *data,
+		uint32_t version, uint32_t id) {
+	struct wlr_idle_inhibit_v1 *idle_inhibit = data;
+	assert(wl_client && idle_inhibit);
+
+	struct wlr_idle_inhibit_manager *manager = calloc(1, sizeof(struct wlr_idle_inhibit_manager));
+	if (!manager) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+
+	struct wl_resource *wl_resource  = wl_resource_create(wl_client,
+		&zwp_idle_inhibit_manager_v1_interface, version, id);
+
+	if (!wl_resource) {
+		wl_client_post_no_memory(wl_client);
+		free(manager);
+		return;
+	}
+
+	manager->resource = wl_resource;
+	wl_list_init(&manager->inhibitors);
+	wl_list_insert(&idle_inhibit->clients, &manager->link);
+	manager->wlr_idle_inhibit = idle_inhibit;
+
+
+	wl_resource_set_implementation(wl_resource, &idle_inhibit_impl,
+		manager, idle_inhibit_manager_destroy);
+	wlr_log(L_DEBUG, "idle_inhibit bound");
+}
+
+void wlr_idle_inhibit_v1_destroy(struct wlr_idle_inhibit_v1 *idle_inhibit) {
+	if (!idle_inhibit) {
+		return;
+	}
+
+	wl_list_remove(&idle_inhibit->display_destroy.link);
+
+	struct wlr_idle_inhibit_manager *manager;
+	struct wlr_idle_inhibit_manager *tmp;
+	wl_list_for_each_safe(manager, tmp, &idle_inhibit->clients, link) {
+		wl_resource_destroy(manager->resource);
+	}
+
+	wl_global_destroy(idle_inhibit->global);
+	free(idle_inhibit);
+}
+
+struct wlr_idle_inhibit_v1 *wlr_idle_inhibit_v1_create(struct wl_display *display) {
+	struct wlr_idle_inhibit_v1 *idle_inhibit = calloc(1, sizeof(struct wlr_idle_inhibit_v1));
+
+	if (!idle_inhibit) {
+		return NULL;
+	}
+
+	wl_list_init(&idle_inhibit->clients);
+	idle_inhibit->display_destroy.notify = handle_display_destroy;
+	wl_display_add_destroy_listener(display, &idle_inhibit->display_destroy);
+	wl_signal_init(&idle_inhibit->new_inhibitor);
+
+	idle_inhibit->global = wl_global_create(display,
+		&zwp_idle_inhibit_manager_v1_interface, 1,
+		idle_inhibit, idle_inhibit_bind);
+
+	if (!idle_inhibit->global) {
+		wl_list_remove(&idle_inhibit->display_destroy.link);
+		free(idle_inhibit);
+		return NULL;
+	}
+
+	wlr_log(L_DEBUG, "idle_inhibit manager created");
+
+	return idle_inhibit;
+}

--- a/types/wlr_idle_inhibit_v1.c
+++ b/types/wlr_idle_inhibit_v1.c
@@ -19,17 +19,16 @@ wlr_idle_inhibit_manager_v1_from_resource(struct wl_resource *resource) {
 	return wl_resource_get_user_data(resource);
 }
 
-struct wlr_idle_inhibit_inhibitor_v1 *
-wlr_idle_inhibit_inhibitor_v1_from_resource(struct wl_resource *resource) {
+struct wlr_idle_inhibitor_v1 *
+wlr_idle_inhibitor_v1_from_resource(struct wl_resource *resource) {
 	assert(wl_resource_instance_of(resource, &zwp_idle_inhibitor_v1_interface,
 		&idle_inhibitor_impl));
 	return wl_resource_get_user_data(resource);
 }
 
-static void idle_inhibit_inhibitor_destroy(struct wl_resource *resource) {
-	struct wlr_idle_inhibit_inhibitor_v1 *inhibitor =
-		wlr_idle_inhibit_inhibitor_v1_from_resource(resource);
-	assert(inhibitor);
+static void idle_inhibitor_destroy(struct wl_resource *resource) {
+	struct wlr_idle_inhibitor_v1 *inhibitor =
+		wlr_idle_inhibitor_v1_from_resource(resource);
 
 	wlr_signal_emit_safe(&inhibitor->events.destroy, inhibitor->surface);
 
@@ -38,21 +37,21 @@ static void idle_inhibit_inhibitor_destroy(struct wl_resource *resource) {
 	free(inhibitor);
 }
 
-static void idle_inhibit_inhibitor_handle_surface_destroy(
+static void idle_inhibitor_handle_surface_destroy(
 		struct wl_listener *listener, void *data) {
-	struct wlr_idle_inhibit_inhibitor_v1 *inhibitor =
+	struct wlr_idle_inhibitor_v1 *inhibitor =
 		wl_container_of(listener, inhibitor, surface_destroy);
 
 	wl_resource_destroy(inhibitor->resource);
 }
 
-static void idle_inhibit_inhibitor_v1_handle_destroy(struct wl_client *client,
+static void idle_inhibitor_v1_handle_destroy(struct wl_client *client,
 		struct wl_resource *manager_resource) {
 	wl_resource_destroy(manager_resource);
 }
 
 static struct zwp_idle_inhibitor_v1_interface idle_inhibitor_impl = {
-	.destroy = idle_inhibit_inhibitor_v1_handle_destroy,
+	.destroy = idle_inhibitor_v1_handle_destroy,
 };
 
 static void wlr_create_inhibitor(struct wl_client *client,
@@ -61,10 +60,9 @@ static void wlr_create_inhibitor(struct wl_client *client,
 	struct wlr_surface *surface = wlr_surface_from_resource(surface_resource);
 	struct wlr_idle_inhibit_manager_v1 *manager =
 		wlr_idle_inhibit_manager_v1_from_resource(resource);
-	assert(surface && manager);
 
-	struct wlr_idle_inhibit_inhibitor_v1 *inhibitor =
-		calloc(1, sizeof(struct wlr_idle_inhibit_inhibitor_v1));
+	struct wlr_idle_inhibitor_v1 *inhibitor =
+		calloc(1, sizeof(struct wlr_idle_inhibitor_v1));
 	if (!inhibitor) {
 		wl_client_post_no_memory(client);
 		return;
@@ -82,12 +80,12 @@ static void wlr_create_inhibitor(struct wl_client *client,
 	inhibitor->surface = surface;
 	wl_signal_init(&inhibitor->events.destroy);
 
-	inhibitor->surface_destroy.notify = idle_inhibit_inhibitor_handle_surface_destroy;
+	inhibitor->surface_destroy.notify = idle_inhibitor_handle_surface_destroy;
 	wl_signal_add(&surface->events.destroy, &inhibitor->surface_destroy);
 
 
 	wl_resource_set_implementation(wl_resource, &idle_inhibitor_impl,
-		inhibitor, idle_inhibit_inhibitor_destroy);
+		inhibitor, idle_inhibitor_destroy);
 
 	wl_list_insert(&manager->inhibitors, &inhibitor->link);
 	wlr_signal_emit_safe(&manager->events.new_inhibitor, inhibitor);
@@ -118,7 +116,6 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 static void idle_inhibit_bind(struct wl_client *wl_client, void *data,
 		uint32_t version, uint32_t id) {
 	struct wlr_idle_inhibit_manager_v1 *idle_inhibit = data;
-	assert(wl_client && idle_inhibit);
 
 	struct wl_resource *wl_resource  = wl_resource_create(wl_client,
 		&zwp_idle_inhibit_manager_v1_interface, version, id);
@@ -142,8 +139,8 @@ void wlr_idle_inhibit_v1_destroy(struct wlr_idle_inhibit_manager_v1 *idle_inhibi
 
 	wl_list_remove(&idle_inhibit->display_destroy.link);
 
-	struct wlr_idle_inhibit_inhibitor_v1 *inhibitor;
-	struct wlr_idle_inhibit_inhibitor_v1 *tmp;
+	struct wlr_idle_inhibitor_v1 *inhibitor;
+	struct wlr_idle_inhibitor_v1 *tmp;
 	wl_list_for_each_safe(inhibitor, tmp, &idle_inhibit->inhibitors, link) {
 		wl_resource_destroy(inhibitor->resource);
 	}


### PR DESCRIPTION
This adds an implementation of the `idle-inhibit-v1` protocol and an example client.

The client is very simple and skips a little bit of error checking (whether the seat actually has a pointer), but works to trigger the code paths in the server.

The implementation in `rootston` does nothing but create the manager.
Since rootston doesn't have any kind of idling action, I'm not sure what else we could do here, ideas?