### PR TITLE
Added user data field for wlr_cursor

### DIFF
--- a/include/wlr/types/wlr_cursor.h
+++ b/include/wlr/types/wlr_cursor.h
@@ -54,6 +54,8 @@ struct wlr_cursor {
 		struct wl_signal tablet_tool_tip;
 		struct wl_signal tablet_tool_button;
 	} events;
+
+	void *data;
 };
 
 struct wlr_cursor *wlr_cursor_create();


### PR DESCRIPTION
This is required for wlroots-rs to implement https://github.com/swaywm/wlroots-rs/issues/125 since we need this field to store a runtime handle to ensure there's not multiple mutable borrows.