### PR TITLE
Add pointer input to layer surfaces

### DIFF
--- a/examples/layer-shell.c
+++ b/examples/layer-shell.c
@@ -162,8 +162,8 @@ static void wl_pointer_leave(void *data, struct wl_pointer *wl_pointer,
 
 static void wl_pointer_motion(void *data, struct wl_pointer *wl_pointer,
 		uint32_t time, wl_fixed_t surface_x, wl_fixed_t surface_y) {
-	cur_x = (int)wl_fixed_to_double(surface_x);
-	cur_y = (int)wl_fixed_to_double(surface_y);
+	cur_x = wl_fixed_to_int(surface_x);
+	cur_y = wl_fixed_to_int(surface_y);
 }
 
 static void wl_pointer_button(void *data, struct wl_pointer *wl_pointer,

--- a/examples/layer-shell.c
+++ b/examples/layer-shell.c
@@ -157,6 +157,7 @@ static void wl_pointer_enter(void *data, struct wl_pointer *wl_pointer,
 static void wl_pointer_leave(void *data, struct wl_pointer *wl_pointer,
 		uint32_t serial, struct wl_surface *surface) {
 	cur_x = cur_y = -1;
+	buttons = 0;
 }
 
 static void wl_pointer_motion(void *data, struct wl_pointer *wl_pointer,

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -6,6 +6,7 @@ lib_shared = static_library(
 )
 
 threads = dependency('threads')
+wayland_cursor = dependency('wayland-cursor')
 
 executable('simple', 'simple.c', dependencies: wlroots, link_with: lib_shared)
 executable('pointer', 'pointer.c', dependencies: wlroots, link_with: lib_shared)
@@ -52,5 +53,5 @@ executable(
 executable(
 	'layer-shell',
 	'layer-shell.c',
-	dependencies: [wayland_client, wlr_protos, wlroots]
+	dependencies: [wayland_cursor, wayland_client, wlr_protos, wlroots]
 )

--- a/include/rootston/desktop.h
+++ b/include/rootston/desktop.h
@@ -73,8 +73,12 @@ struct roots_desktop *desktop_create(struct roots_server *server,
 void desktop_destroy(struct roots_desktop *desktop);
 struct roots_output *desktop_output_from_wlr_output(
 	struct roots_desktop *desktop, struct wlr_output *output);
+
 struct roots_view *desktop_view_at(struct roots_desktop *desktop, double lx,
 	double ly, struct wlr_surface **surface, double *sx, double *sy);
+struct wlr_surface *desktop_surface_at(struct roots_desktop *desktop,
+		double lx, double ly, double *sx, double *sy,
+		struct roots_view **view);
 
 struct roots_view *view_create(struct roots_desktop *desktop);
 void view_destroy(struct roots_view *view);

--- a/include/rootston/desktop.h
+++ b/include/rootston/desktop.h
@@ -1,6 +1,5 @@
 #ifndef ROOTSTON_DESKTOP_H
 #define ROOTSTON_DESKTOP_H
-
 #include <time.h>
 #include <wayland-server.h>
 #include <wlr/config.h>
@@ -74,8 +73,6 @@ void desktop_destroy(struct roots_desktop *desktop);
 struct roots_output *desktop_output_from_wlr_output(
 	struct roots_desktop *desktop, struct wlr_output *output);
 
-struct roots_view *desktop_view_at(struct roots_desktop *desktop, double lx,
-	double ly, struct wlr_surface **surface, double *sx, double *sy);
 struct wlr_surface *desktop_surface_at(struct roots_desktop *desktop,
 		double lx, double ly, double *sx, double *sy,
 		struct roots_view **view);

--- a/include/rootston/output.h
+++ b/include/rootston/output.h
@@ -1,6 +1,5 @@
 #ifndef ROOTSTON_OUTPUT_H
 #define ROOTSTON_OUTPUT_H
-
 #include <pixman.h>
 #include <time.h>
 #include <wayland-server.h>

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -10,6 +10,7 @@
 #include <dev/evdev/input-event-codes.h>
 #endif
 #include "rootston/cursor.h"
+#include "rootston/desktop.h"
 #include "rootston/xcursor.h"
 
 struct roots_cursor *roots_cursor_create(struct roots_seat *seat) {
@@ -98,51 +99,56 @@ static void seat_view_deco_button(struct roots_seat_view *view, double sx,
 	}
 }
 
-static void roots_cursor_update_position(struct roots_cursor *cursor,
+static void roots_passthrough_cursor(struct roots_cursor *cursor,
 		uint32_t time) {
-	struct roots_desktop *desktop = cursor->seat->input->server->desktop;
-	struct roots_seat *seat = cursor->seat;
 	struct roots_view *view;
-	struct wlr_surface *surface = NULL;
 	double sx, sy;
-	switch (cursor->mode) {
-	case ROOTS_CURSOR_PASSTHROUGH:
-		view = desktop_view_at(desktop, cursor->cursor->x, cursor->cursor->y,
-			&surface, &sx, &sy);
+
+	struct roots_seat *seat = cursor->seat;
+	struct roots_desktop *desktop = seat->input->server->desktop;
+	struct wlr_surface *surface = desktop_surface_at(desktop,
+			cursor->cursor->x, cursor->cursor->y, &sx, &sy, &view);
+
+	if (!surface && cursor->cursor_client) {
+		wlr_xcursor_manager_set_cursor_image(cursor->xcursor_manager,
+			cursor->default_xcursor, cursor->cursor);
+		cursor->cursor_client = NULL;
+	}
+
+	if (view) {
 		struct roots_seat_view *seat_view =
 			roots_seat_view_from_view(seat, view);
-		if (cursor->pointer_view && (surface || seat_view != cursor->pointer_view)) {
+		if (cursor->pointer_view && (surface ||
+					seat_view != cursor->pointer_view)) {
 			seat_view_deco_leave(cursor->pointer_view);
 			cursor->pointer_view = NULL;
 		}
-		bool set_compositor_cursor = !view && !surface && cursor->cursor_client;
-		if (view && surface) {
-			struct wl_client *view_client =
-				wl_resource_get_client(view->wlr_surface->resource);
-			set_compositor_cursor = view_client != cursor->cursor_client;
+		if (!surface) {
+			cursor->pointer_view = seat_view;
+			seat_view_deco_motion(seat_view, sx, sy);
 		}
-		if (set_compositor_cursor) {
-			wlr_xcursor_manager_set_cursor_image(cursor->xcursor_manager,
-				cursor->default_xcursor, cursor->cursor);
-			cursor->cursor_client = NULL;
-		}
-		if (view && !surface) {
-			if (seat_view) {
-				cursor->pointer_view = seat_view;
-				seat_view_deco_motion(seat_view, sx, sy);
-			}
-		} if (view && surface) {
-			// motion over a view surface
-			wlr_seat_pointer_notify_enter(seat->seat, surface, sx, sy);
-			wlr_seat_pointer_notify_motion(seat->seat, time, sx, sy);
-		} else {
-			wlr_seat_pointer_clear_focus(seat->seat);
-		}
+	}
 
-		struct roots_drag_icon *drag_icon;
-		wl_list_for_each(drag_icon, &seat->drag_icons, link) {
-			roots_drag_icon_update_position(drag_icon);
-		}
+	if (surface) {
+		wlr_seat_pointer_notify_enter(seat->seat, surface, sx, sy);
+		wlr_seat_pointer_notify_motion(seat->seat, time, sx, sy);
+	} else {
+		wlr_seat_pointer_clear_focus(seat->seat);
+	}
+
+	struct roots_drag_icon *drag_icon;
+	wl_list_for_each(drag_icon, &seat->drag_icons, link) {
+		roots_drag_icon_update_position(drag_icon);
+	}
+}
+
+static void roots_cursor_update_position(
+		struct roots_cursor *cursor, uint32_t time) {
+	struct roots_seat *seat = cursor->seat;
+	struct roots_view *view;
+	switch (cursor->mode) {
+	case ROOTS_CURSOR_PASSTHROUGH:
+		roots_passthrough_cursor(cursor, time);
 		break;
 	case ROOTS_CURSOR_MOVE:
 		view = roots_seat_get_focus(seat);
@@ -180,15 +186,9 @@ static void roots_cursor_update_position(struct roots_cursor *cursor,
 			} else if (cursor->resize_edges & WLR_EDGE_RIGHT) {
 				width += dx;
 			}
-
-			if (width < 1) {
-				width = 1;
-			}
-			if (height < 1) {
-				height = 1;
-			}
-
-			view_move_resize(view, x, y, width, height);
+			view_move_resize(view, x, y,
+					width < 1 ? 1 : width,
+					height < 1 ? 1 : height);
 		}
 		break;
 	case ROOTS_CURSOR_ROTATE:
@@ -214,15 +214,15 @@ static void roots_cursor_press_button(struct roots_cursor *cursor,
 		uint32_t state, double lx, double ly) {
 	struct roots_seat *seat = cursor->seat;
 	struct roots_desktop *desktop = seat->input->server->desktop;
+
 	bool is_touch = device->type == WLR_INPUT_DEVICE_TOUCH;
 
-	struct wlr_surface *surface = NULL;
 	double sx, sy;
-	struct roots_view *view =
-		desktop_view_at(desktop, lx, ly, &surface, &sx, &sy);
+	struct roots_view *view;
+	struct wlr_surface *surface = desktop_surface_at(desktop,
+			lx, ly, &sx, &sy, &view);
 
-	if (state == WLR_BUTTON_PRESSED &&
-			view &&
+	if (state == WLR_BUTTON_PRESSED && view &&
 			roots_seat_has_meta_pressed(seat)) {
 		roots_seat_set_focus(seat, view);
 
@@ -250,11 +250,9 @@ static void roots_cursor_press_button(struct roots_cursor *cursor,
 			break;
 		}
 	} else {
-
-		if (view && !surface) {
-			if (cursor->pointer_view) {
-				seat_view_deco_button(cursor->pointer_view, sx, sy, button, state);
-			}
+		if (view && !surface && cursor->pointer_view) {
+			seat_view_deco_button(cursor->pointer_view,
+					sx, sy, button, state);
 		}
 
 		if (state == WLR_BUTTON_RELEASED &&
@@ -308,7 +306,6 @@ void roots_cursor_handle_axis(struct roots_cursor *cursor,
 void roots_cursor_handle_touch_down(struct roots_cursor *cursor,
 		struct wlr_event_touch_down *event) {
 	struct roots_desktop *desktop = cursor->seat->input->server->desktop;
-	struct wlr_surface *surface = NULL;
 	double lx, ly;
 	bool result = wlr_cursor_absolute_to_layout_coords(cursor->cursor,
 			event->device, event->x, event->y, &lx, &ly);
@@ -316,7 +313,8 @@ void roots_cursor_handle_touch_down(struct roots_cursor *cursor,
 		return;
 	}
 	double sx, sy;
-	desktop_view_at(desktop, lx, ly, &surface, &sx, &sy);
+	struct wlr_surface *surface = desktop_surface_at(
+			desktop, lx, ly, &sx, &sy, NULL);
 
 	uint32_t serial = 0;
 	if (surface) {
@@ -359,17 +357,16 @@ void roots_cursor_handle_touch_motion(struct roots_cursor *cursor,
 		return;
 	}
 
-	struct wlr_surface *surface = NULL;
 	double lx, ly;
-	bool result =
-		wlr_cursor_absolute_to_layout_coords(cursor->cursor,
+	bool result = wlr_cursor_absolute_to_layout_coords(cursor->cursor,
 			event->device, event->x, event->y, &lx, &ly);
 	if (!result) {
 		return;
 	}
 
 	double sx, sy;
-	desktop_view_at(desktop, lx, ly, &surface, &sx, &sy);
+	struct wlr_surface *surface = desktop_surface_at(
+			desktop, lx, ly, &sx, &sy, NULL);
 
 	if (surface) {
 		wlr_seat_touch_point_focus(cursor->seat->seat, surface,

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -101,18 +101,21 @@ static void seat_view_deco_button(struct roots_seat_view *view, double sx,
 
 static void roots_passthrough_cursor(struct roots_cursor *cursor,
 		uint32_t time) {
-	struct roots_view *view;
 	double sx, sy;
-
+	struct roots_view *view = NULL;
 	struct roots_seat *seat = cursor->seat;
 	struct roots_desktop *desktop = seat->input->server->desktop;
 	struct wlr_surface *surface = desktop_surface_at(desktop,
 			cursor->cursor->x, cursor->cursor->y, &sx, &sy, &view);
+	struct wl_client *client = NULL;
+	if (surface) {
+		client = wl_resource_get_client(surface->resource);
+	}
 
-	if (!surface && cursor->cursor_client) {
+	if (cursor->cursor_client != client) {
 		wlr_xcursor_manager_set_cursor_image(cursor->xcursor_manager,
 			cursor->default_xcursor, cursor->cursor);
-		cursor->cursor_client = NULL;
+		cursor->cursor_client = client;
 	}
 
 	if (view) {

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -669,12 +669,13 @@ static struct wlr_surface *layer_surface_at(struct roots_output *output,
 		double _sx = ox - roots_surface->geo.x;
 		double _sy = oy - roots_surface->geo.y;
 		struct wlr_box box = {
-			.x = 0, .y = 0,
-			.width = roots_surface->geo.width,
-			.height = roots_surface->geo.height,
+			.x = roots_surface->geo.x,
+			.y = roots_surface->geo.y,
+			.width = wlr_surface->current->width,
+			.height = wlr_surface->current->height,
 		};
 		// TODO: Test popups/subsurfaces
-		if (wlr_box_contains_point(&box, _sx, _sy) &&
+		if (wlr_box_contains_point(&box, ox, oy) &&
 				pixman_region32_contains_point(&wlr_surface->current->input,
 					_sx, _sy, NULL)) {
 			*sx = _sx;
@@ -692,7 +693,7 @@ struct wlr_surface *desktop_surface_at(struct roots_desktop *desktop,
 	struct wlr_output *wlr_output =
 		wlr_output_layout_output_at(desktop->layout, lx, ly);
 	struct roots_output *roots_output;
-	double ox, oy;
+	double ox = lx, oy = ly;
 	if (wlr_output) {
 		roots_output = wlr_output->data;
 		wlr_output_layout_output_coords(desktop->layout, wlr_output, &ox, &oy);

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -657,6 +657,25 @@ struct roots_view *desktop_view_at(struct roots_desktop *desktop, double lx,
 	return NULL;
 }
 
+struct wlr_surface *desktop_surface_at(struct roots_desktop *desktop,
+		double lx, double ly, double *sx, double *sy,
+		struct roots_view **view) {
+	//struct wlr_output *wlr_output =
+	//	wlr_output_layout_output_at(desktop->layout, lx, ly);
+	// TODO: Iterate over layers
+	*view = NULL;
+	struct roots_view *_view;
+	struct wlr_surface *surface = NULL;
+	if ((_view = desktop_view_at(desktop, lx, ly, &surface, sx, sy))) {
+		if (view) {
+			*view = _view;
+		}
+		return surface;
+	}
+	// TODO: Iterate over layers
+	return NULL;
+}
+
 static void handle_layout_change(struct wl_listener *listener, void *data) {
 	struct roots_desktop *desktop =
 		wl_container_of(listener, desktop, layout_change);

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -694,6 +694,8 @@ struct wlr_surface *desktop_surface_at(struct roots_desktop *desktop,
 		wlr_output_layout_output_at(desktop->layout, lx, ly);
 	struct roots_output *roots_output;
 	double ox = lx, oy = ly;
+	*view = NULL;
+
 	if (wlr_output) {
 		roots_output = wlr_output->data;
 		wlr_output_layout_output_coords(desktop->layout, wlr_output, &ox, &oy);
@@ -710,7 +712,6 @@ struct wlr_surface *desktop_surface_at(struct roots_desktop *desktop,
 		}
 	}
 
-	*view = NULL;
 	struct roots_view *_view;
 	if ((_view = desktop_view_at(desktop, lx, ly, &surface, sx, sy))) {
 		if (view) {


### PR DESCRIPTION
This glues things together in rootston and extends the layer shell example to visually demonstrate pointer events.

Test plan:

1. Run rootston
2. Run layer shell example with various configurations
3. Test that pointer appears in correct place and clicking changes the color of the surface
4. Test that surface gets a client side cursor
5. Bring a shell surface to the party and make sure nothing breaks
6. Test z-ordering works correctly with several layer surfaces