### PR TITLE
xdg-shell-v6: don't destroy role resources on unmap

### DIFF
--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -106,6 +106,7 @@ struct wlr_xdg_surface {
 	uint32_t configure_next_serial;
 	struct wl_list configure_list;
 
+	// Only for toplevel
 	char *title;
 	char *app_id;
 

--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -74,9 +74,22 @@ struct wlr_xdg_toplevel {
 	struct wlr_xdg_surface *base;
 	struct wlr_xdg_surface *parent;
 	bool added;
+
 	struct wlr_xdg_toplevel_state next; // client protocol requests
 	struct wlr_xdg_toplevel_state pending; // user configure requests
 	struct wlr_xdg_toplevel_state current;
+
+	char *title;
+	char *app_id;
+
+	struct {
+		struct wl_signal request_maximize;
+		struct wl_signal request_fullscreen;
+		struct wl_signal request_minimize;
+		struct wl_signal request_move;
+		struct wl_signal request_resize;
+		struct wl_signal request_show_window_menu;
+	} events;
 };
 
 struct wlr_xdg_surface_configure {
@@ -106,10 +119,6 @@ struct wlr_xdg_surface {
 	uint32_t configure_next_serial;
 	struct wl_list configure_list;
 
-	// Only for toplevel
-	char *title;
-	char *app_id;
-
 	bool has_next_geometry;
 	struct wlr_box next_geometry;
 	struct wlr_box geometry;
@@ -122,13 +131,6 @@ struct wlr_xdg_surface {
 		struct wl_signal new_popup;
 		struct wl_signal map;
 		struct wl_signal unmap;
-
-		struct wl_signal request_maximize;
-		struct wl_signal request_fullscreen;
-		struct wl_signal request_minimize;
-		struct wl_signal request_move;
-		struct wl_signal request_resize;
-		struct wl_signal request_show_window_menu;
 	} events;
 
 	void *data;

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -74,9 +74,22 @@ struct wlr_xdg_toplevel_v6 {
 	struct wlr_xdg_surface_v6 *base;
 	struct wlr_xdg_surface_v6 *parent;
 	bool added;
+
 	struct wlr_xdg_toplevel_v6_state next; // client protocol requests
 	struct wlr_xdg_toplevel_v6_state pending; // user configure requests
 	struct wlr_xdg_toplevel_v6_state current;
+
+	char *title;
+	char *app_id;
+
+	struct {
+		struct wl_signal request_maximize;
+		struct wl_signal request_fullscreen;
+		struct wl_signal request_minimize;
+		struct wl_signal request_move;
+		struct wl_signal request_resize;
+		struct wl_signal request_show_window_menu;
+	} events;
 };
 
 struct wlr_xdg_surface_v6_configure {
@@ -106,10 +119,6 @@ struct wlr_xdg_surface_v6 {
 	uint32_t configure_next_serial;
 	struct wl_list configure_list;
 
-	// Only for toplevel
-	char *title;
-	char *app_id;
-
 	bool has_next_geometry;
 	struct wlr_box next_geometry;
 	struct wlr_box geometry;
@@ -122,13 +131,6 @@ struct wlr_xdg_surface_v6 {
 		struct wl_signal new_popup;
 		struct wl_signal map;
 		struct wl_signal unmap;
-
-		struct wl_signal request_maximize;
-		struct wl_signal request_fullscreen;
-		struct wl_signal request_minimize;
-		struct wl_signal request_move;
-		struct wl_signal request_resize;
-		struct wl_signal request_show_window_menu;
 	} events;
 
 	void *data;

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -106,6 +106,7 @@ struct wlr_xdg_surface_v6 {
 	uint32_t configure_next_serial;
 	struct wl_list configure_list;
 
+	// Only for toplevel
 	char *title;
 	char *app_id;
 

--- a/rootston/xdg_shell.c
+++ b/rootston/xdg_shell.c
@@ -339,7 +339,7 @@ void handle_xdg_shell_surface(struct wl_listener *listener, void *data) {
 		wl_container_of(listener, desktop, xdg_shell_surface);
 
 	wlr_log(L_DEBUG, "new xdg toplevel: title=%s, app_id=%s",
-		surface->title, surface->app_id);
+		surface->toplevel->title, surface->toplevel->app_id);
 	wlr_xdg_surface_ping(surface);
 
 	struct roots_xdg_surface *roots_surface =
@@ -357,15 +357,16 @@ void handle_xdg_shell_surface(struct wl_listener *listener, void *data) {
 	roots_surface->unmap.notify = handle_unmap;
 	wl_signal_add(&surface->events.unmap, &roots_surface->unmap);
 	roots_surface->request_move.notify = handle_request_move;
-	wl_signal_add(&surface->events.request_move, &roots_surface->request_move);
+	wl_signal_add(&surface->toplevel->events.request_move,
+		&roots_surface->request_move);
 	roots_surface->request_resize.notify = handle_request_resize;
-	wl_signal_add(&surface->events.request_resize,
+	wl_signal_add(&surface->toplevel->events.request_resize,
 		&roots_surface->request_resize);
 	roots_surface->request_maximize.notify = handle_request_maximize;
-	wl_signal_add(&surface->events.request_maximize,
+	wl_signal_add(&surface->toplevel->events.request_maximize,
 		&roots_surface->request_maximize);
 	roots_surface->request_fullscreen.notify = handle_request_fullscreen;
-	wl_signal_add(&surface->events.request_fullscreen,
+	wl_signal_add(&surface->toplevel->events.request_fullscreen,
 		&roots_surface->request_fullscreen);
 	roots_surface->new_popup.notify = handle_new_popup;
 	wl_signal_add(&surface->events.new_popup, &roots_surface->new_popup);

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -339,7 +339,7 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 		wl_container_of(listener, desktop, xdg_shell_v6_surface);
 
 	wlr_log(L_DEBUG, "new xdg toplevel: title=%s, app_id=%s",
-		surface->title, surface->app_id);
+		surface->toplevel->title, surface->toplevel->app_id);
 	wlr_xdg_surface_v6_ping(surface);
 
 	struct roots_xdg_surface_v6 *roots_surface =
@@ -357,15 +357,16 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	roots_surface->unmap.notify = handle_unmap;
 	wl_signal_add(&surface->events.unmap, &roots_surface->unmap);
 	roots_surface->request_move.notify = handle_request_move;
-	wl_signal_add(&surface->events.request_move, &roots_surface->request_move);
+	wl_signal_add(&surface->toplevel->events.request_move,
+		&roots_surface->request_move);
 	roots_surface->request_resize.notify = handle_request_resize;
-	wl_signal_add(&surface->events.request_resize,
+	wl_signal_add(&surface->toplevel->events.request_resize,
 		&roots_surface->request_resize);
 	roots_surface->request_maximize.notify = handle_request_maximize;
-	wl_signal_add(&surface->events.request_maximize,
+	wl_signal_add(&surface->toplevel->events.request_maximize,
 		&roots_surface->request_maximize);
 	roots_surface->request_fullscreen.notify = handle_request_fullscreen;
-	wl_signal_add(&surface->events.request_fullscreen,
+	wl_signal_add(&surface->toplevel->events.request_fullscreen,
 		&roots_surface->request_fullscreen);
 	roots_surface->new_popup.notify = handle_new_popup;
 	wl_signal_add(&surface->events.new_popup, &roots_surface->new_popup);


### PR DESCRIPTION
The motivation for this is:
- `get_popup` and `get_toplevel` allocate role-specific resources.
- On the first non-null commit, the surface gets mapped.
- On a null commit, the surface gets unmapped. It can be mapped
  again with a non-null commit.
- When the role object (xdg-toplevel or xdg-popup) is
  destroyed, the surface is unmapped and role-specific resources
  are destroyed. The client can call `get_popup` or `get_toplevel`
  again on that surface.
- When the xdg-surface object is destroyed, the surface is
  unmapped, role-specific resources are destroyed and the surface
  itself is destroyed.

TODO:
- [x] zxdg-shell-v6
- [x] xdg-shell stable

Fixes #747