### PR TITLE
emit view->events.destroy on xwayland unmap

### DIFF
--- a/rootston/xwayland.c
+++ b/rootston/xwayland.c
@@ -276,6 +276,8 @@ static void handle_unmap_notify(struct wl_listener *listener, void *data) {
 	view->wlr_surface = NULL;
 	view->width = view->height = 0;
 	wl_list_remove(&view->link);
+
+	wl_signal_emit(&view->events.destroy, view);
 }
 
 void handle_xwayland_surface(struct wl_listener *listener, void *data) {


### PR DESCRIPTION
Emits the view destroy signal when an xwayland view is unmaped.
This makes sure, no references to it are held, and fixes a few
situations where inconsistent view state could lead to segfault.

This fixes the segfaults, but I am honestly not sure, if it could introduce other issues.
Quick testing doesn't expose anything obvious, but there may be more complicated issues.

Relevant issues:
https://github.com/swaywm/wlroots/issues/705
https://github.com/swaywm/wlroots/issues/679
https://github.com/swaywm/wlroots/issues/671
https://github.com/swaywm/wlroots/issues/650


The `view_finish` in `desktop.c` uses the same libwayland signal emit.
Should we change that (in another PR)?