### PR TITLE
rootston: Update cursors on set focus

### DIFF
--- a/include/rootston/cursor.h
+++ b/include/rootston/cursor.h
@@ -48,6 +48,9 @@ struct roots_cursor *roots_cursor_create(struct roots_seat *seat);
 
 void roots_cursor_destroy(struct roots_cursor *cursor);
 
+void roots_cursor_update_position(struct roots_cursor *cursor,
+		uint32_t time);
+
 void roots_cursor_handle_motion(struct roots_cursor *cursor,
 		struct wlr_event_pointer_motion *event);
 

--- a/include/rootston/desktop.h
+++ b/include/rootston/desktop.h
@@ -80,6 +80,8 @@ void view_apply_damage(struct roots_view *view);
 void view_damage_whole(struct roots_view *view);
 void view_update_position(struct roots_view *view, double x, double y);
 void view_update_size(struct roots_view *view, uint32_t width, uint32_t height);
+void view_update_cursors(const struct roots_view *view,
+	const struct wlr_box *before);
 void view_initial_focus(struct roots_view *view);
 void view_map(struct roots_view *view, struct wlr_surface *surface);
 void view_unmap(struct roots_view *view);

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -98,7 +98,7 @@ static void seat_view_deco_button(struct roots_seat_view *view, double sx,
 	}
 }
 
-static void roots_cursor_update_position(struct roots_cursor *cursor,
+void roots_cursor_update_position(struct roots_cursor *cursor,
 		uint32_t time) {
 	struct roots_desktop *desktop = cursor->seat->input->server->desktop;
 	struct roots_seat *seat = cursor->seat;
@@ -134,7 +134,9 @@ static void roots_cursor_update_position(struct roots_cursor *cursor,
 		} if (view && surface) {
 			// motion over a view surface
 			wlr_seat_pointer_notify_enter(seat->seat, surface, sx, sy);
-			wlr_seat_pointer_notify_motion(seat->seat, time, sx, sy);
+			if (time) {
+				wlr_seat_pointer_notify_motion(seat->seat, time, sx, sy);
+			}
 		} else {
 			wlr_seat_pointer_clear_focus(seat->seat);
 		}

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -151,15 +151,11 @@ void view_move(struct roots_view *view, double x, double y) {
 		return;
 	}
 
-	struct wlr_box before;
-	view_get_box(view, &before);
 	if (view->move) {
 		view->move(view, x, y);
 	} else {
 		view_update_position(view, x, y);
 	}
-	view_update_output(view, &before);
-	view_update_cursors(view, &before);
 }
 
 void view_activate(struct roots_view *view, bool activate) {
@@ -169,13 +165,9 @@ void view_activate(struct roots_view *view, bool activate) {
 }
 
 void view_resize(struct roots_view *view, uint32_t width, uint32_t height) {
-	struct wlr_box before;
-	view_get_box(view, &before);
 	if (view->resize) {
 		view->resize(view, width, height);
 	}
-	view_update_output(view, &before);
-	view_update_cursors(view, &before);
 }
 
 void view_move_resize(struct roots_view *view, double x, double y,
@@ -549,10 +541,14 @@ void view_update_position(struct roots_view *view, double x, double y) {
 		return;
 	}
 
+	struct wlr_box before;
+	view_get_box(view, &before);
 	view_damage_whole(view);
 	view->x = x;
 	view->y = y;
 	view_damage_whole(view);
+	view_update_output(view, &before);
+	view_update_cursors(view, &before);
 }
 
 void view_update_size(struct roots_view *view, uint32_t width, uint32_t height) {
@@ -560,10 +556,14 @@ void view_update_size(struct roots_view *view, uint32_t width, uint32_t height) 
 		return;
 	}
 
+	struct wlr_box before;
+	view_get_box(view, &before);
 	view_damage_whole(view);
 	view->width = width;
 	view->height = height;
 	view_damage_whole(view);
+	view_update_output(view, &before);
+	view_update_cursors(view, &before);
 }
 
 static bool view_at(struct roots_view *view, double lx, double ly,

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -721,6 +721,7 @@ void roots_seat_set_focus(struct roots_seat *seat, struct roots_view *view) {
 	if (view != NULL) {
 		wl_list_remove(&view->link);
 		wl_list_insert(&seat->input->server->desktop->views, &view->link);
+		view_update_cursors(view, NULL);
 	}
 
 	struct roots_view *prev_focus = roots_seat_get_focus(seat);


### PR DESCRIPTION
Setting focus can change the views ordering so all cursors need to
be updated to reflect such changes e.g. edges are different.

This is a bigger issue than I thought it'd be.
I've just hooked in `roots_seat_set_focus` and call `roots_cursor_update_position` at the end for all seats, but that's just shoving the dust under the rug - multiseat and cursor as we do them is difficult.
For example what if a seat user moves a window just under another cursor?

As a bonus question, I don't like calling `clock_gettime` and `timespec_to_msec`. Technically I think we could get a time from the event most of the time, e.g. for next_window we have the keyboard event that triggered the key binding all the way up the stack, should I bother and bubble it down?
The problem with this approach is there are two places calling `roots_seat_set_focus` without an `event->time_msec` handy - `view_initial_focus` and `seat_view_destroy`, which makes two places calling `clock_gettime` instead of one...

test plan:
* [x] Go to edge of a view with another view below and alt-tab, check cursor changes both times
* [x] Place an edge somewhere in the middle where a new view would pop and check the new view correctly updates cursor when it appears
* [x] Check fullscreening a view and unfullscreening updates cursor (just noticed it doesn't work right now)
* [ ] Check 2nd seat's cursor gets updated when resizing a window under it
* [ ] . . .but not if the resized view is below another

Fixes #678.