### PR TITLE
rootston: Fix segfault in seat unfullscreening

### DIFF
--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -733,7 +733,7 @@ void roots_seat_set_focus(struct roots_seat *seat, struct roots_view *view) {
 	}
 #endif
 
-	if (unfullscreen) {
+	if (view && unfullscreen) {
 		struct roots_desktop *desktop = view->desktop;
 		struct roots_output *output;
 		struct wlr_box box;


### PR DESCRIPTION
```==32557==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x000000425f96 bp 0x7fff8ac19de0 sp 0x7fff8ac19d20 T0)
==32557==The signal is caused by a READ memory access.
==32557==Hint: address points to the zero page.
    #0 0x425f95 in roots_seat_set_focus ../rootston/seat.c:737
    #1 0x40bcd6 in roots_cursor_press_button ../rootston/cursor.c:272
    #2 0x40c1f7 in roots_cursor_handle_button ../rootston/cursor.c:298
    #3 0x42179b in handle_cursor_button ../rootston/seat.c:58
    #4 0x7f1651062367 in wlr_signal_emit_safe ../util/signal.c:29
    #5 0x7f165101b532 in handle_pointer_button ../types/wlr_cursor.c:344
    #6 0x7f1651062367 in wlr_signal_emit_safe ../util/signal.c:29
    #7 0x7f1650ff633b in handle_pointer_button ../backend/libinput/pointer.c:85
    #8 0x7f1650ff5291 in wlr_libinput_event ../backend/libinput/events.c:215
    #9 0x7f1650ff3990 in wlr_libinput_readable ../backend/libinput/backend.c:35
    #10 0x7f1650d88c11 in wl_event_loop_dispatch (/lib64/libwayland-server.so.0+0x9c11)
    #11 0x7f1650d87449 in wl_display_run (/lib64/libwayland-server.so.0+0x8449)
    #12 0x418e90 in main ../rootston/main.c:81
    #13 0x7f164ff7ef29 in __libc_start_main (/lib64/libc.so.6+0x20f29)
    #14 0x405829 in _start (/home/shared/wayland/wlroots/build/rootston/rootston+0x405829)
```

introduced by #680