### PR TITLE
restore dpms state on drm resume

### DIFF
--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -83,6 +83,8 @@ static void session_signal(struct wl_listener *listener, void *data) {
 		wl_list_for_each(conn, &drm->outputs, link){
 			if (conn->output.current_mode) {
 				wlr_output_set_mode(&conn->output, conn->output.current_mode);
+			} else {
+				wlr_drm_connector_enable(&conn->output, false);
 			}
 
 			if (!conn->crtc) {

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -282,7 +282,7 @@ void wlr_drm_connector_start_renderer(struct wlr_drm_connector *conn) {
 	}
 }
 
-static void wlr_drm_connector_enable(struct wlr_output *output, bool enable) {
+void wlr_drm_connector_enable(struct wlr_output *output, bool enable) {
 	struct wlr_drm_connector *conn = (struct wlr_drm_connector *)output;
 	if (conn->state != WLR_DRM_CONN_CONNECTED) {
 		return;
@@ -296,6 +296,8 @@ static void wlr_drm_connector_enable(struct wlr_output *output, bool enable) {
 
 	if (enable) {
 		wlr_drm_connector_start_renderer(conn);
+	} else {
+		output->current_mode = NULL;
 	}
 
 	wlr_output_update_enabled(&conn->output, enable);

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -144,6 +144,7 @@ void wlr_drm_restore_outputs(struct wlr_drm_backend *drm);
 void wlr_drm_connector_cleanup(struct wlr_drm_connector *conn);
 void wlr_drm_scan_connectors(struct wlr_drm_backend *state);
 int wlr_drm_event(int fd, uint32_t mask, void *data);
+void wlr_drm_connector_enable(struct wlr_output *output, bool enable);
 
 void wlr_drm_connector_start_renderer(struct wlr_drm_connector *conn);
 


### PR DESCRIPTION
If there is no current mode, set outputs to dpms off in drm resume.
Sets current mode to null on disable to ensure this can be checked.

Fixes https://github.com/swaywm/wlroots/issues/675

Testplan: Disable an output in the config (or by any means) and change tty away and back to rootston again.