### PR TITLE
set fullscreen alpha to 1

### DIFF
--- a/rootston/output.c
+++ b/rootston/output.c
@@ -523,6 +523,7 @@ static void render_output(struct roots_output *output) {
 	}
 
 	// Render drag icons
+	data.alpha = 1.0;
 	drag_icons_for_each_surface(server->input, render_surface, &data);
 
 renderer_end:

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -470,6 +470,7 @@ static void render_output(struct roots_output *output) {
 		.output = output,
 		.when = &now,
 		.damage = &damage,
+		.alpha = 1.0,
 	};
 
 	if (!needs_swap) {


### PR DESCRIPTION
Fixes https://github.com/swaywm/wlroots/pull/680#discussion_r170856102

Currently the alpha defaults to 0, which causes fullscreen surfaces to be completly transparent when they have to be rendered by the rootston code and aren't managed by `wlr_output`.