### PR TITLE
rootston: don't crash on shutdown

### DIFF
--- a/rootston/layer_shell.c
+++ b/rootston/layer_shell.c
@@ -270,8 +270,10 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	wl_list_remove(&layer->map.link);
 	wl_list_remove(&layer->unmap.link);
 	wl_list_remove(&layer->surface_commit.link);
-	wl_list_remove(&layer->output_destroy.link);
-	arrange_layers((struct roots_output *)layer->layer_surface->output->data);
+	if (layer->layer_surface->output) {
+		wl_list_remove(&layer->output_destroy.link);
+		arrange_layers((struct roots_output *)layer->layer_surface->output->data);
+	}
 	free(layer);
 }
 


### PR DESCRIPTION
When e.g. running rootston under X11 it would otherwise crash when
closing rootston like:

    #0  0x00007f0197da7327 in wl_list_remove () at /usr/lib/x86_64-linux-gnu/libwayland-server.so.0
    #1  0x000056306fcee7fb in handle_destroy (listener=0x5630723a2948, data=0x5630723a5d20) at ../rootston/layer_shell.c:273
    #2  0x00007f019800a552 in wlr_signal_emit_safe (signal=0x5630723a5e30, data=0x5630723a5d20) at ../util/signal.c:29
    #3  0x00007f0197fef808 in layer_surface_destroy (surface=0x5630723a5d20) at ../types/wlr_layer_shell.c:169
    #4  0x00007f0197ff0001 in client_handle_destroy (resource=0x56307229c4c0) at ../types/wlr_layer_shell.c:371
    #5  0x00007f0197da2f30 in  () at /usr/lib/x86_64-linux-gnu/libwayland-server.so.0
    #6  0x00007f0197da77f9 in  () at /usr/lib/x86_64-linux-gnu/libwayland-server.so.0
    #7  0x00007f0197da301d in wl_client_destroy () at /usr/lib/x86_64-linux-gnu/libwayland-server.so.0
    #8  0x00007f0197da30d8 in  () at /usr/lib/x86_64-linux-gnu/libwayland-server.so.0
    #9  0x00007f0197da4c12 in wl_event_loop_dispatch () at /usr/lib/x86_64-linux-gnu/libwayland-server.so.0
    #10 0x00007f0197da344a in wl_display_run () at /usr/lib/x86_64-linux-gnu/libwayland-server.so.0
    #11 0x000056306fcef069 in main (argc=3, argv=0x7ffd22032528) at ../rootston/main.c:83

since the output_destroy got already removed in handle_output_destroy.