### PR TITLE
Fix wlr_xdg_surface_surface_at for popups

### DIFF
--- a/types/wlr_xdg_shell.c
+++ b/types/wlr_xdg_shell.c
@@ -1644,8 +1644,8 @@ struct wlr_surface *wlr_xdg_surface_surface_at(
 		wlr_xdg_surface_popup_get_position(popup, &popup_sx, &popup_sy);
 
 		struct wlr_surface *sub = wlr_xdg_surface_surface_at(popup,
-			sx - popup_sx + popup->geometry.x,
-			sy - popup_sy + popup->geometry.y,
+			sx - popup_sx,
+			sy - popup_sy,
 			sub_x, sub_y);
 		if (sub != NULL) {
 			return sub;

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -1608,8 +1608,8 @@ struct wlr_surface *wlr_xdg_surface_v6_surface_at(
 		wlr_xdg_surface_v6_popup_get_position(popup, &popup_sx, &popup_sy);
 
 		struct wlr_surface *sub = wlr_xdg_surface_v6_surface_at(popup,
-			sx - popup_sx + popup->geometry.x,
-			sy - popup_sy + popup->geometry.y,
+			sx - popup_sx,
+			sy - popup_sy,
 			sub_x, sub_y);
 		if (sub != NULL) {
 			return sub;


### PR DESCRIPTION
Test plan: open `gnome-calculator`, open a popup (e.g. the combobox or a right click menu), check that pointer input is fixed.

Fixes #858