### PR TITLE
backend/{x11,headless}: use default if supplied refresh is invalid

### DIFF
--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -25,7 +25,7 @@ static bool output_set_custom_mode(struct wlr_output *wlr_output, int32_t width,
 		(struct wlr_headless_output *)wlr_output;
 	struct wlr_headless_backend *backend = output->backend;
 
-	if (refresh == 0) {
+	if (refresh <= 0) {
 		refresh = HEADLESS_DEFAULT_REFRESH;
 	}
 

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -26,7 +26,7 @@ static void parse_xcb_setup(struct wlr_output *output, xcb_connection_t *xcb_con
 static void output_set_refresh(struct wlr_output *wlr_output, int32_t refresh) {
 	struct wlr_x11_output *output = (struct wlr_x11_output *)wlr_output;
 
-	if (refresh == 0) {
+	if (refresh <= 0) {
 		refresh = X11_DEFAULT_REFRESH;
 	}
 


### PR DESCRIPTION
This fixes custom modes in Sway.