### PR TITLE
rootston: fix compilation without XWayland support

### DIFF
--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -593,10 +593,12 @@ static bool view_at(struct roots_view *view, double lx, double ly,
 		_surface = wlr_wl_shell_surface_surface_at(view->wl_shell_surface,
 			view_sx, view_sy, &_sx, &_sy);
 		break;
+#ifdef WLR_HAS_XWAYLAND
 	case ROOTS_XWAYLAND_VIEW:
 		_surface = wlr_surface_surface_at(view->wlr_surface,
 			view_sx, view_sy, &_sx, &_sy);
 		break;
+#endif
 	}
 	if (_surface != NULL) {
 		*sx = _sx;


### PR DESCRIPTION
Continuation of https://github.com/swaywm/wlroots/commit/52cb19d99d3d667f4475f404a333e347654808dc