### PR TITLE
Add keyboard input to layer surfaces

### DIFF
--- a/examples/layer-shell.c
+++ b/examples/layer-shell.c
@@ -36,6 +36,7 @@ static int32_t margin_top = 0;
 static double alpha = 1.0;
 static bool run_display = true;
 static bool animate = false;
+static bool keyboard_interactive = false;
 static double frame = 0;
 static int cur_x = -1, cur_y = -1;
 static int buttons = 0;
@@ -274,7 +275,7 @@ int main(int argc, char **argv) {
 	int32_t margin_right = 0, margin_bottom = 0, margin_left = 0;
 	bool found;
 	int c;
-	while ((c = getopt(argc, argv, "nw:h:o:l:a:x:m:t:")) != -1) {
+	while ((c = getopt(argc, argv, "knw:h:o:l:a:x:m:t:")) != -1) {
 		switch (c) {
 		case 'o':
 			output = atoi(optarg);
@@ -354,6 +355,9 @@ int main(int argc, char **argv) {
 		case 'n':
 			animate = true;
 			break;
+		case 'k':
+			keyboard_interactive = true;
+			break;
 		default:
 			break;
 		}
@@ -407,9 +411,10 @@ int main(int argc, char **argv) {
 	zwlr_layer_surface_v1_set_exclusive_zone(layer_surface, exclusive_zone);
 	zwlr_layer_surface_v1_set_margin(layer_surface,
 			margin_top, margin_right, margin_bottom, margin_left);
+	zwlr_layer_surface_v1_set_keyboard_interactivity(
+			layer_surface, keyboard_interactive);
 	zwlr_layer_surface_v1_add_listener(layer_surface,
-				   &layer_surface_listener, layer_surface);
-	// TODO: interactivity
+			&layer_surface_listener, layer_surface);
 	wl_surface_commit(wl_surface);
 	wl_display_roundtrip(display);
 

--- a/examples/layer-shell.c
+++ b/examples/layer-shell.c
@@ -17,7 +17,7 @@ static struct wl_compositor *compositor = NULL;
 static struct wl_seat *seat = NULL;
 static struct wl_shm *shm = NULL;
 static struct wl_pointer *pointer = NULL;
-//static struct wl_keyboard *keyboard = NULL;
+static struct wl_keyboard *keyboard = NULL;
 static struct zwlr_layer_shell_v1 *layer_shell = NULL;
 struct zwlr_layer_surface_v1 *layer_surface;
 static struct wl_output *wl_output = NULL;
@@ -212,6 +212,46 @@ struct wl_pointer_listener pointer_listener = {
 	.axis_discrete = wl_pointer_axis_discrete,
 };
 
+static void wl_keyboard_keymap(void *data, struct wl_keyboard *wl_keyboard,
+		uint32_t format, int32_t fd, uint32_t size) {
+	// Who cares
+}
+
+static void wl_keyboard_enter(void *data, struct wl_keyboard *wl_keyboard,
+		uint32_t serial, struct wl_surface *surface, struct wl_array *keys) {
+	wlr_log(L_DEBUG, "Keyboard enter");
+}
+
+static void wl_keyboard_leave(void *data, struct wl_keyboard *wl_keyboard,
+		uint32_t serial, struct wl_surface *surface) {
+	wlr_log(L_DEBUG, "Keyboard leave");
+}
+
+static void wl_keyboard_key(void *data, struct wl_keyboard *wl_keyboard,
+		uint32_t serial, uint32_t time, uint32_t key, uint32_t state) {
+	wlr_log(L_DEBUG, "Key event: %d %d", key, state);
+}
+
+static void wl_keyboard_modifiers(void *data, struct wl_keyboard *wl_keyboard,
+		uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched,
+		uint32_t mods_locked, uint32_t group) {
+	// Who cares
+}
+
+static void wl_keyboard_repeat_info(void *data, struct wl_keyboard *wl_keyboard,
+		int32_t rate, int32_t delay) {
+	// Who cares
+}
+
+static struct wl_keyboard_listener keyboard_listener = {
+	.keymap = wl_keyboard_keymap,
+	.enter = wl_keyboard_enter,
+	.leave = wl_keyboard_leave,
+	.key = wl_keyboard_key,
+	.modifiers = wl_keyboard_modifiers,
+	.repeat_info = wl_keyboard_repeat_info,
+};
+
 static void seat_handle_capabilities(void *data, struct wl_seat *wl_seat,
 		enum wl_seat_capability caps) {
 	if ((caps & WL_SEAT_CAPABILITY_POINTER)) {
@@ -219,7 +259,8 @@ static void seat_handle_capabilities(void *data, struct wl_seat *wl_seat,
 		wl_pointer_add_listener(pointer, &pointer_listener, NULL);
 	}
 	if ((caps & WL_SEAT_CAPABILITY_KEYBOARD)) {
-		// TODO
+		keyboard = wl_seat_get_keyboard(wl_seat);
+		wl_keyboard_add_listener(keyboard, &keyboard_listener, NULL);
 	}
 }
 

--- a/include/rootston/seat.h
+++ b/include/rootston/seat.h
@@ -4,6 +4,7 @@
 #include <wayland-server.h>
 #include "rootston/input.h"
 #include "rootston/keyboard.h"
+#include "rootston/layers.h"
 
 struct roots_seat {
 	struct roots_input *input;
@@ -14,6 +15,9 @@ struct roots_seat {
 	// coordinates of the first touch point if it exists
 	int32_t touch_id;
 	double touch_x, touch_y;
+
+	// If the focused layer is set, views cannot receive keyboard focus
+	struct roots_layer_surface *focused_layer;
 
 	struct wl_list views; // roots_seat_view::link
 	bool has_focus;
@@ -99,6 +103,9 @@ bool roots_seat_has_meta_pressed(struct roots_seat *seat);
 struct roots_view *roots_seat_get_focus(struct roots_seat *seat);
 
 void roots_seat_set_focus(struct roots_seat *seat, struct roots_view *view);
+
+void roots_seat_set_focus_layer(struct roots_seat *seat,
+		struct roots_layer_surface *layer);
 
 void roots_seat_cycle_focus(struct roots_seat *seat);
 

--- a/include/rootston/seat.h
+++ b/include/rootston/seat.h
@@ -17,7 +17,7 @@ struct roots_seat {
 	double touch_x, touch_y;
 
 	// If the focused layer is set, views cannot receive keyboard focus
-	struct roots_layer_surface *focused_layer;
+	struct wlr_layer_surface *focused_layer;
 
 	struct wl_list views; // roots_seat_view::link
 	bool has_focus;
@@ -105,7 +105,7 @@ struct roots_view *roots_seat_get_focus(struct roots_seat *seat);
 void roots_seat_set_focus(struct roots_seat *seat, struct roots_view *view);
 
 void roots_seat_set_focus_layer(struct roots_seat *seat,
-		struct roots_layer_surface *layer);
+		struct wlr_layer_surface *layer);
 
 void roots_seat_cycle_focus(struct roots_seat *seat);
 

--- a/include/wlr/types/wlr_layer_shell.h
+++ b/include/wlr/types/wlr_layer_shell.h
@@ -99,4 +99,9 @@ void wlr_layer_surface_configure(struct wlr_layer_surface *surface,
  */
 void wlr_layer_surface_close(struct wlr_layer_surface *surface);
 
+bool wlr_surface_is_layer_surface(struct wlr_surface *surface);
+
+struct wlr_layer_surface *wlr_layer_surface_from_wlr_surface(
+		struct wlr_surface *surface);
+
 #endif

--- a/include/wlr/types/wlr_wl_shell.h
+++ b/include/wlr/types/wlr_wl_shell.h
@@ -150,4 +150,9 @@ struct wlr_wl_shell_surface *wlr_wl_shell_surface_popup_at(
 		struct wlr_wl_shell_surface *surface, double sx, double sy,
 		double *popup_sx, double *popup_sy);
 
+bool wlr_surface_is_wl_shell_surface(struct wlr_surface *surface);
+
+struct wlr_wl_surface *wlr_wl_shell_surface_from_wlr_surface(
+		struct wlr_surface *surface);
+
 #endif

--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -229,4 +229,9 @@ struct wlr_xdg_surface *wlr_xdg_surface_popup_at(
 		struct wlr_xdg_surface *surface, double sx, double sy,
 		double *popup_sx, double *popup_sy);
 
+bool wlr_surface_is_xdg_surface(struct wlr_surface *surface);
+
+struct wlr_xdg_surface *wlr_xdg_surface_from_wlr_surface(
+		struct wlr_surface *surface);
+
 #endif

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -289,4 +289,9 @@ void wlr_positioner_v6_invert_x(
 void wlr_positioner_v6_invert_y(
 		struct wlr_xdg_positioner_v6 *positioner);
 
+bool wlr_surface_is_xdg_surface_v6(struct wlr_surface *surface);
+
+struct wlr_xdg_surface_v6 *wlr_xdg_surface_v6_from_wlr_surface(
+		struct wlr_surface *surface);
+
 #endif

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -271,6 +271,12 @@ static void roots_cursor_press_button(struct roots_cursor *cursor,
 			break;
 		case WLR_BUTTON_PRESSED:
 			roots_seat_set_focus(seat, view);
+			if (surface && !view) {
+				struct wlr_layer_surface *layer = surface->role_data;
+				if (layer->current.keyboard_interactive) {
+					roots_seat_set_focus_layer(seat, layer);
+				}
+			}
 			break;
 		}
 	}

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -271,8 +271,9 @@ static void roots_cursor_press_button(struct roots_cursor *cursor,
 			break;
 		case WLR_BUTTON_PRESSED:
 			roots_seat_set_focus(seat, view);
-			if (surface && !view) {
-				struct wlr_layer_surface *layer = surface->role_data;
+			if (wlr_surface_is_layer_surface(surface)) {
+				struct wlr_layer_surface *layer =
+					wlr_layer_surface_from_wlr_surface(surface);
 				if (layer->current.keyboard_interactive) {
 					roots_seat_set_focus_layer(seat, layer);
 				}

--- a/rootston/layer_shell.c
+++ b/rootston/layer_shell.c
@@ -218,7 +218,8 @@ void arrange_layers(struct roots_output *output) {
 	struct roots_input *input = output->desktop->server->input;
 	struct roots_seat *seat;
 	wl_list_for_each(seat, &input->seats, link) {
-		roots_seat_set_focus_layer(seat, topmost);
+		roots_seat_set_focus_layer(seat,
+				topmost ? topmost->layer_surface : NULL);
 	}
 }
 

--- a/rootston/layer_shell.c
+++ b/rootston/layer_shell.c
@@ -198,13 +198,11 @@ void arrange_layers(struct roots_output *output) {
 		ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY,
 		ZWLR_LAYER_SHELL_V1_LAYER_TOP,
 	};
+	size_t nlayers = sizeof(layers_above_shell) / sizeof(layers_above_shell[0]);
 	struct roots_layer_surface *layer, *topmost = NULL;
-	for (size_t i = 0;
-			i < sizeof(layers_above_shell) / sizeof(layers_above_shell[0]);
-			++i) {
+	for (size_t i = 0; i < nlayers; ++i) {
 		wl_list_for_each_reverse(layer,
-				&output->layers[layers_above_shell[i]],
-				link) {
+				&output->layers[layers_above_shell[i]], link) {
 			if (layer->layer_surface->current.keyboard_interactive) {
 				topmost = layer;
 				break;

--- a/rootston/layer_shell.c
+++ b/rootston/layer_shell.c
@@ -214,7 +214,12 @@ void arrange_layers(struct roots_output *output) {
 			break;
 		}
 	}
-	wlr_log(L_DEBUG, "topmost interactive layer: %p", topmost);
+
+	struct roots_input *input = output->desktop->server->input;
+	struct roots_seat *seat;
+	wl_list_for_each(seat, &input->seats, link) {
+		roots_seat_set_focus_layer(seat, topmost);
+	}
 }
 
 static void handle_output_destroy(struct wl_listener *listener, void *data) {

--- a/rootston/layer_shell.c
+++ b/rootston/layer_shell.c
@@ -192,6 +192,29 @@ void arrange_layers(struct roots_output *output) {
 	arrange_layer(output->wlr_output,
 			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND],
 			&usable_area, false);
+
+	// Find topmost keyboard interactive layer, if such a layer exists
+	uint32_t layers_above_shell[] = {
+		ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY,
+		ZWLR_LAYER_SHELL_V1_LAYER_TOP,
+	};
+	struct roots_layer_surface *layer, *topmost = NULL;
+	for (size_t i = 0;
+			i < sizeof(layers_above_shell) / sizeof(layers_above_shell[0]);
+			++i) {
+		wl_list_for_each_reverse(layer,
+				&output->layers[layers_above_shell[i]],
+				link) {
+			if (layer->layer_surface->current.keyboard_interactive) {
+				topmost = layer;
+				break;
+			}
+		}
+		if (topmost != NULL) {
+			break;
+		}
+	}
+	wlr_log(L_DEBUG, "topmost interactive layer: %p", topmost);
 }
 
 static void handle_output_destroy(struct wl_listener *listener, void *data) {

--- a/types/wlr_layer_shell.c
+++ b/types/wlr_layer_shell.c
@@ -34,6 +34,16 @@ static struct wlr_layer_surface *layer_surface_from_resource(
 	return wl_resource_get_user_data(resource);
 }
 
+bool wlr_surface_is_layer_surface(struct wlr_surface *surface) {
+	return strcmp(surface->role, zwlr_layer_surface_role) == 0;
+}
+
+struct wlr_layer_surface *wlr_layer_surface_from_wlr_surface(
+		struct wlr_surface *surface) {
+	assert(wlr_surface_is_layer_surface(surface));
+	return (struct wlr_layer_surface *)surface->role_data;
+}
+
 static void layer_surface_configure_destroy(
 		struct wlr_layer_surface_configure *configure) {
 	if (configure == NULL) {

--- a/types/wlr_wl_shell.c
+++ b/types/wlr_wl_shell.c
@@ -12,6 +12,16 @@
 
 static const char *wlr_wl_shell_surface_role = "wl-shell-surface";
 
+bool wlr_surface_is_wl_shell_surface(struct wlr_surface *surface) {
+	return strcmp(surface->role, wlr_wl_shell_surface_role) == 0;
+}
+
+struct wlr_wl_surface *wlr_wl_shell_surface_from_wlr_surface(
+		struct wlr_surface *surface) {
+	assert(wlr_surface_is_wl_shell_surface(surface));
+	return (struct wlr_wl_surface *)surface->role_data;
+}
+
 static void shell_pointer_grab_end(struct wlr_seat_pointer_grab *grab) {
 	struct wlr_wl_shell_popup_grab *popup_grab = grab->data;
 

--- a/types/wlr_xdg_shell.c
+++ b/types/wlr_xdg_shell.c
@@ -16,6 +16,17 @@
 static const char *wlr_desktop_xdg_toplevel_role = "xdg_toplevel";
 static const char *wlr_desktop_xdg_popup_role = "xdg_popup";
 
+bool wlr_surface_is_xdg_surface(struct wlr_surface *surface) {
+	return strcmp(surface->role, wlr_desktop_xdg_toplevel_role) == 0 ||
+		strcmp(surface->role, wlr_desktop_xdg_popup_role) == 0;
+}
+
+struct wlr_xdg_surface *wlr_xdg_surface_from_wlr_surface(
+		struct wlr_surface *surface) {
+	assert(wlr_surface_is_xdg_surface(surface));
+	return (struct wlr_xdg_surface *)surface->role_data;
+}
+
 struct wlr_xdg_positioner {
 	struct wl_resource *resource;
 

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -16,6 +16,17 @@
 static const char *wlr_desktop_xdg_toplevel_role = "xdg_toplevel_v6";
 static const char *wlr_desktop_xdg_popup_role = "xdg_popup_v6";
 
+bool wlr_surface_is_xdg_surface_v6(struct wlr_surface *surface) {
+	return strcmp(surface->role, wlr_desktop_xdg_toplevel_role) == 0 ||
+		strcmp(surface->role, wlr_desktop_xdg_popup_role) == 0;
+}
+
+struct wlr_xdg_surface_v6 *wlr_xdg_surface_v6_from_wlr_surface(
+		struct wlr_surface *surface) {
+	assert(wlr_surface_is_xdg_surface_v6(surface));
+	return (struct wlr_xdg_surface_v6 *)surface->role_data;
+}
+
 struct wlr_xdg_positioner_v6_resource {
 	struct wl_resource *resource;
 	struct wlr_xdg_positioner_v6 attrs;


### PR DESCRIPTION
Per the spec, the topmost layer surface above the shell surface layer always has keyboard focus. Beneath the shell surface layer, layer surfaces will receive keyboard focus normally (when clicked). Note that layer surfaces beneath the shell surface layer receive a sort of temporary focus from the seat - they do not participate in the usual focus list for alt-tabbing and such. Layer surfaces that do not want keyboard input continue to not receive keyboard enter events or take focus away from other surfaces when clicked.

To request keyboard events, pass `-k` to the example layer shell and look for key events in the log.