### PR TITLE
Use 'private-code' for wayland-scanner code generation

### DIFF
--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -8,10 +8,17 @@ wayland_scanner_server = generator(
 	arguments: ['server-header', '@INPUT@', '@OUTPUT@'],
 )
 
+# should check wayland_scanner's version, but it is hard to get
+if wayland_server.version().version_compare('>=1.14.91')
+	code_type = 'private-code'
+else
+	code_type = 'code'
+endif
+
 wayland_scanner_code = generator(
 	wayland_scanner,
 	output: '@BASENAME@-protocol.c',
-	arguments: ['code', '@INPUT@', '@OUTPUT@'],
+	arguments: [code_type, '@INPUT@', '@OUTPUT@'],
 )
 
 wayland_scanner_client = generator(


### PR DESCRIPTION
They deprecated 'code' for 'public-code', but suggest using 'private-code'...

arch doesn't have that version of wayland yet, so this is only annoying me and either needs me to live with it or wait until the build bot gets the update (I have 1.14.93 but 1.15.0 just got released and should probably be there soonish)

The second question is I haven't deeply checked what difference is between public/private-code. I haven't had any problem with this using private-code (e.g. swaybar works fine) but maybe some will want to use wlroots in a way that require public-code, I don't really understand the implication of the marshaling difference.

Once something is decide here I'll push the same for sway.