### PR TITLE
Address sanitizer fixes

### DIFF
--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -143,6 +143,7 @@ static bool handle_x11_event(struct wlr_x11_backend *x11, xcb_generic_event_t *e
 		};
 
 		wlr_signal_emit_safe(&x11->pointer.events.motion_absolute, &abs);
+		free(pointer);
 		break;
 	}
 	case XCB_CLIENT_MESSAGE: {
@@ -317,12 +318,20 @@ static void wlr_x11_backend_destroy(struct wlr_backend *backend) {
 
 	wlr_signal_emit_safe(&backend->events.destroy, backend);
 
+	if (x11->event_source) {
+		wl_event_source_remove(x11->event_source);
+	}
 	wl_list_remove(&x11->display_destroy.link);
 
 	wl_event_source_remove(x11->frame_timer);
 	wlr_egl_finish(&x11->egl);
 
-	xcb_disconnect(x11->xcb_conn);
+	if (x11->xcb_conn) {
+		xcb_disconnect(x11->xcb_conn);
+	}
+	if (x11->xlib_conn) {
+		XCloseDisplay(x11->xlib_conn);
+	}
 	free(x11);
 }
 

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -71,6 +71,7 @@ struct wlr_wl_pointer {
 	struct wlr_pointer wlr_pointer;
 	enum wlr_axis_source axis_source;
 	struct wlr_wl_backend_output *current_output;
+	struct wl_listener output_destroy_listener;
 };
 
 void wlr_wl_registry_poll(struct wlr_wl_backend *backend);

--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -53,6 +53,7 @@ struct wlr_xdg_popup_grab {
 	struct wlr_seat *seat;
 	struct wl_list popups;
 	struct wl_list link; // wlr_xdg_shell::popup_grabs
+	struct wl_listener seat_destroy;
 };
 
 enum wlr_xdg_surface_role {

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -53,6 +53,7 @@ struct wlr_xdg_popup_grab_v6 {
 	struct wlr_seat *seat;
 	struct wl_list popups;
 	struct wl_list link; // wlr_xdg_shell_v6::popup_grabs
+	struct wl_listener seat_destroy;
 };
 
 enum wlr_xdg_surface_v6_role {

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -680,6 +680,7 @@ static void damage_from_surface(struct wlr_surface *surface,
 		}
 		pixman_region32_translate(&damage, box.x, box.y);
 		wlr_output_damage_add(output->damage, &damage);
+		pixman_region32_fini(&damage);
 	} else {
 		pixman_box32_t *extents =
 			pixman_region32_extents(&surface->current->surface_damage);

--- a/types/wlr_pointer.c
+++ b/types/wlr_pointer.c
@@ -14,7 +14,10 @@ void wlr_pointer_init(struct wlr_pointer *pointer,
 }
 
 void wlr_pointer_destroy(struct wlr_pointer *pointer) {
-	if (pointer && pointer->impl && pointer->impl->destroy) {
+	if (!pointer) {
+		return;
+	}
+	if (pointer->impl && pointer->impl->destroy) {
 		pointer->impl->destroy(pointer);
 	} else {
 		wl_list_remove(&pointer->events.motion.listener_list);

--- a/types/wlr_xdg_shell.c
+++ b/types/wlr_xdg_shell.c
@@ -131,6 +131,24 @@ static const struct wlr_keyboard_grab_interface xdg_keyboard_grab_impl = {
 	.cancel = xdg_keyboard_grab_cancel,
 };
 
+static void xdg_surface_destroy(struct wlr_xdg_surface *surface);
+
+static void wlr_xdg_popup_grab_handle_seat_destroy(
+		struct wl_listener *listener, void *data) {
+	struct wlr_xdg_popup_grab *xdg_grab =
+		wl_container_of(listener, xdg_grab, seat_destroy);
+
+	wl_list_remove(&xdg_grab->seat_destroy.link);
+
+	struct wlr_xdg_popup *popup, *next;
+	wl_list_for_each_safe(popup, next, &xdg_grab->popups, grab_link) {
+		xdg_surface_destroy(popup->base);
+	}
+
+	wl_list_remove(&xdg_grab->link);
+	free(xdg_grab);
+}
+
 static struct wlr_xdg_popup_grab *xdg_shell_popup_grab_from_seat(
 		struct wlr_xdg_shell *shell, struct wlr_seat *seat) {
 	struct wlr_xdg_popup_grab *xdg_grab;
@@ -154,6 +172,9 @@ static struct wlr_xdg_popup_grab *xdg_shell_popup_grab_from_seat(
 
 	wl_list_insert(&shell->popup_grabs, &xdg_grab->link);
 	xdg_grab->seat = seat;
+
+	xdg_grab->seat_destroy.notify = wlr_xdg_popup_grab_handle_seat_destroy;
+	wl_signal_add(&seat->events.destroy, &xdg_grab->seat_destroy);
 
 	return xdg_grab;
 }


### PR DESCRIPTION
- Some memory leaks in xdg shells, rootston output and x11 backend
- A use after free in wayland backend.

I'm not 100% happy with my use-after-free fix, if someone has a better idea to access the wlr_wl_pointer from the output destroy handler. At first I wanted to add another output event handler listener to the pointer itself but since the wayland backend can have many outputs and a single pointer (at least with the current design, how does it handle being started from a rootston with multiple seats?) it was more straight-forward to cleanup from output, but I'm sure this can be done better.