### PR TITLE
Add tags to anonymous structs

### DIFF
--- a/include/backend/multi.h
+++ b/include/backend/multi.h
@@ -13,7 +13,7 @@ struct wlr_multi_backend {
 
 	struct wl_listener display_destroy;
 
-	struct {
+	struct wlr_multi_backend_events {
 		struct wl_signal backend_add;
 		struct wl_signal backend_remove;
 	} events;

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -45,7 +45,7 @@ struct wlr_wl_backend_output {
 	struct wl_egl_window *egl_window;
 	struct wl_callback *frame_callback;
 
-	struct {
+	struct wlr_wl_backend_cursor {
 		struct wl_shm_pool *pool;
 		void *buffer; // actually a (client-side) struct wl_buffer*
 		uint32_t buf_size;

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -43,7 +43,7 @@ struct wlr_x11_backend {
 	struct wl_event_source *event_source;
 	struct wl_event_source *frame_timer;
 
-	struct {
+	struct wlr_x11_backend_events {
 		struct wlr_x11_atom wm_protocols;
 		struct wlr_x11_atom wm_delete_window;
 		struct wlr_x11_atom net_wm_name;

--- a/include/rootston/config.h
+++ b/include/rootston/config.h
@@ -13,7 +13,7 @@ struct roots_output_config {
 	int x, y;
 	float scale;
 	struct wl_list link;
-	struct {
+	struct roots_output_config_mode {
 		int width, height;
 		float refresh_rate;
 	} mode;

--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -90,13 +90,13 @@ struct roots_view {
 
 	bool maximized;
 	struct roots_output *fullscreen_output;
-	struct {
+	struct roots_view_saved {
 		double x, y;
 		uint32_t width, height;
 		float rotation;
 	} saved;
 
-	struct {
+	struct roots_view_pending_move_resize {
 		bool update_x, update_y;
 		double x, y;
 		uint32_t width, height;
@@ -126,7 +126,7 @@ struct roots_view {
 
 	struct wl_listener new_subsurface;
 
-	struct {
+	struct roots_view_events {
 		struct wl_signal destroy;
 	} events;
 

--- a/include/wlr/backend.h
+++ b/include/wlr/backend.h
@@ -10,7 +10,7 @@ struct wlr_backend_impl;
 struct wlr_backend {
 	const struct wlr_backend_impl *impl;
 
-	struct {
+	struct wlr_backend_events {
 		struct wl_signal destroy;
 		struct wl_signal new_input;
 		struct wl_signal new_output;

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -15,7 +15,7 @@ struct wlr_egl {
 	const char *egl_exts_str;
 	const char *gl_exts_str;
 
-	struct {
+	struct wlr_egl_egl_exts {
 		bool buffer_age;
 		bool swap_buffers_with_damage;
 	} egl_exts;

--- a/include/wlr/types/wlr_compositor.h
+++ b/include/wlr/types/wlr_compositor.h
@@ -12,7 +12,7 @@ struct wlr_compositor {
 
 	struct wl_listener display_destroy;
 
-	struct {
+	struct wlr_compositor_events {
 		struct wl_signal new_surface;
 	} events;
 };

--- a/include/wlr/types/wlr_cursor.h
+++ b/include/wlr/types/wlr_cursor.h
@@ -13,7 +13,7 @@ struct wlr_cursor {
 	struct wlr_cursor_state *state;
 	double x, y;
 
-	struct {
+	struct wlr_cursor_events {
 		struct wl_signal motion;
 		struct wl_signal motion_absolute;
 		struct wl_signal button;

--- a/include/wlr/types/wlr_data_device.h
+++ b/include/wlr/types/wlr_data_device.h
@@ -57,7 +57,7 @@ struct wlr_data_source {
 	enum wl_data_device_manager_dnd_action current_dnd_action;
 	uint32_t compositor_action;
 
-	struct {
+	struct wlr_data_source_events {
 		struct wl_signal destroy;
 	} events;
 };
@@ -73,7 +73,7 @@ struct wlr_drag_icon {
 
 	int32_t sx, sy;
 
-	struct {
+	struct wlr_drag_icon_events {
 		struct wl_signal map; // emitted when mapped or unmapped
 		struct wl_signal destroy;
 	} events;

--- a/include/wlr/types/wlr_gamma_control.h
+++ b/include/wlr/types/wlr_gamma_control.h
@@ -19,7 +19,7 @@ struct wlr_gamma_control {
 
 	struct wl_listener output_destroy_listener;
 
-	struct {
+	struct wlr_gamma_control_events {
 		struct wl_signal destroy;
 	} events;
 

--- a/include/wlr/types/wlr_input_device.h
+++ b/include/wlr/types/wlr_input_device.h
@@ -40,7 +40,7 @@ struct wlr_input_device {
 		struct wlr_tablet_pad *tablet_pad;
 	};
 
-	struct {
+	struct wlr_input_device_events {
 		struct wl_signal destroy;
 	} events;
 

--- a/include/wlr/types/wlr_keyboard.h
+++ b/include/wlr/types/wlr_keyboard.h
@@ -54,12 +54,12 @@ struct wlr_keyboard {
 	size_t num_keycodes;
 	struct wlr_keyboard_modifiers modifiers;
 
-	struct {
+	struct wlr_keyboard_repeat_info {
 		int32_t rate;
 		int32_t delay;
 	} repeat_info;
 
-	struct {
+	struct wlr_keyboard_events {
 		struct wl_signal key;
 		struct wl_signal modifiers;
 		struct wl_signal keymap;

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -31,7 +31,7 @@ struct wlr_output_cursor {
 	struct wl_listener surface_commit;
 	struct wl_listener surface_destroy;
 
-	struct {
+	struct wlr_output_cursor_events {
 		struct wl_signal destroy;
 	} events;
 };
@@ -78,7 +78,7 @@ struct wlr_output {
 	bool frame_pending;
 	float transform_matrix[16];
 
-	struct {
+	struct wlr_output_events {
 		struct wl_signal frame;
 		struct wl_signal needs_swap;
 		struct wl_signal swap_buffers;

--- a/include/wlr/types/wlr_output_damage.h
+++ b/include/wlr/types/wlr_output_damage.h
@@ -29,7 +29,7 @@ struct wlr_output_damage {
 	pixman_region32_t previous[WLR_OUTPUT_DAMAGE_PREVIOUS_LEN];
 	size_t previous_idx;
 
-	struct {
+	struct wlr_output_damage_events {
 		struct wl_signal frame;
 		struct wl_signal destroy;
 	} events;

--- a/include/wlr/types/wlr_output_layout.h
+++ b/include/wlr/types/wlr_output_layout.h
@@ -12,7 +12,7 @@ struct wlr_output_layout {
 	struct wl_list outputs;
 	struct wlr_output_layout_state *state;
 
-	struct {
+	struct wlr_output_layout_events {
 		struct wl_signal add;
 		struct wl_signal change;
 		struct wl_signal destroy;
@@ -27,7 +27,7 @@ struct wlr_output_layout_output {
 	struct wl_list link;
 	struct wlr_output_layout_output_state *state;
 
-	struct {
+	struct wlr_output_layout_output_events {
 		struct wl_signal destroy;
 	} events;
 };

--- a/include/wlr/types/wlr_pointer.h
+++ b/include/wlr/types/wlr_pointer.h
@@ -10,7 +10,7 @@ struct wlr_pointer_impl;
 struct wlr_pointer {
 	struct wlr_pointer_impl *impl;
 
-	struct {
+	struct wlr_pointer_events {
 		struct wl_signal motion;
 		struct wl_signal motion_absolute;
 		struct wl_signal button;

--- a/include/wlr/types/wlr_primary_selection.h
+++ b/include/wlr/types/wlr_primary_selection.h
@@ -27,7 +27,7 @@ struct wlr_primary_selection_source {
 	struct wlr_primary_selection_offer *offer;
 	struct wlr_seat_client *seat_client;
 
-	struct {
+	struct wlr_primary_selection_source_events {
 		struct wl_signal destroy;
 	} events;
 

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -24,7 +24,7 @@ struct wlr_seat_client {
 	struct wl_list data_devices;
 	struct wl_list primary_selection_devices;
 
-	struct {
+	struct wlr_seat_client_events {
 		struct wl_signal destroy;
 	} events;
 
@@ -44,7 +44,7 @@ struct wlr_touch_point {
 	struct wl_listener focus_surface_destroy;
 	struct wl_listener resource_destroy;
 
-	struct {
+	struct wlr_touch_point_events {
 		struct wl_signal destroy;
 	} events;
 
@@ -195,7 +195,7 @@ struct wlr_seat {
 	struct wl_listener selection_data_source_destroy;
 	struct wl_listener primary_selection_source_destroy;
 
-	struct {
+	struct wlr_seat_events {
 		struct wl_signal pointer_grab_begin;
 		struct wl_signal pointer_grab_end;
 

--- a/include/wlr/types/wlr_server_decoration.h
+++ b/include/wlr/types/wlr_server_decoration.h
@@ -35,7 +35,7 @@ struct wlr_server_decoration_manager {
 
 	struct wl_listener display_destroy;
 
-	struct {
+	struct wlr_server_decoration_manager_events {
 		struct wl_signal new_decoration;
 	} events;
 
@@ -49,7 +49,7 @@ struct wlr_server_decoration {
 
 	uint32_t mode; // enum wlr_server_decoration_manager_mode
 
-	struct {
+	struct wlr_server_decoration_events {
 		struct wl_signal destroy;
 		struct wl_signal mode;
 	} events;

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -35,7 +35,7 @@ struct wlr_surface_state {
 	int width, height;
 	int buffer_width, buffer_height;
 
-	struct {
+	struct wlr_surface_state_subsurface_position {
 		int32_t x, y;
 	} subsurface_position;
 
@@ -58,7 +58,7 @@ struct wlr_subsurface {
 
 	struct wl_listener parent_destroy_listener;
 
-	struct {
+	struct wlr_subsurface_events {
 		struct wl_signal destroy;
 	} events;
 };
@@ -73,7 +73,7 @@ struct wlr_surface {
 	float buffer_to_surface_matrix[16];
 	float surface_to_buffer_matrix[16];
 
-	struct {
+	struct wlr_surface_events {
 		struct wl_signal commit;
 		struct wl_signal new_subsurface;
 		struct wl_signal destroy;

--- a/include/wlr/types/wlr_tablet_pad.h
+++ b/include/wlr/types/wlr_tablet_pad.h
@@ -16,7 +16,7 @@ struct wlr_tablet_pad_impl;
 struct wlr_tablet_pad {
 	struct wlr_tablet_pad_impl *impl;
 
-	struct {
+	struct wlr_tablet_pad_events {
 		struct wl_signal button;
 		struct wl_signal ring;
 		struct wl_signal strip;

--- a/include/wlr/types/wlr_tablet_tool.h
+++ b/include/wlr/types/wlr_tablet_tool.h
@@ -10,7 +10,7 @@ struct wlr_tablet_tool_impl;
 struct wlr_tablet_tool {
 	struct wlr_tablet_tool_impl *impl;
 
-	struct {
+	struct wlr_tablet_tool_events {
 		struct wl_signal axis;
 		struct wl_signal proximity;
 		struct wl_signal tip;

--- a/include/wlr/types/wlr_touch.h
+++ b/include/wlr/types/wlr_touch.h
@@ -9,7 +9,7 @@ struct wlr_touch_impl;
 struct wlr_touch {
 	struct wlr_touch_impl *impl;
 
-	struct {
+	struct wlr_touch_events {
 		struct wl_signal down;
 		struct wl_signal up;
 		struct wl_signal motion;

--- a/include/wlr/types/wlr_wl_shell.h
+++ b/include/wlr/types/wlr_wl_shell.h
@@ -14,7 +14,7 @@ struct wlr_wl_shell {
 
 	struct wl_listener display_destroy;
 
-	struct {
+	struct wlr_wl_shell_events {
 		struct wl_signal new_surface;
 	} events;
 
@@ -76,7 +76,7 @@ struct wlr_wl_shell_surface {
 	struct wl_list popups;
 	bool popup_mapped;
 
-	struct {
+	struct wlr_wl_shell_surface_events {
 		struct wl_signal destroy;
 		struct wl_signal ping_timeout;
 		struct wl_signal new_popup;

--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -13,7 +13,7 @@ struct wlr_xdg_shell {
 
 	struct wl_listener display_destroy;
 
-	struct {
+	struct wlr_xdg_shell_events {
 		struct wl_signal new_surface;
 	} events;
 
@@ -123,7 +123,7 @@ struct wlr_xdg_surface {
 
 	struct wl_listener surface_destroy_listener;
 
-	struct {
+	struct wlr_xdg_surface_events {
 		struct wl_signal destroy;
 		struct wl_signal ping_timeout;
 		struct wl_signal new_popup;

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -13,7 +13,7 @@ struct wlr_xdg_shell_v6 {
 
 	struct wl_listener display_destroy;
 
-	struct {
+	struct wlr_xdg_shell_v6_events {
 		struct wl_signal new_surface;
 	} events;
 
@@ -123,7 +123,7 @@ struct wlr_xdg_surface_v6 {
 
 	struct wl_listener surface_destroy_listener;
 
-	struct {
+	struct wlr_xdg_surface_v6_events {
 		struct wl_signal destroy;
 		struct wl_signal ping_timeout;
 		struct wl_signal new_popup;

--- a/include/wlr/xwayland.h
+++ b/include/wlr/xwayland.h
@@ -34,7 +34,7 @@ struct wlr_xwayland {
 	struct wlr_seat *seat;
 	struct wl_listener seat_destroy;
 
-	struct {
+	struct wlr_xwayland_events {
 		struct wl_signal ready;
 		struct wl_signal new_surface;
 	} events;
@@ -122,7 +122,7 @@ struct wlr_xwayland_surface {
 
 	bool has_alpha;
 
-	struct {
+	struct wlr_xwayland_surface_events {
 		struct wl_signal destroy;
 		struct wl_signal request_configure;
 		struct wl_signal request_move;


### PR DESCRIPTION
At present the wlroots interface includes several anonymous structs, which can make it difficult for some tools to create bindings to wlroots. I stumbled on this issue while writing OCaml FFI bindings for wlroots.

## The problem

Currently, a number of struct types have neither a tag name nor a typedef alias. For example, struct `wlr_backend` contains a [struct type without a name](https://github.com/swaywm/wlroots/blob/master/include/wlr/backend.h#L13):

```c
    struct {
        struct wl_signal destroy;
        struct wl_signal new_input;
        struct wl_signal new_output;
    } events;
```

Anonymous struct types like the type above make it difficult or impossible for certain tools to create foreign language bindings to a library. For example, one binding strategy (used, for instance, in the [OCaml ctypes library](https://github.com/ocamllabs/ocaml-ctypes)) is to generate C code that determines the layout of C objects, then use the layout information to access those objects directly from the foreign language. The generated C code uses type names to determine layout, like this:

```c
    … sizeof(struct foo) …
    … offsetof (struct foo, field_x) …
    … alignmentof (struct foo) …
```

Clearly this approach won't work if the types involved don't have names.

## The fix

The patch adds tags to all the anonymous types that form part of the public interface. The tag names are derived from the enclosing type and the name of the member — for example, the type of the `events` member in `wlr_backend` becomes struct `wlr_backend_events`.

-------------

Note that fully anonymous structs and unions with no type and no member name are fine. [For example](https://github.com/swaywm/wlroots/blob/master/include/backend/drm/drm.h#L49):
```c
    union {
        struct {
            struct wlr_drm_plane *overlay;
            struct wlr_drm_plane *primary;
            struct wlr_drm_plane *cursor;
        };
        struct wlr_drm_plane *planes[3];
    };
```

 Since the intermediate anonymous structs and unions cannot be named in C code, simply inferring the layout of their members is enough.