### PR TITLE
rootston: drop saved.alpha from roots_view

### DIFF
--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -95,7 +95,6 @@ struct roots_view {
 		double x, y;
 		uint32_t width, height;
 		float rotation;
-		float alpha;
 	} saved;
 
 	struct {


### PR DESCRIPTION
It's currently unused.