### PR TITLE
WIP: Add partial support for zwp_text_input_unstable_v3

### DIFF
--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -6,6 +6,7 @@
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_keyboard.h>
 #include <wlr/types/wlr_surface.h>
+#include <wlr/types/wlr_text_input.h>
 
 /**
  * Contains state for a single client's bound wl_seat resource and can be used

--- a/include/wlr/types/wlr_text_input.h
+++ b/include/wlr/types/wlr_text_input.h
@@ -1,0 +1,69 @@
+#ifndef WLR_TYPES_WLR_TEXT_INPUT_H
+#define WLR_TYPES_WLR_TEXT_INPUT_H
+
+#include <wayland-server.h>
+#include <wlr/types/wlr_seat.h>
+#include <wlr/types/wlr_surface.h>
+
+struct wlr_text_input_properties {
+	struct {
+		char *text; // NULL is allowed and equivalent to empty string
+		uint32_t cursor;
+		uint32_t anchor;
+	} surrounding;
+
+	struct {
+		uint32_t hint;
+		uint32_t purpose;
+	} content_type;
+
+	struct {
+		int32_t x;
+		int32_t y;
+		int32_t width;
+		int32_t height;
+	} cursor_rectangle;
+};
+
+struct wlr_text_input {
+	struct wlr_seat *seat; // used only for unlinking seat->text_input; perhaps better to use the destroy signal
+	struct wl_resource *resource;
+	struct wlr_surface *focused_surface;
+	struct wlr_text_input_properties pending;
+	struct wlr_text_input_properties current;
+	struct wl_listener seat_destroy_listener;
+
+	struct {
+		struct wl_signal enable; // (uint32_t show_input_panel)
+		struct wl_signal commit; // (wlr_text_input*)
+		struct wl_signal disable; // (void*)
+		struct wl_signal destroy; // (wlr_seat* seat)
+	} events;
+};
+
+struct wlr_text_input_manager {
+	struct wl_global *wl_global;
+	struct wl_list text_inputs; // wlr_text_input::resource::link
+
+	struct {
+		struct wl_signal text_input; // (wlr_text_input*)
+	} events;
+};
+
+struct wlr_text_input_manager *wlr_text_input_manager_create(
+	struct wl_display *wl_display);
+void wlr_text_input_manager_destroy(
+	struct wlr_text_input_manager *manager);
+void wlr_text_input_send_enter(struct wlr_text_input *text_input,
+	struct wlr_surface *wlr_surface);
+void wlr_text_input_send_leave(struct wlr_text_input *text_input,
+	struct wlr_surface *wlr_surface);
+void wlr_text_input_send_preedit_string(struct wlr_text_input *text_input,
+	const char *text, uint32_t cursor);
+void wlr_text_input_send_commit_string(struct wlr_text_input *text_input,
+	const char *text);
+void wlr_text_input_send_delete_surrounding_text(
+	struct wlr_text_input *text_input, uint32_t before_length,
+	uint32_t after_length);
+
+#endif

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -30,6 +30,7 @@ protocols = [
 	'idle.xml',
 	'screenshooter.xml',
 	'server-decoration.xml',
+	'text-input-unstable-v3.xml',
 	'wlr-layer-shell-unstable-v1.xml',
 ]
 

--- a/protocol/text-input-unstable-v3.xml
+++ b/protocol/text-input-unstable-v3.xml
@@ -1,0 +1,308 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<protocol name="text_input_unstable_v3">
+  <copyright>
+    Copyright © 2012, 2013 Intel Corporation
+    Copyright © 2015, 2016 Jan Arne Petersen
+    Copyright © 2017, 2018 Red Hat, Inc.
+    Copyright © 2018 Purism SPC
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <interface name="zwp_text_input_v3" version="1">
+    <description summary="text input">
+      The zwp_text_input_v3 interface represents text input and input methods
+      associated with a seat. It provides enter/leave events to follow the
+      text input focus for a seat.
+
+      Requests are used to enable/disable the text-input object and set
+      state information like surrounding and selected text or the content type.
+      The information about the entered text is sent to the text-input object
+      via the pre-edit and commit_string events.
+
+      Text is valid UTF-8 encoded, indices and lengths are in bytes. Indices
+      have to always point to the first byte of an UTF-8 encoded code point.
+      Lengths are not allowed to contain just a part of an UTF-8 encoded code
+      point.
+
+      Focus moving throughout surfaces will result in the emission of
+      zwp_text_input_v3.enter and zwp_text_input_v3.leave events. The focused
+      surface must perform zwp_text_input_v3.enable and
+      zwp_text_input_v3.disable requests as the keyboard focus moves across
+      editable and non-editable elements of the UI. Those two requests are not
+      expected to be paired with each other, the compositor must be able to
+      handle consecutive series of the same request.
+
+      State is sent by the state requests (set_surrounding_text,
+      set_content_type and set_cursor_rectangle) and a commit request.
+      After an enter event or disable request all state information is
+      invalidated and needs to be resent by the client.
+
+      This protocol defines requests and events necessary for regular clients
+      to communicate with an input method. The zwp_input_method protocol
+      defines the interfaces necessary to implement standalone input methods.
+      If a compositor implements both interfaces, it will be the arbiter of the
+      communication between both.
+
+      Warning! The protocol described in this file is experimental and
+      backward incompatible changes may be made. Backward compatible changes
+      may be added together with the corresponding interface version bump.
+      Backward incompatible changes are done by bumping the version number in
+      the protocol and interface names and resetting the interface version.
+      Once the protocol is to be declared stable, the 'z' prefix and the
+      version number in the protocol and interface names are removed and the
+      interface version number is reset.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="Destroy the wp_text_input">
+       Destroy the wp_text_input object. Also disables all surfaces enabled
+       through this wp_text_input object.
+      </description>
+    </request>
+
+    <enum name="enable_flags" bitfield="true">
+      <description summary="enable flags">
+       Enable flags is a bitmask to allow to modify the behavior of the text
+       input.
+      </description>
+      <entry name="none" value="0x0" summary="no special behavior"/>
+      <entry name="can_show_preedit" value="0x1" summary="hints that the UI is capable of showing pre-edit text"/>
+      <entry name="toggle_input_panel" value="0x2" summary="requests toggling input panel (eg. on-screen keyboard)"/>
+    </enum>
+
+    <request name="enable">
+      <description summary="Request text input to be enabled">
+        Requests text input on a surface.
+      </description>
+      <arg name="flags" type="uint" enum="enable_flags" summary="details of the enable request"/>
+    </request>
+
+    <request name="disable">
+      <description summary="Disable text input on a surface">
+        Explicitly disable text input in a surface (typically when there is no
+        focus on any text entry inside the surface).
+      </description>
+    </request>
+
+    <request name="set_surrounding_text">
+      <description summary="sets the surrounding text">
+       Sets the surrounding plain text around the input position. Text is
+       UTF-8 encoded. Cursor is the byte offset within the surrounding text.
+       Anchor is the byte offset of the selection anchor within the
+       surrounding text. If there is no selected text, anchor is the same as
+       cursor.
+
+       Make sure to always send some text before and after the cursor
+       except when the cursor is at the beginning or end of text.
+
+       There is a maximum length of wayland messages so text can not be
+       longer than 4000 bytes.
+       
+       Values set with this request are double-buffered. They will get applied
+       on the next zwp_text_input_v3.commit request.
+
+       The initial value for text is an empty string, and the initial values for 
+       cursor and anchor are 0.
+      </description>
+      <arg name="text" type="string"/>
+      <arg name="cursor" type="int"/>
+      <arg name="anchor" type="int"/>
+    </request>
+
+    <enum name="content_hint" bitfield="true">
+      <description summary="content hint">
+       Content hint is a bitmask to allow to modify the behavior of the text
+       input.
+      </description>
+      <entry name="none" value="0x0" summary="no special behavior"/>
+      <entry name="completion" value="0x1" summary="suggest word completions"/>
+      <entry name="spellcheck" value="0x2" summary="suggest word corrections"/>
+      <entry name="auto_capitalization" value="0x4" summary="switch to uppercase letters at the start of a sentence"/>
+      <entry name="lowercase" value="0x8" summary="prefer lowercase letters"/>
+      <entry name="uppercase" value="0x10" summary="prefer uppercase letters"/>
+      <entry name="titlecase" value="0x20" summary="prefer casing for titles and headings (can be language dependent)"/>
+      <entry name="hidden_text" value="0x40" summary="characters should be hidden"/>
+      <entry name="sensitive_data" value="0x80" summary="typed text should not be stored"/>
+      <entry name="latin" value="0x100" summary="just Latin characters should be entered"/>
+      <entry name="multiline" value="0x200" summary="the text input is multiline"/>
+    </enum>
+
+    <enum name="content_purpose">
+      <description summary="content purpose">
+       The content purpose allows to specify the primary purpose of a text
+       input.
+
+       This allows an input method to show special purpose input panels with
+       extra characters or to disallow some characters.
+      </description>
+      <entry name="normal" value="0" summary="default input, allowing all characters"/>
+      <entry name="alpha" value="1" summary="allow only alphabetic characters"/>
+      <entry name="digits" value="2" summary="allow only digits"/>
+      <entry name="number" value="3" summary="input a number (including decimal separator and sign)"/>
+      <entry name="phone" value="4" summary="input a phone number"/>
+      <entry name="url" value="5" summary="input an URL"/>
+      <entry name="email" value="6" summary="input an email address"/>
+      <entry name="name" value="7" summary="input a name of a person"/>
+      <entry name="password" value="8" summary="input a password (combine with sensitive_data hint)"/>
+      <entry name="pin" value="9" summary="input is a numeric password (combine with sensitive_data hint)"/>
+      <entry name="date" value="10" summary="input a date"/>
+      <entry name="time" value="11" summary="input a time"/>
+      <entry name="datetime" value="12" summary="input a date and time"/>
+      <entry name="terminal" value="13" summary="input for a terminal"/>
+    </enum>
+
+    <request name="set_content_type">
+      <description summary="set content purpose and hint">
+       Sets the content purpose and content hint. While the purpose is the
+       basic purpose of an input field, the hint flags allow to modify some
+       of the behavior.
+       
+       Values set with this request are double-buffered. They will get applied
+       on the next zwp_text_input_v3.commit request.
+
+       The initial value for hint is none, and the initial value for purpose
+       is normal.
+      </description>
+      <arg name="hint" type="uint" enum="content_hint"/>
+      <arg name="purpose" type="uint" enum="content_purpose"/>
+    </request>
+
+    <request name="set_cursor_rectangle">
+      <description summary="set cursor position">
+       Sets the cursor outline as a x, y, width, height rectangle in surface
+       local coordinates.
+
+       Allows the compositor to put a window with word suggestions near the
+       cursor.
+       
+       Values set with this request are double-buffered. They will get applied
+       on the next zwp_text_input_v3.commit request.
+
+       The initial values describing a cursor rectangle are invalid. That means
+       the pending cursor rectangle values must be set before the first commit
+       request.
+      </description>
+      <arg name="x" type="int"/>
+      <arg name="y" type="int"/>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+    </request>
+
+    <request name="commit">
+      <description summary="commit state">
+       Text input state (content purpose, content hint, surrounding text,
+       cursor rectangle) is conceptually double-buffered. Protocol requests
+       modify the pending state, as opposed to the current state in use by the
+       input method. A commit request atomically applies all pending state,
+       replacing the current state. After commit, the new pending state is as
+       documented for each related request.
+       
+       The current and pending state never changes unless noted otherwise.
+      </description>
+    </request>
+
+    <event name="enter">
+      <description summary="enter event">
+       Notification that this seat's text-input focus is on a certain surface.
+
+       When the seat has the keyboard capability the text-input focus follows
+       the keyboard focus.
+      </description>
+      <arg name="surface" type="object" interface="wl_surface"/>
+    </event>
+
+    <event name="leave">
+      <description summary="leave event">
+       Notification that this seat's text-input focus is no longer on
+       a certain surface. The client should reset any preedit string previously
+       set.
+
+       The leave notification is sent before the enter notification
+       for the new focus.
+
+       When the seat has the keyboard capability the text-input focus follows
+       the keyboard focus.
+      </description>
+      <arg name="surface" type="object" interface="wl_surface"/>
+    </event>
+
+    <event name="preedit_string">
+      <description summary="pre-edit">
+       Notify when a new composing text (pre-edit) should be set around the
+       current cursor position. Any previously set composing text should
+       be removed.
+      </description>
+      <arg name="text" type="string" allow-null="true"/>
+      <arg name="cursor" type="uint"/>
+    </event>
+
+    <event name="commit_string">
+      <description summary="text commit">
+       Notify when text should be inserted into the editor widget. The text to
+       commit could be either just a single character after a key press or the
+       result of some composing (pre-edit).
+
+       The text argument could be also null if some text is removed (see
+       zwp_text_input_v3.delete_surrounding_text).
+
+       Any previously set composing text should be removed.
+      </description>
+      <arg name="text" type="string" allow-null="true"/>
+    </event>
+
+    <event name="delete_surrounding_text">
+      <description summary="delete surrounding text">
+       Notify when the text around the current cursor position should be
+       deleted. Before_length and after_length is the length (in bytes) of text
+       before and after the current cursor position (excluding the selection)
+       to delete.
+
+       This event should be handled as part of a following commit_string or
+       preedit_string event.
+      </description>
+      <arg name="before_length" type="uint" summary="length of text before current cursor position"/>
+      <arg name="after_length" type="uint" summary="length of text after current cursor position"/>
+    </event>
+  </interface>
+
+  <interface name="zwp_text_input_manager_v3" version="1">
+    <description summary="text input manager">
+      A factory for text-input objects. This object is a global singleton.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="Destroy the wp_text_input_manager">
+       Destroy the wp_text_input_manager object.
+      </description>
+    </request>
+
+    <request name="get_text_input">
+      <description summary="create a new text input object">
+       Creates a new text-input object for a given seat.
+      </description>
+      <arg name="id" type="new_id" interface="zwp_text_input_v3"/>
+      <arg name="seat" type="object" interface="wl_seat"/>
+    </request>
+  </interface>
+</protocol>

--- a/types/meson.build
+++ b/types/meson.build
@@ -27,6 +27,7 @@ lib_wlr_types = static_library(
 		'wlr_surface.c',
 		'wlr_tablet_pad.c',
 		'wlr_tablet_tool.c',
+		'wlr_text_input.c',
 		'wlr_touch.c',
 		'wlr_wl_shell.c',
 		'wlr_xcursor_manager.c',

--- a/types/wlr_text_input.c
+++ b/types/wlr_text_input.c
@@ -1,0 +1,258 @@
+#define _POSIX_C_SOURCE 200809L
+#include <assert.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <wlr/types/wlr_text_input.h>
+#include <wlr/util/log.h>
+#include "text-input-unstable-v3-protocol.h"
+#include "util/signal.h"
+
+static const struct zwp_text_input_v3_interface text_input_impl;
+
+static struct wlr_text_input *text_input_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &zwp_text_input_v3_interface,
+		&text_input_impl));
+	return wl_resource_get_user_data(resource);
+}
+
+void wlr_text_input_send_enter(struct wlr_text_input *text_input,
+		struct wlr_surface *wlr_surface) {
+	zwp_text_input_v3_send_enter(text_input->resource, wlr_surface->resource);
+}
+
+void wlr_text_input_send_leave(struct wlr_text_input *text_input,
+		struct wlr_surface *wlr_surface) {
+	zwp_text_input_v3_send_leave(text_input->resource, wlr_surface->resource);
+}
+
+void wlr_text_input_send_preedit_string(struct wlr_text_input *text_input,
+		const char *text, uint32_t cursor) {
+	zwp_text_input_v3_send_preedit_string(text_input->resource, text, cursor);
+}
+
+void wlr_text_input_send_commit_string(struct wlr_text_input *text_input,
+		const char *text) {
+	zwp_text_input_v3_send_commit_string(text_input->resource, text);
+}
+
+void wlr_text_input_send_delete_surrounding_text(
+		struct wlr_text_input *text_input, uint32_t before_length,
+		uint32_t after_length) {
+	zwp_text_input_v3_send_delete_surrounding_text(text_input->resource,
+		before_length, after_length);
+}
+
+static void wlr_text_input_destroy(struct wlr_text_input *text_input) {
+	if (!text_input) {
+		return;
+	}
+	wlr_signal_emit_safe(&text_input->events.destroy, text_input);
+	// remove from manager::text_inputs
+	wl_list_remove(wl_resource_get_link(text_input->resource));
+	wl_resource_destroy(text_input->resource);
+	if (text_input->current.surrounding.text) {
+		free(text_input->current.surrounding.text);
+	}
+	if (text_input->pending.surrounding.text) {
+		free(text_input->pending.surrounding.text);
+	}
+	free(text_input);
+}
+
+static void text_input_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
+	struct wlr_text_input *text_input = text_input_from_resource(resource);
+	wlr_text_input_destroy(text_input);
+}
+
+static void text_input_enable(struct wl_client *client,
+		struct wl_resource *resource, uint32_t show_input_panel) {
+	struct wlr_text_input *text_input = text_input_from_resource(resource);
+	wlr_signal_emit_safe(&text_input->events.enable,
+		(void*)&show_input_panel);
+}
+
+static void text_input_disable(struct wl_client *client,
+		struct wl_resource *resource) {
+	struct wlr_text_input *text_input = text_input_from_resource(resource);
+	wlr_signal_emit_safe(&text_input->events.disable, NULL);
+}
+
+static void text_input_set_surrounding_text(struct wl_client *client,
+		struct wl_resource *resource, const char *text, int32_t cursor,
+		int32_t anchor) {
+	struct wlr_text_input *text_input = text_input_from_resource(resource);
+	if (text_input->pending.surrounding.text) {
+		free(text_input->pending.surrounding.text);
+	}
+	text_input->pending.surrounding.text = strdup(text);
+	if (!text_input->pending.surrounding.text) {
+		wl_client_post_no_memory(client);
+	}
+
+	text_input->pending.surrounding.cursor = cursor;
+	text_input->pending.surrounding.anchor = anchor;
+}
+
+static void text_input_set_content_type(struct wl_client *client,
+		struct wl_resource *resource, uint32_t hint, uint32_t purpose) {
+	struct wlr_text_input *text_input = text_input_from_resource(resource);
+	text_input->pending.content_type.hint = hint;
+	text_input->pending.content_type.purpose = purpose;
+}
+
+static void text_input_set_cursor_rectangle(struct wl_client *client,
+		struct wl_resource *resource, int32_t x, int32_t y, int32_t width,
+		int32_t height) {
+	struct wlr_text_input *text_input = text_input_from_resource(resource);
+	text_input->pending.cursor_rectangle.x = x;
+	text_input->pending.cursor_rectangle.y = y;
+	text_input->pending.cursor_rectangle.width = width;
+	text_input->pending.cursor_rectangle.height = height;
+}
+
+static void text_input_commit(struct wl_client *client,
+		struct wl_resource *resource) {
+	struct wlr_text_input *text_input = text_input_from_resource(resource);
+	if (text_input->current.surrounding.text) {
+		free(text_input->pending.surrounding.text);
+	}
+	text_input->current = text_input->pending;
+	if (text_input->pending.surrounding.text) {
+		text_input->current.surrounding.text =
+			strdup(text_input->pending.surrounding.text);
+	}
+	wlr_signal_emit_safe(&text_input->events.commit, text_input);
+}
+
+static const struct zwp_text_input_v3_interface text_input_impl = {
+	.destroy = text_input_destroy,
+	.enable = text_input_enable,
+	.disable = text_input_disable,
+	.set_surrounding_text = text_input_set_surrounding_text,
+	.set_content_type = text_input_set_content_type,
+	.set_cursor_rectangle = text_input_set_cursor_rectangle,
+	.commit = text_input_commit,
+};
+
+static const struct zwp_text_input_manager_v3_interface text_input_manager_impl;
+
+static struct wlr_text_input_manager *text_input_manager_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource,
+		&zwp_text_input_manager_v3_interface, &text_input_manager_impl));
+	return wl_resource_get_user_data(resource);
+}
+
+static void text_input_manager_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
+	struct wlr_text_input_manager *manager =
+		text_input_manager_from_resource(resource);
+	wlr_text_input_manager_destroy(manager);
+}
+
+static void text_input_handle_seat_destroy(struct wl_listener *listener,
+		void *data) {
+	struct wlr_text_input *text_input = wl_container_of(listener, text_input,
+		seat_destroy_listener);
+	wlr_text_input_destroy(text_input);
+}
+
+static void text_input_manager_get_text_input(struct wl_client *client,
+		struct wl_resource *resource, uint32_t id, struct wl_resource *seat) {
+	struct wlr_text_input *text_input =
+		calloc(1, sizeof(struct wlr_text_input));
+	if (text_input == NULL) {
+		wl_client_post_no_memory(client);
+		return;
+	}
+
+	wl_signal_init(&text_input->events.enable);
+	wl_signal_init(&text_input->events.commit);
+	wl_signal_init(&text_input->events.disable);
+	wl_signal_init(&text_input->events.destroy);
+
+	int version = wl_resource_get_version(resource);
+	struct wl_resource *wl_resource = wl_resource_create(client,
+		&zwp_text_input_v3_interface, version, id);
+	if (wl_resource == NULL) {
+		free(text_input);
+		wl_client_post_no_memory(client);
+		return;
+	}
+	text_input->resource = wl_resource;
+
+	wl_resource_set_implementation(text_input->resource, &text_input_impl,
+		text_input, NULL);
+
+	struct wlr_seat_client *seat_client = wlr_seat_client_from_resource(seat);
+	struct wlr_seat *wlr_seat = seat_client->seat;
+	text_input->seat = wlr_seat;
+	wl_signal_add(&wlr_seat->events.destroy,
+		&text_input->seat_destroy_listener);
+	text_input->seat_destroy_listener.notify =
+		text_input_handle_seat_destroy;
+
+	struct wlr_text_input_manager *manager =
+		text_input_manager_from_resource(resource);
+	wl_list_insert(&manager->text_inputs, wl_resource_get_link(wl_resource));
+
+	wlr_signal_emit_safe(&manager->events.text_input, text_input);
+}
+
+static const struct zwp_text_input_manager_v3_interface
+		text_input_manager_impl = {
+	.destroy = text_input_manager_destroy,
+	.get_text_input = text_input_manager_get_text_input,
+};
+
+static void text_input_manager_bind(struct wl_client *wl_client, void *data,
+		uint32_t version, uint32_t id) {
+	struct wlr_text_input_manager *manager = data;
+	assert(wl_client && manager);
+
+	struct wl_resource *wl_resource = wl_resource_create(wl_client,
+		&zwp_text_input_manager_v3_interface, version, id);
+	if (wl_resource == NULL) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+	wl_resource_set_implementation(wl_resource, &text_input_manager_impl,
+		manager, NULL);
+}
+
+struct wlr_text_input_manager *wlr_text_input_manager_create(
+		struct wl_display *wl_display) {
+	struct wlr_text_input_manager *manager =
+		calloc(1, sizeof(struct wlr_text_input_manager));
+	wl_list_init(&manager->text_inputs);
+	wl_signal_init(&manager->events.text_input);
+	manager->wl_global = wl_global_create(wl_display,
+		&zwp_text_input_manager_v3_interface, 1, manager,
+		text_input_manager_bind);
+	if (!manager->wl_global) {
+		free(manager);
+		return NULL;
+	}
+	return manager;
+}
+
+void wlr_text_input_manager_destroy(
+		struct wlr_text_input_manager *manager) {
+	if (!manager) {
+		return;
+	}
+	if (!wl_list_empty(&manager->text_inputs)) {
+		struct wl_resource *text_input_resource;
+		struct wl_resource *tmp;
+		wl_resource_for_each_safe(text_input_resource, tmp,
+				&manager->text_inputs) {
+			struct wlr_text_input *text_input =
+				text_input_from_resource(text_input_resource);
+			wlr_text_input_destroy(text_input);
+		}
+	}
+	wl_global_destroy(manager->wl_global);
+	free(manager);
+}


### PR DESCRIPTION
Present features: preediting string, sending enter/leave events and handling basic events.

There is a rootston version taking advantage of this change to paste some text into text fields [here](https://code.puri.sm/dorota.czaplejewicz/wlroots/src/text_input_test). GTK version updated to support this input method is [here](https://code.puri.sm/dorota.czaplejewicz/gtk).