### PR TITLE
Add map/unmap to xdg-shell

### DIFF
--- a/include/rootston/desktop.h
+++ b/include/rootston/desktop.h
@@ -71,14 +71,16 @@ struct roots_output *desktop_output_from_wlr_output(
 struct roots_view *desktop_view_at(struct roots_desktop *desktop, double lx,
 	double ly, struct wlr_surface **surface, double *sx, double *sy);
 
-void view_init(struct roots_view *view, struct roots_desktop *desktop);
-void view_finish(struct roots_view *view);
+struct roots_view *view_create(struct roots_desktop *desktop);
+void view_destroy(struct roots_view *view);
 void view_activate(struct roots_view *view, bool activate);
 void view_apply_damage(struct roots_view *view);
 void view_damage_whole(struct roots_view *view);
 void view_update_position(struct roots_view *view, double x, double y);
 void view_update_size(struct roots_view *view, uint32_t width, uint32_t height);
 void view_initial_focus(struct roots_view *view);
+void view_map(struct roots_view *view, struct wlr_surface *surface);
+void view_unmap(struct roots_view *view);
 
 void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data);
 void handle_xdg_shell_surface(struct wl_listener *listener, void *data);

--- a/include/rootston/seat.h
+++ b/include/rootston/seat.h
@@ -39,6 +39,7 @@ struct roots_seat_view {
 
 	struct wl_list link; // roots_seat::views
 
+	struct wl_listener view_unmap;
 	struct wl_listener view_destroy;
 };
 

--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -181,7 +181,6 @@ struct roots_xdg_popup {
 	struct wl_listener new_popup;
 };
 
-struct roots_view *view_create();
 void view_get_box(const struct roots_view *view, struct wlr_box *box);
 void view_activate(struct roots_view *view, bool active);
 void view_move(struct roots_view *view, double x, double y);

