### PR TITLE
wlroots handle protocol request pre first commit

### DIFF
--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -139,7 +139,7 @@ struct roots_view {
 	void (*move_resize)(struct roots_view *view, double x, double y,
 		uint32_t width, uint32_t height);
 	void (*maximize)(struct roots_view *view, bool maximized);
-	void (*set_fullscreen)(struct roots_view *view, bool fullscreen);
+	void (*set_fullscreen)(struct roots_view *view, bool fullscreen, struct wlr_output* output);
 	void (*close)(struct roots_view *view);
 };
 

--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -63,9 +63,10 @@ enum wlr_xdg_surface_role {
 
 struct wlr_xdg_toplevel_state {
 	bool maximized;
-	bool fullscreen;
 	bool resizing;
 	bool activated;
+	bool fullscreen;
+	struct wlr_output *fullscreen_output;
 
 	uint32_t width;
 	uint32_t height;
@@ -200,7 +201,7 @@ uint32_t wlr_xdg_toplevel_set_maximized(struct wlr_xdg_surface *surface,
  * fullscreen. Returns the associated configure serial.
  */
 uint32_t wlr_xdg_toplevel_set_fullscreen(struct wlr_xdg_surface *surface,
-		bool fullscreen);
+		bool fullscreen, struct wlr_output *output);
 
 /**
  * Request that this toplevel surface consider itself to be resizing or not

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -63,9 +63,10 @@ enum wlr_xdg_surface_v6_role {
 
 struct wlr_xdg_toplevel_v6_state {
 	bool maximized;
-	bool fullscreen;
 	bool resizing;
 	bool activated;
+	bool fullscreen;
+	struct wlr_output *fullscreen_output;
 
 	uint32_t width;
 	uint32_t height;
@@ -200,7 +201,7 @@ uint32_t wlr_xdg_toplevel_v6_set_maximized(struct wlr_xdg_surface_v6 *surface,
  * fullscreen. Returns the associated configure serial.
  */
 uint32_t wlr_xdg_toplevel_v6_set_fullscreen(struct wlr_xdg_surface_v6 *surface,
-		bool fullscreen);
+		bool fullscreen, struct wlr_output *output);
 
 /**
  * Request that this toplevel surface consider itself to be resizing or not

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -225,7 +225,7 @@ void view_set_fullscreen(struct roots_view *view, bool fullscreen,
 	// TODO: check if client is focused?
 
 	if (view->set_fullscreen) {
-		view->set_fullscreen(view, fullscreen);
+		view->set_fullscreen(view, fullscreen, output);
 	}
 
 	if (!was_fullscreen && fullscreen) {

--- a/rootston/xdg_shell.c
+++ b/rootston/xdg_shell.c
@@ -162,14 +162,14 @@ static void maximize(struct roots_view *view, bool maximized) {
 	wlr_xdg_toplevel_set_maximized(surface, maximized);
 }
 
-static void set_fullscreen(struct roots_view *view, bool fullscreen) {
+static void set_fullscreen(struct roots_view *view, bool fullscreen, struct wlr_output *output) {
 	assert(view->type == ROOTS_XDG_SHELL_VIEW);
 	struct wlr_xdg_surface *surface = view->xdg_surface;
 	if (surface->role != WLR_XDG_SURFACE_ROLE_TOPLEVEL) {
 		return;
 	}
 
-	wlr_xdg_toplevel_set_fullscreen(surface, fullscreen);
+	wlr_xdg_toplevel_set_fullscreen(surface, fullscreen, output);
 }
 
 static void close(struct roots_view *view) {
@@ -360,4 +360,9 @@ void handle_xdg_shell_surface(struct wl_listener *listener, void *data) {
 	wl_list_insert(&desktop->views, &view->link);
 
 	view_setup(view);
+
+	if (surface->toplevel_state->current.fullscreen) {
+		view_set_fullscreen(view, true,
+			surface->toplevel_state->current.fullscreen_output);
+	}
 }

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -162,14 +162,15 @@ static void maximize(struct roots_view *view, bool maximized) {
 	wlr_xdg_toplevel_v6_set_maximized(surface, maximized);
 }
 
-static void set_fullscreen(struct roots_view *view, bool fullscreen) {
+static void set_fullscreen(struct roots_view *view, bool fullscreen,
+		struct wlr_output *output) {
 	assert(view->type == ROOTS_XDG_SHELL_V6_VIEW);
 	struct wlr_xdg_surface_v6 *surface = view->xdg_surface_v6;
 	if (surface->role != WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL) {
 		return;
 	}
 
-	wlr_xdg_toplevel_v6_set_fullscreen(surface, fullscreen);
+	wlr_xdg_toplevel_v6_set_fullscreen(surface, fullscreen, output);
 }
 
 static void close(struct roots_view *view) {
@@ -360,4 +361,9 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	wl_list_insert(&desktop->views, &view->link);
 
 	view_setup(view);
+
+	if (surface->toplevel_state->current.fullscreen) {
+		view_set_fullscreen(view, true,
+			surface->toplevel_state->current.fullscreen_output);
+	}
 }

--- a/rootston/xwayland.c
+++ b/rootston/xwayland.c
@@ -100,7 +100,8 @@ static void maximize(struct roots_view *view, bool maximized) {
 	wlr_xwayland_surface_set_maximized(view->xwayland_surface, maximized);
 }
 
-static void set_fullscreen(struct roots_view *view, bool fullscreen) {
+static void set_fullscreen(struct roots_view *view, bool fullscreen,
+		struct wlr_output *output) {
 	assert(view->type == ROOTS_XWAYLAND_VIEW);
 
 	wlr_xwayland_surface_set_fullscreen(view->xwayland_surface, fullscreen);

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -730,6 +730,7 @@ static void xdg_toplevel_protocol_set_fullscreen(struct wl_client *client,
 	}
 
 	surface->toplevel_state->next.fullscreen = true;
+	surface->toplevel_state->next.fullscreen_output = output;
 
 	struct wlr_xdg_toplevel_v6_set_fullscreen_event event = {
 		.surface = surface,
@@ -737,7 +738,11 @@ static void xdg_toplevel_protocol_set_fullscreen(struct wl_client *client,
 		.output = output,
 	};
 
-	wlr_signal_emit_safe(&surface->events.request_fullscreen, &event);
+	if (surface->toplevel_state->added) {
+		wlr_signal_emit_safe(&surface->events.request_fullscreen, &event);
+	} else {
+		wlr_xdg_toplevel_v6_set_fullscreen(surface, true, output);
+	}
 }
 
 static void xdg_toplevel_protocol_unset_fullscreen(struct wl_client *client,
@@ -746,6 +751,7 @@ static void xdg_toplevel_protocol_unset_fullscreen(struct wl_client *client,
 		xdg_surface_from_xdg_toplevel_resource(resource);
 
 	surface->toplevel_state->next.fullscreen = false;
+	surface->toplevel_state->next.fullscreen_output = NULL;
 
 	struct wlr_xdg_toplevel_v6_set_fullscreen_event event = {
 		.surface = surface,
@@ -753,7 +759,11 @@ static void xdg_toplevel_protocol_unset_fullscreen(struct wl_client *client,
 		.output = NULL,
 	};
 
-	wlr_signal_emit_safe(&surface->events.request_fullscreen, &event);
+	if (surface->toplevel_state->added) {
+		wlr_signal_emit_safe(&surface->events.request_fullscreen, &event);
+	} else {
+		wlr_xdg_toplevel_v6_set_fullscreen(surface, false, NULL);
+	}
 }
 
 static void xdg_toplevel_protocol_set_minimized(struct wl_client *client,
@@ -1430,9 +1440,10 @@ uint32_t wlr_xdg_toplevel_v6_set_maximized(struct wlr_xdg_surface_v6 *surface,
 }
 
 uint32_t wlr_xdg_toplevel_v6_set_fullscreen(struct wlr_xdg_surface_v6 *surface,
-		bool fullscreen) {
+		bool fullscreen, struct wlr_output *output) {
 	assert(surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL);
 	surface->toplevel_state->pending.fullscreen = fullscreen;
+	surface->toplevel_state->pending.fullscreen_output = output;
 
 	return wlr_xdg_surface_v6_schedule_configure(surface);
 }


### PR DESCRIPTION
Clients are supposed to set themselves up completly before their first
commit, so no crud gets rendered.
The wlr_shell(_v6) implementations emit the events, but they don't reach
any listener and effectivly get dropped.

With this commit, wlroots will handle the protocol internally (just
allowing clients to do as they please) if the surface hasn't been passed
to the compositor yet.
This requires to keep track of the output a surface is fullscreened on.

The compositor is responsible for checking the state and ensuring it
sets up internal state on new_surface event.

Fixes https://github.com/swaywm/wlroots/issues/674
Testplan: start mpv with --fs argument and watch it appear fullscreened.