### PR TITLE
examples: get wlr_renderer from the backend

### DIFF
--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -13,7 +13,6 @@
 #include <wayland-server.h>
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
-#include <wlr/render/gles2.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_keyboard.h>
 #include <wlr/types/wlr_matrix.h>
@@ -196,8 +195,7 @@ int main(int argc, char *argv[]) {
 	compositor.keyboard_key_cb = handle_keyboard_key;
 	compositor_init(&compositor);
 
-	struct wlr_egl *egl = wlr_backend_get_egl(compositor.backend);
-	state.renderer = wlr_gles2_renderer_create(egl);
+	state.renderer = wlr_backend_get_renderer(compositor.backend);
 	state.cat_texture = wlr_texture_from_pixels(state.renderer,
 		WL_SHM_FORMAT_ABGR8888, cat_tex.width * 4, cat_tex.width, cat_tex.height,
 		cat_tex.pixel_data);

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -13,7 +13,6 @@
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
 #include <wlr/render/wlr_renderer.h>
-#include <wlr/render/gles2.h>
 #include <wlr/types/wlr_keyboard.h>
 #include <wlr/types/wlr_matrix.h>
 #include <wlr/util/log.h>
@@ -137,8 +136,7 @@ int main(int argc, char *argv[]) {
 	compositor.keyboard_key_cb = handle_keyboard_key;
 	compositor_init(&compositor);
 
-	struct wlr_egl *egl = wlr_backend_get_egl(compositor.backend);
-	state.renderer = wlr_gles2_renderer_create(egl);
+	state.renderer = wlr_backend_get_renderer(compositor.backend);
 	if (!state.renderer) {
 		wlr_log(L_ERROR, "Could not start compositor, OOM");
 		exit(EXIT_FAILURE);

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -11,7 +11,6 @@
 #include <wayland-server.h>
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
-#include <wlr/render/gles2.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_matrix.h>
@@ -192,8 +191,7 @@ int main(int argc, char *argv[]) {
 	};
 	compositor_init(&compositor);
 
-	struct wlr_egl *egl = wlr_backend_get_egl(compositor.backend);
-	state.renderer = wlr_gles2_renderer_create(egl);
+	state.renderer = wlr_backend_get_renderer(compositor.backend);
 	if (!state.renderer) {
 		wlr_log(L_ERROR, "Could not start compositor, OOM");
 		exit(EXIT_FAILURE);

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -12,7 +12,6 @@
 #include <wayland-server.h>
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
-#include <wlr/render/gles2.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_list.h>
 #include <wlr/types/wlr_matrix.h>
@@ -108,8 +107,7 @@ int main(int argc, char *argv[]) {
 	};
 	compositor_init(&compositor);
 
-	struct wlr_egl *egl = wlr_backend_get_egl(compositor.backend);
-	state.renderer = wlr_gles2_renderer_create(egl);
+	state.renderer = wlr_backend_get_renderer(compositor.backend);
 	if (!state.renderer) {
 		wlr_log(L_ERROR, "Could not start compositor, OOM");
 		exit(EXIT_FAILURE);


### PR DESCRIPTION
We don't need to create a new renderer, the backend already provides one.