### PR TITLE
prevent current_mode null on output_enable(false)

### DIFF
--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -81,7 +81,7 @@ static void session_signal(struct wl_listener *listener, void *data) {
 
 		struct wlr_drm_connector *conn;
 		wl_list_for_each(conn, &drm->outputs, link){
-			if (conn->output.current_mode) {
+			if (conn->output.enabled) {
 				wlr_output_set_mode(&conn->output, conn->output.current_mode);
 			} else {
 				wlr_drm_connector_enable(&conn->output, false);

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -296,8 +296,6 @@ void wlr_drm_connector_enable(struct wlr_output *output, bool enable) {
 
 	if (enable) {
 		wlr_drm_connector_start_renderer(conn);
-	} else {
-		output->current_mode = NULL;
 	}
 
 	wlr_output_update_enabled(&conn->output, enable);


### PR DESCRIPTION
The current mode was set to NULL to abuse it as state variable
persisting DRM suspend/resume, this results resulted in a segfault on
normal DPMS cycle.

This reverts that change and uses the wlr_output enabled variable, which
also persists and makes more sense.

I'm dumb =.=