### PR TITLE
Some changes to the x11 backend

### DIFF
--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -67,9 +67,7 @@ void x11_output_layout_get_box(struct wlr_x11_backend *backend,
 
 static void handle_x11_event(struct wlr_x11_backend *x11,
 		xcb_generic_event_t *event) {
-	if (x11_handle_input_event(x11, event)) {
-		return;
-	}
+	x11_handle_input_event(x11, event);
 
 	switch (event->response_type & XCB_EVENT_RESPONSE_TYPE_MASK) {
 	case XCB_EXPOSE: {

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -74,7 +74,7 @@ static void handle_x11_event(struct wlr_x11_backend *x11,
 		xcb_expose_event_t *ev = (xcb_expose_event_t *)event;
 		struct wlr_x11_output *output =
 			x11_output_from_window_id(x11, ev->window);
-		if (output != NULL) {
+		if (output != NULL && !output->wlr_output.frame_pending) {
 			wlr_output_send_frame(&output->wlr_output);
 		}
 		break;

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -65,10 +65,10 @@ void x11_output_layout_get_box(struct wlr_x11_backend *backend,
 	box->height = max_y - min_y;
 }
 
-static bool handle_x11_event(struct wlr_x11_backend *x11,
+static void handle_x11_event(struct wlr_x11_backend *x11,
 		xcb_generic_event_t *event) {
 	if (x11_handle_input_event(x11, event)) {
-		return false;
+		return;
 	}
 
 	switch (event->response_type & XCB_EVENT_RESPONSE_TYPE_MASK) {
@@ -103,8 +103,6 @@ static bool handle_x11_event(struct wlr_x11_backend *x11,
 		break;
 	}
 	}
-
-	return false;
 }
 
 static int x11_event(int fd, uint32_t mask, void *data) {
@@ -117,11 +115,8 @@ static int x11_event(int fd, uint32_t mask, void *data) {
 
 	xcb_generic_event_t *e;
 	while ((e = xcb_poll_for_event(x11->xcb_conn))) {
-		bool quit = handle_x11_event(x11, e);
+		handle_x11_event(x11, e);
 		free(e);
-		if (quit) {
-			break;
-		}
 	}
 
 	return 0;

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -114,9 +114,8 @@ struct wlr_output *wlr_x11_output_create(struct wlr_backend *backend) {
 		wl_list_length(&x11->outputs) + 1);
 	parse_xcb_setup(wlr_output, x11->xcb_conn);
 
-	uint32_t mask = XCB_CW_BACK_PIXEL | XCB_CW_EVENT_MASK;
-	uint32_t values[2] = {
-		x11->screen->white_pixel,
+	uint32_t mask = XCB_CW_EVENT_MASK;
+	uint32_t values[] = {
 		XCB_EVENT_MASK_EXPOSURE |
 		XCB_EVENT_MASK_KEY_PRESS | XCB_EVENT_MASK_KEY_RELEASE |
 		XCB_EVENT_MASK_BUTTON_PRESS | XCB_EVENT_MASK_BUTTON_RELEASE |

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -79,7 +79,7 @@ void x11_output_layout_get_box(struct wlr_x11_backend *backend,
 
 const struct wlr_input_device_impl input_device_impl;
 
-bool x11_handle_input_event(struct wlr_x11_backend *x11,
+void x11_handle_input_event(struct wlr_x11_backend *x11,
 	xcb_generic_event_t *event);
 void x11_update_pointer_position(struct wlr_x11_output *output,
 	xcb_timestamp_t time);


### PR DESCRIPTION
The first commit is a refactoring with (I think) obviously no change in behaviour.
The second commit has a harmless, internal-only behaviour change that should not make any difference.
The last two commits in this deal with resizing. They can be tested by starting rootston with the X11 backend, (making it floating if on a tiling WM,) and resizing it with the mouse a lot.