### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
-CMakeCache.txt
-CMakeFiles
-Makefile
-cmake_install.cmake
-install_manifest.txt
 .clang_complete
 *.o
 *.a
@@ -11,3 +6,4 @@ test/
 build/
 wayland-*-protocol.*
 wlr-example.ini
+rootston.ini


### PR DESCRIPTION
- Remove old cmake ignores
- Add rootston.ini (example is rootston.ini.example)
- ~~Add cscope files~~
- ~~Add various swap/backup files~~

I couldn't find it anymore, but I seem to recall some reluctance to ignore vim swap/backup files - happy to remove these if appropriate.
At least rootston.ini would be nice :)