### PR TITLE
reorder xkb state handling in wlr_keyboard

### DIFF
--- a/types/wlr_keyboard.c
+++ b/types/wlr_keyboard.c
@@ -120,6 +120,10 @@ void wlr_keyboard_notify_key(struct wlr_keyboard *keyboard,
 	if (keyboard->xkb_state == NULL) {
 		return;
 	}
+
+	keyboard_key_update(keyboard, event);
+	wlr_signal_emit_safe(&keyboard->events.key, event);
+
 	if (event->update_state) {
 		uint32_t keycode = event->keycode + 8;
 		xkb_state_update_key(keyboard->xkb_state, keycode,
@@ -131,9 +135,6 @@ void wlr_keyboard_notify_key(struct wlr_keyboard *keyboard,
 	if (updated) {
 		wlr_signal_emit_safe(&keyboard->events.modifiers, keyboard);
 	}
-
-	keyboard_key_update(keyboard, event);
-	wlr_signal_emit_safe(&keyboard->events.key, event);
 }
 
 void wlr_keyboard_init(struct wlr_keyboard *kb,


### PR DESCRIPTION
wlr_keyboard manages the xkb-common state of the compositor.
It used to update the state, update the modifiers, then notify the
compositor.
When [Shift_L] was pressed and released, this resulted in an event chain:
  Modifiers: Shift
  Key: Shift_L (Pressed)

  Modifiers:
  Key: Shift_L (Release)

The xkb-docs state that the state should be updated *after* the key was
handled [1], to prevent the new state from influencing the actual key
generated.

To achieve this, the event to the compositor is emitted, *before*
wlroots handles the xkb and internal keyboard state.

With this patch applied, the emitted events ill be:
  Modifiers:
  Key: Shift_L (Pressed)

  Modifiers: Shift
  Key: Shift_L (Release)

[1] https://xkbcommon.org/doc/current/group__state.html#gac554aa20743a621692c1a744a05e06ce

Testplan: Log the generated keybind checks and see the difference.
**Might** be related to swaywm/sway#1161, though I haven't tested that.