### PR TITLE
xwayland: rename map_notify to map for consistency

### DIFF
--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -64,8 +64,8 @@ struct roots_xwayland_surface {
 	struct wl_listener request_resize;
 	struct wl_listener request_maximize;
 	struct wl_listener request_fullscreen;
-	struct wl_listener map_notify;
-	struct wl_listener unmap_notify;
+	struct wl_listener map;
+	struct wl_listener unmap;
 
 	struct wl_listener surface_commit;
 };

--- a/include/wlr/xwayland.h
+++ b/include/wlr/xwayland.h
@@ -126,8 +126,8 @@ struct wlr_xwayland_surface {
 		struct wl_signal request_maximize;
 		struct wl_signal request_fullscreen;
 
-		struct wl_signal map_notify;
-		struct wl_signal unmap_notify;
+		struct wl_signal map;
+		struct wl_signal unmap;
 		struct wl_signal set_title;
 		struct wl_signal set_class;
 		struct wl_signal set_parent;

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -426,7 +426,6 @@ void roots_cursor_handle_request_set_cursor(struct roots_cursor *cursor,
 		return;
 	}
 
-	wlr_log(L_DEBUG, "Setting client cursor");
 	wlr_cursor_set_surface(cursor->cursor, event->surface, event->hotspot_x,
 		event->hotspot_y);
 	cursor->cursor_client = event->seat_client->client;

--- a/rootston/xwayland.c
+++ b/rootston/xwayland.c
@@ -114,8 +114,8 @@ static void destroy(struct roots_view *view) {
 	wl_list_remove(&roots_surface->request_move.link);
 	wl_list_remove(&roots_surface->request_resize.link);
 	wl_list_remove(&roots_surface->request_maximize.link);
-	wl_list_remove(&roots_surface->map_notify.link);
-	wl_list_remove(&roots_surface->unmap_notify.link);
+	wl_list_remove(&roots_surface->map.link);
+	wl_list_remove(&roots_surface->unmap.link);
 	free(roots_surface);
 }
 
@@ -225,9 +225,9 @@ static void handle_surface_commit(struct wl_listener *listener, void *data) {
 	view_update_position(view, x, y);
 }
 
-static void handle_map_notify(struct wl_listener *listener, void *data) {
+static void handle_map(struct wl_listener *listener, void *data) {
 	struct roots_xwayland_surface *roots_surface =
-		wl_container_of(listener, roots_surface, map_notify);
+		wl_container_of(listener, roots_surface, map);
 	struct wlr_xwayland_surface *xsurface = data;
 	struct roots_view *view = roots_surface->view;
 
@@ -243,9 +243,9 @@ static void handle_map_notify(struct wl_listener *listener, void *data) {
 		&roots_surface->surface_commit);
 }
 
-static void handle_unmap_notify(struct wl_listener *listener, void *data) {
+static void handle_unmap(struct wl_listener *listener, void *data) {
 	struct roots_xwayland_surface *roots_surface =
-		wl_container_of(listener, roots_surface, unmap_notify);
+		wl_container_of(listener, roots_surface, unmap);
 	struct roots_view *view = roots_surface->view;
 
 	wl_list_remove(&roots_surface->surface_commit.link);
@@ -272,10 +272,10 @@ void handle_xwayland_surface(struct wl_listener *listener, void *data) {
 	roots_surface->request_configure.notify = handle_request_configure;
 	wl_signal_add(&surface->events.request_configure,
 		&roots_surface->request_configure);
-	roots_surface->map_notify.notify = handle_map_notify;
-	wl_signal_add(&surface->events.map_notify, &roots_surface->map_notify);
-	roots_surface->unmap_notify.notify = handle_unmap_notify;
-	wl_signal_add(&surface->events.unmap_notify, &roots_surface->unmap_notify);
+	roots_surface->map.notify = handle_map;
+	wl_signal_add(&surface->events.map, &roots_surface->map);
+	roots_surface->unmap.notify = handle_unmap;
+	wl_signal_add(&surface->events.unmap, &roots_surface->unmap);
 	roots_surface->request_move.notify = handle_request_move;
 	wl_signal_add(&surface->events.request_move, &roots_surface->request_move);
 	roots_surface->request_resize.notify = handle_request_resize;

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -107,8 +107,8 @@ static struct wlr_xwayland_surface *wlr_xwayland_surface_create(
 	wl_signal_init(&surface->events.request_resize);
 	wl_signal_init(&surface->events.request_maximize);
 	wl_signal_init(&surface->events.request_fullscreen);
-	wl_signal_init(&surface->events.map_notify);
-	wl_signal_init(&surface->events.unmap_notify);
+	wl_signal_init(&surface->events.map);
+	wl_signal_init(&surface->events.unmap);
 	wl_signal_init(&surface->events.set_class);
 	wl_signal_init(&surface->events.set_title);
 	wl_signal_init(&surface->events.set_parent);
@@ -581,7 +581,7 @@ static void xwm_map_shell_surface(struct wlr_xwm *xwm,
 	wl_signal_add(&surface->events.destroy, &xsurface->surface_destroy);
 
 	xsurface->mapped = true;
-	wlr_signal_emit_safe(&xsurface->events.map_notify, xsurface);
+	wlr_signal_emit_safe(&xsurface->events.map, xsurface);
 }
 
 static void xwm_handle_create_notify(struct wlr_xwm *xwm,
@@ -713,7 +713,7 @@ static void xwm_handle_unmap_notify(struct wlr_xwm *xwm,
 
 	if (xsurface->mapped) {
 		xsurface->mapped = false;
-		wlr_signal_emit_safe(&xsurface->events.unmap_notify, xsurface);
+		wlr_signal_emit_safe(&xsurface->events.unmap, xsurface);
 	}
 
 	xsurface_set_wm_state(xsurface, ICCCM_WITHDRAWN_STATE);
@@ -1531,4 +1531,3 @@ bool xwm_atoms_contains(struct wlr_xwm *xwm, xcb_atom_t *atoms,
 
 	return false;
 }
-


### PR DESCRIPTION
`notify` is never used in event names, and `map` is used in other shells.

Will send a Sway PR when this one gets approved.