### PR TITLE
xwm: fix call of xcb_change_window_attributes for old gcc versions

### DIFF
--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -93,7 +93,7 @@ static struct wlr_xwayland_surface *wlr_xwayland_surface_create(
 		XCB_EVENT_MASK_FOCUS_CHANGE |
 		XCB_EVENT_MASK_PROPERTY_CHANGE;
 	xcb_change_window_attributes(xwm->xcb_conn, window_id,
-		XCB_CW_EVENT_MASK, &values);
+		XCB_CW_EVENT_MASK, values);
 
 	surface->xwm = xwm;
 	surface->window_id = window_id;


### PR DESCRIPTION
gcc 6.3.0 (at least) complains about &values:
```
expected ‘const uint32_t * {aka const unsigned int *}’ but argument
is of type ‘uint32_t (*)[1] {aka unsigned int (*)[1]}’
```

Reported by thorwil on irc