### PR TITLE
Fix null deref in wlr_libinput_backend_destroy

### DIFF
--- a/backend/libinput/backend.c
+++ b/backend/libinput/backend.c
@@ -118,7 +118,9 @@ static void wlr_libinput_backend_destroy(struct wlr_backend *wlr_backend) {
 	wl_list_remove(&backend->session_signal.link);
 
 	wlr_list_finish(&backend->wlr_device_lists);
-	wl_event_source_remove(backend->input_event);
+	if (backend->input_event) {
+		wl_event_source_remove(backend->input_event);
+	}
 	libinput_unref(backend->libinput_context);
 	free(backend);
 }


### PR DESCRIPTION
If input_event is null (e.g. if backend_start has not been called yet)
`wl_event_source_remove` will result in a null deref.

Hit this when running `rootston` at [rootston/main.c:51](https://github.com/swaywm/wlroots/blob/master/rootston/main.c#L51)