### PR TITLE
rootston: fix segfault in handle_tablet_tool_destroy

### DIFF
--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -514,13 +514,13 @@ static void seat_add_tablet_pad(struct roots_seat *seat,
 
 static void handle_tablet_tool_destroy(struct wl_listener *listener,
 		void *data) {
-	struct roots_pointer *tablet_tool =
+	struct roots_tablet_tool *tablet_tool =
 		wl_container_of(listener, tablet_tool, device_destroy);
 	struct roots_seat *seat = tablet_tool->seat;
 
-	wl_list_remove(&tablet_tool->link);
 	wlr_cursor_detach_input_device(seat->cursor->cursor, tablet_tool->device);
 	wl_list_remove(&tablet_tool->device_destroy.link);
+	wl_list_remove(&tablet_tool->link);
 	free(tablet_tool);
 
 	seat_update_capabilities(seat);


### PR DESCRIPTION
```
#0  0x00007f2d856e5db7 in wl_list_remove (elm=0x55db001795c8) at src/wayland-util.c:55
#1  0x000055dafd418b5e in handle_tablet_tool_destroy (listener=0x55db001795b0, data=0x55db0013b510) at ../rootston/seat.c:524
#2  0x00007f2d859484dc in wlr_signal_emit_safe (signal=0x55db0013b538, data=0x55db0013b510) at ../util/signal.c:29
#3  0x00007f2d8592e5c3 in wlr_input_device_destroy (dev=0x55db0013b510) at ../types/wlr_input_device.c:33
#4  0x00007f2d85915af3 in wlr_libinput_backend_destroy (wlr_backend=0x55daff607770) at ../backend/libinput/backend.c:110
#5  0x00007f2d8590c74d in wlr_backend_destroy (backend=0x55daff607770) at ../backend/backend.c:39
#6  0x00007f2d859182b6 in multi_backend_destroy (wlr_backend=0x55daff5ff250) at ../backend/multi/backend.c:47
#7  0x00007f2d85918578 in handle_display_destroy (listener=0x55daff5ff298, data=0x55daff5f9700) at ../backend/multi/backend.c:90
#8  0x00007f2d856e0651 in wl_priv_signal_emit (signal=0x55daff5f9768, data=0x55daff5f9700) at src/wayland-server.c:2024
#9  0x00007f2d856e0cc4 in wl_display_destroy (display=0x55daff5f9700) at src/wayland-server.c:1092
#10 0x000055dafd41384a in main (argc=1, argv=0x7fffe9179598) at ../rootston/main.c:82
```