### PR TITLE
prevent screenshot from resuing template array

### DIFF
--- a/examples/screenshot.c
+++ b/examples/screenshot.c
@@ -122,7 +122,7 @@ static const struct wl_registry_listener registry_listener = {
 };
 
 static int backingfile(off_t size) {
-	static char template[] = "/tmp/wlroots-shared-XXXXXX";
+	char template[] = "/tmp/wlroots-shared-XXXXXX";
 	int fd, ret;
 
 	fd = mkstemp(template);


### PR DESCRIPTION
The template array given to mkstemp was declared static. This reused the
memory, which caused mkstemp to fail if backingfile is run more than
once, because the array no longer contained the template syntax
(which is forced to end in XXXXXX) but the previous file name.