--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -44,6 +44,8 @@ struct roots_xdg_surface {
 
 	struct wl_listener destroy;
 	struct wl_listener new_popup;
+	struct wl_listener map;
+	struct wl_listener unmap;
 	struct wl_listener request_move;
 	struct wl_listener request_resize;
 	struct wl_listener request_maximize;

--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -142,6 +142,7 @@ struct roots_view {
 	void (*maximize)(struct roots_view *view, bool maximized);
 	void (*set_fullscreen)(struct roots_view *view, bool fullscreen);
 	void (*close)(struct roots_view *view);
+	void (*destroy)(struct roots_view *view);
 };
 
 struct roots_view_child {

--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -130,6 +130,7 @@ struct roots_view {
 	struct wl_listener new_subsurface;
 
 	struct {
+		struct wl_signal unmap;
 		struct wl_signal destroy;
 	} events;
 

--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -27,6 +27,8 @@ struct roots_xdg_surface_v6 {
 
 	struct wl_listener destroy;
 	struct wl_listener new_popup;
+	struct wl_listener map;
+	struct wl_listener unmap;
 	struct wl_listener request_move;
 	struct wl_listener request_resize;
 	struct wl_listener request_maximize;

--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -62,19 +62,10 @@ enum wlr_xdg_surface_role {
 };
 
 struct wlr_xdg_toplevel_state {
-	bool maximized;
-	bool fullscreen;
-	bool resizing;
-	bool activated;
-
-	uint32_t width;
-	uint32_t height;
-
-	uint32_t max_width;
-	uint32_t max_height;
-
-	uint32_t min_width;
-	uint32_t min_height;
+	bool maximized, fullscreen, resizing, activated;
+	uint32_t width, height;
+	uint32_t max_width, max_height;
+	uint32_t min_width, min_height;
 };
 
 struct wlr_xdg_toplevel {
@@ -90,7 +81,8 @@ struct wlr_xdg_toplevel {
 struct wlr_xdg_surface_configure {
 	struct wl_list link; // wlr_xdg_surface::configure_list
 	uint32_t serial;
-	struct wlr_xdg_toplevel_state state;
+
+	struct wlr_xdg_toplevel_state *toplevel_state;
 };
 
 struct wlr_xdg_surface {
@@ -101,14 +93,13 @@ struct wlr_xdg_surface {
 	enum wlr_xdg_surface_role role;
 
 	union {
-		struct wlr_xdg_toplevel *toplevel_state;
-		struct wlr_xdg_popup *popup_state;
+		struct wlr_xdg_toplevel *toplevel;
+		struct wlr_xdg_popup *popup;
 	};
 
 	struct wl_list popups; // wlr_xdg_popup::link
 
-	bool configured;
-	bool added;
+	bool added, configured, mapped;
 	uint32_t configure_serial;
 	struct wl_event_source *configure_idle;
 	uint32_t configure_next_serial;
@@ -118,8 +109,8 @@ struct wlr_xdg_surface {
 	char *app_id;
 
 	bool has_next_geometry;
-	struct wlr_box *next_geometry;
-	struct wlr_box *geometry;
+	struct wlr_box next_geometry;
+	struct wlr_box geometry;
 
 	struct wl_listener surface_destroy_listener;
 
@@ -127,6 +118,8 @@ struct wlr_xdg_surface {
 		struct wl_signal destroy;
 		struct wl_signal ping_timeout;
 		struct wl_signal new_popup;
+		struct wl_signal map;
+		struct wl_signal unmap;
 
 		struct wl_signal request_maximize;
 		struct wl_signal request_fullscreen;

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -109,8 +109,8 @@ struct wlr_xdg_surface_v6 {
 	char *app_id;
 
 	bool has_next_geometry;
-	struct wlr_box *next_geometry;
-	struct wlr_box *geometry; // TODO: should not be a pointer
+	struct wlr_box next_geometry;
+	struct wlr_box geometry;
 
 	struct wl_listener surface_destroy_listener;
 

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -62,19 +62,10 @@ enum wlr_xdg_surface_v6_role {
 };
 
 struct wlr_xdg_toplevel_v6_state {
-	bool maximized;
-	bool fullscreen;
-	bool resizing;
-	bool activated;
-
-	uint32_t width;
-	uint32_t height;
-
-	uint32_t max_width;
-	uint32_t max_height;
-
-	uint32_t min_width;
-	uint32_t min_height;
+	bool maximized, fullscreen, resizing, activated;
+	uint32_t width, height;
+	uint32_t max_width, max_height;
+	uint32_t min_width, min_height;
 };
 
 struct wlr_xdg_toplevel_v6 {
@@ -90,7 +81,8 @@ struct wlr_xdg_toplevel_v6 {
 struct wlr_xdg_surface_v6_configure {
 	struct wl_list link; // wlr_xdg_surface_v6::configure_list
 	uint32_t serial;
-	struct wlr_xdg_toplevel_v6_state state;
+
+	struct wlr_xdg_toplevel_v6_state toplevel_state; // TODO: should be null-able
 };
 
 struct wlr_xdg_surface_v6 {
@@ -100,6 +92,7 @@ struct wlr_xdg_surface_v6 {
 	struct wl_list link; // wlr_xdg_client_v6::surfaces
 	enum wlr_xdg_surface_v6_role role;
 
+	// TODO: the _state prefix should be dropped
 	union {
 		struct wlr_xdg_toplevel_v6 *toplevel_state;
 		struct wlr_xdg_popup_v6 *popup_state;
@@ -118,7 +111,7 @@ struct wlr_xdg_surface_v6 {
 
 	bool has_next_geometry;
 	struct wlr_box *next_geometry;
-	struct wlr_box *geometry;
+	struct wlr_box *geometry; // TODO: should not be a pointer
 
 	struct wl_listener surface_destroy_listener;
 

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -107,8 +107,7 @@ struct wlr_xdg_surface_v6 {
 
 	struct wl_list popups; // wlr_xdg_popup_v6::link
 
-	bool configured;
-	bool added;
+	bool added, configured, mapped;
 	uint32_t configure_serial;
 	struct wl_event_source *configure_idle;
 	uint32_t configure_next_serial;
@@ -127,6 +126,8 @@ struct wlr_xdg_surface_v6 {
 		struct wl_signal destroy;
 		struct wl_signal ping_timeout;
 		struct wl_signal new_popup;
+		struct wl_signal map;
+		struct wl_signal unmap;
 
 		struct wl_signal request_maximize;
 		struct wl_signal request_fullscreen;

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -82,7 +82,7 @@ struct wlr_xdg_surface_v6_configure {
 	struct wl_list link; // wlr_xdg_surface_v6::configure_list
 	uint32_t serial;
 
-	struct wlr_xdg_toplevel_v6_state toplevel_state; // TODO: should be null-able
+	struct wlr_xdg_toplevel_v6_state *toplevel_state;
 };
 
 struct wlr_xdg_surface_v6 {

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -92,10 +92,9 @@ struct wlr_xdg_surface_v6 {
 	struct wl_list link; // wlr_xdg_client_v6::surfaces
 	enum wlr_xdg_surface_v6_role role;
 
-	// TODO: the _state prefix should be dropped
 	union {
-		struct wlr_xdg_toplevel_v6 *toplevel_state;
-		struct wlr_xdg_popup_v6 *popup_state;
+		struct wlr_xdg_toplevel_v6 *toplevel;
+		struct wlr_xdg_popup_v6 *popup;
 	};
 
 	struct wl_list popups; // wlr_xdg_popup_v6::link

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -54,7 +54,8 @@ void view_get_deco_box(const struct roots_view *view, struct wlr_box *box) {
 	box->height += (view->border_width * 2 + view->titlebar_height);
 }
 
-enum roots_deco_part view_get_deco_part(struct roots_view *view, double sx, double sy) {
+enum roots_deco_part view_get_deco_part(struct roots_view *view, double sx,
+		double sy) {
 	if (!view->decorated) {
 		return ROOTS_DECO_PART_NONE;
 	}
@@ -94,9 +95,15 @@ enum roots_deco_part view_get_deco_part(struct roots_view *view, double sx, doub
 static void view_update_output(const struct roots_view *view,
 		const struct wlr_box *before) {
 	struct roots_desktop *desktop = view->desktop;
-	struct roots_output *output;
+
+	if (view->wlr_surface == NULL) {
+		return;
+	}
+
 	struct wlr_box box;
 	view_get_box(view, &box);
+
+	struct roots_output *output;
 	wl_list_for_each(output, &desktop->outputs, link) {
 		bool intersected = before != NULL && wlr_output_layout_intersects(
 			desktop->layout, output->wlr_output, before);
@@ -479,7 +486,10 @@ void view_initial_focus(struct roots_view *view) {
 void view_setup(struct roots_view *view) {
 	view_initial_focus(view);
 
-	view_center(view);
+	if (view->fullscreen_output == NULL) {
+		view_center(view);
+	}
+
 	view_update_output(view, NULL);
 }
 

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -417,11 +417,11 @@ void view_destroy(struct roots_view *view) {
 		return;
 	}
 
+	wl_signal_emit(&view->events.destroy, view);
+
 	if (view->wlr_surface != NULL) {
 		view_unmap(view);
 	}
-
-	wl_signal_emit(&view->events.destroy, view);
 
 	if (view->destroy) {
 		view->destroy(view);

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -30,6 +30,7 @@ struct roots_view *view_create(struct roots_desktop *desktop) {
 	}
 	view->desktop = desktop;
 	view->alpha = 1.0f;
+	wl_signal_init(&view->events.unmap);
 	wl_signal_init(&view->events.destroy);
 	wl_list_init(&view->children);
 	return view;

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -459,6 +459,8 @@ void view_map(struct roots_view *view, struct wlr_surface *surface) {
 void view_unmap(struct roots_view *view) {
 	assert(view->wlr_surface != NULL);
 
+	wl_signal_emit(&view->events.unmap, view);
+
 	view_damage_whole(view);
 	wl_list_remove(&view->link);
 

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -422,6 +422,10 @@ void view_destroy(struct roots_view *view) {
 
 	wl_signal_emit(&view->events.destroy, view);
 
+	if (view->destroy) {
+		view->destroy(view);
+	}
+
 	free(view);
 }
 

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -491,7 +491,7 @@ void view_initial_focus(struct roots_view *view) {
 void view_setup(struct roots_view *view) {
 	view_initial_focus(view);
 
-	if (view->fullscreen_output == NULL) {
+	if (view->fullscreen_output == NULL && !view->maximized) {
 		view_center(view);
 	}
 

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -501,7 +501,9 @@ static void render_output(struct roots_output *output) {
 			goto renderer_end;
 		}
 
-		view_for_each_surface(view, render_surface, &data);
+		if (view->wlr_surface != NULL) {
+			view_for_each_surface(view, render_surface, &data);
+		}
 
 		// During normal rendering the xwayland window tree isn't traversed
 		// because all windows are rendered. Here we only want to render
@@ -570,6 +572,9 @@ void output_damage_whole(struct roots_output *output) {
 
 static bool view_accept_damage(struct roots_output *output,
 		struct roots_view *view) {
+	if (view->wlr_surface == NULL) {
+		return false;
+	}
 	if (output->fullscreen_view == NULL) {
 		return true;
 	}

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -433,7 +433,8 @@ static void render_output(struct roots_output *output) {
 	float clear_color[] = {0.25f, 0.25f, 0.25f, 1.0f};
 
 	// Check if we can delegate the fullscreen surface to the output
-	if (output->fullscreen_view != NULL) {
+	if (output->fullscreen_view != NULL &&
+			output->fullscreen_view->wlr_surface != NULL) {
 		struct roots_view *view = output->fullscreen_view;
 
 		// Make sure the view is centered on screen

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -645,6 +645,7 @@ static void seat_view_destroy(struct roots_seat_view *seat_view) {
 		seat->cursor->pointer_view = NULL;
 	}
 
+	wl_list_remove(&seat_view->view_unmap.link);
 	wl_list_remove(&seat_view->view_destroy.link);
 	wl_list_remove(&seat_view->link);
 	free(seat_view);
@@ -655,6 +656,12 @@ static void seat_view_destroy(struct roots_seat_view *seat_view) {
 			seat->views.next, first_seat_view, link);
 		roots_seat_set_focus(seat, first_seat_view->view);
 	}
+}
+
+static void seat_view_handle_unmap(struct wl_listener *listener, void *data) {
+	struct roots_seat_view *seat_view =
+		wl_container_of(listener, seat_view, view_unmap);
+	seat_view_destroy(seat_view);
 }
 
 static void seat_view_handle_destroy(struct wl_listener *listener, void *data) {
@@ -675,6 +682,8 @@ static struct roots_seat_view *seat_add_view(struct roots_seat *seat,
 
 	wl_list_insert(seat->views.prev, &seat_view->link);
 
+	seat_view->view_unmap.notify = seat_view_handle_unmap;
+	wl_signal_add(&view->events.unmap, &seat_view->view_unmap);
 	seat_view->view_destroy.notify = seat_view_handle_destroy;
 	wl_signal_add(&view->events.destroy, &seat_view->view_destroy);
 

--- a/rootston/wl_shell.c
+++ b/rootston/wl_shell.c
@@ -181,9 +181,7 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	wl_list_remove(&roots_surface->request_fullscreen.link);
 	wl_list_remove(&roots_surface->set_state.link);
 	wl_list_remove(&roots_surface->surface_commit.link);
-	wl_list_remove(&roots_surface->view->link);
-	view_finish(roots_surface->view);
-	free(roots_surface->view);
+	view_destroy(roots_surface->view);
 	free(roots_surface);
 }
 
@@ -227,7 +225,7 @@ void handle_wl_shell_surface(struct wl_listener *listener, void *data) {
 	roots_surface->surface_commit.notify = handle_surface_commit;
 	wl_signal_add(&surface->surface->events.commit, &roots_surface->surface_commit);
 
-	struct roots_view *view = view_create();
+	struct roots_view *view = view_create(desktop);
 	if (!view) {
 		free(roots_surface);
 		return;
@@ -238,13 +236,11 @@ void handle_wl_shell_surface(struct wl_listener *listener, void *data) {
 
 	view->wl_shell_surface = surface;
 	view->roots_wl_shell_surface = roots_surface;
-	view->wlr_surface = surface->surface;
 	view->resize = resize;
 	view->close = close;
 	roots_surface->view = view;
-	view_init(view, desktop);
-	wl_list_insert(&desktop->views, &view->link);
 
+	view_map(view, surface->surface);
 	view_setup(view);
 
 	if (surface->state == WLR_WL_SHELL_SURFACE_STATE_TRANSIENT) {

--- a/rootston/wl_shell.c
+++ b/rootston/wl_shell.c
@@ -78,6 +78,19 @@ static void close(struct roots_view *view) {
 	wl_client_destroy(surf->client);
 }
 
+static void destroy(struct roots_view *view) {
+	assert(view->type == ROOTS_WL_SHELL_VIEW);
+	struct roots_wl_shell_surface *roots_surface = view->roots_wl_shell_surface;
+	wl_list_remove(&roots_surface->destroy.link);
+	wl_list_remove(&roots_surface->request_move.link);
+	wl_list_remove(&roots_surface->request_resize.link);
+	wl_list_remove(&roots_surface->request_maximize.link);
+	wl_list_remove(&roots_surface->request_fullscreen.link);
+	wl_list_remove(&roots_surface->set_state.link);
+	wl_list_remove(&roots_surface->surface_commit.link);
+	free(roots_surface);
+}
+
 static void handle_request_move(struct wl_listener *listener, void *data) {
 	struct roots_wl_shell_surface *roots_surface =
 		wl_container_of(listener, roots_surface, request_move);
@@ -174,15 +187,7 @@ static void handle_new_popup(struct wl_listener *listener, void *data) {
 static void handle_destroy(struct wl_listener *listener, void *data) {
 	struct roots_wl_shell_surface *roots_surface =
 		wl_container_of(listener, roots_surface, destroy);
-	wl_list_remove(&roots_surface->destroy.link);
-	wl_list_remove(&roots_surface->request_move.link);
-	wl_list_remove(&roots_surface->request_resize.link);
-	wl_list_remove(&roots_surface->request_maximize.link);
-	wl_list_remove(&roots_surface->request_fullscreen.link);
-	wl_list_remove(&roots_surface->set_state.link);
-	wl_list_remove(&roots_surface->surface_commit.link);
 	view_destroy(roots_surface->view);
-	free(roots_surface);
 }
 
 void handle_wl_shell_surface(struct wl_listener *listener, void *data) {
@@ -238,6 +243,7 @@ void handle_wl_shell_surface(struct wl_listener *listener, void *data) {
 	view->roots_wl_shell_surface = roots_surface;
 	view->resize = resize;
 	view->close = close;
+	view->destroy = destroy;
 	roots_surface->view = view;
 
 	view_map(view, surface->surface);

--- a/rootston/xdg_shell.c
+++ b/rootston/xdg_shell.c
@@ -60,12 +60,14 @@ static void get_size(const struct roots_view *view, struct wlr_box *box) {
 	assert(view->type == ROOTS_XDG_SHELL_VIEW);
 	struct wlr_xdg_surface *surface = view->xdg_surface;
 
-	if (surface->geometry->width > 0 && surface->geometry->height > 0) {
-		box->width = surface->geometry->width;
-		box->height = surface->geometry->height;
-	} else {
+	if (surface->geometry.width > 0 && surface->geometry.height > 0) {
+		box->width = surface->geometry.width;
+		box->height = surface->geometry.height;
+	} else if (view->wlr_surface != NULL) {
 		box->width = view->wlr_surface->current->width;
 		box->height = view->wlr_surface->current->height;
+	} else {
+		box->width = box->height = 0;
 	}
 }
 
@@ -83,7 +85,7 @@ static void apply_size_constraints(struct wlr_xdg_surface *surface,
 	*dest_width = width;
 	*dest_height = height;
 
-	struct wlr_xdg_toplevel_state *state = &surface->toplevel_state->current;
+	struct wlr_xdg_toplevel_state *state = &surface->toplevel->current;
 	if (width < state->min_width) {
 		*dest_width = state->min_width;
 	} else if (state->max_width > 0 &&
@@ -181,10 +183,13 @@ static void close(struct roots_view *view) {
 }
 
 static void destroy(struct roots_view *view) {
+	assert(view->type == ROOTS_XDG_SHELL_VIEW);
 	struct roots_xdg_surface *roots_xdg_surface = view->roots_xdg_surface;
 	wl_list_remove(&roots_xdg_surface->surface_commit.link);
 	wl_list_remove(&roots_xdg_surface->destroy.link);
 	wl_list_remove(&roots_xdg_surface->new_popup.link);
+	wl_list_remove(&roots_xdg_surface->map.link);
+	wl_list_remove(&roots_xdg_surface->unmap.link);
 	wl_list_remove(&roots_xdg_surface->request_move.link);
 	wl_list_remove(&roots_xdg_surface->request_resize.link);
 	wl_list_remove(&roots_xdg_surface->request_maximize.link);
@@ -231,7 +236,7 @@ static void handle_request_maximize(struct wl_listener *listener, void *data) {
 		return;
 	}
 
-	view_maximize(view, surface->toplevel_state->next.maximized);
+	view_maximize(view, surface->toplevel->next.maximized);
 }
 
 static void handle_request_fullscreen(struct wl_listener *listener,
@@ -254,6 +259,10 @@ static void handle_surface_commit(struct wl_listener *listener, void *data) {
 		wl_container_of(listener, roots_surface, surface_commit);
 	struct roots_view *view = roots_surface->view;
 	struct wlr_xdg_surface *surface = view->xdg_surface;
+
+	if (!surface->mapped) {
+		return;
+	}
 
 	view_apply_damage(view);
 
@@ -289,6 +298,26 @@ static void handle_new_popup(struct wl_listener *listener, void *data) {
 	popup_create(roots_xdg_surface->view, wlr_popup);
 }
 
+static void handle_map(struct wl_listener *listener, void *data) {
+	struct roots_xdg_surface *roots_xdg_surface =
+		wl_container_of(listener, roots_xdg_surface, map);
+	struct roots_view *view = roots_xdg_surface->view;
+
+	struct wlr_box box;
+	get_size(view, &box);
+	view->width = box.width;
+	view->height = box.height;
+
+	view_map(view, view->xdg_surface->surface);
+	view_setup(view);
+}
+
+static void handle_unmap(struct wl_listener *listener, void *data) {
+	struct roots_xdg_surface *roots_xdg_surface =
+		wl_container_of(listener, roots_xdg_surface, unmap);
+	view_unmap(roots_xdg_surface->view);
+}
+
 static void handle_destroy(struct wl_listener *listener, void *data) {
 	struct roots_xdg_surface *roots_xdg_surface =
 		wl_container_of(listener, roots_xdg_surface, destroy);
@@ -321,6 +350,10 @@ void handle_xdg_shell_surface(struct wl_listener *listener, void *data) {
 		&roots_surface->surface_commit);
 	roots_surface->destroy.notify = handle_destroy;
 	wl_signal_add(&surface->events.destroy, &roots_surface->destroy);
+	roots_surface->map.notify = handle_map;
+	wl_signal_add(&surface->events.map, &roots_surface->map);
+	roots_surface->unmap.notify = handle_unmap;
+	wl_signal_add(&surface->events.unmap, &roots_surface->unmap);
 	roots_surface->request_move.notify = handle_request_move;
 	wl_signal_add(&surface->events.request_move, &roots_surface->request_move);
 	roots_surface->request_resize.notify = handle_request_resize;
@@ -353,11 +386,10 @@ void handle_xdg_shell_surface(struct wl_listener *listener, void *data) {
 	view->destroy = destroy;
 	roots_surface->view = view;
 
-	struct wlr_box box;
-	get_size(view, &box);
-	view->width = box.width;
-	view->height = box.height;
-
-	view_map(view, surface->surface);
-	view_setup(view);
+	if (surface->toplevel->next.maximized) {
+		view_maximize(view, true);
+	}
+	if (surface->toplevel->next.fullscreen) {
+		view_set_fullscreen(view, true, NULL);
+	}
 }

--- a/rootston/xdg_shell.c
+++ b/rootston/xdg_shell.c
@@ -180,6 +180,18 @@ static void close(struct roots_view *view) {
 	}
 }
 
+static void destroy(struct roots_view *view) {
+	struct roots_xdg_surface *roots_xdg_surface = view->roots_xdg_surface;
+	wl_list_remove(&roots_xdg_surface->surface_commit.link);
+	wl_list_remove(&roots_xdg_surface->destroy.link);
+	wl_list_remove(&roots_xdg_surface->new_popup.link);
+	wl_list_remove(&roots_xdg_surface->request_move.link);
+	wl_list_remove(&roots_xdg_surface->request_resize.link);
+	wl_list_remove(&roots_xdg_surface->request_maximize.link);
+	wl_list_remove(&roots_xdg_surface->request_fullscreen.link);
+	free(roots_xdg_surface);
+}
+
 static void handle_request_move(struct wl_listener *listener, void *data) {
 	struct roots_xdg_surface *roots_xdg_surface =
 		wl_container_of(listener, roots_xdg_surface, request_move);
@@ -280,15 +292,7 @@ static void handle_new_popup(struct wl_listener *listener, void *data) {
 static void handle_destroy(struct wl_listener *listener, void *data) {
 	struct roots_xdg_surface *roots_xdg_surface =
 		wl_container_of(listener, roots_xdg_surface, destroy);
-	wl_list_remove(&roots_xdg_surface->surface_commit.link);
-	wl_list_remove(&roots_xdg_surface->destroy.link);
-	wl_list_remove(&roots_xdg_surface->new_popup.link);
-	wl_list_remove(&roots_xdg_surface->request_move.link);
-	wl_list_remove(&roots_xdg_surface->request_resize.link);
-	wl_list_remove(&roots_xdg_surface->request_maximize.link);
-	wl_list_remove(&roots_xdg_surface->request_fullscreen.link);
 	view_destroy(roots_xdg_surface->view);
-	free(roots_xdg_surface);
 }
 
 void handle_xdg_shell_surface(struct wl_listener *listener, void *data) {
@@ -346,6 +350,7 @@ void handle_xdg_shell_surface(struct wl_listener *listener, void *data) {
 	view->maximize = maximize;
 	view->set_fullscreen = set_fullscreen;
 	view->close = close;
+	view->destroy = destroy;
 	roots_surface->view = view;
 
 	struct wlr_box box;

--- a/rootston/xdg_shell.c
+++ b/rootston/xdg_shell.c
@@ -287,9 +287,7 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	wl_list_remove(&roots_xdg_surface->request_resize.link);
 	wl_list_remove(&roots_xdg_surface->request_maximize.link);
 	wl_list_remove(&roots_xdg_surface->request_fullscreen.link);
-	wl_list_remove(&roots_xdg_surface->view->link);
-	view_finish(roots_xdg_surface->view);
-	free(roots_xdg_surface->view);
+	view_destroy(roots_xdg_surface->view);
 	free(roots_xdg_surface);
 }
 
@@ -333,7 +331,7 @@ void handle_xdg_shell_surface(struct wl_listener *listener, void *data) {
 	roots_surface->new_popup.notify = handle_new_popup;
 	wl_signal_add(&surface->events.new_popup, &roots_surface->new_popup);
 
-	struct roots_view *view = view_create();
+	struct roots_view *view = view_create(desktop);
 	if (!view) {
 		free(roots_surface);
 		return;
@@ -342,7 +340,6 @@ void handle_xdg_shell_surface(struct wl_listener *listener, void *data) {
 
 	view->xdg_surface = surface;
 	view->roots_xdg_surface = roots_surface;
-	view->wlr_surface = surface->surface;
 	view->activate = activate;
 	view->resize = resize;
 	view->move_resize = move_resize;
@@ -356,8 +353,6 @@ void handle_xdg_shell_surface(struct wl_listener *listener, void *data) {
 	view->width = box.width;
 	view->height = box.height;
 
-	view_init(view, desktop);
-	wl_list_insert(&desktop->views, &view->link);
-
+	view_map(view, surface->surface);
 	view_setup(view);
 }

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -63,9 +63,11 @@ static void get_size(const struct roots_view *view, struct wlr_box *box) {
 	if (surface->geometry->width > 0 && surface->geometry->height > 0) {
 		box->width = surface->geometry->width;
 		box->height = surface->geometry->height;
-	} else {
+	} else if (view->wlr_surface != NULL) {
 		box->width = view->wlr_surface->current->width;
 		box->height = view->wlr_surface->current->height;
+	} else {
+		box->width = box->height = 0;
 	}
 }
 

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -309,6 +309,8 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	wl_list_remove(&roots_xdg_surface->surface_commit.link);
 	wl_list_remove(&roots_xdg_surface->destroy.link);
 	wl_list_remove(&roots_xdg_surface->new_popup.link);
+	wl_list_remove(&roots_xdg_surface->map.link);
+	wl_list_remove(&roots_xdg_surface->unmap.link);
 	wl_list_remove(&roots_xdg_surface->request_move.link);
 	wl_list_remove(&roots_xdg_surface->request_resize.link);
 	wl_list_remove(&roots_xdg_surface->request_maximize.link);

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -180,6 +180,21 @@ static void close(struct roots_view *view) {
 	}
 }
 
+static void destroy(struct roots_view *view) {
+	assert(view->type == ROOTS_XDG_SHELL_V6_VIEW);
+	struct roots_xdg_surface_v6 *roots_xdg_surface = view->roots_xdg_surface_v6;
+	wl_list_remove(&roots_xdg_surface->surface_commit.link);
+	wl_list_remove(&roots_xdg_surface->destroy.link);
+	wl_list_remove(&roots_xdg_surface->new_popup.link);
+	wl_list_remove(&roots_xdg_surface->map.link);
+	wl_list_remove(&roots_xdg_surface->unmap.link);
+	wl_list_remove(&roots_xdg_surface->request_move.link);
+	wl_list_remove(&roots_xdg_surface->request_resize.link);
+	wl_list_remove(&roots_xdg_surface->request_maximize.link);
+	wl_list_remove(&roots_xdg_surface->request_fullscreen.link);
+	free(roots_xdg_surface);
+}
+
 static void handle_request_move(struct wl_listener *listener, void *data) {
 	struct roots_xdg_surface_v6 *roots_xdg_surface =
 		wl_container_of(listener, roots_xdg_surface, request_move);
@@ -298,25 +313,13 @@ static void handle_map(struct wl_listener *listener, void *data) {
 static void handle_unmap(struct wl_listener *listener, void *data) {
 	struct roots_xdg_surface_v6 *roots_xdg_surface =
 		wl_container_of(listener, roots_xdg_surface, unmap);
-	struct roots_view *view = roots_xdg_surface->view;
-
-	view_unmap(view);
+	view_unmap(roots_xdg_surface->view);
 }
 
 static void handle_destroy(struct wl_listener *listener, void *data) {
 	struct roots_xdg_surface_v6 *roots_xdg_surface =
 		wl_container_of(listener, roots_xdg_surface, destroy);
-	wl_list_remove(&roots_xdg_surface->surface_commit.link);
-	wl_list_remove(&roots_xdg_surface->destroy.link);
-	wl_list_remove(&roots_xdg_surface->new_popup.link);
-	wl_list_remove(&roots_xdg_surface->map.link);
-	wl_list_remove(&roots_xdg_surface->unmap.link);
-	wl_list_remove(&roots_xdg_surface->request_move.link);
-	wl_list_remove(&roots_xdg_surface->request_resize.link);
-	wl_list_remove(&roots_xdg_surface->request_maximize.link);
-	wl_list_remove(&roots_xdg_surface->request_fullscreen.link);
 	view_destroy(roots_xdg_surface->view);
-	free(roots_xdg_surface);
 }
 
 void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
@@ -378,5 +381,6 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	view->maximize = maximize;
 	view->set_fullscreen = set_fullscreen;
 	view->close = close;
+	view->destroy = destroy;
 	roots_surface->view = view;
 }

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -60,9 +60,9 @@ static void get_size(const struct roots_view *view, struct wlr_box *box) {
 	assert(view->type == ROOTS_XDG_SHELL_V6_VIEW);
 	struct wlr_xdg_surface_v6 *surface = view->xdg_surface_v6;
 
-	if (surface->geometry->width > 0 && surface->geometry->height > 0) {
-		box->width = surface->geometry->width;
-		box->height = surface->geometry->height;
+	if (surface->geometry.width > 0 && surface->geometry.height > 0) {
+		box->width = surface->geometry.width;
+		box->height = surface->geometry.height;
 	} else if (view->wlr_surface != NULL) {
 		box->width = view->wlr_surface->current->width;
 		box->height = view->wlr_surface->current->height;

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -385,4 +385,11 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	view->close = close;
 	view->destroy = destroy;
 	roots_surface->view = view;
+
+	if (surface->toplevel_state->next.maximized) {
+		view_maximize(view, true);
+	}
+	if (surface->toplevel_state->next.fullscreen) {
+		view_set_fullscreen(view, true, NULL);
+	}
 }

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -287,9 +287,7 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	wl_list_remove(&roots_xdg_surface->request_resize.link);
 	wl_list_remove(&roots_xdg_surface->request_maximize.link);
 	wl_list_remove(&roots_xdg_surface->request_fullscreen.link);
-	wl_list_remove(&roots_xdg_surface->view->link);
-	view_finish(roots_xdg_surface->view);
-	free(roots_xdg_surface->view);
+	view_destroy(roots_xdg_surface->view);
 	free(roots_xdg_surface);
 }
 
@@ -333,7 +331,7 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	roots_surface->new_popup.notify = handle_new_popup;
 	wl_signal_add(&surface->events.new_popup, &roots_surface->new_popup);
 
-	struct roots_view *view = view_create();
+	struct roots_view *view = view_create(desktop);
 	if (!view) {
 		free(roots_surface);
 		return;
@@ -342,7 +340,6 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 
 	view->xdg_surface_v6 = surface;
 	view->roots_xdg_surface_v6 = roots_surface;
-	view->wlr_surface = surface->surface;
 	view->activate = activate;
 	view->resize = resize;
 	view->move_resize = move_resize;
@@ -356,8 +353,6 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	view->width = box.width;
 	view->height = box.height;
 
-	view_init(view, desktop);
-	wl_list_insert(&desktop->views, &view->link);
-
+	view_map(view, surface->surface);
 	view_setup(view);
 }

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -85,7 +85,7 @@ static void apply_size_constraints(struct wlr_xdg_surface_v6 *surface,
 	*dest_width = width;
 	*dest_height = height;
 
-	struct wlr_xdg_toplevel_v6_state *state = &surface->toplevel_state->current;
+	struct wlr_xdg_toplevel_v6_state *state = &surface->toplevel->current;
 	if (width < state->min_width) {
 		*dest_width = state->min_width;
 	} else if (state->max_width > 0 &&
@@ -236,7 +236,7 @@ static void handle_request_maximize(struct wl_listener *listener, void *data) {
 		return;
 	}
 
-	view_maximize(view, surface->toplevel_state->next.maximized);
+	view_maximize(view, surface->toplevel->next.maximized);
 }
 
 static void handle_request_fullscreen(struct wl_listener *listener,
@@ -386,10 +386,10 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	view->destroy = destroy;
 	roots_surface->view = view;
 
-	if (surface->toplevel_state->next.maximized) {
+	if (surface->toplevel->next.maximized) {
 		view_maximize(view, true);
 	}
-	if (surface->toplevel_state->next.fullscreen) {
+	if (surface->toplevel->next.fullscreen) {
 		view_set_fullscreen(view, true, NULL);
 	}
 }

--- a/rootston/xwayland.c
+++ b/rootston/xwayland.c
@@ -109,8 +109,6 @@ static void set_fullscreen(struct roots_view *view, bool fullscreen) {
 static void handle_destroy(struct wl_listener *listener, void *data) {
 	struct roots_xwayland_surface *roots_surface =
 		wl_container_of(listener, roots_surface, destroy);
-	struct wlr_xwayland_surface *xwayland_surface =
-		roots_surface->view->xwayland_surface;
 	wl_list_remove(&roots_surface->destroy.link);
 	wl_list_remove(&roots_surface->request_configure.link);
 	wl_list_remove(&roots_surface->request_move.link);
@@ -118,11 +116,7 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	wl_list_remove(&roots_surface->request_maximize.link);
 	wl_list_remove(&roots_surface->map_notify.link);
 	wl_list_remove(&roots_surface->unmap_notify.link);
-	if (xwayland_surface->mapped) {
-		wl_list_remove(&roots_surface->view->link);
-	}
-	view_finish(roots_surface->view);
-	free(roots_surface->view);
+	view_destroy(roots_surface->view);
 	free(roots_surface);
 }
 
@@ -231,22 +225,13 @@ static void handle_map_notify(struct wl_listener *listener, void *data) {
 		wl_container_of(listener, roots_surface, map_notify);
 	struct wlr_xwayland_surface *xsurface = data;
 	struct roots_view *view = roots_surface->view;
-	struct roots_desktop *desktop = view->desktop;
 
-	view->wlr_surface = xsurface->surface;
 	view->x = xsurface->x;
 	view->y = xsurface->y;
 	view->width = xsurface->surface->current->width;
 	view->height = xsurface->surface->current->height;
-	wl_list_insert(&desktop->views, &view->link);
 
-	struct wlr_subsurface *subsurface;
-	wl_list_for_each(subsurface, &view->wlr_surface->subsurface_list,
-			parent_link) {
-		subsurface_create(view, subsurface);
-	}
-
-	view_damage_whole(view);
+	view_map(view, xsurface->surface);
 
 	roots_surface->surface_commit.notify = handle_surface_commit;
 	wl_signal_add(&xsurface->surface->events.commit,
@@ -260,22 +245,7 @@ static void handle_unmap_notify(struct wl_listener *listener, void *data) {
 
 	wl_list_remove(&roots_surface->surface_commit.link);
 
-	view_damage_whole(view);
-
-	struct roots_view_child *child, *tmp;
-	wl_list_for_each_safe(child, tmp, &view->children, link) {
-		child->destroy(child);
-	}
-
-	if (view->fullscreen_output != NULL) {
-		output_damage_whole(view->fullscreen_output);
-		view->fullscreen_output->fullscreen_view = NULL;
-		view->fullscreen_output = NULL;
-	}
-
-	view->wlr_surface = NULL;
-	view->width = view->height = 0;
-	wl_list_remove(&view->link);
+	view_unmap(view);
 }
 
 void handle_xwayland_surface(struct wl_listener *listener, void *data) {
@@ -317,7 +287,7 @@ void handle_xwayland_surface(struct wl_listener *listener, void *data) {
 	wl_signal_add(&surface->surface->events.commit,
 		&roots_surface->surface_commit);
 
-	struct roots_view *view = view_create();
+	struct roots_view *view = view_create(desktop);
 	if (view == NULL) {
 		free(roots_surface);
 		return;
@@ -330,7 +300,6 @@ void handle_xwayland_surface(struct wl_listener *listener, void *data) {
 
 	view->xwayland_surface = surface;
 	view->roots_xwayland_surface = roots_surface;
-	view->wlr_surface = surface->surface;
 	view->activate = activate;
 	view->resize = resize;
 	view->move = move;
@@ -339,8 +308,8 @@ void handle_xwayland_surface(struct wl_listener *listener, void *data) {
 	view->set_fullscreen = set_fullscreen;
 	view->close = close;
 	roots_surface->view = view;
-	view_init(view, desktop);
-	wl_list_insert(&desktop->views, &view->link);
+
+	view_map(view, surface->surface);
 
 	if (!surface->override_redirect) {
 		if (surface->decorations == WLR_XWAYLAND_SURFACE_DECORATIONS_ALL) {

--- a/rootston/xwayland.c
+++ b/rootston/xwayland.c
@@ -106,9 +106,9 @@ static void set_fullscreen(struct roots_view *view, bool fullscreen) {
 	wlr_xwayland_surface_set_fullscreen(view->xwayland_surface, fullscreen);
 }
 
-static void handle_destroy(struct wl_listener *listener, void *data) {
-	struct roots_xwayland_surface *roots_surface =
-		wl_container_of(listener, roots_surface, destroy);
+static void destroy(struct roots_view *view) {
+	assert(view->type == ROOTS_XWAYLAND_VIEW);
+	struct roots_xwayland_surface *roots_surface = view->roots_xwayland_surface;
 	wl_list_remove(&roots_surface->destroy.link);
 	wl_list_remove(&roots_surface->request_configure.link);
 	wl_list_remove(&roots_surface->request_move.link);
@@ -116,8 +116,13 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	wl_list_remove(&roots_surface->request_maximize.link);
 	wl_list_remove(&roots_surface->map_notify.link);
 	wl_list_remove(&roots_surface->unmap_notify.link);
-	view_destroy(roots_surface->view);
 	free(roots_surface);
+}
+
+static void handle_destroy(struct wl_listener *listener, void *data) {
+	struct roots_xwayland_surface *roots_surface =
+		wl_container_of(listener, roots_surface, destroy);
+	view_destroy(roots_surface->view);
 }
 
 static void handle_request_configure(struct wl_listener *listener, void *data) {
@@ -307,6 +312,7 @@ void handle_xwayland_surface(struct wl_listener *listener, void *data) {
 	view->maximize = maximize;
 	view->set_fullscreen = set_fullscreen;
 	view->close = close;
+	view->destroy = destroy;
 	roots_surface->view = view;
 
 	view_map(view, surface->surface);

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -506,8 +506,7 @@ static void xdg_popup_handle_destroy(struct wl_client *client,
 	if (topmost != surface) {
 		wl_resource_post_error(surface->client->resource,
 			ZXDG_SHELL_V6_ERROR_NOT_THE_TOPMOST_POPUP,
-			"xdg_popup was destroyed while it was not the topmost "
-			"popup");
+			"xdg_popup was destroyed while it was not the topmost popup");
 		return;
 	}
 
@@ -805,8 +804,8 @@ static void xdg_toplevel_handle_set_minimized(struct wl_client *client,
 	wlr_signal_emit_safe(&surface->events.request_minimize, surface);
 }
 
-static const struct zxdg_toplevel_v6_interface zxdg_toplevel_v6_implementation =
-{
+static const struct zxdg_toplevel_v6_interface
+		zxdg_toplevel_v6_implementation = {
 	.destroy = resource_handle_destroy,
 	.set_parent = xdg_toplevel_handle_set_parent,
 	.set_title = xdg_toplevel_handle_set_title,
@@ -820,7 +819,7 @@ static const struct zxdg_toplevel_v6_interface zxdg_toplevel_v6_implementation =
 	.unset_maximized = xdg_toplevel_handle_unset_maximized,
 	.set_fullscreen = xdg_toplevel_handle_set_fullscreen,
 	.unset_fullscreen = xdg_toplevel_handle_unset_fullscreen,
-	.set_minimized = xdg_toplevel_handle_set_minimized
+	.set_minimized = xdg_toplevel_handle_set_minimized,
 };
 
 static void xdg_surface_resource_destroy(struct wl_resource *resource) {
@@ -902,11 +901,8 @@ static void xdg_surface_handle_ack_configure(struct wl_client *client,
 	struct wlr_xdg_surface_v6_configure *configure, *tmp;
 	wl_list_for_each_safe(configure, tmp, &surface->configure_list, link) {
 		if (configure->serial < serial) {
-			wl_list_remove(&configure->link);
 			xdg_surface_configure_destroy(configure);
 		} else if (configure->serial == serial) {
-			wl_list_remove(&configure->link);
-			wl_list_init(&configure->link);
 			found = true;
 			break;
 		} else {


### PR DESCRIPTION
- [x] Add unmap support to zxdg-shell v6
- [x] Read client requested state in `new_surface` in zxdg-shell-v6
- [x] Add map/unmap support to xdg-shell stable

Test plan:
* Make sure xdg-shell still works
* Try `mpv --fs` or https://gist.github.com/emersion/34ed72adecd78bdfac9208a97ffb46a3
* Try to reproduce crashes described in issues below

Fixes #688
Fixes #674
Fixes #679
Fixes #671
Fixes #650
Closes #681
Closes #708