### PR TITLE
[WIP] xdg-shell: damage view when popup is mapped/unmapped

### DIFF
--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -186,6 +186,8 @@ struct roots_xdg_popup {
 	struct roots_view_child view_child;
 	struct wlr_xdg_popup *wlr_popup;
 	struct wl_listener destroy;
+	struct wl_listener map;
+	struct wl_listener unmap;
 	struct wl_listener new_popup;
 };
 

--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -177,6 +177,8 @@ struct roots_xdg_popup_v6 {
 	struct roots_view_child view_child;
 	struct wlr_xdg_popup_v6 *wlr_popup;
 	struct wl_listener destroy;
+	struct wl_listener map;
+	struct wl_listener unmap;
 	struct wl_listener new_popup;
 };
 

--- a/rootston/xdg_shell.c
+++ b/rootston/xdg_shell.c
@@ -28,6 +28,16 @@ static void popup_handle_destroy(struct wl_listener *listener, void *data) {
 	popup_destroy((struct roots_view_child *)popup);
 }
 
+static void popup_handle_map(struct wl_listener *listener, void *data) {
+	struct roots_xdg_popup *popup = wl_container_of(listener, popup, map);
+	view_damage_whole(popup->view_child.view);
+}
+
+static void popup_handle_unmap(struct wl_listener *listener, void *data) {
+	struct roots_xdg_popup *popup = wl_container_of(listener, popup, unmap);
+	view_damage_whole(popup->view_child.view);
+}
+
 static struct roots_xdg_popup *popup_create(struct roots_view *view,
 	struct wlr_xdg_popup *wlr_popup);
 
@@ -50,6 +60,10 @@ static struct roots_xdg_popup *popup_create(struct roots_view *view,
 	view_child_init(&popup->view_child, view, wlr_popup->base->surface);
 	popup->destroy.notify = popup_handle_destroy;
 	wl_signal_add(&wlr_popup->base->events.destroy, &popup->destroy);
+	popup->map.notify = popup_handle_map;
+	wl_signal_add(&wlr_popup->base->events.map, &popup->map);
+	popup->unmap.notify = popup_handle_unmap;
+	wl_signal_add(&wlr_popup->base->events.unmap, &popup->unmap);
 	popup->new_popup.notify = popup_handle_new_popup;
 	wl_signal_add(&wlr_popup->base->events.new_popup, &popup->new_popup);
 	return popup;

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -28,6 +28,18 @@ static void popup_handle_destroy(struct wl_listener *listener, void *data) {
 	popup_destroy((struct roots_view_child *)popup);
 }
 
+static void popup_handle_map(struct wl_listener *listener, void *data) {
+	struct roots_xdg_popup_v6 *popup =
+		wl_container_of(listener, popup, map);
+	view_damage_whole(popup->view_child.view);
+}
+
+static void popup_handle_unmap(struct wl_listener *listener, void *data) {
+	struct roots_xdg_popup_v6 *popup =
+		wl_container_of(listener, popup, unmap);
+	view_damage_whole(popup->view_child.view);
+}
+
 static struct roots_xdg_popup_v6 *popup_create(struct roots_view *view,
 	struct wlr_xdg_popup_v6 *wlr_popup);
 
@@ -50,6 +62,10 @@ static struct roots_xdg_popup_v6 *popup_create(struct roots_view *view,
 	view_child_init(&popup->view_child, view, wlr_popup->base->surface);
 	popup->destroy.notify = popup_handle_destroy;
 	wl_signal_add(&wlr_popup->base->events.destroy, &popup->destroy);
+	popup->map.notify = popup_handle_map;
+	wl_signal_add(&wlr_popup->base->events.map, &popup->map);
+	popup->unmap.notify = popup_handle_unmap;
+	wl_signal_add(&wlr_popup->base->events.unmap, &popup->unmap);
 	popup->new_popup.notify = popup_handle_new_popup;
 	wl_signal_add(&wlr_popup->base->events.new_popup, &popup->new_popup);
 	return popup;


### PR DESCRIPTION
Test plan: spawn an xdg-shell client that has menus with xdg-popups. Resize the window so that it becomes small. Open a menu and then open a submenu so that the submenu si displayed outside the parent toplevel. Close the submenu. There are damage artifacts on master, there shouldn't be any with this PR.

TODO:
- [x] zxdg-shell-v6
- [x] xdg-shell stable

Fixes #752