### PR TITLE
Untie wlr_gles2_renderer and wlr_gles2_texture

### DIFF
--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <wlr/backend.h>
 #include <wlr/render/egl.h>
+#include <wlr/render/gles2.h>
 #include <wlr/render/interface.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/render/wlr_texture.h>
@@ -49,7 +50,7 @@ enum wlr_gles2_texture_type {
 struct wlr_gles2_texture {
 	struct wlr_texture wlr_texture;
 
-	struct wlr_gles2_renderer *renderer;
+	struct wlr_egl *egl;
 	enum wlr_gles2_texture_type type;
 	int width, height;
 	bool has_alpha;
@@ -68,20 +69,8 @@ struct wlr_gles2_texture {
 const struct gles2_pixel_format *gles2_format_from_wl(enum wl_shm_format fmt);
 const enum wl_shm_format *gles2_formats(size_t *len);
 
-struct wlr_gles2_renderer *gles2_get_renderer(
-	struct wlr_renderer *wlr_renderer);
-struct wlr_gles2_renderer *gles2_get_renderer_in_context(
-	struct wlr_renderer *wlr_renderer);
-
 struct wlr_gles2_texture *gles2_get_texture_in_context(
 	struct wlr_texture *wlr_texture);
-struct wlr_texture *gles2_texture_from_pixels(struct wlr_renderer *wlr_renderer,
-	enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width, uint32_t height,
-	const void *data);
-struct wlr_texture *gles2_texture_from_wl_drm(struct wlr_renderer *wlr_renderer,
-	struct wl_resource *data);
-struct wlr_texture *gles2_texture_from_dmabuf(struct wlr_renderer *wlr_renderer,
-	struct wlr_dmabuf_buffer_attribs *attribs);
 
 void gles2_push_marker(const char *file, const char *func);
 void gles2_pop_marker(void);

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -93,6 +93,8 @@ bool wlr_egl_destroy_image(struct wlr_egl *egl, EGLImageKHR image);
 bool wlr_egl_make_current(struct wlr_egl *egl, EGLSurface surface,
 	int *buffer_age);
 
+bool wlr_egl_is_current(struct wlr_egl *egl);
+
 bool wlr_egl_swap_buffers(struct wlr_egl *egl, EGLSurface surface,
 	pixman_region32_t *damage);
 

--- a/include/wlr/render/gles2.h
+++ b/include/wlr/render/gles2.h
@@ -8,4 +8,12 @@ struct wlr_egl;
 
 struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_egl *egl);
 
+struct wlr_texture *wlr_gles2_texture_from_pixels(struct wlr_egl *egl,
+	enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width, uint32_t height,
+	const void *data);
+struct wlr_texture *wlr_gles2_texture_from_wl_drm(struct wlr_egl *egl,
+	struct wl_resource *data);
+struct wlr_texture *wlr_gles2_texture_from_dmabuf(struct wlr_egl *egl,
+	struct wlr_dmabuf_buffer_attribs *attribs);
+
 #endif

--- a/render/egl.c
+++ b/render/egl.c
@@ -270,6 +270,10 @@ bool wlr_egl_make_current(struct wlr_egl *egl, EGLSurface surface,
 	return true;
 }
 
+bool wlr_egl_is_current(struct wlr_egl *egl) {
+	return eglGetCurrentContext() == egl->context;
+}
+
 bool wlr_egl_swap_buffers(struct wlr_egl *egl, EGLSurface surface,
 		pixman_region32_t *damage) {
 	EGLBoolean ret;


### PR DESCRIPTION
This makes `wlr_gles2_texture` more modular: it can be re-used in another external GLES2 renderer.

Updates #775