### PR TITLE
unified xdg-surface close

### DIFF
--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -204,9 +204,9 @@ uint32_t wlr_xdg_toplevel_set_resizing(struct wlr_xdg_surface *surface,
 		bool resizing);
 
 /**
- * Request that this toplevel surface closes.
+ * Request that this xdg surface closes.
  */
-void wlr_xdg_toplevel_send_close(struct wlr_xdg_surface *surface);
+void wlr_xdg_surface_send_close(struct wlr_xdg_surface *surface);
 
 /**
  * Compute the popup position in surface-local coordinates.

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -204,9 +204,9 @@ uint32_t wlr_xdg_toplevel_v6_set_resizing(struct wlr_xdg_surface_v6 *surface,
 		bool resizing);
 
 /**
- * Request that this toplevel surface closes.
+ * Request that this xdg surface closes.
  */
-void wlr_xdg_toplevel_v6_send_close(struct wlr_xdg_surface_v6 *surface);
+void wlr_xdg_surface_v6_send_close(struct wlr_xdg_surface_v6 *surface);
 
 /**
  * Compute the popup position in surface-local coordinates.

--- a/rootston/xdg_shell.c
+++ b/rootston/xdg_shell.c
@@ -177,9 +177,11 @@ static void set_fullscreen(struct roots_view *view, bool fullscreen) {
 static void close(struct roots_view *view) {
 	assert(view->type == ROOTS_XDG_SHELL_VIEW);
 	struct wlr_xdg_surface *surface = view->xdg_surface;
-	if (surface->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL) {
-		wlr_xdg_toplevel_send_close(surface);
+	struct wlr_xdg_popup *popup = NULL;
+	wl_list_for_each(popup, &surface->popups, link) {
+		wlr_xdg_surface_send_close(popup->base);
 	}
+	wlr_xdg_surface_send_close(surface);
 }
 
 static void destroy(struct roots_view *view) {

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -177,9 +177,11 @@ static void set_fullscreen(struct roots_view *view, bool fullscreen) {
 static void close(struct roots_view *view) {
 	assert(view->type == ROOTS_XDG_SHELL_V6_VIEW);
 	struct wlr_xdg_surface_v6 *surface = view->xdg_surface_v6;
-	if (surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL) {
-		wlr_xdg_toplevel_v6_send_close(surface);
+	struct wlr_xdg_popup_v6 *popup = NULL;
+	wl_list_for_each(popup, &surface->popups, link) {
+		wlr_xdg_surface_v6_send_close(popup->base);
 	}
+	wlr_xdg_surface_v6_send_close(surface);
 }
 
 static void destroy(struct roots_view *view) {

--- a/types/wlr_xdg_shell.c
+++ b/types/wlr_xdg_shell.c
@@ -1568,9 +1568,22 @@ uint32_t wlr_xdg_toplevel_set_resizing(struct wlr_xdg_surface *surface,
 	return wlr_xdg_surface_schedule_configure(surface);
 }
 
-void wlr_xdg_toplevel_send_close(struct wlr_xdg_surface *surface) {
-	assert(surface->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL);
-	xdg_toplevel_send_close(surface->toplevel->resource);
+void wlr_xdg_surface_send_close(struct wlr_xdg_surface *surface) {
+	switch (surface->role) {
+	case WLR_XDG_SURFACE_ROLE_NONE:
+		assert(0 && "not reached");
+		break;
+	case WLR_XDG_SURFACE_ROLE_TOPLEVEL:
+		if (surface->toplevel) {
+			xdg_toplevel_send_close(surface->toplevel->resource);
+		}
+		break;
+	case WLR_XDG_SURFACE_ROLE_POPUP:
+		if (surface->popup) {
+			xdg_popup_send_popup_done(surface->popup->resource);
+		}
+		break;
+	}
 }
 
 void wlr_xdg_surface_popup_get_position(struct wlr_xdg_surface *surface,

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -1537,9 +1537,22 @@ uint32_t wlr_xdg_toplevel_v6_set_resizing(struct wlr_xdg_surface_v6 *surface,
 	return wlr_xdg_surface_v6_schedule_configure(surface);
 }
 
-void wlr_xdg_toplevel_v6_send_close(struct wlr_xdg_surface_v6 *surface) {
-	assert(surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL);
-	zxdg_toplevel_v6_send_close(surface->toplevel->resource);
+void wlr_xdg_surface_v6_send_close(struct wlr_xdg_surface_v6 *surface) {
+	switch (surface->role) {
+	case WLR_XDG_SURFACE_V6_ROLE_NONE:
+		assert(0 && "not reached");
+		break;
+	case WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL:
+		if (surface->toplevel) {
+			zxdg_toplevel_v6_send_close(surface->toplevel->resource);
+		}
+		break;
+	case WLR_XDG_SURFACE_V6_ROLE_POPUP:
+		if (surface->popup) {
+			zxdg_popup_v6_send_popup_done(surface->popup->resource);
+		}
+		break;
+	}
 }
 
 void wlr_xdg_surface_v6_popup_get_position(struct wlr_xdg_surface_v6 *surface,


### PR DESCRIPTION
Unify the xdg-surface close functions for toplevels and popups.

Close popups in rootston before closing the view.

fixes #543