### PR TITLE
Don't use OpenGL matrix transposition

### DIFF
--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -178,7 +178,8 @@ static void free_eglimage(struct gbm_bo *bo, void *data) {
 	free(tex);
 }
 
-static struct wlr_texture *get_tex_for_bo(struct wlr_drm_renderer *renderer, struct gbm_bo *bo) {
+static struct wlr_texture *get_tex_for_bo(struct wlr_drm_renderer *renderer,
+		struct gbm_bo *bo) {
 	struct tex *tex = gbm_bo_get_user_data(bo);
 	if (tex) {
 		return tex->tex;
@@ -231,13 +232,8 @@ struct gbm_bo *wlr_drm_surface_mgpu_copy(struct wlr_drm_surface *dest,
 
 	static const float color[] = {0.0, 0.0, 0.0, 1.0};
 
-	static const float mat[9] = {
-		[0] = 2.0f,
-		[2] = -1.0f,
-		[4] = 2.0f,
-		[5] = -1.0f,
-		[8] = 1.0f,
-	};
+	float mat[9];
+	wlr_matrix_projection(mat, 1, 1, WL_OUTPUT_TRANSFORM_FLIPPED_180);
 
 	glViewport(0, 0, dest->width, dest->height);
 	wlr_renderer_clear(dest->renderer->wlr_rend, color);
@@ -246,8 +242,9 @@ struct gbm_bo *wlr_drm_surface_mgpu_copy(struct wlr_drm_surface *dest,
 	return wlr_drm_surface_swap_buffers(dest, NULL);
 }
 
-bool wlr_drm_plane_surfaces_init(struct wlr_drm_plane *plane, struct wlr_drm_backend *drm,
-		int32_t width, uint32_t height, uint32_t format) {
+bool wlr_drm_plane_surfaces_init(struct wlr_drm_plane *plane,
+		struct wlr_drm_backend *drm, int32_t width, uint32_t height,
+		uint32_t format) {
 	if (!drm->parent) {
 		return wlr_drm_surface_init(&plane->surf, &drm->renderer, width, height,
 			format, GBM_BO_USE_SCANOUT);

--- a/include/wlr/types/wlr_matrix.h
+++ b/include/wlr/types/wlr_matrix.h
@@ -5,11 +5,12 @@
 #include <wlr/types/wlr_box.h>
 
 void wlr_matrix_identity(float mat[static 9]);
+void wlr_matrix_multiply(float mat[static 9], const float a[static 9],
+	const float b[static 9]);
+void wlr_matrix_transpose(float mat[static 9], const float a[static 9]);
 void wlr_matrix_translate(float mat[static 9], float x, float y);
 void wlr_matrix_scale(float mat[static 9], float x, float y);
 void wlr_matrix_rotate(float mat[static 9], float rad);
-void wlr_matrix_multiply(float mat[static 9], const float a[static 9],
-	const float b[static 9]);
 void wlr_matrix_transform(float mat[static 9],
 	enum wl_output_transform transform);
 void wlr_matrix_projection(float mat[static 9], int width, int height,

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -180,8 +180,13 @@ static bool wlr_gles2_render_texture_with_matrix(
 		return false;
 	}
 
+	// OpenGL ES 2 requires the glUniformMatrix3fv transpose parameter to be set
+	// to GL_FALSE
+	float transposition[9];
+	wlr_matrix_transpose(transposition, matrix);
+
 	wlr_texture_bind(texture);
-	GL_CALL(glUniformMatrix3fv(0, 1, GL_TRUE, matrix));
+	GL_CALL(glUniformMatrix3fv(0, 1, GL_FALSE, transposition));
 	GL_CALL(glUniform1i(1, texture->inverted_y));
 	GL_CALL(glUniform1f(3, alpha));
 	draw_quad();
@@ -191,16 +196,26 @@ static bool wlr_gles2_render_texture_with_matrix(
 
 static void wlr_gles2_render_quad(struct wlr_renderer *wlr_renderer,
 		const float color[static 4], const float matrix[static 9]) {
+	// OpenGL ES 2 requires the glUniformMatrix3fv transpose parameter to be set
+	// to GL_FALSE
+	float transposition[9];
+	wlr_matrix_transpose(transposition, matrix);
+
 	GL_CALL(glUseProgram(shaders.quad));
-	GL_CALL(glUniformMatrix3fv(0, 1, GL_TRUE, matrix));
+	GL_CALL(glUniformMatrix3fv(0, 1, GL_FALSE, transposition));
 	GL_CALL(glUniform4f(1, color[0], color[1], color[2], color[3]));
 	draw_quad();
 }
 
 static void wlr_gles2_render_ellipse(struct wlr_renderer *wlr_renderer,
 		const float color[static 4], const float matrix[static 9]) {
+	// OpenGL ES 2 requires the glUniformMatrix3fv transpose parameter to be set
+	// to GL_FALSE
+	float transposition[9];
+	wlr_matrix_transpose(transposition, matrix);
+
 	GL_CALL(glUseProgram(shaders.ellipse));
-	GL_CALL(glUniformMatrix3fv(0, 1, GL_TRUE, matrix));
+	GL_CALL(glUniformMatrix3fv(0, 1, GL_FALSE, transposition));
 	GL_CALL(glUniform4f(1, color[0], color[1], color[2], color[3]));
 	draw_quad();
 }

--- a/types/wlr_matrix.c
+++ b/types/wlr_matrix.c
@@ -33,6 +33,15 @@ void wlr_matrix_multiply(float mat[static 9], const float a[static 9],
 	memcpy(mat, product, sizeof(product));
 }
 
+void wlr_matrix_transpose(float mat[static 9], const float a[static 9]) {
+	float transposition[9] = {
+		a[0], a[3], a[6],
+		a[1], a[4], a[7],
+		a[2], a[5], a[8],
+	};
+	memcpy(mat, transposition, sizeof(transposition));
+}
+
 void wlr_matrix_translate(float mat[static 9], float x, float y) {
 	float translate[9] = {
 		1.0f, 0.0f, x,


### PR DESCRIPTION
See https://github.com/swaywm/wlroots/commit/f1cbbac636d59d22373883f6bc85f8863e01c8c5#r28140751

We have two potential solutions:
- Transpose right before binding, this introduces a little overhead
- Use column-major matrices, this makes matrix functions a little confusing because the indices are not in the order we'd expect