### PR TITLE
Fix gcc string truncation warnings

### DIFF
--- a/examples/support/config.c
+++ b/examples/support/config.c
@@ -202,7 +202,10 @@ struct example_config *parse_args(int argc, char *argv[]) {
 		char cwd[MAXPATHLEN];
 		if (getcwd(cwd, sizeof(cwd)) != NULL) {
 			char buf[MAXPATHLEN];
-			snprintf(buf, MAXPATHLEN, "%s/%s", cwd, "wlr-example.ini");
+			if (snprintf(buf, MAXPATHLEN, "%s/%s", cwd, "wlr-example.ini") >= MAXPATHLEN) {
+				wlr_log(L_ERROR, "config path too long");
+				exit(1);
+			}
 			config->config_path = strdup(buf);
 		} else {
 			wlr_log(L_ERROR, "could not get cwd");

--- a/examples/support/ini.c
+++ b/examples/support/ini.c
@@ -64,7 +64,7 @@ static char* find_chars_or_comment(const char* s, const char* chars)
 /* Version of strncpy that ensures dest (size bytes) is null-terminated. */
 static char* strncpy0(char* dest, const char* src, size_t size)
 {
-    strncpy(dest, src, size);
+    strncpy(dest, src, size-1);
     dest[size - 1] = '\0';
     return dest;
 }

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -55,7 +55,7 @@ struct wlr_output {
 	struct wl_global *wl_global;
 	struct wl_list wl_resources;
 
-	char name[16];
+	char name[24];
 	char make[48];
 	char model[16];
 	char serial[16];

--- a/rootston/config.c
+++ b/rootston/config.c
@@ -418,7 +418,10 @@ struct roots_config *roots_config_create_from_args(int argc, char *argv[]) {
 		char cwd[MAXPATHLEN];
 		if (getcwd(cwd, sizeof(cwd)) != NULL) {
 			char buf[MAXPATHLEN];
-			snprintf(buf, MAXPATHLEN, "%s/%s", cwd, "rootston.ini");
+			if (snprintf(buf, MAXPATHLEN, "%s/%s", cwd, "rootston.ini") >= MAXPATHLEN) {
+				wlr_log(L_ERROR, "config path too long");
+				exit(1);
+			}
 			config->config_path = strdup(buf);
 		} else {
 			wlr_log(L_ERROR, "could not get cwd");

--- a/rootston/ini.c
+++ b/rootston/ini.c
@@ -64,7 +64,7 @@ static char* find_chars_or_comment(const char* s, const char* chars)
 /* Version of strncpy that ensures dest (size bytes) is null-terminated. */
 static char* strncpy0(char* dest, const char* src, size_t size)
 {
-    strncpy(dest, src, size);
+    strncpy(dest, src, size-1);
     dest[size - 1] = '\0';
     return dest;
 }


### PR DESCRIPTION
Or if you don't like these let's add -Wno-format-truncation -Wno-stringop-truncation (the later only happens in -O2, but I'm not sure what enables both as I only get them on fedora)

likewise, I have the same for sway, just waiting to see how this is received to push.