### PR TITLE
move activity_notify into events in wlr_idle

### DIFF
--- a/include/wlr/types/wlr_idle.h
+++ b/include/wlr/types/wlr_idle.h
@@ -19,7 +19,9 @@ struct wlr_idle {
 	struct wl_event_loop *event_loop;
 
 	struct wl_listener display_destroy;
-	struct wl_signal activity_notify;
+	struct {
+		struct wl_signal activity_notify;
+	} events;
 
 	void *data;
 };

--- a/types/wlr_idle.c
+++ b/types/wlr_idle.c
@@ -122,7 +122,7 @@ static void create_idle_timer(struct wl_client *client,
 	wl_signal_add(&timer->seat->events.destroy, &timer->seat_destroy);
 
 	timer->input_listener.notify = handle_input_notification;
-	wl_signal_add(&idle->activity_notify, &timer->input_listener);
+	wl_signal_add(&idle->events.activity_notify, &timer->input_listener);
 	// create the timer
 	timer->idle_source =
 		wl_event_loop_add_timer(idle->event_loop, idle_notify, timer);
@@ -181,7 +181,7 @@ struct wlr_idle *wlr_idle_create(struct wl_display *display) {
 		return NULL;
 	}
 	wl_list_init(&idle->idle_timers);
-	wl_signal_init(&idle->activity_notify);
+	wl_signal_init(&idle->events.activity_notify);
 
 	idle->event_loop = wl_display_get_event_loop(display);
 	if (idle->event_loop == NULL) {
@@ -204,5 +204,5 @@ struct wlr_idle *wlr_idle_create(struct wl_display *display) {
 }
 
 void wlr_idle_notify_activity(struct wlr_idle *idle, struct wlr_seat *seat) {
-	wlr_signal_emit_safe(&idle->activity_notify, seat);
+	wlr_signal_emit_safe(&idle->events.activity_notify, seat);
 }


### PR DESCRIPTION
This moves the `struct wl_signal activity_notify` in `struct wlr_idle`
into a local `struct {} events` to keep consistency with other modules
in the library.

Pointing it out on my PR but merging one that doesn't do it >:[
Just noticed that, checking the naming for protocol interface implementations.