### PR TITLE
xwayland: specify xwm cursor stride in bytes

### DIFF
--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -834,7 +834,7 @@ struct roots_desktop *desktop_create(struct roots_server *server,
 		if (xcursor != NULL) {
 			struct wlr_xcursor_image *image = xcursor->images[0];
 			wlr_xwayland_set_cursor(desktop->xwayland, image->buffer,
-				image->width, image->width, image->height, image->hotspot_x,
+				image->width * 4, image->width, image->height, image->hotspot_x,
 				image->hotspot_y);
 		}
 	}

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -1378,7 +1378,6 @@ void xwm_set_cursor(struct wlr_xwm *xwm, const uint8_t *pixels, uint32_t stride,
 		xcb_free_cursor(xwm->xcb_conn, xwm->cursor);
 	}
 
-	stride *= 4;
 	int depth = 32;
 
 	xcb_pixmap_t pix = xcb_generate_id(xwm->xcb_conn);


### PR DESCRIPTION
This makes it consistent with the rest of the codebase.