### PR TITLE
xdg-shell, xdg-shell-v6: don't emit unmap if surface is unmapped

### DIFF
--- a/types/wlr_xdg_shell.c
+++ b/types/wlr_xdg_shell.c
@@ -173,7 +173,9 @@ static void xdg_surface_unmap(struct wlr_xdg_surface *surface) {
 	assert(surface->role != WLR_XDG_SURFACE_ROLE_NONE);
 
 	// TODO: probably need to ungrab before this event
-	wlr_signal_emit_safe(&surface->events.unmap, surface);
+	if (surface->mapped) {
+		wlr_signal_emit_safe(&surface->events.unmap, surface);
+	}
 
 	if (surface->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL) {
 		wl_resource_set_user_data(surface->toplevel->resource, NULL);

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -173,7 +173,9 @@ static void xdg_surface_unmap(struct wlr_xdg_surface_v6 *surface) {
 	assert(surface->role != WLR_XDG_SURFACE_V6_ROLE_NONE);
 
 	// TODO: probably need to ungrab before this event
-	wlr_signal_emit_safe(&surface->events.unmap, surface);
+	if (surface->mapped) {
+		wlr_signal_emit_safe(&surface->events.unmap, surface);
+	}
 
 	if (surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL) {
 		wl_resource_set_user_data(surface->toplevel->resource, NULL);


### PR DESCRIPTION
Some clients create an xdg_surface, then create an xdg_toplevel,
but don't map it and destroy it right after. The xdg_surface ends
up in a state where it isn't mapped but role-specific resources
have been allocated. xdg_surface_unmap needs to free these
resources without emitting the unmap signal.

Test plan: try @agx's `weston-simple-dmabuf-drm --import-format=NV12`

Fixes #737