### PR TITLE
Fix y-inverted rendering for xwayland surfaces

### DIFF
--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -163,8 +163,10 @@ static bool gles2_texture_upload_drm(struct wlr_texture *_tex,
 			(EGLint*)&tex->wlr_texture.height);
 
 	EGLint inverted_y;
-	wlr_egl_query_buffer(tex->egl, buf, EGL_WAYLAND_Y_INVERTED_WL, &inverted_y);
-	tex->wlr_texture.inverted_y = !!inverted_y;
+	if (wlr_egl_query_buffer(tex->egl, buf, EGL_WAYLAND_Y_INVERTED_WL,
+			&inverted_y)) {
+		tex->wlr_texture.inverted_y = !!inverted_y;
+	}
 
 	GLenum target;
 	const struct pixel_format *pf;


### PR DESCRIPTION
#698 introduces a regression for xwayland surfaces, they appear inverted wrt the y axis.