### PR TITLE
output: don't move hidden cursors

### DIFF
--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -669,6 +669,31 @@ static void output_cursor_reset(struct wlr_output_cursor *cursor) {
 	}
 }
 
+static void output_cursor_update_visible(struct wlr_output_cursor *cursor) {
+	struct wlr_box output_box;
+	output_box.x = output_box.y = 0;
+	wlr_output_transformed_resolution(cursor->output, &output_box.width,
+		&output_box.height);
+
+	struct wlr_box cursor_box;
+	output_cursor_get_box(cursor, &cursor_box);
+
+	struct wlr_box intersection;
+	bool visible =
+		wlr_box_intersection(&output_box, &cursor_box, &intersection);
+
+	if (cursor->surface != NULL) {
+		if (cursor->visible && !visible) {
+			wlr_surface_send_leave(cursor->surface, cursor->output);
+		}
+		if (!cursor->visible && visible) {
+			wlr_surface_send_enter(cursor->surface, cursor->output);
+		}
+	}
+
+	cursor->visible = visible;
+}
+
 bool wlr_output_cursor_set_image(struct wlr_output_cursor *cursor,
 		const uint8_t *pixels, int32_t stride, uint32_t width, uint32_t height,
 		int32_t hotspot_x, int32_t hotspot_y) {
@@ -682,6 +707,7 @@ bool wlr_output_cursor_set_image(struct wlr_output_cursor *cursor,
 	cursor->height = height;
 	cursor->hotspot_x = hotspot_x;
 	cursor->hotspot_y = hotspot_y;
+	output_cursor_update_visible(cursor);
 
 	struct wlr_output_cursor *hwcur = cursor->output->hardware_cursor;
 	if (cursor->output->impl->set_cursor && (hwcur == NULL || hwcur == cursor)) {
@@ -714,31 +740,6 @@ bool wlr_output_cursor_set_image(struct wlr_output_cursor *cursor,
 
 	return wlr_texture_upload_pixels(cursor->texture, WL_SHM_FORMAT_ARGB8888,
 		stride, width, height, pixels);
-}
-
-static void output_cursor_update_visible(struct wlr_output_cursor *cursor) {
-	struct wlr_box output_box;
-	output_box.x = output_box.y = 0;
-	wlr_output_transformed_resolution(cursor->output, &output_box.width,
-		&output_box.height);
-
-	struct wlr_box cursor_box;
-	output_cursor_get_box(cursor, &cursor_box);
-
-	struct wlr_box intersection;
-	bool visible =
-		wlr_box_intersection(&output_box, &cursor_box, &intersection);
-
-	if (cursor->surface != NULL) {
-		if (cursor->visible && !visible) {
-			wlr_surface_send_leave(cursor->surface, cursor->output);
-		}
-		if (!cursor->visible && visible) {
-			wlr_surface_send_enter(cursor->surface, cursor->output);
-		}
-	}
-
-	cursor->visible = visible;
 }
 
 static void output_cursor_commit(struct wlr_output_cursor *cursor) {
@@ -882,6 +883,7 @@ struct wlr_output_cursor *wlr_output_cursor_create(struct wlr_output *output) {
 	wl_list_init(&cursor->surface_destroy.link);
 	cursor->surface_destroy.notify = output_cursor_handle_destroy;
 	wl_list_insert(&output->cursors, &cursor->link);
+	cursor->visible = true; // default position is at (0, 0)
 	return cursor;
 }
 

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -846,11 +846,17 @@ bool wlr_output_cursor_move(struct wlr_output_cursor *cursor,
 		output_cursor_damage_whole(cursor);
 	}
 
+	bool was_visible = cursor->visible;
 	x *= cursor->output->scale;
 	y *= cursor->output->scale;
 	cursor->x = x;
 	cursor->y = y;
 	output_cursor_update_visible(cursor);
+
+	if (!was_visible && !cursor->visible) {
+		// Cursor is still hidden, do nothing
+		return true;
+	}
 
 	if (cursor->output->hardware_cursor != cursor) {
 		output_cursor_damage_whole(cursor);


### PR DESCRIPTION
When using the DRM backend and multiple outputs, that reduces the
number of commits.

Test plan: check that cursors aren't broken on a multi-monitor setup