### PR TITLE
ELF Visibility

### DIFF
--- a/backend/backend.c
+++ b/backend/backend.c
@@ -150,7 +150,3 @@ struct wlr_backend *wlr_backend_autocreate(struct wl_display *display) {
 
 	return backend;
 }
-
-uint32_t usec_to_msec(uint64_t usec) {
-	return (uint32_t)(usec / 1000);
-}

--- a/backend/backend.c
+++ b/backend/backend.c
@@ -13,7 +13,9 @@
 #include <wlr/backend/wayland.h>
 #include <wlr/backend/x11.h>
 #include <wlr/util/log.h>
+#include "util/defs.h"
 
+WLR_API
 void wlr_backend_init(struct wlr_backend *backend,
 		const struct wlr_backend_impl *impl) {
 	assert(backend);
@@ -23,6 +25,7 @@ void wlr_backend_init(struct wlr_backend *backend,
 	wl_signal_init(&backend->events.new_output);
 }
 
+WLR_API
 bool wlr_backend_start(struct wlr_backend *backend) {
 	if (backend->impl->start) {
 		return backend->impl->start(backend);
@@ -30,6 +33,7 @@ bool wlr_backend_start(struct wlr_backend *backend) {
 	return true;
 }
 
+WLR_API
 void wlr_backend_destroy(struct wlr_backend *backend) {
 	if (!backend) {
 		return;
@@ -42,6 +46,7 @@ void wlr_backend_destroy(struct wlr_backend *backend) {
 	}
 }
 
+WLR_API
 struct wlr_egl *wlr_backend_get_egl(struct wlr_backend *backend) {
 	if (backend->impl->get_egl) {
 		return backend->impl->get_egl(backend);
@@ -49,6 +54,7 @@ struct wlr_egl *wlr_backend_get_egl(struct wlr_backend *backend) {
 	return NULL;
 }
 
+WLR_API
 struct wlr_renderer *wlr_backend_get_renderer(struct wlr_backend *backend) {
 	if (backend->impl->get_renderer) {
 		return backend->impl->get_renderer(backend);
@@ -79,6 +85,7 @@ static struct wlr_backend *attempt_wl_backend(struct wl_display *display) {
 	return backend;
 }
 
+WLR_API
 struct wlr_backend *wlr_backend_autocreate(struct wl_display *display) {
 	struct wlr_backend *backend = wlr_multi_backend_create(display);
 	if (!backend) {

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -13,6 +13,7 @@
 #include <wlr/util/log.h>
 #include <xf86drm.h>
 #include "backend/drm/drm.h"
+#include "util/defs.h"
 #include "util/signal.h"
 
 static bool wlr_drm_backend_start(struct wlr_backend *backend) {
@@ -66,6 +67,7 @@ static struct wlr_backend_impl backend_impl = {
 	.get_renderer = wlr_drm_backend_get_renderer,
 };
 
+WLR_API
 bool wlr_backend_is_drm(struct wlr_backend *b) {
 	return b->impl == &backend_impl;
 }
@@ -117,6 +119,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	wlr_drm_backend_destroy(&drm->backend);
 }
 
+WLR_API
 struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
 		struct wlr_session *session, int gpu_fd, struct wlr_backend *parent) {
 	assert(display && session && gpu_fd >= 0);

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -24,6 +24,7 @@
 #include "backend/drm/drm.h"
 #include "backend/drm/iface.h"
 #include "backend/drm/util.h"
+#include "util/defs.h"
 #include "util/signal.h"
 
 bool wlr_drm_check_features(struct wlr_drm_backend *drm) {
@@ -728,6 +729,7 @@ static struct wlr_output_impl output_impl = {
 	.get_gamma_size = wlr_drm_connector_get_gamma_size,
 };
 
+WLR_API
 bool wlr_output_is_drm(struct wlr_output *output) {
 	return output->impl == &output_impl;
 }

--- a/backend/headless/backend.c
+++ b/backend/headless/backend.c
@@ -7,6 +7,7 @@
 #include <wlr/util/log.h>
 #include "backend/headless.h"
 #include "glapi.h"
+#include "util/defs.h"
 
 static bool backend_start(struct wlr_backend *wlr_backend) {
 	struct wlr_headless_backend *backend =
@@ -84,6 +85,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	backend_destroy(&backend->backend);
 }
 
+WLR_API
 struct wlr_backend *wlr_headless_backend_create(struct wl_display *display) {
 	wlr_log(L_INFO, "Creating headless backend");
 
@@ -125,6 +127,7 @@ struct wlr_backend *wlr_headless_backend_create(struct wl_display *display) {
 	return &backend->backend;
 }
 
+WLR_API
 bool wlr_backend_is_headless(struct wlr_backend *backend) {
 	return backend->impl == &backend_impl;
 }

--- a/backend/headless/input_device.c
+++ b/backend/headless/input_device.c
@@ -7,6 +7,7 @@
 #include <wlr/interfaces/wlr_touch.h>
 #include <wlr/util/log.h>
 #include "backend/headless.h"
+#include "util/defs.h"
 #include "util/signal.h"
 
 static void input_device_destroy(struct wlr_input_device *wlr_dev) {
@@ -19,10 +20,12 @@ static struct wlr_input_device_impl input_device_impl = {
 	.destroy = input_device_destroy,
 };
 
+WLR_API
 bool wlr_input_device_is_headless(struct wlr_input_device *wlr_dev) {
 	return wlr_dev->impl == &input_device_impl;
 }
 
+WLR_API
 struct wlr_input_device *wlr_headless_add_input_device(
 		struct wlr_backend *wlr_backend, enum wlr_input_device_type type) {
 	struct wlr_headless_backend *backend =

--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -5,6 +5,7 @@
 #include <wlr/interfaces/wlr_output.h>
 #include <wlr/util/log.h>
 #include "backend/headless.h"
+#include "util/defs.h"
 #include "util/signal.h"
 
 static EGLSurface egl_create_surface(struct wlr_egl *egl, unsigned int width,
@@ -79,6 +80,7 @@ static const struct wlr_output_impl output_impl = {
 	.swap_buffers = output_swap_buffers,
 };
 
+WLR_API
 bool wlr_output_is_headless(struct wlr_output *wlr_output) {
 	return wlr_output->impl == &output_impl;
 }
@@ -90,6 +92,7 @@ static int signal_frame(void *data) {
 	return 0;
 }
 
+WLR_API
 struct wlr_output *wlr_headless_add_output(struct wlr_backend *wlr_backend,
 		unsigned int width, unsigned int height) {
 	struct wlr_headless_backend *backend =

--- a/backend/libinput/backend.c
+++ b/backend/libinput/backend.c
@@ -189,3 +189,7 @@ struct libinput_device *wlr_libinput_get_device_handle(struct wlr_input_device *
 	struct wlr_libinput_input_device *dev = (struct wlr_libinput_input_device *)_dev;
 	return dev->handle;
 }
+
+uint32_t usec_to_msec(uint64_t usec) {
+	return (uint32_t)(usec / 1000);
+}

--- a/backend/libinput/backend.c
+++ b/backend/libinput/backend.c
@@ -5,6 +5,7 @@
 #include <wlr/backend/session.h>
 #include <wlr/util/log.h>
 #include "backend/libinput.h"
+#include "util/defs.h"
 #include "util/signal.h"
 
 static int wlr_libinput_open_restricted(const char *path,
@@ -128,6 +129,7 @@ static struct wlr_backend_impl backend_impl = {
 	.destroy = wlr_libinput_backend_destroy
 };
 
+WLR_API
 bool wlr_backend_is_libinput(struct wlr_backend *b) {
 	return b->impl == &backend_impl;
 }
@@ -154,6 +156,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	wlr_libinput_backend_destroy(&backend->backend);
 }
 
+WLR_API
 struct wlr_backend *wlr_libinput_backend_create(struct wl_display *display,
 		struct wlr_session *session) {
 	assert(display && session);
@@ -185,6 +188,7 @@ error_backend:
 	return NULL;
 }
 
+WLR_API
 struct libinput_device *wlr_libinput_get_device_handle(struct wlr_input_device *_dev) {
 	struct wlr_libinput_input_device *dev = (struct wlr_libinput_input_device *)_dev;
 	return dev->handle;

--- a/backend/libinput/events.c
+++ b/backend/libinput/events.c
@@ -6,6 +6,7 @@
 #include <wlr/interfaces/wlr_input_device.h>
 #include <wlr/util/log.h>
 #include "backend/libinput.h"
+#include "util/defs.h"
 #include "util/signal.h"
 
 struct wlr_input_device *get_appropriate_device(
@@ -54,6 +55,7 @@ static struct wlr_input_device *allocate_device(
 	return wlr_dev;
 }
 
+WLR_API
 bool wlr_input_device_is_libinput(struct wlr_input_device *wlr_dev) {
         return wlr_dev->impl == &input_device_impl;
 }

--- a/backend/multi/backend.c
+++ b/backend/multi/backend.c
@@ -6,6 +6,7 @@
 #include <wlr/util/log.h>
 #include "backend/drm/drm.h"
 #include "backend/multi.h"
+#include "util/defs.h"
 #include "util/signal.h"
 
 struct subbackend_state {
@@ -90,6 +91,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	multi_backend_destroy((struct wlr_backend*)backend);
 }
 
+WLR_API
 struct wlr_backend *wlr_multi_backend_create(struct wl_display *display) {
 	struct wlr_multi_backend *backend =
 		calloc(1, sizeof(struct wlr_multi_backend));
@@ -110,6 +112,7 @@ struct wlr_backend *wlr_multi_backend_create(struct wl_display *display) {
 	return &backend->backend;
 }
 
+WLR_API
 bool wlr_backend_is_multi(struct wlr_backend *b) {
 	return b->impl == &backend_impl;
 }
@@ -143,6 +146,7 @@ static struct subbackend_state *multi_backend_get_subbackend(struct wlr_multi_ba
 	return NULL;
 }
 
+WLR_API
 void wlr_multi_backend_add(struct wlr_backend *_multi,
 		struct wlr_backend *backend) {
 	assert(wlr_backend_is_multi(_multi));
@@ -175,6 +179,7 @@ void wlr_multi_backend_add(struct wlr_backend *_multi,
 	wlr_signal_emit_safe(&multi->events.backend_add, backend);
 }
 
+WLR_API
 void wlr_multi_backend_remove(struct wlr_backend *_multi,
 		struct wlr_backend *backend) {
 	assert(wlr_backend_is_multi(_multi));
@@ -189,6 +194,7 @@ void wlr_multi_backend_remove(struct wlr_backend *_multi,
 	}
 }
 
+WLR_API
 struct wlr_session *wlr_multi_get_session(struct wlr_backend *_backend) {
 	assert(wlr_backend_is_multi(_backend));
 
@@ -202,6 +208,7 @@ struct wlr_session *wlr_multi_get_session(struct wlr_backend *_backend) {
 	return NULL;
 }
 
+WLR_API
 bool wlr_multi_is_empty(struct wlr_backend *_backend) {
 	assert(wlr_backend_is_multi(_backend));
 	struct wlr_multi_backend *backend = (struct wlr_multi_backend *)_backend;

--- a/backend/session/session.c
+++ b/backend/session/session.c
@@ -13,6 +13,7 @@
 #include <wlr/util/log.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
+#include "util/defs.h"
 #include "util/signal.h"
 
 extern const struct session_impl session_logind;
@@ -66,6 +67,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	wlr_session_destroy(session);
 }
 
+WLR_API
 struct wlr_session *wlr_session_create(struct wl_display *disp) {
 	struct wlr_session *session = NULL;
 	const struct session_impl **iter;
@@ -122,6 +124,7 @@ error_session:
 	return NULL;
 }
 
+WLR_API
 void wlr_session_destroy(struct wlr_session *session) {
 	if (!session) {
 		return;
@@ -136,6 +139,7 @@ void wlr_session_destroy(struct wlr_session *session) {
 	session->impl->destroy(session);
 }
 
+WLR_API
 int wlr_session_open_file(struct wlr_session *session, const char *path) {
 	int fd = session->impl->open(session, path);
 	if (fd < 0) {
@@ -179,6 +183,7 @@ static struct wlr_device *find_device(struct wlr_session *session, int fd) {
 	assert(0);
 }
 
+WLR_API
 void wlr_session_close_file(struct wlr_session *session, int fd) {
 	struct wlr_device *dev = find_device(session, fd);
 
@@ -187,6 +192,7 @@ void wlr_session_close_file(struct wlr_session *session, int fd) {
 	free(dev);
 }
 
+WLR_API
 void wlr_session_signal_add(struct wlr_session *session, int fd,
 		struct wl_listener *listener) {
 	struct wlr_device *dev = find_device(session, fd);
@@ -194,6 +200,7 @@ void wlr_session_signal_add(struct wlr_session *session, int fd,
 	wl_signal_add(&dev->signal, listener);
 }
 
+WLR_API
 bool wlr_session_change_vt(struct wlr_session *session, unsigned vt) {
 	if (!session) {
 		return false;
@@ -269,6 +276,7 @@ static size_t explicit_find_gpus(struct wlr_session *session,
 /* Tries to find the primary GPU by checking for the "boot_vga" attribute.
  * If it's not found, it returns the first valid GPU it finds.
  */
+WLR_API
 size_t wlr_session_find_gpus(struct wlr_session *session,
 		size_t ret_len, int *ret) {
 	const char *explicit = getenv("WLR_DRM_DEVICES");

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -12,6 +12,7 @@
 #include <wlr/render/gles2.h>
 #include <wlr/util/log.h>
 #include "backend/wayland.h"
+#include "util/defs.h"
 #include "util/signal.h"
 #include "xdg-shell-unstable-v6-client-protocol.h"
 
@@ -128,6 +129,7 @@ static struct wlr_backend_impl backend_impl = {
 	.get_renderer = wlr_wl_backend_get_renderer,
 };
 
+WLR_API
 bool wlr_backend_is_wl(struct wlr_backend *b) {
 	return b->impl == &backend_impl;
 }
@@ -181,6 +183,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	wlr_wl_backend_destroy(&backend->backend);
 }
 
+WLR_API
 struct wlr_backend *wlr_wl_backend_create(struct wl_display *display, const char *remote) {
 	wlr_log(L_INFO, "Creating wayland backend");
 

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -11,6 +11,7 @@
 #include <wlr/interfaces/wlr_output.h>
 #include <wlr/util/log.h>
 #include "backend/wayland.h"
+#include "util/defs.h"
 #include "util/signal.h"
 #include "xdg-shell-unstable-v6-client-protocol.h"
 
@@ -217,6 +218,7 @@ static struct wlr_output_impl output_impl = {
 	.move_cursor = wlr_wl_output_move_cursor,
 };
 
+WLR_API
 bool wlr_output_is_wl(struct wlr_output *wlr_output) {
 	return wlr_output->impl == &output_impl;
 }
@@ -260,6 +262,7 @@ static struct zxdg_toplevel_v6_listener xdg_toplevel_listener = {
 	.close = xdg_toplevel_handle_close,
 };
 
+WLR_API
 struct wlr_output *wlr_wl_output_create(struct wlr_backend *_backend) {
 	assert(wlr_backend_is_wl(_backend));
 	struct wlr_wl_backend *backend = (struct wlr_wl_backend *)_backend;

--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -11,6 +11,7 @@
 #include <wlr/interfaces/wlr_touch.h>
 #include <wlr/util/log.h>
 #include "backend/wayland.h"
+#include "util/defs.h"
 #include "util/signal.h"
 
 static void pointer_handle_enter(void *data, struct wl_pointer *wl_pointer,
@@ -205,6 +206,7 @@ static struct wlr_input_device_impl input_device_impl = {
 	.destroy = input_device_destroy
 };
 
+WLR_API
 bool wlr_input_device_is_wl(struct wlr_input_device *dev) {
 	return dev->impl == &input_device_impl;
 }

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -23,6 +23,7 @@
 #include <dev/evdev/input-event-codes.h>
 #endif
 #include "backend/x11.h"
+#include "util/defs.h"
 #include "util/signal.h"
 
 static struct wlr_backend_impl backend_impl;
@@ -289,6 +290,7 @@ static struct wlr_backend_impl backend_impl = {
 	.get_renderer = wlr_x11_backend_get_renderer,
 };
 
+WLR_API
 bool wlr_backend_is_x11(struct wlr_backend *backend) {
 	return backend->impl == &backend_impl;
 }
@@ -299,6 +301,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	wlr_x11_backend_destroy(&x11->backend);
 }
 
+WLR_API
 struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
 		const char *x11_display) {
 	struct wlr_x11_backend *x11 = calloc(1, sizeof(*x11));
@@ -418,10 +421,12 @@ static struct wlr_output_impl output_impl = {
 	.swap_buffers = output_swap_buffers,
 };
 
+WLR_API
 bool wlr_output_is_x11(struct wlr_output *wlr_output) {
 	return wlr_output->impl == &output_impl;
 }
 
+WLR_API
 bool wlr_input_device_is_x11(struct wlr_input_device *wlr_dev) {
 	return wlr_dev->impl == &input_device_impl;
 }

--- a/include/backend/libinput.h
+++ b/include/backend/libinput.h
@@ -83,4 +83,6 @@ void handle_tablet_pad_ring(struct libinput_event *event,
 void handle_tablet_pad_strip(struct libinput_event *event,
 		struct libinput_device *device);
 
+uint32_t usec_to_msec(uint64_t usec);
+
 #endif

--- a/include/util/defs.h
+++ b/include/util/defs.h
@@ -1,0 +1,10 @@
+#ifndef UTIL_DEFS_H
+#define UTIL_DEFS_H
+
+#ifdef __GNUC__
+#define WLR_API __attribute__((visibility("default")))
+#else
+#define WLR_API
+#endif
+
+#endif

--- a/include/wlr/backend.h
+++ b/include/wlr/backend.h
@@ -23,6 +23,4 @@ void wlr_backend_destroy(struct wlr_backend *backend);
 struct wlr_egl *wlr_backend_get_egl(struct wlr_backend *backend);
 struct wlr_renderer *wlr_backend_get_renderer(struct wlr_backend *backend);
 
-uint32_t usec_to_msec(uint64_t usec);
-
 #endif

--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,7 @@ project(
 so_version = ['0', '0', '0']
 
 add_project_arguments('-Wno-unused-parameter', language: 'c')
+add_project_arguments('-fvisibility=hidden', language: 'c')
 add_project_arguments(
 	'-DWLR_SRC_DIR="@0@"'.format(meson.source_root()),
 	language: 'c',

--- a/render/egl.c
+++ b/render/egl.c
@@ -6,11 +6,13 @@
 #include <wlr/render/egl.h>
 #include <wlr/util/log.h>
 #include "glapi.h"
+#include "util/defs.h"
 
 // Extension documentation
 // https://www.khronos.org/registry/EGL/extensions/KHR/EGL_KHR_image_base.txt.
 // https://cgit.freedesktop.org/mesa/mesa/tree/docs/specs/WL_bind_wayland_display.spec
 
+WLR_API
 const char *egl_error(void) {
 	switch (eglGetError()) {
 	case EGL_SUCCESS:
@@ -83,6 +85,7 @@ static bool egl_get_config(EGLDisplay disp, EGLint *attribs, EGLConfig *out,
 	return false;
 }
 
+WLR_API
 bool wlr_egl_init(struct wlr_egl *egl, EGLenum platform, void *remote_display,
 		EGLint *config_attribs, EGLint visual_id) {
 	if (!load_glapi()) {
@@ -158,6 +161,7 @@ error:
 	return false;
 }
 
+WLR_API
 void wlr_egl_finish(struct wlr_egl *egl) {
 	eglMakeCurrent(EGL_NO_DISPLAY, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
 	if (egl->wl_display && eglUnbindWaylandDisplayWL) {
@@ -169,6 +173,7 @@ void wlr_egl_finish(struct wlr_egl *egl) {
 	eglReleaseThread();
 }
 
+WLR_API
 bool wlr_egl_bind_display(struct wlr_egl *egl, struct wl_display *local_display) {
 	if (!eglBindWaylandDisplayWL) {
 		return false;
@@ -182,6 +187,7 @@ bool wlr_egl_bind_display(struct wlr_egl *egl, struct wl_display *local_display)
 	return false;
 }
 
+WLR_API
 bool wlr_egl_query_buffer(struct wlr_egl *egl, struct wl_resource *buf,
 		int attrib, int *value) {
 	if (!eglQueryWaylandBufferWL) {
@@ -190,6 +196,7 @@ bool wlr_egl_query_buffer(struct wlr_egl *egl, struct wl_resource *buf,
 	return eglQueryWaylandBufferWL(egl->display, buf, attrib, value);
 }
 
+WLR_API
 EGLImage wlr_egl_create_image(struct wlr_egl *egl, EGLenum target,
 		EGLClientBuffer buffer, const EGLint *attribs) {
 	if (!eglCreateImageKHR) {
@@ -200,6 +207,7 @@ EGLImage wlr_egl_create_image(struct wlr_egl *egl, EGLenum target,
 		buffer, attribs);
 }
 
+WLR_API
 bool wlr_egl_destroy_image(struct wlr_egl *egl, EGLImage image) {
 	if (!eglDestroyImageKHR) {
 		return false;
@@ -209,6 +217,7 @@ bool wlr_egl_destroy_image(struct wlr_egl *egl, EGLImage image) {
 	return true;
 }
 
+WLR_API
 EGLSurface wlr_egl_create_surface(struct wlr_egl *egl, void *window) {
 	EGLSurface surf = eglCreatePlatformWindowSurfaceEXT(egl->display, egl->config,
 		window, NULL);
@@ -235,6 +244,7 @@ int wlr_egl_get_buffer_age(struct wlr_egl *egl, EGLSurface surface) {
 	return buffer_age;
 }
 
+WLR_API
 bool wlr_egl_make_current(struct wlr_egl *egl, EGLSurface surface,
 		int *buffer_age) {
 	if (!eglMakeCurrent(egl->display, surface, surface, egl->context)) {
@@ -248,6 +258,7 @@ bool wlr_egl_make_current(struct wlr_egl *egl, EGLSurface surface,
 	return true;
 }
 
+WLR_API
 bool wlr_egl_swap_buffers(struct wlr_egl *egl, EGLSurface surface,
 		pixman_region32_t *damage) {
 	EGLBoolean ret;

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -13,6 +13,7 @@
 #include <wlr/util/log.h>
 #include "render/gles2.h"
 #include "glapi.h"
+#include "util/defs.h"
 
 struct shaders shaders;
 
@@ -266,6 +267,7 @@ static struct wlr_renderer_impl wlr_renderer_impl = {
 	.format_supported = wlr_gles2_format_supported,
 };
 
+WLR_API
 struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_backend *backend) {
 	init_globals();
 	struct wlr_gles2_renderer *renderer;

--- a/render/matrix.c
+++ b/render/matrix.c
@@ -4,12 +4,14 @@
 #include <wlr/render/matrix.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_output.h>
+#include "util/defs.h"
 
 /* Obtains the index for the given row/column */
 static inline int mind(int row, int col) {
 	return (row - 1) * 4 + col - 1;
 }
 
+WLR_API
 void wlr_matrix_identity(float (*output)[16]) {
 	static const float identity[16] = {
 		1.0f, 0.0f, 0.0f, 0.0f,
@@ -20,6 +22,7 @@ void wlr_matrix_identity(float (*output)[16]) {
 	memcpy(*output, identity, sizeof(identity));
 }
 
+WLR_API
 void wlr_matrix_translate(float (*output)[16], float x, float y, float z) {
 	wlr_matrix_identity(output);
 	(*output)[mind(1, 4)] = x;
@@ -27,6 +30,7 @@ void wlr_matrix_translate(float (*output)[16], float x, float y, float z) {
 	(*output)[mind(3, 4)] = z;
 }
 
+WLR_API
 void wlr_matrix_scale(float (*output)[16], float x, float y, float z) {
 	wlr_matrix_identity(output);
 	(*output)[mind(1, 1)] = x;
@@ -34,6 +38,7 @@ void wlr_matrix_scale(float (*output)[16], float x, float y, float z) {
 	(*output)[mind(3, 3)] = z;
 }
 
+WLR_API
 void wlr_matrix_rotate(float (*output)[16], float radians) {
 	wlr_matrix_identity(output);
 	float _cos = cosf(radians);
@@ -44,6 +49,7 @@ void wlr_matrix_rotate(float (*output)[16], float radians) {
 	(*output)[mind(2, 2)] = _cos;
 }
 
+WLR_API
 void wlr_matrix_mul(const float (*x)[16], const float (*y)[16], float (*product)[16]) {
 	float _product[16] = {
 		(*x)[mind(1, 1)] * (*y)[mind(1, 1)] + (*x)[mind(1, 2)] * (*y)[mind(2, 1)] +
@@ -120,6 +126,7 @@ static const float transforms[][4] = {
 	},
 };
 
+WLR_API
 void wlr_matrix_transform(float mat[static 16],
 		enum wl_output_transform transform) {
 	memset(mat, 0, sizeof(*mat) * 16);
@@ -138,6 +145,7 @@ void wlr_matrix_transform(float mat[static 16],
 }
 
 // Equivilent to glOrtho(0, width, 0, height, 1, -1) with the transform applied
+WLR_API
 void wlr_matrix_texture(float mat[static 16], int32_t width, int32_t height,
 		enum wl_output_transform transform) {
 	memset(mat, 0, sizeof(*mat) * 16);
@@ -161,6 +169,7 @@ void wlr_matrix_texture(float mat[static 16], int32_t width, int32_t height,
 	mat[15] = 1.0f;
 }
 
+WLR_API
 void wlr_matrix_project_box(float (*mat)[16], struct wlr_box *box,
 		enum wl_output_transform transform, float rotation,
 		float (*projection)[16]) {

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -1,12 +1,15 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <wlr/render/interface.h>
+#include "util/defs.h"
 
+WLR_API
 void wlr_renderer_init(struct wlr_renderer *renderer,
 		struct wlr_renderer_impl *impl) {
 	renderer->impl = impl;
 }
 
+WLR_API
 void wlr_renderer_destroy(struct wlr_renderer *r) {
 	if (r && r->impl && r->impl->destroy) {
 		r->impl->destroy(r);
@@ -15,51 +18,62 @@ void wlr_renderer_destroy(struct wlr_renderer *r) {
 	}
 }
 
+WLR_API
 void wlr_renderer_begin(struct wlr_renderer *r, struct wlr_output *o) {
 	r->impl->begin(r, o);
 }
 
+WLR_API
 void wlr_renderer_end(struct wlr_renderer *r) {
 	r->impl->end(r);
 }
 
+WLR_API
 void wlr_renderer_clear(struct wlr_renderer *r, const float (*color)[4]) {
 	r->impl->clear(r, color);
 }
 
+WLR_API
 void wlr_renderer_scissor(struct wlr_renderer *r, struct wlr_box *box) {
 	r->impl->scissor(r, box);
 }
 
+WLR_API
 struct wlr_texture *wlr_render_texture_create(struct wlr_renderer *r) {
 	return r->impl->texture_create(r);
 }
 
+WLR_API
 bool wlr_render_with_matrix(struct wlr_renderer *r,
 		struct wlr_texture *texture, const float (*matrix)[16]) {
 	return r->impl->render_with_matrix(r, texture, matrix);
 }
 
+WLR_API
 void wlr_render_colored_quad(struct wlr_renderer *r,
 		const float (*color)[4], const float (*matrix)[16]) {
 	r->impl->render_quad(r, color, matrix);
 }
 
+WLR_API
 void wlr_render_colored_ellipse(struct wlr_renderer *r,
 		const float (*color)[4], const float (*matrix)[16]) {
 	r->impl->render_ellipse(r, color, matrix);
 }
 
+WLR_API
 const enum wl_shm_format *wlr_renderer_get_formats(
 		struct wlr_renderer *r, size_t *len) {
 	return r->impl->formats(r, len);
 }
 
+WLR_API
 bool wlr_renderer_buffer_is_drm(struct wlr_renderer *r,
 		struct wl_resource *buffer) {
 	return r->impl->buffer_is_drm(r, buffer);
 }
 
+WLR_API
 bool wlr_renderer_read_pixels(struct wlr_renderer *r, enum wl_shm_format fmt,
 		uint32_t stride, uint32_t width, uint32_t height,
 		uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y,
@@ -68,6 +82,7 @@ bool wlr_renderer_read_pixels(struct wlr_renderer *r, enum wl_shm_format fmt,
 		dst_x, dst_y, data);
 }
 
+WLR_API
 bool wlr_renderer_format_supported(struct wlr_renderer *r,
 		enum wl_shm_format fmt) {
 	return r->impl->format_supported(r, fmt);

--- a/render/wlr_texture.c
+++ b/render/wlr_texture.c
@@ -1,13 +1,16 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <wlr/render/interface.h>
+#include "util/defs.h"
 
+WLR_API
 void wlr_texture_init(struct wlr_texture *texture,
 		struct wlr_texture_impl *impl) {
 	texture->impl = impl;
 	wl_signal_init(&texture->destroy_signal);
 }
 
+WLR_API
 void wlr_texture_destroy(struct wlr_texture *texture) {
 	if (texture && texture->impl && texture->impl->destroy) {
 		texture->impl->destroy(texture);
@@ -16,16 +19,19 @@ void wlr_texture_destroy(struct wlr_texture *texture) {
 	}
 }
 
+WLR_API
 void wlr_texture_bind(struct wlr_texture *texture) {
 	texture->impl->bind(texture);
 }
 
+WLR_API
 bool wlr_texture_upload_pixels(struct wlr_texture *texture, uint32_t format,
 		int stride, int width, int height, const unsigned char *pixels) {
 	return texture->impl->upload_pixels(texture, format, stride,
 			width, height, pixels);
 }
 
+WLR_API
 bool wlr_texture_update_pixels(struct wlr_texture *texture,
 		enum wl_shm_format format, int stride, int x, int y,
 		int width, int height, const unsigned char *pixels) {
@@ -33,31 +39,37 @@ bool wlr_texture_update_pixels(struct wlr_texture *texture,
 			width, height, pixels);
 }
 
+WLR_API
 bool wlr_texture_upload_shm(struct wlr_texture *texture, uint32_t format,
 		struct wl_shm_buffer *shm) {
 	return texture->impl->upload_shm(texture, format, shm);
 }
 
+WLR_API
 bool wlr_texture_update_shm(struct wlr_texture *texture, uint32_t format,
 		int x, int y, int width, int height, struct wl_shm_buffer *shm) {
 	return texture->impl->update_shm(texture, format, x, y, width, height, shm);
 }
 
+WLR_API
 bool wlr_texture_upload_drm(struct wlr_texture *texture,
 		struct wl_resource *drm_buffer) {
 	return texture->impl->upload_drm(texture, drm_buffer);
 }
 
+WLR_API
 bool wlr_texture_upload_eglimage(struct wlr_texture *texture,
 		EGLImageKHR image, uint32_t width, uint32_t height) {
 	return texture->impl->upload_eglimage(texture, image, width, height);
 }
 
+WLR_API
 void wlr_texture_get_matrix(struct wlr_texture *texture,
 		float (*matrix)[16], const float (*projection)[16], int x, int y) {
 	texture->impl->get_matrix(texture, matrix, projection, x, y);
 }
 
+WLR_API
 void wlr_texture_get_buffer_size(struct wlr_texture *texture, struct wl_resource
 		*resource, int *width, int *height) {
 	texture->impl->get_buffer_size(texture, resource, width, height);

--- a/types/wlr_box.c
+++ b/types/wlr_box.c
@@ -5,7 +5,9 @@
 #include <wayland-server-protocol.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/util/log.h>
+#include "util/defs.h"
 
+WLR_API
 void wlr_box_closest_point(const struct wlr_box *box, double x, double y,
 		double *dest_x, double *dest_y) {
 	// find the closest x point
@@ -27,10 +29,12 @@ void wlr_box_closest_point(const struct wlr_box *box, double x, double y,
 	}
 }
 
+WLR_API
 bool wlr_box_empty(const struct wlr_box *box) {
 	return box == NULL || box->width <= 0 || box->height <= 0;
 }
 
+WLR_API
 bool wlr_box_intersection(const struct wlr_box *box_a,
 		const struct wlr_box *box_b, struct wlr_box *dest) {
 	bool a_empty = wlr_box_empty(box_a);
@@ -57,6 +61,7 @@ bool wlr_box_intersection(const struct wlr_box *box_a,
 	return !wlr_box_empty(dest);
 }
 
+WLR_API
 bool wlr_box_contains_point(const struct wlr_box *box, double x, double y) {
 	if (wlr_box_empty(box)) {
 		return false;
@@ -66,6 +71,7 @@ bool wlr_box_contains_point(const struct wlr_box *box, double x, double y) {
 	}
 }
 
+WLR_API
 void wlr_box_transform(const struct wlr_box *box,
 		enum wl_output_transform transform, int width, int height,
 		struct wlr_box *dest) {
@@ -115,6 +121,7 @@ void wlr_box_transform(const struct wlr_box *box,
 	}
 }
 
+WLR_API
 void wlr_box_rotated_bounds(const struct wlr_box *box, float rotation,
 		struct wlr_box *dest) {
 	if (rotation == 0) {

--- a/types/wlr_compositor.c
+++ b/types/wlr_compositor.c
@@ -5,6 +5,7 @@
 #include <wlr/types/wlr_region.h>
 #include <wlr/types/wlr_surface.h>
 #include <wlr/util/log.h>
+#include "util/defs.h"
 #include "util/signal.h"
 
 static const struct wl_compositor_interface wl_compositor_impl;
@@ -86,6 +87,7 @@ static void wl_compositor_bind(struct wl_client *wl_client, void *data,
 		wl_resource_get_link(wl_resource));
 }
 
+WLR_API
 void wlr_compositor_destroy(struct wlr_compositor *compositor) {
 	if (compositor == NULL) {
 		return;
@@ -170,6 +172,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	wlr_compositor_destroy(compositor);
 }
 
+WLR_API
 struct wlr_compositor *wlr_compositor_create(struct wl_display *display,
 		struct wlr_renderer *renderer) {
 	struct wlr_compositor *compositor =

--- a/types/wlr_cursor.c
+++ b/types/wlr_cursor.c
@@ -7,6 +7,7 @@
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/util/log.h>
+#include "util/defs.h"
 #include "util/signal.h"
 
 struct wlr_cursor_device {
@@ -55,6 +56,7 @@ struct wlr_cursor_state {
 	struct wl_listener layout_destroy;
 };
 
+WLR_API
 struct wlr_cursor *wlr_cursor_create() {
 	struct wlr_cursor *cur = calloc(1, sizeof(struct wlr_cursor));
 	if (!cur) {
@@ -149,6 +151,7 @@ static void wlr_cursor_device_destroy(struct wlr_cursor_device *c_device) {
 	free(c_device);
 }
 
+WLR_API
 void wlr_cursor_destroy(struct wlr_cursor *cur) {
 	wlr_cursor_detach_output_layout(cur);
 
@@ -232,6 +235,7 @@ static struct wlr_box *get_mapping(struct wlr_cursor *cur,
 	return NULL;
 }
 
+WLR_API
 bool wlr_cursor_warp(struct wlr_cursor *cur, struct wlr_input_device *dev,
 		double x, double y) {
 	assert(cur->state->layout);
@@ -253,6 +257,7 @@ bool wlr_cursor_warp(struct wlr_cursor *cur, struct wlr_input_device *dev,
 	return result;
 }
 
+WLR_API
 void wlr_cursor_warp_absolute(struct wlr_cursor *cur,
 		struct wlr_input_device *dev, double x_mm, double y_mm) {
 	assert(cur->state->layout);
@@ -268,6 +273,7 @@ void wlr_cursor_warp_absolute(struct wlr_cursor *cur,
 	wlr_cursor_warp_unchecked(cur, x, y);
 }
 
+WLR_API
 void wlr_cursor_move(struct wlr_cursor *cur, struct wlr_input_device *dev,
 		double delta_x, double delta_y) {
 	assert(cur->state->layout);
@@ -298,6 +304,7 @@ void wlr_cursor_move(struct wlr_cursor *cur, struct wlr_input_device *dev,
 	wlr_cursor_warp_unchecked(cur, x, y);
 }
 
+WLR_API
 void wlr_cursor_set_image(struct wlr_cursor *cur, const uint8_t *pixels,
 		int32_t stride, uint32_t width, uint32_t height, int32_t hotspot_x,
 		int32_t hotspot_y, float scale) {
@@ -313,6 +320,7 @@ void wlr_cursor_set_image(struct wlr_cursor *cur, const uint8_t *pixels,
 	}
 }
 
+WLR_API
 void wlr_cursor_set_surface(struct wlr_cursor *cur, struct wlr_surface *surface,
 		int32_t hotspot_x, int32_t hotspot_y) {
 	struct wlr_cursor_output_cursor *output_cursor;
@@ -478,6 +486,7 @@ static struct wlr_cursor_device *wlr_cursor_device_create(
 	return c_device;
 }
 
+WLR_API
 void wlr_cursor_attach_input_device(struct wlr_cursor *cur,
 		struct wlr_input_device *dev) {
 	if (dev->type != WLR_INPUT_DEVICE_POINTER &&
@@ -499,6 +508,7 @@ void wlr_cursor_attach_input_device(struct wlr_cursor *cur,
 	wlr_cursor_device_create(cur, dev);
 }
 
+WLR_API
 void wlr_cursor_detach_input_device(struct wlr_cursor *cur,
 		struct wlr_input_device *dev) {
 	struct wlr_cursor_device *c_device, *tmp = NULL;
@@ -571,6 +581,7 @@ static void handle_layout_change(struct wl_listener *listener, void *data) {
 	}
 }
 
+WLR_API
 void wlr_cursor_attach_output_layout(struct wlr_cursor *cur,
 		struct wlr_output_layout *l) {
 	wlr_cursor_detach_output_layout(cur);
@@ -594,11 +605,13 @@ void wlr_cursor_attach_output_layout(struct wlr_cursor *cur,
 	}
 }
 
+WLR_API
 void wlr_cursor_map_to_output(struct wlr_cursor *cur,
 		struct wlr_output *output) {
 	cur->state->mapped_output = output;
 }
 
+WLR_API
 void wlr_cursor_map_input_to_output(struct wlr_cursor *cur,
 		struct wlr_input_device *dev, struct wlr_output *output) {
 	struct wlr_cursor_device *c_device = get_cursor_device(cur, dev);
@@ -611,6 +624,7 @@ void wlr_cursor_map_input_to_output(struct wlr_cursor *cur,
 	c_device->mapped_output = output;
 }
 
+WLR_API
 void wlr_cursor_map_to_region(struct wlr_cursor *cur,
 		struct wlr_box *box) {
 	if (box && wlr_box_empty(box)) {
@@ -621,6 +635,7 @@ void wlr_cursor_map_to_region(struct wlr_cursor *cur,
 	cur->state->mapped_box = box;
 }
 
+WLR_API
 void wlr_cursor_map_input_to_region(struct wlr_cursor *cur,
 		struct wlr_input_device *dev, struct wlr_box *box) {
 	if (box && wlr_box_empty(box)) {
@@ -639,6 +654,7 @@ void wlr_cursor_map_input_to_region(struct wlr_cursor *cur,
 	c_device->mapped_box = box;
 }
 
+WLR_API
 bool wlr_cursor_absolute_to_layout_coords(struct wlr_cursor *cur,
 		struct wlr_input_device *device, double x_mm, double y_mm,
 		double width_mm, double height_mm, double *lx, double *ly) {

--- a/types/wlr_data_device.c
+++ b/types/wlr_data_device.c
@@ -8,6 +8,7 @@
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/util/log.h>
+#include "util/defs.h"
 #include "util/signal.h"
 
 #define ALL_ACTIONS (WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY | \
@@ -270,6 +271,7 @@ static struct wlr_data_offer *wlr_data_source_send_offer(
 	return offer;
 }
 
+WLR_API
 void wlr_seat_client_send_selection(struct wlr_seat_client *seat_client) {
 	if (wl_list_empty(&seat_client->data_devices)) {
 		return;
@@ -312,6 +314,7 @@ static void seat_client_selection_data_source_destroy(
 	wlr_signal_emit_safe(&seat->events.selection, seat);
 }
 
+WLR_API
 void wlr_seat_set_selection(struct wlr_seat *seat,
 		struct wlr_data_source *source, uint32_t serial) {
 	if (source) {
@@ -962,12 +965,14 @@ static void data_source_resource_handle_destroy(struct wl_resource *resource) {
 	free(source);
 }
 
+WLR_API
 void wlr_data_source_init(struct wlr_data_source *source) {
 	wl_array_init(&source->mime_types);
 	wl_signal_init(&source->events.destroy);
 	source->actions = -1;
 }
 
+WLR_API
 void wlr_data_source_finish(struct wlr_data_source *source) {
 	if (source == NULL) {
 		return;
@@ -1059,6 +1064,7 @@ static void data_device_manager_bind(struct wl_client *client,
 		NULL, NULL);
 }
 
+WLR_API
 void wlr_data_device_manager_destroy(struct wlr_data_device_manager *manager) {
 	if (!manager) {
 		return;
@@ -1075,6 +1081,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	wlr_data_device_manager_destroy(manager);
 }
 
+WLR_API
 struct wlr_data_device_manager *wlr_data_device_manager_create(
 		struct wl_display *display) {
 	struct wlr_data_device_manager *manager =

--- a/types/wlr_gamma_control.c
+++ b/types/wlr_gamma_control.c
@@ -5,6 +5,7 @@
 #include <wlr/types/wlr_output.h>
 #include <wlr/util/log.h>
 #include "gamma-control-protocol.h"
+#include "util/defs.h"
 #include "util/signal.h"
 
 static void resource_destroy(struct wl_client *client,
@@ -146,6 +147,7 @@ static void gamma_control_manager_bind(struct wl_client *client, void *data,
 		manager, NULL);
 }
 
+WLR_API
 void wlr_gamma_control_manager_destroy(
 		struct wlr_gamma_control_manager *manager) {
 	if (!manager) {
@@ -166,6 +168,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	wlr_gamma_control_manager_destroy(manager);
 }
 
+WLR_API
 struct wlr_gamma_control_manager *wlr_gamma_control_manager_create(
 		struct wl_display *display) {
 	struct wlr_gamma_control_manager *manager =

--- a/types/wlr_idle.c
+++ b/types/wlr_idle.c
@@ -5,6 +5,7 @@
 #include <wlr/types/wlr_idle.h>
 #include <wlr/util/log.h>
 #include "idle-protocol.h"
+#include "util/defs.h"
 #include "util/signal.h"
 
 static const struct org_kde_kwin_idle_timeout_interface idle_timeout_impl;
@@ -157,6 +158,7 @@ static void idle_bind(struct wl_client *wl_client, void *data,
 	wl_resource_set_implementation(wl_resource, &idle_impl, idle, NULL);
 }
 
+WLR_API
 void wlr_idle_destroy(struct wlr_idle *idle) {
 	if (!idle) {
 		return;
@@ -175,6 +177,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	wlr_idle_destroy(idle);
 }
 
+WLR_API
 struct wlr_idle *wlr_idle_create(struct wl_display *display) {
 	struct wlr_idle *idle = calloc(1, sizeof(struct wlr_idle));
 	if (!idle) {
@@ -203,6 +206,7 @@ struct wlr_idle *wlr_idle_create(struct wl_display *display) {
 	return idle;
 }
 
+WLR_API
 void wlr_idle_notify_activity(struct wlr_idle *idle, struct wlr_seat *seat) {
 	wlr_signal_emit_safe(&idle->activity_notify, seat);
 }

--- a/types/wlr_input_device.c
+++ b/types/wlr_input_device.c
@@ -10,8 +10,10 @@
 #include <wlr/interfaces/wlr_touch.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/util/log.h>
+#include "util/defs.h"
 #include "util/signal.h"
 
+WLR_API
 void wlr_input_device_init(struct wlr_input_device *dev,
 		enum wlr_input_device_type type,
 		struct wlr_input_device_impl *impl,
@@ -25,6 +27,7 @@ void wlr_input_device_init(struct wlr_input_device *dev,
 	wl_signal_init(&dev->events.destroy);
 }
 
+WLR_API
 void wlr_input_device_destroy(struct wlr_input_device *dev) {
 	if (!dev) {
 		return;

--- a/types/wlr_keyboard.c
+++ b/types/wlr_keyboard.c
@@ -7,6 +7,7 @@
 #include <wlr/interfaces/wlr_keyboard.h>
 #include <wlr/types/wlr_keyboard.h>
 #include <wlr/util/log.h>
+#include "util/defs.h"
 #include "util/signal.h"
 
 int os_create_anonymous_file(off_t size);
@@ -100,6 +101,7 @@ static void keyboard_key_update(struct wlr_keyboard *keyboard,
 	assert(keyboard->num_keycodes <= WLR_KEYBOARD_KEYS_CAP);
 }
 
+WLR_API
 void wlr_keyboard_notify_modifiers(struct wlr_keyboard *keyboard,
 		uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked,
 		uint32_t group) {
@@ -115,6 +117,7 @@ void wlr_keyboard_notify_modifiers(struct wlr_keyboard *keyboard,
 	}
 }
 
+WLR_API
 void wlr_keyboard_notify_key(struct wlr_keyboard *keyboard,
 		struct wlr_event_keyboard_key *event) {
 	if (keyboard->xkb_state == NULL) {
@@ -136,6 +139,7 @@ void wlr_keyboard_notify_key(struct wlr_keyboard *keyboard,
 	wlr_signal_emit_safe(&keyboard->events.key, event);
 }
 
+WLR_API
 void wlr_keyboard_init(struct wlr_keyboard *kb,
 		struct wlr_keyboard_impl *impl) {
 	kb->impl = impl;
@@ -149,6 +153,7 @@ void wlr_keyboard_init(struct wlr_keyboard *kb,
 	kb->repeat_info.delay = 600;
 }
 
+WLR_API
 void wlr_keyboard_destroy(struct wlr_keyboard *kb) {
 	if (kb == NULL) {
 		return;
@@ -164,12 +169,14 @@ void wlr_keyboard_destroy(struct wlr_keyboard *kb) {
 	free(kb);
 }
 
+WLR_API
 void wlr_keyboard_led_update(struct wlr_keyboard *kb, uint32_t leds) {
 	if (kb->impl && kb->impl->led_update) {
 		kb->impl->led_update(kb, leds);
 	}
 }
 
+WLR_API
 void wlr_keyboard_set_keymap(struct wlr_keyboard *kb,
 		struct xkb_keymap *keymap) {
 	char *keymap_str = NULL;
@@ -247,6 +254,7 @@ err:
 	free(keymap_str);
 }
 
+WLR_API
 void wlr_keyboard_set_repeat_info(struct wlr_keyboard *kb, int32_t rate,
 		int32_t delay) {
 	if (kb->repeat_info.rate == rate && kb->repeat_info.delay == delay) {
@@ -257,6 +265,7 @@ void wlr_keyboard_set_repeat_info(struct wlr_keyboard *kb, int32_t rate,
 	wlr_signal_emit_safe(&kb->events.repeat_info, kb);
 }
 
+WLR_API
 uint32_t wlr_keyboard_get_modifiers(struct wlr_keyboard *kb) {
 	xkb_mod_mask_t mask = kb->modifiers.depressed | kb->modifiers.latched;
 	uint32_t modifiers = 0;

--- a/types/wlr_list.c
+++ b/types/wlr_list.c
@@ -5,7 +5,9 @@
 #include <string.h>
 #include <sys/types.h>
 #include <wlr/types/wlr_list.h>
+#include "util/defs.h"
 
+WLR_API
 bool wlr_list_init(struct wlr_list *list) {
 	list->capacity = 10;
 	list->length = 0;
@@ -29,16 +31,19 @@ static bool list_resize(struct wlr_list *list) {
 	return true;
 }
 
+WLR_API
 void wlr_list_finish(struct wlr_list *list) {
 	free(list->items);
 }
 
+WLR_API
 void wlr_list_for_each(struct wlr_list *list, void (*callback)(void *item)) {
 	for (size_t i = 0; i < list->length; i++) {
 		callback(list->items[i]);
 	}
 }
 
+WLR_API
 ssize_t wlr_list_push(struct wlr_list *list, void *item) {
 	if (!list_resize(list)) {
 		return -1;
@@ -47,6 +52,7 @@ ssize_t wlr_list_push(struct wlr_list *list, void *item) {
 	return list->length;
 }
 
+WLR_API
 ssize_t wlr_list_insert(struct wlr_list *list, size_t index, void *item) {
 	if (!list_resize(list)) {
 		return -1;
@@ -58,12 +64,14 @@ ssize_t wlr_list_insert(struct wlr_list *list, size_t index, void *item) {
 	return list->length;
 }
 
+WLR_API
 void wlr_list_del(struct wlr_list *list, size_t index) {
 	list->length--;
 	memmove(&list->items[index], &list->items[index + 1],
 		sizeof(void *) * (list->length - index));
 }
 
+WLR_API
 void *wlr_list_pop(struct wlr_list *list) {
 	if (list->length == 0) {
 		return NULL;
@@ -73,6 +81,7 @@ void *wlr_list_pop(struct wlr_list *list) {
 	return last;
 }
 
+WLR_API
 void *wlr_list_peek(struct wlr_list *list) {
 	if (list->length == 0) {
 		return NULL;
@@ -80,6 +89,7 @@ void *wlr_list_peek(struct wlr_list *list) {
 	return list->items[list->length - 1];
 }
 
+WLR_API
 ssize_t wlr_list_cat(struct wlr_list *list, const struct wlr_list *source) {
 	size_t old_len = list->length;
 	size_t i;
@@ -92,11 +102,13 @@ ssize_t wlr_list_cat(struct wlr_list *list, const struct wlr_list *source) {
 	return list->length;
 }
 
+WLR_API
 void wlr_list_qsort(struct wlr_list *list,
 		int compare(const void *left, const void *right)) {
 	qsort(list->items, list->length, sizeof(void *), compare);
 }
 
+WLR_API
 ssize_t wlr_list_find(struct wlr_list *list,
 		int compare(const void *item, const void *data), const void *data) {
 	for (size_t i = 0; i < list->length; i++) {

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -13,6 +13,7 @@
 #include <wlr/types/wlr_surface.h>
 #include <wlr/util/log.h>
 #include <wlr/util/region.h>
+#include "util/defs.h"
 #include "util/signal.h"
 
 static void wl_output_send_to_resource(struct wl_resource *resource) {
@@ -113,6 +114,7 @@ static void wl_output_bind(struct wl_client *wl_client, void *data,
 	wl_output_send_to_resource(wl_resource);
 }
 
+WLR_API
 void wlr_output_create_global(struct wlr_output *output) {
 	if (output->wl_global != NULL) {
 		return;
@@ -122,6 +124,7 @@ void wlr_output_create_global(struct wlr_output *output) {
 	output->wl_global = wl_global;
 }
 
+WLR_API
 void wlr_output_destroy_global(struct wlr_output *output) {
 	if (output->wl_global == NULL) {
 		return;
@@ -134,6 +137,7 @@ void wlr_output_destroy_global(struct wlr_output *output) {
 	output->wl_global = NULL;
 }
 
+WLR_API
 void wlr_output_update_enabled(struct wlr_output *output, bool enabled) {
 	if (output->enabled == enabled) {
 		return;
@@ -148,6 +152,7 @@ static void wlr_output_update_matrix(struct wlr_output *output) {
 		output->transform);
 }
 
+WLR_API
 void wlr_output_enable(struct wlr_output *output, bool enable) {
 	if (output->enabled == enable) {
 		return;
@@ -158,6 +163,7 @@ void wlr_output_enable(struct wlr_output *output, bool enable) {
 	}
 }
 
+WLR_API
 bool wlr_output_set_mode(struct wlr_output *output,
 		struct wlr_output_mode *mode) {
 	if (!output->impl || !output->impl->set_mode) {
@@ -166,6 +172,7 @@ bool wlr_output_set_mode(struct wlr_output *output,
 	return output->impl->set_mode(output, mode);
 }
 
+WLR_API
 bool wlr_output_set_custom_mode(struct wlr_output *output, int32_t width,
 		int32_t height, int32_t refresh) {
 	if (!output->impl || !output->impl->set_custom_mode) {
@@ -174,6 +181,7 @@ bool wlr_output_set_custom_mode(struct wlr_output *output, int32_t width,
 	return output->impl->set_custom_mode(output, width, height, refresh);
 }
 
+WLR_API
 void wlr_output_update_mode(struct wlr_output *output,
 		struct wlr_output_mode *mode) {
 	output->current_mode = mode;
@@ -181,6 +189,7 @@ void wlr_output_update_mode(struct wlr_output *output,
 		mode->refresh);
 }
 
+WLR_API
 void wlr_output_update_custom_mode(struct wlr_output *output, int32_t width,
 		int32_t height, int32_t refresh) {
 	output->width = width;
@@ -197,6 +206,7 @@ void wlr_output_update_custom_mode(struct wlr_output *output, int32_t width,
 	wlr_signal_emit_safe(&output->events.mode, output);
 }
 
+WLR_API
 void wlr_output_set_transform(struct wlr_output *output,
 		enum wl_output_transform transform) {
 	output->impl->transform(output, transform);
@@ -211,6 +221,7 @@ void wlr_output_set_transform(struct wlr_output *output,
 	wlr_signal_emit_safe(&output->events.transform, output);
 }
 
+WLR_API
 void wlr_output_set_position(struct wlr_output *output, int32_t lx,
 		int32_t ly) {
 	if (lx == output->lx && ly == output->ly) {
@@ -227,6 +238,7 @@ void wlr_output_set_position(struct wlr_output *output, int32_t lx,
 	}
 }
 
+WLR_API
 void wlr_output_set_scale(struct wlr_output *output, float scale) {
 	if (output->scale == scale) {
 		return;
@@ -249,6 +261,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	wlr_output_destroy_global(output);
 }
 
+WLR_API
 void wlr_output_init(struct wlr_output *output, struct wlr_backend *backend,
 		const struct wlr_output_impl *impl, struct wl_display *display) {
 	assert(impl->make_current && impl->swap_buffers && impl->transform);
@@ -276,6 +289,7 @@ void wlr_output_init(struct wlr_output *output, struct wlr_backend *backend,
 	output->frame_pending = true;
 }
 
+WLR_API
 void wlr_output_destroy(struct wlr_output *output) {
 	if (!output) {
 		return;
@@ -307,6 +321,7 @@ void wlr_output_destroy(struct wlr_output *output) {
 	}
 }
 
+WLR_API
 void wlr_output_transformed_resolution(struct wlr_output *output,
 		int *width, int *height) {
 	if (output->transform % 2 == 0) {
@@ -318,6 +333,7 @@ void wlr_output_transformed_resolution(struct wlr_output *output,
 	}
 }
 
+WLR_API
 void wlr_output_effective_resolution(struct wlr_output *output,
 		int *width, int *height) {
 	wlr_output_transformed_resolution(output, width, height);
@@ -325,6 +341,7 @@ void wlr_output_effective_resolution(struct wlr_output *output,
 	*height /= output->scale;
 }
 
+WLR_API
 bool wlr_output_make_current(struct wlr_output *output, int *buffer_age) {
 	return output->impl->make_current(output, buffer_age);
 }
@@ -460,6 +477,7 @@ surface_damage_finish:
 	pixman_region32_fini(&surface_damage);
 }
 
+WLR_API
 bool wlr_output_swap_buffers(struct wlr_output *output, struct timespec *when,
 		pixman_region32_t *damage) {
 	if (output->frame_pending) {
@@ -526,6 +544,7 @@ bool wlr_output_swap_buffers(struct wlr_output *output, struct timespec *when,
 	return true;
 }
 
+WLR_API
 void wlr_output_send_frame(struct wlr_output *output) {
 	output->frame_pending = false;
 	wlr_signal_emit_safe(&output->events.frame, output);
@@ -539,6 +558,7 @@ static void schedule_frame_handle_idle_timer(void *data) {
 	}
 }
 
+WLR_API
 void wlr_output_schedule_frame(struct wlr_output *output) {
 	if (output->frame_pending || output->idle_frame != NULL) {
 		return;
@@ -550,6 +570,7 @@ void wlr_output_schedule_frame(struct wlr_output *output) {
 		wl_event_loop_add_idle(ev, schedule_frame_handle_idle_timer, output);
 }
 
+WLR_API
 void wlr_output_set_gamma(struct wlr_output *output,
 	uint32_t size, uint16_t *r, uint16_t *g, uint16_t *b) {
 	if (output->impl->set_gamma) {
@@ -557,6 +578,7 @@ void wlr_output_set_gamma(struct wlr_output *output,
 	}
 }
 
+WLR_API
 uint32_t wlr_output_get_gamma_size(struct wlr_output *output) {
 	if (!output->impl->get_gamma_size) {
 		return 0;
@@ -564,6 +586,7 @@ uint32_t wlr_output_get_gamma_size(struct wlr_output *output) {
 	return output->impl->get_gamma_size(output);
 }
 
+WLR_API
 void wlr_output_update_needs_swap(struct wlr_output *output) {
 	output->needs_swap = true;
 	wlr_signal_emit_safe(&output->events.needs_swap, output);
@@ -622,6 +645,7 @@ static void output_fullscreen_surface_handle_destroy(
 	output_fullscreen_surface_reset(output);
 }
 
+WLR_API
 void wlr_output_set_fullscreen_surface(struct wlr_output *output,
 		struct wlr_surface *surface) {
 	// TODO: hardware fullscreen
@@ -648,6 +672,7 @@ void wlr_output_set_fullscreen_surface(struct wlr_output *output,
 		&output->fullscreen_surface_destroy);
 }
 
+WLR_API
 struct wlr_output *wlr_output_from_resource(struct wl_resource *resource) {
 	assert(wl_resource_instance_of(resource, &wl_output_interface,
 		&wl_output_impl));
@@ -674,6 +699,7 @@ static void output_cursor_reset(struct wlr_output_cursor *cursor) {
 	}
 }
 
+WLR_API
 bool wlr_output_cursor_set_image(struct wlr_output_cursor *cursor,
 		const uint8_t *pixels, int32_t stride, uint32_t width, uint32_t height,
 		int32_t hotspot_x, int32_t hotspot_y) {
@@ -781,6 +807,7 @@ static void output_cursor_handle_destroy(struct wl_listener *listener,
 	output_cursor_reset(cursor);
 }
 
+WLR_API
 void wlr_output_cursor_set_surface(struct wlr_output_cursor *cursor,
 		struct wlr_surface *surface, int32_t hotspot_x, int32_t hotspot_y) {
 	if (surface && strcmp(surface->role, "wl_pointer-cursor") != 0) {
@@ -841,6 +868,7 @@ void wlr_output_cursor_set_surface(struct wlr_output_cursor *cursor,
 	}
 }
 
+WLR_API
 bool wlr_output_cursor_move(struct wlr_output_cursor *cursor,
 		double x, double y) {
 	if (cursor->x == x && cursor->y == y) {
@@ -868,6 +896,7 @@ bool wlr_output_cursor_move(struct wlr_output_cursor *cursor,
 	return cursor->output->impl->move_cursor(cursor->output, (int)x, (int)y);
 }
 
+WLR_API
 struct wlr_output_cursor *wlr_output_cursor_create(struct wlr_output *output) {
 	struct wlr_output_cursor *cursor =
 		calloc(1, sizeof(struct wlr_output_cursor));
@@ -884,6 +913,7 @@ struct wlr_output_cursor *wlr_output_cursor_create(struct wlr_output *output) {
 	return cursor;
 }
 
+WLR_API
 void wlr_output_cursor_destroy(struct wlr_output_cursor *cursor) {
 	if (cursor == NULL) {
 		return;
@@ -906,6 +936,7 @@ void wlr_output_cursor_destroy(struct wlr_output_cursor *cursor) {
 }
 
 
+WLR_API
 enum wl_output_transform wlr_output_transform_invert(
 		enum wl_output_transform tr) {
 	if ((tr & WL_OUTPUT_TRANSFORM_90) && !(tr & WL_OUTPUT_TRANSFORM_FLIPPED)) {
@@ -914,6 +945,7 @@ enum wl_output_transform wlr_output_transform_invert(
 	return tr;
 }
 
+WLR_API
 enum wl_output_transform wlr_output_transform_compose(
 		enum wl_output_transform tr_a, enum wl_output_transform tr_b) {
 	uint32_t flipped = (tr_a ^ tr_b) & WL_OUTPUT_TRANSFORM_FLIPPED;

--- a/types/wlr_output_damage.c
+++ b/types/wlr_output_damage.c
@@ -5,6 +5,7 @@
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_output_damage.h>
 #include <wlr/types/wlr_output.h>
+#include "util/defs.h"
 #include "util/signal.h"
 
 static void output_handle_destroy(struct wl_listener *listener, void *data) {
@@ -50,6 +51,7 @@ static void output_handle_frame(struct wl_listener *listener, void *data) {
 	wlr_signal_emit_safe(&output_damage->events.frame, output_damage);
 }
 
+WLR_API
 struct wlr_output_damage *wlr_output_damage_create(struct wlr_output *output) {
 	struct wlr_output_damage *output_damage =
 		calloc(1, sizeof(struct wlr_output_damage));
@@ -82,6 +84,7 @@ struct wlr_output_damage *wlr_output_damage_create(struct wlr_output *output) {
 	return output_damage;
 }
 
+WLR_API
 void wlr_output_damage_destroy(struct wlr_output_damage *output_damage) {
 	if (output_damage == NULL) {
 		return;
@@ -100,6 +103,7 @@ void wlr_output_damage_destroy(struct wlr_output_damage *output_damage) {
 	free(output_damage);
 }
 
+WLR_API
 bool wlr_output_damage_make_current(struct wlr_output_damage *output_damage,
 		bool *needs_swap, pixman_region32_t *damage) {
 	struct wlr_output *output = output_damage->output;
@@ -131,6 +135,7 @@ bool wlr_output_damage_make_current(struct wlr_output_damage *output_damage,
 	return true;
 }
 
+WLR_API
 bool wlr_output_damage_swap_buffers(struct wlr_output_damage *output_damage,
 		struct timespec *when, pixman_region32_t *damage) {
 	if (!wlr_output_swap_buffers(output_damage->output, when, damage)) {
@@ -148,6 +153,7 @@ bool wlr_output_damage_swap_buffers(struct wlr_output_damage *output_damage,
 	return true;
 }
 
+WLR_API
 void wlr_output_damage_add(struct wlr_output_damage *output_damage,
 		pixman_region32_t *damage) {
 	int width, height;
@@ -160,6 +166,7 @@ void wlr_output_damage_add(struct wlr_output_damage *output_damage,
 	wlr_output_schedule_frame(output_damage->output);
 }
 
+WLR_API
 void wlr_output_damage_add_whole(struct wlr_output_damage *output_damage) {
 	int width, height;
 	wlr_output_transformed_resolution(output_damage->output, &width, &height);
@@ -170,6 +177,7 @@ void wlr_output_damage_add_whole(struct wlr_output_damage *output_damage) {
 	wlr_output_schedule_frame(output_damage->output);
 }
 
+WLR_API
 void wlr_output_damage_add_box(struct wlr_output_damage *output_damage,
 		struct wlr_box *box) {
 	int width, height;

--- a/types/wlr_output_layout.c
+++ b/types/wlr_output_layout.c
@@ -6,6 +6,7 @@
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/util/log.h>
+#include "util/defs.h"
 #include "util/signal.h"
 
 struct wlr_output_layout_state {
@@ -25,6 +26,7 @@ struct wlr_output_layout_output_state {
 	struct wl_listener output_destroy;
 };
 
+WLR_API
 struct wlr_output_layout *wlr_output_layout_create() {
 	struct wlr_output_layout *layout =
 		calloc(1, sizeof(struct wlr_output_layout));
@@ -57,6 +59,7 @@ static void wlr_output_layout_output_destroy(
 	free(l_output);
 }
 
+WLR_API
 void wlr_output_layout_destroy(struct wlr_output_layout *layout) {
 	if (!layout) {
 		return;
@@ -189,6 +192,7 @@ static struct wlr_output_layout_output *wlr_output_layout_output_create(
 	return l_output;
 }
 
+WLR_API
 void wlr_output_layout_add(struct wlr_output_layout *layout,
 		struct wlr_output *output, int x, int y) {
 	struct wlr_output_layout_output *l_output =
@@ -208,6 +212,7 @@ void wlr_output_layout_add(struct wlr_output_layout *layout,
 	wlr_signal_emit_safe(&layout->events.add, l_output);
 }
 
+WLR_API
 struct wlr_output_layout_output *wlr_output_layout_get(
 		struct wlr_output_layout *layout, struct wlr_output *reference) {
 	struct wlr_output_layout_output *l_output;
@@ -219,6 +224,7 @@ struct wlr_output_layout_output *wlr_output_layout_get(
 	return NULL;
 }
 
+WLR_API
 bool wlr_output_layout_contains_point(struct wlr_output_layout *layout,
 		struct wlr_output *reference, int x, int y) {
 	if (reference) {
@@ -231,6 +237,7 @@ bool wlr_output_layout_contains_point(struct wlr_output_layout *layout,
 	}
 }
 
+WLR_API
 bool wlr_output_layout_intersects(struct wlr_output_layout *layout,
 		struct wlr_output *reference, const struct wlr_box *target_box) {
 	struct wlr_box out_box;
@@ -257,6 +264,7 @@ bool wlr_output_layout_intersects(struct wlr_output_layout *layout,
 	}
 }
 
+WLR_API
 struct wlr_output *wlr_output_layout_output_at(struct wlr_output_layout *layout,
 		double x, double y) {
 	struct wlr_output_layout_output *l_output;
@@ -269,6 +277,7 @@ struct wlr_output *wlr_output_layout_output_at(struct wlr_output_layout *layout,
 	return NULL;
 }
 
+WLR_API
 void wlr_output_layout_move(struct wlr_output_layout *layout,
 		struct wlr_output *output, int x, int y) {
 	struct wlr_output_layout_output *l_output =
@@ -283,6 +292,7 @@ void wlr_output_layout_move(struct wlr_output_layout *layout,
 	}
 }
 
+WLR_API
 void wlr_output_layout_remove(struct wlr_output_layout *layout,
 		struct wlr_output *output) {
 	struct wlr_output_layout_output *l_output =
@@ -294,6 +304,7 @@ void wlr_output_layout_remove(struct wlr_output_layout *layout,
 	wlr_output_destroy_global(output);
 }
 
+WLR_API
 void wlr_output_layout_output_coords(struct wlr_output_layout *layout,
 		struct wlr_output *reference, double *x, double *y) {
 	assert(layout && reference);
@@ -310,6 +321,7 @@ void wlr_output_layout_output_coords(struct wlr_output_layout *layout,
 	}
 }
 
+WLR_API
 void wlr_output_layout_closest_point(struct wlr_output_layout *layout,
 		struct wlr_output *reference, double x, double y, double *dest_x,
 		double *dest_y) {
@@ -343,6 +355,7 @@ void wlr_output_layout_closest_point(struct wlr_output_layout *layout,
 	*dest_y = min_y;
 }
 
+WLR_API
 struct wlr_box *wlr_output_layout_get_box(
 		struct wlr_output_layout *layout, struct wlr_output *reference) {
 	struct wlr_output_layout_output *l_output;
@@ -387,6 +400,7 @@ struct wlr_box *wlr_output_layout_get_box(
 	// not reached
 }
 
+WLR_API
 void wlr_output_layout_add_auto(struct wlr_output_layout *layout,
 		struct wlr_output *output) {
 	struct wlr_output_layout_output *l_output =
@@ -405,6 +419,7 @@ void wlr_output_layout_add_auto(struct wlr_output_layout *layout,
 	wlr_signal_emit_safe(&layout->events.add, l_output);
 }
 
+WLR_API
 struct wlr_output *wlr_output_layout_get_center_output(
 		struct wlr_output_layout *layout) {
 	if (wl_list_empty(&layout->outputs)) {

--- a/types/wlr_pointer.c
+++ b/types/wlr_pointer.c
@@ -3,7 +3,9 @@
 #include <wayland-server.h>
 #include <wlr/interfaces/wlr_pointer.h>
 #include <wlr/types/wlr_pointer.h>
+#include "util/defs.h"
 
+WLR_API
 void wlr_pointer_init(struct wlr_pointer *pointer,
 		struct wlr_pointer_impl *impl) {
 	pointer->impl = impl;
@@ -13,6 +15,7 @@ void wlr_pointer_init(struct wlr_pointer *pointer,
 	wl_signal_init(&pointer->events.axis);
 }
 
+WLR_API
 void wlr_pointer_destroy(struct wlr_pointer *pointer) {
 	if (pointer && pointer->impl && pointer->impl->destroy) {
 		pointer->impl->destroy(pointer);

--- a/types/wlr_primary_selection.c
+++ b/types/wlr_primary_selection.c
@@ -7,6 +7,7 @@
 #include <wlr/types/wlr_seat.h>
 #include <wlr/util/log.h>
 #include "gtk-primary-selection-protocol.h"
+#include "util/defs.h"
 #include "util/signal.h"
 
 static const struct gtk_primary_selection_offer_interface offer_impl;
@@ -173,6 +174,7 @@ static void source_resource_handle_destroy(struct wl_resource *resource) {
 }
 
 
+WLR_API
 void wlr_seat_client_send_primary_selection(
 		struct wlr_seat_client *seat_client) {
 	if (wl_list_empty(&seat_client->primary_selection_devices)) {
@@ -216,6 +218,7 @@ static void seat_client_primary_selection_source_destroy(
 	wlr_signal_emit_safe(&seat->events.primary_selection, seat);
 }
 
+WLR_API
 void wlr_seat_set_primary_selection(struct wlr_seat *seat,
 		struct wlr_primary_selection_source *source, uint32_t serial) {
 	if (source) {
@@ -283,13 +286,14 @@ static void device_resource_handle_destroy(struct wl_resource *resource) {
 	wl_list_remove(wl_resource_get_link(resource));
 }
 
-
+WLR_API
 void wlr_primary_selection_source_init(
 		struct wlr_primary_selection_source *source) {
 	wl_array_init(&source->mime_types);
 	wl_signal_init(&source->events.destroy);
 }
 
+WLR_API
 void wlr_primary_selection_source_finish(
 		struct wlr_primary_selection_source *source) {
 	if (source == NULL) {
@@ -382,6 +386,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	wlr_primary_selection_device_manager_destroy(manager);
 }
 
+WLR_API
 struct wlr_primary_selection_device_manager *
 		wlr_primary_selection_device_manager_create(
 		struct wl_display *display) {
@@ -404,6 +409,7 @@ struct wlr_primary_selection_device_manager *
 	return manager;
 }
 
+WLR_API
 void wlr_primary_selection_device_manager_destroy(
 		struct wlr_primary_selection_device_manager *manager) {
 	if (manager == NULL) {

--- a/types/wlr_region.c
+++ b/types/wlr_region.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <wayland-server.h>
 #include <wlr/types/wlr_region.h>
+#include "util/defs.h"
 
 static void region_add(struct wl_client *client, struct wl_resource *resource,
 		int32_t x, int32_t y, int32_t width, int32_t height) {
@@ -38,6 +39,7 @@ static void destroy_region(struct wl_resource *resource) {
 	free(reg);
 }
 
+WLR_API
 void wlr_region_create(struct wl_client *client, struct wl_resource *res,
 		uint32_t id) {
 	pixman_region32_t *region = calloc(1, sizeof(pixman_region32_t));
@@ -59,6 +61,7 @@ void wlr_region_create(struct wl_client *client, struct wl_resource *res,
 		destroy_region);
 }
 
+WLR_API
 pixman_region32_t *wlr_region_from_resource(struct wl_resource *resource) {
 	assert(wl_resource_instance_of(resource, &wl_region_interface,
 		&region_impl));

--- a/types/wlr_screenshooter.c
+++ b/types/wlr_screenshooter.c
@@ -8,6 +8,7 @@
 #include <wlr/types/wlr_screenshooter.h>
 #include <wlr/util/log.h>
 #include "screenshooter-protocol.h"
+#include "util/defs.h"
 
 static struct wlr_screenshot *screenshot_from_resource(
 		struct wl_resource *resource) {
@@ -168,6 +169,7 @@ static void screenshooter_bind(struct wl_client *wl_client, void *data,
 		screenshooter, NULL);
 }
 
+WLR_API
 void wlr_screenshooter_destroy(struct wlr_screenshooter *screenshooter) {
 	if (!screenshooter) {
 		return;
@@ -187,6 +189,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	wlr_screenshooter_destroy(screenshooter);
 }
 
+WLR_API
 struct wlr_screenshooter *wlr_screenshooter_create(struct wl_display *display) {
 	struct wlr_screenshooter *screenshooter =
 		calloc(1, sizeof(struct wlr_screenshooter));

--- a/types/wlr_seat.c
+++ b/types/wlr_seat.c
@@ -9,6 +9,7 @@
 #include <wlr/types/wlr_primary_selection.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/util/log.h>
+#include "util/defs.h"
 #include "util/signal.h"
 
 static void resource_destroy(struct wl_client *client,
@@ -356,6 +357,7 @@ static const struct wlr_touch_grab_interface default_touch_grab_impl = {
 };
 
 
+WLR_API
 void wlr_seat_destroy(struct wlr_seat *seat) {
 	if (!seat) {
 		return;
@@ -396,6 +398,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	wlr_seat_destroy(seat);
 }
 
+WLR_API
 struct wlr_seat *wlr_seat_create(struct wl_display *display, const char *name) {
 	struct wlr_seat *wlr_seat = calloc(1, sizeof(struct wlr_seat));
 	if (!wlr_seat) {
@@ -489,6 +492,7 @@ struct wlr_seat *wlr_seat_create(struct wl_display *display, const char *name) {
 	return wlr_seat;
 }
 
+WLR_API
 struct wlr_seat_client *wlr_seat_client_for_wl_client(struct wlr_seat *wlr_seat,
 		struct wl_client *wl_client) {
 	assert(wlr_seat);
@@ -501,6 +505,7 @@ struct wlr_seat_client *wlr_seat_client_for_wl_client(struct wlr_seat *wlr_seat,
 	return NULL;
 }
 
+WLR_API
 void wlr_seat_set_capabilities(struct wlr_seat *wlr_seat,
 		uint32_t capabilities) {
 	wlr_seat->capabilities = capabilities;
@@ -510,6 +515,7 @@ void wlr_seat_set_capabilities(struct wlr_seat *wlr_seat,
 	}
 }
 
+WLR_API
 void wlr_seat_set_name(struct wlr_seat *wlr_seat, const char *name) {
 	free(wlr_seat->name);
 	wlr_seat->name = strdup(name);
@@ -519,6 +525,7 @@ void wlr_seat_set_name(struct wlr_seat *wlr_seat, const char *name) {
 	}
 }
 
+WLR_API
 bool wlr_seat_pointer_surface_has_focus(struct wlr_seat *wlr_seat,
 		struct wlr_surface *surface) {
 	return surface == wlr_seat->pointer_state.focused_surface;
@@ -542,6 +549,7 @@ static void pointer_resource_destroy_notify(struct wl_listener *listener,
 	wlr_seat_pointer_clear_focus(state->seat);
 }
 
+WLR_API
 void wlr_seat_pointer_enter(struct wlr_seat *wlr_seat,
 		struct wlr_surface *surface, double sx, double sy) {
 	assert(wlr_seat);
@@ -605,10 +613,12 @@ void wlr_seat_pointer_enter(struct wlr_seat *wlr_seat,
 	// TODO: send focus change event
 }
 
+WLR_API
 void wlr_seat_pointer_clear_focus(struct wlr_seat *wlr_seat) {
 	wlr_seat_pointer_enter(wlr_seat, NULL, 0, 0);
 }
 
+WLR_API
 void wlr_seat_pointer_send_motion(struct wlr_seat *wlr_seat, uint32_t time,
 		double sx, double sy) {
 	struct wlr_seat_client *client = wlr_seat->pointer_state.focused_client;
@@ -624,6 +634,7 @@ void wlr_seat_pointer_send_motion(struct wlr_seat *wlr_seat, uint32_t time,
 	}
 }
 
+WLR_API
 uint32_t wlr_seat_pointer_send_button(struct wlr_seat *wlr_seat, uint32_t time,
 		uint32_t button, uint32_t state) {
 	struct wlr_seat_client *client = wlr_seat->pointer_state.focused_client;
@@ -640,6 +651,7 @@ uint32_t wlr_seat_pointer_send_button(struct wlr_seat *wlr_seat, uint32_t time,
 	return serial;
 }
 
+WLR_API
 void wlr_seat_pointer_send_axis(struct wlr_seat *wlr_seat, uint32_t time,
 		enum wlr_axis_orientation orientation, double value) {
 	struct wlr_seat_client *client = wlr_seat->pointer_state.focused_client;
@@ -660,6 +672,7 @@ void wlr_seat_pointer_send_axis(struct wlr_seat *wlr_seat, uint32_t time,
 	}
 }
 
+WLR_API
 void wlr_seat_pointer_start_grab(struct wlr_seat *wlr_seat,
 		struct wlr_seat_pointer_grab *grab) {
 	assert(wlr_seat);
@@ -670,6 +683,7 @@ void wlr_seat_pointer_start_grab(struct wlr_seat *wlr_seat,
 	wlr_signal_emit_safe(&wlr_seat->events.pointer_grab_begin, grab);
 }
 
+WLR_API
 void wlr_seat_pointer_end_grab(struct wlr_seat *wlr_seat) {
 	struct wlr_seat_pointer_grab *grab = wlr_seat->pointer_state.grab;
 	if (grab != wlr_seat->pointer_state.default_grab) {
@@ -681,12 +695,14 @@ void wlr_seat_pointer_end_grab(struct wlr_seat *wlr_seat) {
 	}
 }
 
+WLR_API
 void wlr_seat_pointer_notify_enter(struct wlr_seat *wlr_seat,
 		struct wlr_surface *surface, double sx, double sy) {
 	struct wlr_seat_pointer_grab *grab = wlr_seat->pointer_state.grab;
 	grab->interface->enter(grab, surface, sx, sy);
 }
 
+WLR_API
 void wlr_seat_pointer_notify_motion(struct wlr_seat *wlr_seat, uint32_t time,
 		double sx, double sy) {
 	clock_gettime(CLOCK_MONOTONIC, &wlr_seat->last_event);
@@ -694,6 +710,7 @@ void wlr_seat_pointer_notify_motion(struct wlr_seat *wlr_seat, uint32_t time,
 	grab->interface->motion(grab, time, sx, sy);
 }
 
+WLR_API
 uint32_t wlr_seat_pointer_notify_button(struct wlr_seat *wlr_seat,
 		uint32_t time, uint32_t button, uint32_t state) {
 	clock_gettime(CLOCK_MONOTONIC, &wlr_seat->last_event);
@@ -717,6 +734,7 @@ uint32_t wlr_seat_pointer_notify_button(struct wlr_seat *wlr_seat,
 	return serial;
 }
 
+WLR_API
 void wlr_seat_pointer_notify_axis(struct wlr_seat *wlr_seat, uint32_t time,
 		enum wlr_axis_orientation orientation, double value) {
 	clock_gettime(CLOCK_MONOTONIC, &wlr_seat->last_event);
@@ -724,10 +742,12 @@ void wlr_seat_pointer_notify_axis(struct wlr_seat *wlr_seat, uint32_t time,
 	grab->interface->axis(grab, time, orientation, value);
 }
 
+WLR_API
 bool wlr_seat_pointer_has_grab(struct wlr_seat *seat) {
 	return seat->pointer_state.grab->interface != &default_pointer_grab_impl;
 }
 
+WLR_API
 void wlr_seat_keyboard_send_key(struct wlr_seat *wlr_seat, uint32_t time,
 		uint32_t key, uint32_t state) {
 	struct wlr_seat_client *client = wlr_seat->keyboard_state.focused_client;
@@ -770,6 +790,7 @@ static void handle_keyboard_destroy(struct wl_listener *listener, void *data) {
 	state->keyboard = NULL;
 }
 
+WLR_API
 void wlr_seat_set_keyboard(struct wlr_seat *seat,
 		struct wlr_input_device *device) {
 	// TODO call this on device key event before the event reaches the
@@ -814,10 +835,12 @@ void wlr_seat_set_keyboard(struct wlr_seat *seat,
 	}
 }
 
+WLR_API
 struct wlr_keyboard *wlr_seat_get_keyboard(struct wlr_seat *seat) {
 	return seat->keyboard_state.keyboard;
 }
 
+WLR_API
 void wlr_seat_keyboard_start_grab(struct wlr_seat *wlr_seat,
 		struct wlr_seat_keyboard_grab *grab) {
 	grab->seat = wlr_seat;
@@ -826,6 +849,7 @@ void wlr_seat_keyboard_start_grab(struct wlr_seat *wlr_seat,
 	wlr_signal_emit_safe(&wlr_seat->events.keyboard_grab_begin, grab);
 }
 
+WLR_API
 void wlr_seat_keyboard_end_grab(struct wlr_seat *wlr_seat) {
 	struct wlr_seat_keyboard_grab *grab = wlr_seat->keyboard_state.grab;
 
@@ -856,6 +880,7 @@ static void keyboard_resource_destroy_notify(struct wl_listener *listener,
 	wlr_seat_keyboard_clear_focus(state->seat);
 }
 
+WLR_API
 void wlr_seat_keyboard_send_modifiers(struct wlr_seat *seat,
 		struct wlr_keyboard_modifiers *modifiers) {
 	struct wlr_seat_client *client = seat->keyboard_state.focused_client;
@@ -876,6 +901,7 @@ void wlr_seat_keyboard_send_modifiers(struct wlr_seat *seat,
 	}
 }
 
+WLR_API
 void wlr_seat_keyboard_enter(struct wlr_seat *seat,
 		struct wlr_surface *surface, uint32_t keycodes[], size_t num_keycodes,
 		struct wlr_keyboard_modifiers *modifiers) {
@@ -955,6 +981,7 @@ void wlr_seat_keyboard_enter(struct wlr_seat *seat,
 	}
 }
 
+WLR_API
 void wlr_seat_keyboard_notify_enter(struct wlr_seat *seat,
 		struct wlr_surface *surface, uint32_t keycodes[], size_t num_keycodes,
 		struct wlr_keyboard_modifiers *modifiers) {
@@ -962,15 +989,18 @@ void wlr_seat_keyboard_notify_enter(struct wlr_seat *seat,
 	grab->interface->enter(grab, surface, keycodes, num_keycodes, modifiers);
 }
 
+WLR_API
 void wlr_seat_keyboard_clear_focus(struct wlr_seat *seat) {
 	// TODO respect grabs here?
 	wlr_seat_keyboard_enter(seat, NULL, NULL, 0, NULL);
 }
 
+WLR_API
 bool wlr_seat_keyboard_has_grab(struct wlr_seat *seat) {
 	return seat->keyboard_state.grab->interface != &default_keyboard_grab_impl;
 }
 
+WLR_API
 void wlr_seat_keyboard_notify_modifiers(struct wlr_seat *seat,
 		struct wlr_keyboard_modifiers *modifiers) {
 	clock_gettime(CLOCK_MONOTONIC, &seat->last_event);
@@ -978,6 +1008,7 @@ void wlr_seat_keyboard_notify_modifiers(struct wlr_seat *seat,
 	grab->interface->modifiers(grab, modifiers);
 }
 
+WLR_API
 void wlr_seat_keyboard_notify_key(struct wlr_seat *seat, uint32_t time,
 		uint32_t key, uint32_t state) {
 	clock_gettime(CLOCK_MONOTONIC, &seat->last_event);
@@ -985,6 +1016,7 @@ void wlr_seat_keyboard_notify_key(struct wlr_seat *seat, uint32_t time,
 	grab->interface->key(grab, time, key, state);
 }
 
+WLR_API
 void wlr_seat_touch_start_grab(struct wlr_seat *wlr_seat,
 		struct wlr_seat_touch_grab *grab) {
 	grab->seat = wlr_seat;
@@ -993,6 +1025,7 @@ void wlr_seat_touch_start_grab(struct wlr_seat *wlr_seat,
 	wlr_signal_emit_safe(&wlr_seat->events.touch_grab_begin, grab);
 }
 
+WLR_API
 void wlr_seat_touch_end_grab(struct wlr_seat *wlr_seat) {
 	struct wlr_seat_touch_grab *grab = wlr_seat->touch_state.grab;
 
@@ -1072,6 +1105,7 @@ static struct wlr_touch_point *touch_point_create(
 	return point;
 }
 
+WLR_API
 struct wlr_touch_point *wlr_seat_touch_get_point(
 		struct wlr_seat *seat, int32_t touch_id) {
 	struct wlr_touch_point *point = NULL;
@@ -1084,6 +1118,7 @@ struct wlr_touch_point *wlr_seat_touch_get_point(
 	return NULL;
 }
 
+WLR_API
 uint32_t wlr_seat_touch_notify_down(struct wlr_seat *seat,
 		struct wlr_surface *surface, uint32_t time, int32_t touch_id, double sx,
 		double sy) {
@@ -1106,6 +1141,7 @@ uint32_t wlr_seat_touch_notify_down(struct wlr_seat *seat,
 	return serial;
 }
 
+WLR_API
 void wlr_seat_touch_notify_up(struct wlr_seat *seat, uint32_t time,
 		int32_t touch_id) {
 	clock_gettime(CLOCK_MONOTONIC, &seat->last_event);
@@ -1121,6 +1157,7 @@ void wlr_seat_touch_notify_up(struct wlr_seat *seat, uint32_t time,
 	touch_point_destroy(point);
 }
 
+WLR_API
 void wlr_seat_touch_notify_motion(struct wlr_seat *seat, uint32_t time,
 		int32_t touch_id, double sx, double sy) {
 	clock_gettime(CLOCK_MONOTONIC, &seat->last_event);
@@ -1168,6 +1205,7 @@ static void touch_point_set_focus(struct wlr_touch_point *point,
 	}
 }
 
+WLR_API
 void wlr_seat_touch_point_focus(struct wlr_seat *seat,
 		struct wlr_surface *surface, uint32_t time, int32_t touch_id, double sx,
 		double sy) {
@@ -1186,6 +1224,7 @@ void wlr_seat_touch_point_focus(struct wlr_seat *seat,
 	}
 }
 
+WLR_API
 void wlr_seat_touch_point_clear_focus(struct wlr_seat *seat, uint32_t time,
 		int32_t touch_id) {
 	struct wlr_touch_point *point = wlr_seat_touch_get_point(seat, touch_id);
@@ -1197,6 +1236,7 @@ void wlr_seat_touch_point_clear_focus(struct wlr_seat *seat, uint32_t time,
 	touch_point_clear_focus(point);
 }
 
+WLR_API
 uint32_t wlr_seat_touch_send_down(struct wlr_seat *seat,
 		struct wlr_surface *surface, uint32_t time, int32_t touch_id, double sx,
 		double sy) {
@@ -1217,6 +1257,7 @@ uint32_t wlr_seat_touch_send_down(struct wlr_seat *seat,
 	return serial;
 }
 
+WLR_API
 void wlr_seat_touch_send_up(struct wlr_seat *seat, uint32_t time, int32_t touch_id) {
 	struct wlr_touch_point *point = wlr_seat_touch_get_point(seat, touch_id);
 	if (!point) {
@@ -1232,6 +1273,7 @@ void wlr_seat_touch_send_up(struct wlr_seat *seat, uint32_t time, int32_t touch_
 	}
 }
 
+WLR_API
 void wlr_seat_touch_send_motion(struct wlr_seat *seat, uint32_t time, int32_t touch_id,
 		double sx, double sy) {
 	struct wlr_touch_point *point = wlr_seat_touch_get_point(seat, touch_id);
@@ -1248,19 +1290,23 @@ void wlr_seat_touch_send_motion(struct wlr_seat *seat, uint32_t time, int32_t to
 	}
 }
 
+WLR_API
 int wlr_seat_touch_num_points(struct wlr_seat *seat) {
 	return wl_list_length(&seat->touch_state.touch_points);
 }
 
+WLR_API
 bool wlr_seat_touch_has_grab(struct wlr_seat *seat) {
 	return seat->touch_state.grab->interface != &default_touch_grab_impl;
 }
 
+WLR_API
 bool wlr_seat_validate_grab_serial(struct wlr_seat *seat, uint32_t serial) {
 	return serial == seat->pointer_state.grab_serial ||
 		serial == seat->touch_state.grab_serial;
 }
 
+WLR_API
 struct wlr_seat_client *wlr_seat_client_from_resource(
 		struct wl_resource *resource) {
 	assert(wl_resource_instance_of(resource, &wl_seat_interface,

--- a/types/wlr_server_decoration.c
+++ b/types/wlr_server_decoration.c
@@ -4,6 +4,7 @@
 #include <wlr/types/wlr_surface.h>
 #include <wlr/util/log.h>
 #include "server-decoration-protocol.h"
+#include "util/defs.h"
 #include "util/signal.h"
 
 static const struct org_kde_kwin_server_decoration_interface
@@ -127,6 +128,7 @@ static const struct org_kde_kwin_server_decoration_manager_interface
 	.create = server_decoration_manager_handle_create,
 };
 
+WLR_API
 void wlr_server_decoration_manager_set_default_mode(
 		struct wlr_server_decoration_manager *manager, uint32_t default_mode) {
 	manager->default_mode = default_mode;
@@ -162,6 +164,7 @@ static void server_decoration_manager_bind(struct wl_client *client, void *data,
 		manager->default_mode);
 }
 
+WLR_API
 void wlr_server_decoration_manager_destroy(
 		struct wlr_server_decoration_manager *manager) {
 	if (manager == NULL) {
@@ -187,6 +190,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	wlr_server_decoration_manager_destroy(manager);
 }
 
+WLR_API
 struct wlr_server_decoration_manager *wlr_server_decoration_manager_create(
 		struct wl_display *display) {
 	struct wlr_server_decoration_manager *manager =

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -8,6 +8,7 @@
 #include <wlr/types/wlr_surface.h>
 #include <wlr/util/log.h>
 #include <wlr/util/region.h>
+#include "util/defs.h"
 #include "util/signal.h"
 
 static void wlr_surface_state_reset_buffer(struct wlr_surface_state *state) {
@@ -530,6 +531,7 @@ const struct wl_surface_interface surface_interface = {
 	.damage_buffer = surface_damage_buffer
 };
 
+WLR_API
 struct wlr_surface *wlr_surface_from_resource(struct wl_resource *resource) {
 	assert(wl_resource_instance_of(resource, &wl_surface_interface,
 		&surface_interface));
@@ -605,6 +607,7 @@ static void destroy_surface(struct wl_resource *resource) {
 	free(surface);
 }
 
+WLR_API
 struct wlr_surface *wlr_surface_create(struct wl_resource *res,
 		struct wlr_renderer *renderer) {
 	struct wlr_surface *surface = calloc(1, sizeof(struct wlr_surface));
@@ -630,6 +633,7 @@ struct wlr_surface *wlr_surface_create(struct wl_resource *res,
 	return surface;
 }
 
+WLR_API
 void wlr_surface_get_matrix(struct wlr_surface *surface,
 		float (*matrix)[16],
 		const float (*projection)[16],
@@ -646,10 +650,12 @@ void wlr_surface_get_matrix(struct wlr_surface *surface,
 	wlr_matrix_mul(projection, matrix, matrix);
 }
 
+WLR_API
 bool wlr_surface_has_buffer(struct wlr_surface *surface) {
 	return surface->texture && surface->texture->valid;
 }
 
+WLR_API
 int wlr_surface_set_role(struct wlr_surface *surface, const char *role,
 		struct wl_resource *error_resource, uint32_t error_code) {
 	assert(role);
@@ -808,6 +814,7 @@ static void subsurface_handle_parent_destroy(struct wl_listener *listener,
 	subsurface->parent = NULL;
 }
 
+WLR_API
 void wlr_surface_make_subsurface(struct wlr_surface *surface,
 		struct wlr_surface *parent, uint32_t id) {
 	struct wl_client *client = wl_resource_get_client(surface->resource);
@@ -857,7 +864,7 @@ void wlr_surface_make_subsurface(struct wlr_surface *surface,
 	wlr_signal_emit_safe(&parent->events.new_subsurface, subsurface);
 }
 
-
+WLR_API
 struct wlr_surface *wlr_surface_get_main_surface(struct wlr_surface *surface) {
 	struct wlr_subsurface *sub;
 
@@ -868,6 +875,7 @@ struct wlr_surface *wlr_surface_get_main_surface(struct wlr_surface *surface) {
 	return surface;
 }
 
+WLR_API
 struct wlr_subsurface *wlr_surface_subsurface_at(struct wlr_surface *surface,
 		double sx, double sy, double *sub_x, double *sub_y) {
 	struct wlr_subsurface *subsurface;
@@ -900,6 +908,7 @@ struct wlr_subsurface *wlr_surface_subsurface_at(struct wlr_surface *surface,
 	return NULL;
 }
 
+WLR_API
 void wlr_surface_send_enter(struct wlr_surface *surface,
 		struct wlr_output *output) {
 	struct wl_client *client = wl_resource_get_client(surface->resource);
@@ -912,6 +921,7 @@ void wlr_surface_send_enter(struct wlr_surface *surface,
 	}
 }
 
+WLR_API
 void wlr_surface_send_leave(struct wlr_surface *surface,
 		struct wlr_output *output) {
 	struct wl_client *client = wl_resource_get_client(surface->resource);
@@ -928,6 +938,7 @@ static inline int64_t timespec_to_msec(const struct timespec *a) {
 	return (int64_t)a->tv_sec * 1000 + a->tv_nsec / 1000000;
 }
 
+WLR_API
 void wlr_surface_send_frame_done(struct wlr_surface *surface,
 		const struct timespec *when) {
 	struct wlr_frame_callback *cb, *cnext;
@@ -938,6 +949,7 @@ void wlr_surface_send_frame_done(struct wlr_surface *surface,
 	}
 }
 
+WLR_API
 void wlr_surface_set_role_committed(struct wlr_surface *surface,
 		void (*role_committed)(struct wlr_surface *surface, void *role_data),
 		void *role_data) {

--- a/types/wlr_tablet_pad.c
+++ b/types/wlr_tablet_pad.c
@@ -3,7 +3,9 @@
 #include <wayland-server.h>
 #include <wlr/interfaces/wlr_tablet_pad.h>
 #include <wlr/types/wlr_tablet_pad.h>
+#include "util/defs.h"
 
+WLR_API
 void wlr_tablet_pad_init(struct wlr_tablet_pad *pad,
 		struct wlr_tablet_pad_impl *impl) {
 	pad->impl = impl;
@@ -12,6 +14,7 @@ void wlr_tablet_pad_init(struct wlr_tablet_pad *pad,
 	wl_signal_init(&pad->events.strip);
 }
 
+WLR_API
 void wlr_tablet_pad_destroy(struct wlr_tablet_pad *pad) {
 	if (pad && pad->impl && pad->impl->destroy) {
 		pad->impl->destroy(pad);

--- a/types/wlr_tablet_tool.c
+++ b/types/wlr_tablet_tool.c
@@ -3,7 +3,9 @@
 #include <wayland-server.h>
 #include <wlr/interfaces/wlr_tablet_tool.h>
 #include <wlr/types/wlr_tablet_tool.h>
+#include "util/defs.h"
 
+WLR_API
 void wlr_tablet_tool_init(struct wlr_tablet_tool *tool,
 		struct wlr_tablet_tool_impl *impl) {
 	tool->impl = impl;
@@ -13,6 +15,7 @@ void wlr_tablet_tool_init(struct wlr_tablet_tool *tool,
 	wl_signal_init(&tool->events.button);
 }
 
+WLR_API
 void wlr_tablet_tool_destroy(struct wlr_tablet_tool *tool) {
 	if (!tool) {
 		return;

--- a/types/wlr_touch.c
+++ b/types/wlr_touch.c
@@ -3,7 +3,9 @@
 #include <wayland-server.h>
 #include <wlr/interfaces/wlr_touch.h>
 #include <wlr/types/wlr_touch.h>
+#include "util/defs.h"
 
+WLR_API
 void wlr_touch_init(struct wlr_touch *touch,
 		struct wlr_touch_impl *impl) {
 	touch->impl = impl;
@@ -13,6 +15,7 @@ void wlr_touch_init(struct wlr_touch *touch,
 	wl_signal_init(&touch->events.cancel);
 }
 
+WLR_API
 void wlr_touch_destroy(struct wlr_touch *touch) {
 	if (touch && touch->impl && touch->impl->destroy) {
 		touch->impl->destroy(touch);

--- a/types/wlr_wl_shell.c
+++ b/types/wlr_wl_shell.c
@@ -8,6 +8,7 @@
 #include <wlr/types/wlr_surface.h>
 #include <wlr/types/wlr_wl_shell.h>
 #include <wlr/util/log.h>
+#include "util/defs.h"
 #include "util/signal.h"
 
 static const char *wlr_wl_shell_surface_role = "wl-shell-surface";
@@ -591,6 +592,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	wlr_wl_shell_destroy(wl_shell);
 }
 
+WLR_API
 struct wlr_wl_shell *wlr_wl_shell_create(struct wl_display *display) {
 	struct wlr_wl_shell *wl_shell = calloc(1, sizeof(struct wlr_wl_shell));
 	if (!wl_shell) {
@@ -615,6 +617,7 @@ struct wlr_wl_shell *wlr_wl_shell_create(struct wl_display *display) {
 	return wl_shell;
 }
 
+WLR_API
 void wlr_wl_shell_destroy(struct wlr_wl_shell *wlr_wl_shell) {
 	if (!wlr_wl_shell) {
 		return;
@@ -630,6 +633,7 @@ void wlr_wl_shell_destroy(struct wlr_wl_shell *wlr_wl_shell) {
 	free(wlr_wl_shell);
 }
 
+WLR_API
 void wlr_wl_shell_surface_ping(struct wlr_wl_shell_surface *surface) {
 	if (surface->ping_serial != 0) {
 		// already pinged
@@ -643,11 +647,13 @@ void wlr_wl_shell_surface_ping(struct wlr_wl_shell_surface *surface) {
 	wl_shell_surface_send_ping(surface->resource, surface->ping_serial);
 }
 
+WLR_API
 void wlr_wl_shell_surface_configure(struct wlr_wl_shell_surface *surface,
 		uint32_t edges, int32_t width, int32_t height) {
 	wl_shell_surface_send_configure(surface->resource, edges, width, height);
 }
 
+WLR_API
 struct wlr_wl_shell_surface *wlr_wl_shell_surface_popup_at(
 		struct wlr_wl_shell_surface *surface, double sx, double sy,
 		double *popup_sx, double *popup_sy) {

--- a/types/wlr_xcursor_manager.c
+++ b/types/wlr_xcursor_manager.c
@@ -2,7 +2,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <wlr/types/wlr_xcursor_manager.h>
+#include "util/defs.h"
 
+WLR_API
 struct wlr_xcursor_manager *wlr_xcursor_manager_create(const char *name,
 		uint32_t size) {
 	struct wlr_xcursor_manager *manager =
@@ -18,6 +20,7 @@ struct wlr_xcursor_manager *wlr_xcursor_manager_create(const char *name,
 	return manager;
 }
 
+WLR_API
 void wlr_xcursor_manager_destroy(struct wlr_xcursor_manager *manager) {
 	if (manager == NULL) {
 		return;
@@ -32,6 +35,7 @@ void wlr_xcursor_manager_destroy(struct wlr_xcursor_manager *manager) {
 	free(manager);
 }
 
+WLR_API
 int wlr_xcursor_manager_load(struct wlr_xcursor_manager *manager,
 		float scale) {
 	struct wlr_xcursor_manager_theme *theme;
@@ -55,6 +59,7 @@ int wlr_xcursor_manager_load(struct wlr_xcursor_manager *manager,
 	return 0;
 }
 
+WLR_API
 struct wlr_xcursor *wlr_xcursor_manager_get_xcursor(
 		struct wlr_xcursor_manager *manager, const char *name, float scale) {
 	struct wlr_xcursor_manager_theme *theme;
@@ -66,6 +71,7 @@ struct wlr_xcursor *wlr_xcursor_manager_get_xcursor(
 	return NULL;
 }
 
+WLR_API
 void wlr_xcursor_manager_set_cursor_image(struct wlr_xcursor_manager *manager,
 		const char *name, struct wlr_cursor *cursor) {
 	struct wlr_xcursor_manager_theme *theme;

--- a/types/wlr_xdg_shell.c
+++ b/types/wlr_xdg_shell.c
@@ -10,6 +10,7 @@
 #include <wlr/types/wlr_surface.h>
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/util/log.h>
+#include "util/defs.h"
 #include "util/signal.h"
 #include "xdg-shell-protocol.h"
 
@@ -1383,6 +1384,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	wlr_xdg_shell_destroy(xdg_shell);
 }
 
+WLR_API
 struct wlr_xdg_shell *wlr_xdg_shell_create(struct wl_display *display) {
 	struct wlr_xdg_shell *xdg_shell =
 		calloc(1, sizeof(struct wlr_xdg_shell));
@@ -1411,6 +1413,7 @@ struct wlr_xdg_shell *wlr_xdg_shell_create(struct wl_display *display) {
 	return xdg_shell;
 }
 
+WLR_API
 void wlr_xdg_shell_destroy(struct wlr_xdg_shell *xdg_shell) {
 	if (!xdg_shell) {
 		return;
@@ -1420,6 +1423,7 @@ void wlr_xdg_shell_destroy(struct wlr_xdg_shell *xdg_shell) {
 	free(xdg_shell);
 }
 
+WLR_API
 void wlr_xdg_surface_ping(struct wlr_xdg_surface *surface) {
 	if (surface->client->ping_serial != 0) {
 		// already pinged
@@ -1434,6 +1438,7 @@ void wlr_xdg_surface_ping(struct wlr_xdg_surface *surface) {
 		surface->client->ping_serial);
 }
 
+WLR_API
 uint32_t wlr_xdg_toplevel_set_size(struct wlr_xdg_surface *surface,
 		uint32_t width, uint32_t height) {
 	assert(surface->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL);
@@ -1443,6 +1448,7 @@ uint32_t wlr_xdg_toplevel_set_size(struct wlr_xdg_surface *surface,
 	return wlr_xdg_surface_schedule_configure(surface);
 }
 
+WLR_API
 uint32_t wlr_xdg_toplevel_set_activated(struct wlr_xdg_surface *surface,
 		bool activated) {
 	assert(surface->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL);
@@ -1451,6 +1457,7 @@ uint32_t wlr_xdg_toplevel_set_activated(struct wlr_xdg_surface *surface,
 	return wlr_xdg_surface_schedule_configure(surface);
 }
 
+WLR_API
 uint32_t wlr_xdg_toplevel_set_maximized(struct wlr_xdg_surface *surface,
 		bool maximized) {
 	assert(surface->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL);
@@ -1459,6 +1466,7 @@ uint32_t wlr_xdg_toplevel_set_maximized(struct wlr_xdg_surface *surface,
 	return wlr_xdg_surface_schedule_configure(surface);
 }
 
+WLR_API
 uint32_t wlr_xdg_toplevel_set_fullscreen(struct wlr_xdg_surface *surface,
 		bool fullscreen) {
 	assert(surface->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL);
@@ -1467,6 +1475,7 @@ uint32_t wlr_xdg_toplevel_set_fullscreen(struct wlr_xdg_surface *surface,
 	return wlr_xdg_surface_schedule_configure(surface);
 }
 
+WLR_API
 uint32_t wlr_xdg_toplevel_set_resizing(struct wlr_xdg_surface *surface,
 		bool resizing) {
 	assert(surface->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL);
@@ -1475,11 +1484,13 @@ uint32_t wlr_xdg_toplevel_set_resizing(struct wlr_xdg_surface *surface,
 	return wlr_xdg_surface_schedule_configure(surface);
 }
 
+WLR_API
 void wlr_xdg_toplevel_send_close(struct wlr_xdg_surface *surface) {
 	assert(surface->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL);
 	xdg_toplevel_send_close(surface->toplevel_state->resource);
 }
 
+WLR_API
 void wlr_xdg_surface_popup_get_position(struct wlr_xdg_surface *surface,
 		double *popup_sx, double *popup_sy) {
 	assert(surface->role == WLR_XDG_SURFACE_ROLE_POPUP);
@@ -1490,6 +1501,7 @@ void wlr_xdg_surface_popup_get_position(struct wlr_xdg_surface *surface,
 		surface->geometry->y;
 }
 
+WLR_API
 struct wlr_xdg_surface *wlr_xdg_surface_popup_at(
 		struct wlr_xdg_surface *surface, double sx, double sy,
 		double *popup_sx, double *popup_sy) {

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -10,6 +10,7 @@
 #include <wlr/types/wlr_surface.h>
 #include <wlr/types/wlr_xdg_shell_v6.h>
 #include <wlr/util/log.h>
+#include "util/defs.h"
 #include "util/signal.h"
 #include "xdg-shell-unstable-v6-protocol.h"
 
@@ -1353,6 +1354,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	wlr_xdg_shell_v6_destroy(xdg_shell);
 }
 
+WLR_API
 struct wlr_xdg_shell_v6 *wlr_xdg_shell_v6_create(struct wl_display *display) {
 	struct wlr_xdg_shell_v6 *xdg_shell =
 		calloc(1, sizeof(struct wlr_xdg_shell_v6));
@@ -1381,6 +1383,7 @@ struct wlr_xdg_shell_v6 *wlr_xdg_shell_v6_create(struct wl_display *display) {
 	return xdg_shell;
 }
 
+WLR_API
 void wlr_xdg_shell_v6_destroy(struct wlr_xdg_shell_v6 *xdg_shell) {
 	if (!xdg_shell) {
 		return;
@@ -1390,6 +1393,7 @@ void wlr_xdg_shell_v6_destroy(struct wlr_xdg_shell_v6 *xdg_shell) {
 	free(xdg_shell);
 }
 
+WLR_API
 void wlr_xdg_surface_v6_ping(struct wlr_xdg_surface_v6 *surface) {
 	if (surface->client->ping_serial != 0) {
 		// already pinged
@@ -1404,6 +1408,7 @@ void wlr_xdg_surface_v6_ping(struct wlr_xdg_surface_v6 *surface) {
 		surface->client->ping_serial);
 }
 
+WLR_API
 uint32_t wlr_xdg_toplevel_v6_set_size(struct wlr_xdg_surface_v6 *surface,
 		uint32_t width, uint32_t height) {
 	assert(surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL);
@@ -1413,6 +1418,7 @@ uint32_t wlr_xdg_toplevel_v6_set_size(struct wlr_xdg_surface_v6 *surface,
 	return wlr_xdg_surface_v6_schedule_configure(surface);
 }
 
+WLR_API
 uint32_t wlr_xdg_toplevel_v6_set_activated(struct wlr_xdg_surface_v6 *surface,
 		bool activated) {
 	assert(surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL);
@@ -1421,6 +1427,7 @@ uint32_t wlr_xdg_toplevel_v6_set_activated(struct wlr_xdg_surface_v6 *surface,
 	return wlr_xdg_surface_v6_schedule_configure(surface);
 }
 
+WLR_API
 uint32_t wlr_xdg_toplevel_v6_set_maximized(struct wlr_xdg_surface_v6 *surface,
 		bool maximized) {
 	assert(surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL);
@@ -1429,6 +1436,7 @@ uint32_t wlr_xdg_toplevel_v6_set_maximized(struct wlr_xdg_surface_v6 *surface,
 	return wlr_xdg_surface_v6_schedule_configure(surface);
 }
 
+WLR_API
 uint32_t wlr_xdg_toplevel_v6_set_fullscreen(struct wlr_xdg_surface_v6 *surface,
 		bool fullscreen) {
 	assert(surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL);
@@ -1437,6 +1445,7 @@ uint32_t wlr_xdg_toplevel_v6_set_fullscreen(struct wlr_xdg_surface_v6 *surface,
 	return wlr_xdg_surface_v6_schedule_configure(surface);
 }
 
+WLR_API
 uint32_t wlr_xdg_toplevel_v6_set_resizing(struct wlr_xdg_surface_v6 *surface,
 		bool resizing) {
 	assert(surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL);
@@ -1445,11 +1454,13 @@ uint32_t wlr_xdg_toplevel_v6_set_resizing(struct wlr_xdg_surface_v6 *surface,
 	return wlr_xdg_surface_v6_schedule_configure(surface);
 }
 
+WLR_API
 void wlr_xdg_toplevel_v6_send_close(struct wlr_xdg_surface_v6 *surface) {
 	assert(surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL);
 	zxdg_toplevel_v6_send_close(surface->toplevel_state->resource);
 }
 
+WLR_API
 void wlr_xdg_surface_v6_popup_get_position(struct wlr_xdg_surface_v6 *surface,
 		double *popup_sx, double *popup_sy) {
 	assert(surface->role == WLR_XDG_SURFACE_V6_ROLE_POPUP);
@@ -1460,6 +1471,7 @@ void wlr_xdg_surface_v6_popup_get_position(struct wlr_xdg_surface_v6 *surface,
 		surface->geometry->y;
 }
 
+WLR_API
 struct wlr_xdg_surface_v6 *wlr_xdg_surface_v6_popup_at(
 		struct wlr_xdg_surface_v6 *surface, double sx, double sy,
 		double *popup_sx, double *popup_sy) {

--- a/util/log.c
+++ b/util/log.c
@@ -7,6 +7,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <wlr/util/log.h>
+#include "util/defs.h"
 
 static bool colored = true;
 static log_importance_t log_importance = L_ERROR;
@@ -48,6 +49,7 @@ void wlr_log_stderr(log_importance_t verbosity, const char *fmt, va_list args) {
 
 static log_callback_t log_callback = wlr_log_stderr;
 
+WLR_API
 void wlr_log_init(log_importance_t verbosity, log_callback_t callback) {
 	if (verbosity < L_LAST) {
 		log_importance = verbosity;
@@ -57,10 +59,12 @@ void wlr_log_init(log_importance_t verbosity, log_callback_t callback) {
 	}
 }
 
+WLR_API
 void _wlr_vlog(log_importance_t verbosity, const char *fmt, va_list args) {
 	log_callback(verbosity, fmt, args);
 }
 
+WLR_API
 void _wlr_log(log_importance_t verbosity, const char *fmt, ...) {
 	va_list args;
 	va_start(args, fmt);
@@ -73,6 +77,7 @@ void _wlr_log(log_importance_t verbosity, const char *fmt, ...) {
 // e.g. '/src/build/wlroots/backend/wayland/backend.c' and
 // '../backend/wayland/backend.c' will both be stripped to
 // 'backend/wayland/backend.c'
+WLR_API
 const char *_strip_path(const char *filepath) {
 	static int srclen = sizeof(WLR_SRC_DIR);
 	if (strstr(filepath, WLR_SRC_DIR) == filepath) {

--- a/util/os-compatibility.c
+++ b/util/os-compatibility.c
@@ -31,6 +31,7 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include "util/defs.h"
 #include "util/os-compatibility.h"
 
 int os_fd_set_cloexec(int fd) {
@@ -97,6 +98,11 @@ int create_tmpfile_cloexec(char *tmpname)
  * If posix_fallocate() is not supported, program may receive
  * SIGBUS on accessing mmap()'ed file contents instead.
  */
+/*
+ * XXX: This is not part of our public headers, but one of the examples uses it.
+ * We really should not export this.
+ */
+WLR_API
 int os_create_anonymous_file(off_t size) {
 	static const char template[] = "/wlroots-shared-XXXXXX";
 	const char *path;

--- a/util/region.c
+++ b/util/region.c
@@ -1,7 +1,9 @@
 #include <math.h>
 #include <stdlib.h>
 #include <wlr/util/region.h>
+#include "util/defs.h"
 
+WLR_API
 void wlr_region_scale(pixman_region32_t *dst, pixman_region32_t *src,
 		float scale) {
 	if (scale == 1) {
@@ -29,6 +31,7 @@ void wlr_region_scale(pixman_region32_t *dst, pixman_region32_t *src,
 	free(dst_rects);
 }
 
+WLR_API
 void wlr_region_transform(pixman_region32_t *dst, pixman_region32_t *src,
 		enum wl_output_transform transform, int width, int height) {
 	if (transform == WL_OUTPUT_TRANSFORM_NORMAL) {
@@ -102,6 +105,7 @@ void wlr_region_transform(pixman_region32_t *dst, pixman_region32_t *src,
 	free(dst_rects);
 }
 
+WLR_API
 void wlr_region_expand(pixman_region32_t *dst, pixman_region32_t *src,
 		int distance) {
 	if (distance == 0) {

--- a/xcursor/wlr_xcursor.c
+++ b/xcursor/wlr_xcursor.c
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <wlr/util/log.h>
 #include <wlr/xcursor.h>
+#include "util/defs.h"
 #include "xcursor/xcursor.h"
 
 static void wlr_xcursor_destroy(struct wlr_xcursor *cursor) {
@@ -212,6 +213,7 @@ static void load_callback(XcursorImages *images, void *data) {
 	XcursorImagesDestroy(images);
 }
 
+WLR_API
 struct wlr_xcursor_theme *wlr_xcursor_theme_load(const char *name, int size) {
 	struct wlr_xcursor_theme *theme;
 
@@ -255,6 +257,7 @@ out_error_name:
 	return NULL;
 }
 
+WLR_API
 void wlr_xcursor_theme_destroy(struct wlr_xcursor_theme *theme) {
 	unsigned int i;
 
@@ -267,6 +270,7 @@ void wlr_xcursor_theme_destroy(struct wlr_xcursor_theme *theme) {
 	free(theme);
 }
 
+WLR_API
 struct wlr_xcursor *wlr_xcursor_theme_get_cursor(struct wlr_xcursor_theme *theme,
 		const char *name) {
 	unsigned int i;
@@ -322,10 +326,12 @@ static int wlr_xcursor_frame_and_duration(struct wlr_xcursor *cursor,
 	return i;
 }
 
+WLR_API
 int wlr_xcursor_frame(struct wlr_xcursor *_cursor, uint32_t time) {
 	return wlr_xcursor_frame_and_duration(_cursor, time, NULL);
 }
 
+WLR_API
 const char *wlr_xcursor_get_resize_name(enum wlr_edges edges) {
 	if (edges & WLR_EDGE_TOP) {
 		if (edges & WLR_EDGE_RIGHT) {

--- a/xwayland/selection.c
+++ b/xwayland/selection.c
@@ -9,6 +9,7 @@
 #include <wlr/util/log.h>
 #include <wlr/xwm.h>
 #include <xcb/xfixes.h>
+#include "util/defs.h"
 
 static const size_t incr_chunk_size = 64 * 1024;
 
@@ -805,6 +806,7 @@ static void selection_init(struct wlr_xwm *xwm,
 		selection->atom, mask);
 }
 
+WLR_API
 void xwm_selection_init(struct wlr_xwm *xwm) {
 	uint32_t values[] = { XCB_EVENT_MASK_PROPERTY_CHANGE };
 	xwm->selection_window = xcb_generate_id(xwm->xcb_conn);
@@ -828,6 +830,7 @@ void xwm_selection_init(struct wlr_xwm *xwm) {
 	selection_init(xwm, &xwm->primary_selection, xwm->atoms[PRIMARY]);
 }
 
+WLR_API
 void xwm_selection_finish(struct wlr_xwm *xwm) {
 	if (!xwm) {
 		return;
@@ -896,6 +899,7 @@ static void seat_handle_primary_selection(struct wl_listener *listener,
 	xwm_selection_set_owner(&xwm->primary_selection, source != NULL);
 }
 
+WLR_API
 void xwm_set_seat(struct wlr_xwm *xwm, struct wlr_seat *seat) {
 	if (xwm->seat != NULL) {
 		wl_list_remove(&xwm->seat_selection.link);

--- a/xwayland/xwayland.c
+++ b/xwayland/xwayland.c
@@ -20,6 +20,7 @@
 #include <wlr/xwayland.h>
 #include <wlr/xwm.h>
 #include "sockets.h"
+#include "util/defs.h"
 #include "util/signal.h"
 
 #ifdef __FreeBSD__
@@ -336,12 +337,14 @@ static bool wlr_xwayland_start(struct wlr_xwayland *wlr_xwayland,
 	return true;
 }
 
+WLR_API
 void wlr_xwayland_destroy(struct wlr_xwayland *wlr_xwayland) {
 	wlr_xwayland_set_seat(wlr_xwayland, NULL);
 	wlr_xwayland_finish(wlr_xwayland);
 	free(wlr_xwayland);
 }
 
+WLR_API
 struct wlr_xwayland *wlr_xwayland_create(struct wl_display *wl_display,
 		struct wlr_compositor *compositor) {
 	struct wlr_xwayland *wlr_xwayland = calloc(1, sizeof(struct wlr_xwayland));
@@ -355,6 +358,7 @@ struct wlr_xwayland *wlr_xwayland_create(struct wl_display *wl_display,
 	return NULL;
 }
 
+WLR_API
 void wlr_xwayland_set_cursor(struct wlr_xwayland *wlr_xwayland,
 		uint8_t *pixels, uint32_t stride, uint32_t width, uint32_t height,
 		int32_t hotspot_x, int32_t hotspot_y) {
@@ -386,6 +390,7 @@ static void wlr_xwayland_handle_seat_destroy(struct wl_listener *listener,
 	wlr_xwayland_set_seat(xwayland, NULL);
 }
 
+WLR_API
 void wlr_xwayland_set_seat(struct wlr_xwayland *xwayland,
 		struct wlr_seat *seat) {
 	if (xwayland->seat) {

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -14,6 +14,7 @@
 #include <xcb/render.h>
 #include <xcb/xcb_image.h>
 #include <xcb/xfixes.h>
+#include "util/defs.h"
 #include "util/signal.h"
 
 #ifdef WLR_HAS_XCB_ICCCM
@@ -1043,6 +1044,7 @@ static void handle_compositor_surface_create(struct wl_listener *listener,
 	}
 }
 
+WLR_API
 void wlr_xwayland_surface_activate(struct wlr_xwayland_surface *xsurface,
 		bool activated) {
 	struct wlr_xwayland_surface *focused = xsurface->xwm->focus_surface;
@@ -1053,6 +1055,7 @@ void wlr_xwayland_surface_activate(struct wlr_xwayland_surface *xsurface,
 	}
 }
 
+WLR_API
 void wlr_xwayland_surface_configure(struct wlr_xwayland_surface *xsurface,
 		int16_t x, int16_t y, uint16_t width, uint16_t height) {
 	xsurface->x = x;
@@ -1069,6 +1072,7 @@ void wlr_xwayland_surface_configure(struct wlr_xwayland_surface *xsurface,
 	xcb_flush(xwm->xcb_conn);
 }
 
+WLR_API
 void wlr_xwayland_surface_close(struct wlr_xwayland_surface *xsurface) {
 	struct wlr_xwm *xwm = xsurface->xwm;
 
@@ -1100,6 +1104,7 @@ void wlr_xwayland_surface_close(struct wlr_xwayland_surface *xsurface) {
 	xcb_flush(xwm->xcb_conn);
 }
 
+WLR_API
 void xwm_destroy(struct wlr_xwm *xwm) {
 	if (!xwm) {
 		return;
@@ -1292,6 +1297,7 @@ static void xwm_get_render_format(struct wlr_xwm *xwm) {
 	free(reply);
 }
 
+WLR_API
 void xwm_set_cursor(struct wlr_xwm *xwm, const uint8_t *pixels, uint32_t stride,
 		uint32_t width, uint32_t height, int32_t hotspot_x, int32_t hotspot_y) {
 	if (!xwm->render_format_id) {
@@ -1332,6 +1338,7 @@ void xwm_set_cursor(struct wlr_xwm *xwm, const uint8_t *pixels, uint32_t stride,
 	xcb_flush(xwm->xcb_conn);
 }
 
+WLR_API
 struct wlr_xwm *xwm_create(struct wlr_xwayland *wlr_xwayland) {
 	struct wlr_xwm *xwm = calloc(1, sizeof(struct wlr_xwm));
 	if (xwm == NULL) {
@@ -1418,6 +1425,7 @@ struct wlr_xwm *xwm_create(struct wlr_xwayland *wlr_xwayland) {
 	return xwm;
 }
 
+WLR_API
 void wlr_xwayland_surface_set_maximized(struct wlr_xwayland_surface *surface,
 		bool maximized) {
 	surface->maximized_horz = maximized;
@@ -1426,6 +1434,7 @@ void wlr_xwayland_surface_set_maximized(struct wlr_xwayland_surface *surface,
 	xcb_flush(surface->xwm->xcb_conn);
 }
 
+WLR_API
 void wlr_xwayland_surface_set_fullscreen(struct wlr_xwayland_surface *surface,
 		bool fullscreen) {
 	surface->fullscreen = fullscreen;


### PR DESCRIPTION
This explicitly exports API functions, and sets the default visibility to hidden.
It's a pretty typical and recommended thing for libraries to do.

Yes, it requires a GNU extension (appropriately hidden behind a feature test macro), but I believe this is a justified exception.

Compiled with `-Dbuildtype=minsize -Db_lto=true` and opening rootston
With patch:
```
     22109:	
     22109:	runtime linker statistics:
     22109:	  total startup time in dynamic loader: 27169614 cycles
     22109:		    time needed for relocation: 15428710 cycles (56.7%)
     22109:	                 number of relocations: 4717
     22109:	      number of relocations from cache: 2556
     22109:	        number of relative relocations: 16210
     22109:		   time needed to load objects: 10641900 cycles (39.1%)
```
`436K	libwlroots.so.0.0.0`

Without patch:
```
     22987:	
     22987:	runtime linker statistics:
     22987:	  total startup time in dynamic loader: 42604509 cycles
     22987:		    time needed for relocation: 25563909 cycles (60.0%)
     22987:	                 number of relocations: 4763
     22987:	      number of relocations from cache: 2560
     22987:	        number of relative relocations: 16194
     22987:		   time needed to load objects: 15456870 cycles (36.2%)
```
`460K	libwlroots.so.0.0.0`

As you can see, it makes loading libwlroots a fair bit faster, and makes the final binary a little bit smaller.
It may also be faster, because the LTO can do more, but I have not benchmarked this.