### PR TITLE
Untie wlr_backend from wlr_renderer

### DIFF
--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -31,7 +31,7 @@ bool wlr_drm_renderer_init(struct wlr_drm_backend *drm,
 		goto error_gbm;
 	}
 
-	renderer->wlr_rend = wlr_gles2_renderer_create(&drm->backend);
+	renderer->wlr_rend = wlr_gles2_renderer_create(&renderer->egl);
 	if (!renderer->wlr_rend) {
 		wlr_log(L_ERROR, "Failed to create WLR renderer");
 		goto error_egl;

--- a/backend/headless/backend.c
+++ b/backend/headless/backend.c
@@ -114,7 +114,7 @@ struct wlr_backend *wlr_headless_backend_create(struct wl_display *display) {
 		return NULL;
 	}
 
-	backend->renderer = wlr_gles2_renderer_create(&backend->backend);
+	backend->renderer = wlr_gles2_renderer_create(&backend->egl);
 	if (backend->renderer == NULL) {
 		wlr_log(L_ERROR, "Failed to create renderer");
 	}

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -212,7 +212,7 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display, const char
 		backend->remote_display, NULL, WL_SHM_FORMAT_ARGB8888);
 	wlr_egl_bind_display(&backend->egl, backend->local_display);
 
-	backend->renderer = wlr_gles2_renderer_create(&backend->backend);
+	backend->renderer = wlr_gles2_renderer_create(&backend->egl);
 	if (backend->renderer == NULL) {
 		wlr_log_errno(L_ERROR, "Could not create renderer");
 	}

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -314,7 +314,7 @@ struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
 		goto error_event;
 	}
 
-	x11->renderer = wlr_gles2_renderer_create(&x11->backend);
+	x11->renderer = wlr_gles2_renderer_create(&x11->egl);
 	if (x11->renderer == NULL) {
 		wlr_log(L_ERROR, "Failed to create renderer");
 		goto error_egl;

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -196,7 +196,8 @@ int main(int argc, char *argv[]) {
 	compositor.keyboard_key_cb = handle_keyboard_key;
 	compositor_init(&compositor);
 
-	state.renderer = wlr_gles2_renderer_create(compositor.backend);
+	struct wlr_egl *egl = wlr_backend_get_egl(compositor.backend);
+	state.renderer = wlr_gles2_renderer_create(egl);
 	state.cat_texture = wlr_texture_from_pixels(state.renderer,
 		WL_SHM_FORMAT_ABGR8888, cat_tex.width * 4, cat_tex.width, cat_tex.height,
 		cat_tex.pixel_data);

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -137,7 +137,8 @@ int main(int argc, char *argv[]) {
 	compositor.keyboard_key_cb = handle_keyboard_key;
 	compositor_init(&compositor);
 
-	state.renderer = wlr_gles2_renderer_create(compositor.backend);
+	struct wlr_egl *egl = wlr_backend_get_egl(compositor.backend);
+	state.renderer = wlr_gles2_renderer_create(egl);
 	if (!state.renderer) {
 		wlr_log(L_ERROR, "Could not start compositor, OOM");
 		exit(EXIT_FAILURE);

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -192,7 +192,8 @@ int main(int argc, char *argv[]) {
 	};
 	compositor_init(&compositor);
 
-	state.renderer = wlr_gles2_renderer_create(compositor.backend);
+	struct wlr_egl *egl = wlr_backend_get_egl(compositor.backend);
+	state.renderer = wlr_gles2_renderer_create(egl);
 	if (!state.renderer) {
 		wlr_log(L_ERROR, "Could not start compositor, OOM");
 		exit(EXIT_FAILURE);

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -108,7 +108,8 @@ int main(int argc, char *argv[]) {
 	};
 	compositor_init(&compositor);
 
-	state.renderer = wlr_gles2_renderer_create(compositor.backend);
+	struct wlr_egl *egl = wlr_backend_get_egl(compositor.backend);
+	state.renderer = wlr_gles2_renderer_create(egl);
 	if (!state.renderer) {
 		wlr_log(L_ERROR, "Could not start compositor, OOM");
 		exit(EXIT_FAILURE);

--- a/include/wlr/render/gles2.h
+++ b/include/wlr/render/gles2.h
@@ -5,6 +5,7 @@
 #include <wlr/render/wlr_renderer.h>
 
 struct wlr_egl;
-struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_backend *backend);
+
+struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_egl *egl);
 
 #endif

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -6,7 +6,6 @@
 #include <stdlib.h>
 #include <wayland-server-protocol.h>
 #include <wayland-util.h>
-#include <wlr/backend.h>
 #include <wlr/render/egl.h>
 #include <wlr/render/interface.h>
 #include <wlr/render/wlr_renderer.h>
@@ -400,7 +399,7 @@ extern const GLchar tex_fragment_src_rgba[];
 extern const GLchar tex_fragment_src_rgbx[];
 extern const GLchar tex_fragment_src_external[];
 
-struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_backend *backend) {
+struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_egl *egl) {
 	struct wlr_gles2_renderer *renderer =
 		calloc(1, sizeof(struct wlr_gles2_renderer));
 	if (renderer == NULL) {
@@ -408,7 +407,7 @@ struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_backend *backend) {
 	}
 	wlr_renderer_init(&renderer->wlr_renderer, &renderer_impl);
 
-	renderer->egl = wlr_backend_get_egl(backend);
+	renderer->egl = egl;
 	wlr_egl_make_current(renderer->egl, EGL_NO_SURFACE, NULL);
 
 	renderer->exts_str = (const char*) glGetString(GL_EXTENSIONS);


### PR DESCRIPTION
There's no reason why the renderer needs the backend. This PR makes the renderer more modular.

This makes it possible to use the renderer in test clients. We probably won't do that because we want to keep our client examples readable for someone unfamiliar with wlr_renderer.