### PR TITLE
x11 backend: Expose events mean "needs swap"

### DIFF
--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -74,8 +74,8 @@ static void handle_x11_event(struct wlr_x11_backend *x11,
 		xcb_expose_event_t *ev = (xcb_expose_event_t *)event;
 		struct wlr_x11_output *output =
 			x11_output_from_window_id(x11, ev->window);
-		if (output != NULL && !output->wlr_output.frame_pending) {
-			wlr_output_send_frame(&output->wlr_output);
+		if (output != NULL) {
+			wlr_output_update_needs_swap(&output->wlr_output);
 		}
 		break;
 	}


### PR DESCRIPTION
When the X11 server sends an expose event, that means that "this
rectangle here (the event contains x,y,width,height) has undefined
contents on your window; please redraw that". This means that we need a
swap. However, so far the code does not actually enforce that a swap
happens.

For example, start rootston, switch to another workspace and then switch
back. The rootston window will not be redrawn (before commit
52b058c2a31fb, it would just be fully white; after that commit it will
show whatever was visible on the old workspace). This is because the
drawing code concludes that nothing needs to be done. However, in fact a
swap is necessary.

This reverts commit e79d92458852373, because its optimisation is already
done now: wlr_output_update_needs_swap() emits a signal, which is
handled by wlr_output_damage with a call to wlr_output_schedule_frame().
This function does nothing if a frame is already pending. Thus, the
optimisation from commit e79d92458852373 now happens implicitly.

Signed-off-by: Uli Schlachter <psychon@znc.in>