### PR TITLE
fix debug log color

### DIFF
--- a/util/log.c
+++ b/util/log.c
@@ -15,7 +15,7 @@ static const char *verbosity_colors[] = {
 	[L_SILENT] = "",
 	[L_ERROR ] = "\x1B[1;31m",
 	[L_INFO  ] = "\x1B[1;34m",
-	[L_DEBUG ] = "\x1B[1;30m",
+	[L_DEBUG ] = "\x1B[1;37m",
 };
 
 void wlr_log_stderr(log_importance_t verbosity, const char *fmt, va_list args) {


### PR DESCRIPTION
According to [this](https://misc.flogisoft.com/bash/tip_colors_and_formatting), `\x1B[1;30m` is a black color. My vim uses this color for the background. Change it to `\x1B[1;37m` which is light gray according to the thing.