### PR TITLE
DPMS handling for wlr_output

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -461,6 +461,17 @@ error_conn:
 	return 0;
 }
 
+static void wlr_drm_connector_set_dpms(struct wlr_output *output, enum dpms_enum level) {
+	struct wlr_drm_connector *conn = (struct wlr_drm_connector *)output;
+	struct wlr_drm_backend *drm = (struct wlr_drm_backend *)output->backend;
+
+    if (drmModeObjectSetProperty (drm->fd, conn->id,
+                DRM_MODE_OBJECT_CONNECTOR,
+                conn->props.dpms, level) < 0)
+        wlr_log(L_ERROR, "Failed to set dpms state for %s", conn->output.name);
+
+}
+
 static bool wlr_drm_connector_set_mode(struct wlr_output *output,
 		struct wlr_output_mode *mode) {
 	struct wlr_drm_connector *conn = (struct wlr_drm_connector *)output;
@@ -710,6 +721,7 @@ static void wlr_drm_connector_destroy(struct wlr_output *output) {
 static struct wlr_output_impl output_impl = {
 	.enable = wlr_drm_connector_enable,
 	.set_mode = wlr_drm_connector_set_mode,
+	.set_dpms = wlr_drm_connector_set_dpms,
 	.transform = wlr_drm_connector_transform,
 	.set_cursor = wlr_drm_connector_set_cursor,
 	.move_cursor = wlr_drm_connector_move_cursor,

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -9,6 +9,7 @@
 struct wlr_output_impl {
 	void (*enable)(struct wlr_output *output, bool enable);
 	bool (*set_mode)(struct wlr_output *output, struct wlr_output_mode *mode);
+	void (*set_dpms)(struct wlr_output *output, enum dpms_enum level);
 	bool (*set_custom_mode)(struct wlr_output *output, int32_t width,
 		int32_t height, int32_t refresh);
 	void (*transform)(struct wlr_output *output,

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -14,6 +14,16 @@ struct wlr_output_mode {
 	struct wl_list link;
 };
 
+/* From weston */
+/* bit compatible with drm definitions. */
+enum dpms_enum {
+    WLR_DPMS_ON,
+    WLR_DPMS_STANDBY,
+    WLR_DPMS_SUSPEND,
+    WLR_DPMS_OFF
+};
+
+
 struct wlr_output_cursor {
 	struct wlr_output *output;
 	double x, y;
@@ -117,6 +127,9 @@ void wlr_output_destroy_global(struct wlr_output *output);
  */
 bool wlr_output_set_mode(struct wlr_output *output,
 	struct wlr_output_mode *mode);
+
+void wlr_output_set_dpms(struct wlr_output *output, enum dpms_enum level);
+
 /**
  * Sets a custom mode on the output. If modes are available, they are preferred.
  * Setting `refresh` to zero lets the backend pick a preferred value.

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -161,6 +161,15 @@ bool wlr_output_set_mode(struct wlr_output *output,
 	return output->impl->set_mode(output, mode);
 }
 
+void wlr_output_set_dpms(struct wlr_output *output,
+		enum dpms_enum level) {
+	if (!output->impl || !output->impl->set_dpms) {
+		return;
+	}
+	return output->impl->set_dpms(output, level);
+}
+
+
 bool wlr_output_set_custom_mode(struct wlr_output *output, int32_t width,
 		int32_t height, int32_t refresh) {
 	if (!output->impl || !output->impl->set_custom_mode) {


### PR DESCRIPTION
This pull request adds DPMS handling to wlr_output.
This is needed for https://github.com/swaywm/sway/pull/1824
That fixes  https://github.com/swaywm/sway/issues/541