### PR TITLE
Linux-dmabuf with n_planes > 1

### DIFF
--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -275,9 +275,15 @@ static bool gles2_texture_upload_dmabuf(struct wlr_texture *wlr_texture,
 		wlr_texture->inverted_y = true;
 	}
 
-	GLenum target = GL_TEXTURE_2D;
-	const struct gles2_pixel_format *pf =
-		gles2_format_from_wl(WL_SHM_FORMAT_ARGB8888);
+	GLenum target;
+	const struct gles2_pixel_format *pf;
+	if (dmabuf->attributes.n_planes > 1) {
+		target = GL_TEXTURE_EXTERNAL_OES;
+		pf = &external_pixel_format;
+	} else {
+		target = GL_TEXTURE_2D;
+		pf = gles2_format_from_wl(WL_SHM_FORMAT_ARGB8888);
+	}
 	GLES2_DEBUG_PUSH;
 	gles2_texture_ensure(tex, target);
 	glBindTexture(target, tex->tex_id);

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -325,8 +325,7 @@ static void wlr_surface_apply_damage(struct wlr_surface *surface,
 					surface->current->buffer)) {
 			wlr_texture_upload_drm(surface->texture, surface->current->buffer);
 			goto release;
-		} else if (wlr_dmabuf_resource_is_buffer(
-					   surface->current->buffer)) {
+		} else if (wlr_dmabuf_resource_is_buffer(surface->current->buffer)) {
 			wlr_texture_upload_dmabuf(surface->texture, surface->current->buffer);
 			goto release;
 		} else {


### PR DESCRIPTION
This aims to add support for formats with more than one plane like NV12.

Test plan
- [x] ./weston-simple-dmabuf-drm --import-format=NV12 (new functionality)
- [X] ./weston-simple-dmabuf-drm --import-format=XRGB (make sure old code still works)

The drivers I have don't support NV12 but maybe someone's does. Therefore marking as WiP since I can't really test it atm but I'll see if can come up with s.th. else that has more than one plane.

According to https://cgit.freedesktop.org/wayland/weston/commit/?id=ee58911912d88caacf340a5cb6a9e25fcba24996 freedreno supports NV12 if somebody running rootston on freedreno could test it that would be great.