### PR TITLE
backend/x11: correctly update keyboard modifiers

### DIFF
--- a/backend/meson.build
+++ b/backend/meson.build
@@ -51,6 +51,7 @@ endif
 
 if conf_data.get('WLR_HAS_X11_BACKEND', false)
 	backend_files += files('x11/backend.c')
+	backend_deps += xcb_xkb
 endif
 
 if conf_data.get('WLR_HAS_ELOGIND', false)

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -48,6 +48,12 @@ struct wlr_x11_backend {
 	// The time we last received an event
 	xcb_timestamp_t time;
 
+#ifdef WLR_HAS_XCB_XKB
+	bool xkb_supported;
+	uint8_t xkb_base_event;
+	uint8_t xkb_base_error;
+#endif
+
 	struct wl_listener display_destroy;
 };
 

--- a/meson.build
+++ b/meson.build
@@ -85,16 +85,20 @@ if get_option('enable_x11_backend') or get_option('enable_xwayland')
 	xcb            = dependency('xcb')
 	xcb_composite  = dependency('xcb-composite')
 	xcb_xfixes     = dependency('xcb-xfixes')
-	xcb_xkb        = dependency('xcb-xkb') # TODO: make this optional
 	xcb_image      = dependency('xcb-image')
 	xcb_render     = dependency('xcb-render')
 	x11_xcb        = dependency('x11-xcb')
 
 	xcb_icccm      = dependency('xcb-icccm', required: false)
+	xcb_xkb        = dependency('xcb-xkb', required: false)
 	xcb_errors     = dependency('xcb-errors', required: get_option('enable_xcb_errors') == 'true')
 
 	if xcb_icccm.found()
 		conf_data.set('WLR_HAS_XCB_ICCCM', true)
+	endif
+
+	if xcb_xkb.found()
+		conf_data.set('WLR_HAS_XCB_XKB', true)
 	endif
 
 	if xcb_errors.found() and get_option('enable_xcb_errors') != 'false'

--- a/meson.build
+++ b/meson.build
@@ -82,35 +82,36 @@ if elogind.found() and get_option('enable_elogind') != 'false'
 endif
 
 if get_option('enable_x11_backend') or get_option('enable_xwayland')
-        xcb            = dependency('xcb')
-        xcb_composite  = dependency('xcb-composite')
-        xcb_xfixes     = dependency('xcb-xfixes')
-        xcb_image      = dependency('xcb-image')
-        xcb_render     = dependency('xcb-render')
-        x11_xcb        = dependency('x11-xcb')
+	xcb            = dependency('xcb')
+	xcb_composite  = dependency('xcb-composite')
+	xcb_xfixes     = dependency('xcb-xfixes')
+	xcb_xkb        = dependency('xcb-xkb') # TODO: make this optional
+	xcb_image      = dependency('xcb-image')
+	xcb_render     = dependency('xcb-render')
+	x11_xcb        = dependency('x11-xcb')
 
-        xcb_icccm      = dependency('xcb-icccm', required: false)
-        xcb_errors     = dependency('xcb-errors', required: get_option('enable_xcb_errors') == 'true')
+	xcb_icccm      = dependency('xcb-icccm', required: false)
+	xcb_errors     = dependency('xcb-errors', required: get_option('enable_xcb_errors') == 'true')
 
-        if xcb_icccm.found()
-                conf_data.set('WLR_HAS_XCB_ICCCM', true)
-        endif
+	if xcb_icccm.found()
+		conf_data.set('WLR_HAS_XCB_ICCCM', true)
+	endif
 
-        if xcb_errors.found() and get_option('enable_xcb_errors') != 'false'
-                conf_data.set('WLR_HAS_XCB_ERRORS', true)
-        endif
+	if xcb_errors.found() and get_option('enable_xcb_errors') != 'false'
+		conf_data.set('WLR_HAS_XCB_ERRORS', true)
+	endif
 
-        wlr_deps += [
-                xcb,
-                xcb_composite,
-                x11_xcb,
-        ]
+	wlr_deps += [
+		xcb,
+		xcb_composite,
+		x11_xcb,
+	]
 else
-        add_project_arguments('-DMESA_EGL_NO_X11_HEADERS', language: 'c')
+	add_project_arguments('-DMESA_EGL_NO_X11_HEADERS', language: 'c')
 endif
 
 if get_option('enable_x11_backend')
-        conf_data.set('WLR_HAS_X11_BACKEND', true)
+	conf_data.set('WLR_HAS_X11_BACKEND', true)
 endif
 
 if get_option('enable_xwayland')


### PR DESCRIPTION
Test plan: under X11 backend, focus rootston, open a terminal, press Shift, focus another window, release Shift, focus rootston, type something. The characters typed should be lowercase, not uppercase.

TODO:
- [x] Make this optional
- [x] Remove global state

Fixes #227