### PR TITLE
Layer popups: work on top of PR 867

### DIFF
--- a/examples/layer-shell.c
+++ b/examples/layer-shell.c
@@ -165,14 +165,19 @@ static void create_popup() {
 	}
 	struct wl_surface *surface = wl_compositor_create_surface(compositor);
 	assert(xdg_wm_base && surface);
-	struct xdg_surface *xdg_surface = xdg_wm_base_get_xdg_surface(
-			xdg_wm_base, surface);
-	struct xdg_positioner *xdg_positioner = xdg_wm_base_create_positioner(
-			xdg_wm_base);
+	struct xdg_surface *xdg_surface =
+		xdg_wm_base_get_xdg_surface(xdg_wm_base, surface);
+	struct xdg_positioner *xdg_positioner =
+		xdg_wm_base_create_positioner(xdg_wm_base);
 	assert(xdg_surface && xdg_positioner);
 
 	xdg_positioner_set_size(xdg_positioner, 256, 256);
-	xdg_positioner_set_anchor_rect(xdg_positioner, 0, 0, width, height);
+	xdg_positioner_set_offset(xdg_positioner, 0, 0);
+	xdg_positioner_set_anchor_rect(xdg_positioner, cur_x, cur_y, 1, 1);
+	xdg_positioner_set_anchor(xdg_positioner, XDG_POSITIONER_ANCHOR_TOP_LEFT);
+	xdg_positioner_set_gravity(xdg_positioner, XDG_POSITIONER_GRAVITY_TOP_LEFT);
+	xdg_positioner_set_constraint_adjustment(xdg_positioner,
+			XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_NONE);
 
 	popup = xdg_surface_get_popup(xdg_surface, NULL, xdg_positioner);
 	assert(popup);
@@ -184,6 +189,8 @@ static void create_popup() {
 
 	wl_surface_commit(surface);
 	wl_display_roundtrip(display);
+
+	xdg_positioner_destroy(xdg_positioner);
 
 	struct wl_egl_window *egl_window;
 	struct wlr_egl_surface *egl_surface;

--- a/examples/layer-shell.c
+++ b/examples/layer-shell.c
@@ -188,12 +188,20 @@ static void xdg_popup_configure(void *data, struct xdg_popup *xdg_popup,
 	}
 }
 
-static void xdg_popup_done(void *data, struct xdg_popup *xdg_popup) {
+static void popup_destroy()
+{
 	eglDestroySurface(egl.display, popup_egl_surface);
 	wl_egl_window_destroy(popup_egl_window);
-	wl_surface_destroy(popup_wl_surface);
 	xdg_popup_destroy(popup);
+	wl_surface_destroy(popup_wl_surface);
+	popup_wl_surface = NULL;
 	popup = NULL;
+	popup_egl_window = NULL;
+}
+
+static void xdg_popup_done(void *data, struct xdg_popup *xdg_popup) {
+	wlr_log(L_DEBUG, "Popup done");
+	popup_destroy();
 }
 
 static const struct xdg_popup_listener xdg_popup_listener = {
@@ -300,7 +308,11 @@ static void wl_pointer_button(void *data, struct wl_pointer *wl_pointer,
 	if (input_surface == wl_surface) {
 		if (state == WL_POINTER_BUTTON_STATE_PRESSED) {
 			if (button == BTN_RIGHT) {
-				create_popup();
+				if (popup_wl_surface) {
+					popup_destroy();
+				} else {
+					create_popup();
+				}
 			} else {
 				buttons++;
 			}

--- a/examples/layer-shell.c
+++ b/examples/layer-shell.c
@@ -175,8 +175,7 @@ static void create_popup() {
 	xdg_positioner_set_size(xdg_positioner, 256, 256);
 	xdg_positioner_set_offset(xdg_positioner, 0, 0);
 	xdg_positioner_set_anchor_rect(xdg_positioner, cur_x, cur_y, 1, 1);
-	xdg_positioner_set_anchor(xdg_positioner, XDG_POSITIONER_ANCHOR_TOP_LEFT);
-	xdg_positioner_set_gravity(xdg_positioner, XDG_POSITIONER_GRAVITY_TOP_LEFT);
+	xdg_positioner_set_anchor(xdg_positioner, XDG_POSITIONER_ANCHOR_BOTTOM_RIGHT);
 
 	popup = xdg_surface_get_popup(xdg_surface, NULL, xdg_positioner);
 	assert(popup);

--- a/examples/layer-shell.c
+++ b/examples/layer-shell.c
@@ -145,7 +145,8 @@ static const struct xdg_surface_listener xdg_surface_listener = {
 
 static void xdg_popup_configure(void *data, struct xdg_popup *xdg_popup,
 		int32_t x, int32_t y, int32_t width, int32_t height) {
-	// Meh.
+	wlr_log(L_DEBUG, "Popup configured %dx%d@%d,%d",
+			width, height, x, y);
 }
 
 static void xdg_popup_done(void *data, struct xdg_popup *xdg_popup) {
@@ -176,8 +177,6 @@ static void create_popup() {
 	xdg_positioner_set_anchor_rect(xdg_positioner, cur_x, cur_y, 1, 1);
 	xdg_positioner_set_anchor(xdg_positioner, XDG_POSITIONER_ANCHOR_TOP_LEFT);
 	xdg_positioner_set_gravity(xdg_positioner, XDG_POSITIONER_GRAVITY_TOP_LEFT);
-	xdg_positioner_set_constraint_adjustment(xdg_positioner,
-			XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_NONE);
 
 	popup = xdg_surface_get_popup(xdg_surface, NULL, xdg_positioner);
 	assert(popup);

--- a/examples/layer-shell.c
+++ b/examples/layer-shell.c
@@ -39,7 +39,6 @@ struct wlr_egl_surface *egl_surface;
 struct wl_callback *frame_callback;
 
 static uint32_t output = UINT32_MAX;
-struct xdg_surface *popup_surface;
 struct xdg_popup *popup;
 
 static uint32_t layer = ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND;

--- a/include/rootston/layers.h
+++ b/include/rootston/layers.h
@@ -14,9 +14,19 @@ struct roots_layer_surface {
 	struct wl_listener unmap;
 	struct wl_listener surface_commit;
 	struct wl_listener output_destroy;
+	struct wl_listener new_popup;
 
 	bool configured;
 	struct wlr_box geo;
+};
+
+struct roots_layer_popup {
+	struct roots_layer_surface *parent;
+	struct wlr_xdg_popup *wlr_popup;
+	struct wl_listener map;
+	struct wl_listener unmap;
+	struct wl_listener destroy;
+	struct wl_listener commit;
 };
 
 struct roots_output;

--- a/include/wlr/types/wlr_layer_shell.h
+++ b/include/wlr/types/wlr_layer_shell.h
@@ -109,4 +109,8 @@ bool wlr_surface_is_layer_surface(struct wlr_surface *surface);
 struct wlr_layer_surface *wlr_layer_surface_from_wlr_surface(
 		struct wlr_surface *surface);
 
+/* Calls the iterator function for each sub-surface and popup of this surface */
+void wlr_layer_surface_for_each_surface(struct wlr_layer_surface *surface,
+		wlr_surface_iterator_func_t iterator, void *user_data);
+
 #endif

--- a/include/wlr/types/wlr_layer_shell.h
+++ b/include/wlr/types/wlr_layer_shell.h
@@ -59,6 +59,7 @@ struct wlr_layer_surface {
 	struct wlr_output *output;
 	struct wl_resource *resource;
 	struct wlr_layer_shell *shell;
+	struct wl_list popups; // wlr_xdg_popup::link
 
 	const char *namespace;
 	enum zwlr_layer_shell_v1_layer layer;
@@ -81,6 +82,7 @@ struct wlr_layer_surface {
 		struct wl_signal destroy;
 		struct wl_signal map;
 		struct wl_signal unmap;
+		struct wl_signal new_popup;
 	} events;
 
 	void *data;

--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -259,6 +259,46 @@ void wlr_xdg_surface_popup_get_position(struct wlr_xdg_surface *surface,
 		double *popup_sx, double *popup_sy);
 
 /**
+ * Get the geometry for this positioner based on the anchor rect, gravity, and
+ * size of this positioner.
+ */
+struct wlr_box wlr_xdg_positioner_get_geometry(
+		struct wlr_xdg_positioner *positioner);
+
+/**
+ * Get the anchor point for this popup in the toplevel parent's coordinate system.
+ */
+void wlr_xdg_popup_get_anchor_point(struct wlr_xdg_popup *popup,
+		int *toplevel_sx, int *toplevel_sy);
+
+/**
+ * Convert the given coordinates in the popup coordinate system to the toplevel
+ * surface coordinate system.
+ */
+void wlr_xdg_popup_get_toplevel_coords(struct wlr_xdg_popup *popup,
+		int popup_sx, int popup_sy, int *toplevel_sx, int *toplevel_sy);
+
+/**
+ * Set the geometry of this popup to unconstrain it according to its
+ * xdg-positioner rules. The box should be in the popup's root toplevel parent
+ * surface coordinate system.
+ */
+void wlr_xdg_popup_unconstrain_from_box(struct wlr_xdg_popup *popup,
+		struct wlr_box *toplevel_sx_box);
+
+/**
+  Invert the right/left anchor and gravity for this positioner. This can be
+  used to "flip" the positioner around the anchor rect in the x direction.
+ */
+void wlr_positioner_invert_x(struct wlr_xdg_positioner *positioner);
+
+/**
+  Invert the top/bottom anchor and gravity for this positioner. This can be
+  used to "flip" the positioner around the anchor rect in the y direction.
+ */
+void wlr_positioner_invert_y(struct wlr_xdg_positioner *positioner);
+
+/**
  * Find a surface within this xdg-surface tree at the given surface-local
  * coordinates. Returns the surface and coordinates in the leaf surface
  * coordinate system or NULL if no surface is found at that location.

--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -1,9 +1,9 @@
 #ifndef WLR_TYPES_WLR_XDG_SHELL_H
 #define WLR_TYPES_WLR_XDG_SHELL_H
-
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_seat.h>
 #include <wayland-server.h>
+#include "xdg-shell-protocol.h"
 
 struct wlr_xdg_shell {
 	struct wl_global *wl_global;
@@ -32,7 +32,22 @@ struct wlr_xdg_client {
 	struct wl_event_source *ping_timer;
 };
 
-struct wlr_xdg_positioner;
+struct wlr_xdg_positioner {
+	struct wl_resource *resource;
+
+	struct wlr_box anchor_rect;
+	enum xdg_positioner_anchor anchor;
+	enum xdg_positioner_gravity gravity;
+	enum xdg_positioner_constraint_adjustment constraint_adjustment;
+
+	struct {
+		int32_t width, height;
+	} size;
+
+	struct {
+		int32_t x, y;
+	} offset;
+};
 
 struct wlr_xdg_popup {
 	struct wlr_xdg_surface *base;
@@ -43,10 +58,11 @@ struct wlr_xdg_popup {
 	struct wlr_surface *parent;
 	struct wlr_seat *seat;
 
-	struct wlr_xdg_positioner *positioner;
 	// Position of the popup relative to the upper left corner of the window
 	// geometry of the parent surface
 	struct wlr_box geometry;
+
+	struct wlr_xdg_positioner positioner;
 
 	struct wl_list grab_link; // wlr_xdg_popup_grab::popups
 };
@@ -186,7 +202,8 @@ struct wlr_xdg_surface *wlr_xdg_surface_from_resource(
 struct wlr_xdg_surface *wlr_xdg_surface_from_popup_resource(
 		struct wl_resource *resource);
 
-struct wlr_box wlr_xdg_popup_get_geometry(struct wlr_xdg_popup *popup);
+struct wlr_box wlr_xdg_positioner_get_geometry(
+		struct wlr_xdg_positioner *positioner);
 
 /**
  * Send a ping to the surface. If the surface does not respond in a reasonable

--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -32,15 +32,18 @@ struct wlr_xdg_client {
 	struct wl_event_source *ping_timer;
 };
 
+struct wlr_xdg_positioner;
+
 struct wlr_xdg_popup {
 	struct wlr_xdg_surface *base;
 	struct wl_list link;
 
 	struct wl_resource *resource;
 	bool committed;
-	struct wlr_xdg_surface *parent;
+	struct wlr_surface *parent;
 	struct wlr_seat *seat;
 
+	struct wlr_xdg_positioner *positioner;
 	// Position of the popup relative to the upper left corner of the window
 	// geometry of the parent surface
 	struct wlr_box geometry;
@@ -178,6 +181,11 @@ struct wlr_xdg_toplevel_show_window_menu_event {
 struct wlr_xdg_shell *wlr_xdg_shell_create(struct wl_display *display);
 void wlr_xdg_shell_destroy(struct wlr_xdg_shell *xdg_shell);
 
+struct wlr_xdg_surface *wlr_xdg_surface_from_resource(
+		struct wl_resource *resource);
+
+struct wlr_box wlr_xdg_popup_get_geometry(struct wlr_xdg_popup *popup);
+
 /**
  * Send a ping to the surface. If the surface does not respond in a reasonable
  * amount of time, the ping_timeout event will be emitted.
@@ -226,6 +234,7 @@ void wlr_xdg_surface_send_close(struct wlr_xdg_surface *surface);
 
 /**
  * Compute the popup position in its parent's surface-local coordinate system.
+ * This aborts if called for popups whose parent is not an xdg_surface.
  */
 void wlr_xdg_surface_popup_get_position(struct wlr_xdg_surface *surface,
 		double *popup_sx, double *popup_sy);

--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -183,6 +183,8 @@ void wlr_xdg_shell_destroy(struct wlr_xdg_shell *xdg_shell);
 
 struct wlr_xdg_surface *wlr_xdg_surface_from_resource(
 		struct wl_resource *resource);
+struct wlr_xdg_surface *wlr_xdg_surface_from_popup_resource(
+		struct wl_resource *resource);
 
 struct wlr_box wlr_xdg_popup_get_geometry(struct wlr_xdg_popup *popup);
 

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -641,11 +641,24 @@ static struct wlr_surface *layer_surface_at(struct roots_output *output,
 		struct wl_list *layer, double ox, double oy, double *sx, double *sy) {
 	struct roots_layer_surface *roots_surface;
 	wl_list_for_each_reverse(roots_surface, layer, link) {
-		struct wlr_surface *wlr_surface =
-			roots_surface->layer_surface->surface;
-		double _sx = ox - roots_surface->geo.x;
-		double _sy = oy - roots_surface->geo.y;
-		// TODO: Test popups/subsurfaces
+		struct wlr_surface *wlr_surface;
+		double _sx, _sy;
+		struct wlr_xdg_popup *popup;
+		wl_list_for_each(popup, &roots_surface->layer_surface->popups, link) {
+			wlr_surface = popup->base->surface;
+			 _sx = ox - roots_surface->geo.x - popup->geometry.x;
+			 _sy = oy - roots_surface->geo.y - popup->geometry.y;
+			if (wlr_surface_point_accepts_input(wlr_surface, _sx, _sy)) {
+				*sx = _sx;
+				*sy = _sy;
+				return wlr_surface;
+			}
+			// TODO: popups can have popups
+		}
+		// TODO: Test subsurfaces
+		wlr_surface = roots_surface->layer_surface->surface;
+		 _sx = ox - roots_surface->geo.x;
+		 _sy = oy - roots_surface->geo.y;
 		if (wlr_surface_point_accepts_input(wlr_surface, _sx, _sy)) {
 			*sx = _sx;
 			*sy = _sy;

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -379,6 +379,10 @@ static void layers_send_done(
 		wl_list_for_each(roots_surface, &output->layers[i], link) {
 			struct wlr_layer_surface *layer = roots_surface->layer_surface;
 			wlr_surface_send_frame_done(layer->surface, when);
+			struct wlr_xdg_popup *popup;
+			wl_list_for_each(popup, &roots_surface->layer_surface->popups, link) {
+				wlr_surface_send_frame_done(popup->base->surface, when);
+			}
 		}
 	}
 }

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -366,6 +366,8 @@ static void render_layer(struct roots_output *output,
 			roots_surface->geo.x + output_layout_box->x,
 			roots_surface->geo.y + output_layout_box->y,
 			0, &data->layout, render_surface, data);
+
+		wlr_layer_surface_for_each_surface(layer, render_surface, data);
 	}
 }
 

--- a/rootston/xdg_shell.c
+++ b/rootston/xdg_shell.c
@@ -48,6 +48,59 @@ static void popup_handle_new_popup(struct wl_listener *listener, void *data) {
 	popup_create(popup->view_child.view, wlr_popup);
 }
 
+static void popup_unconstrain(struct roots_xdg_popup *popup) {
+	// get the output of the popup's positioner anchor point and convert it to
+	// the toplevel parent's coordinate system and then pass it to
+	// wlr_xdg_popup_v6_unconstrain_from_box
+
+	// TODO: unconstrain popups for rotated windows
+	if (popup->view_child.view->rotation != 0.0) {
+		return;
+	}
+
+	struct roots_view *view = popup->view_child.view;
+	struct wlr_output_layout *layout = view->desktop->layout;
+	struct wlr_xdg_popup *wlr_popup = popup->wlr_popup;
+
+	int anchor_lx, anchor_ly;
+	wlr_xdg_popup_get_anchor_point(wlr_popup, &anchor_lx, &anchor_ly);
+
+	int popup_lx, popup_ly;
+	wlr_xdg_popup_get_toplevel_coords(wlr_popup, wlr_popup->geometry.x,
+		wlr_popup->geometry.y, &popup_lx, &popup_ly);
+	popup_lx += view->x;
+	popup_ly += view->y;
+
+	anchor_lx += popup_lx;
+	anchor_ly += popup_ly;
+
+	double dest_x = 0, dest_y = 0;
+	wlr_output_layout_closest_point(layout, NULL, anchor_lx, anchor_ly,
+		&dest_x, &dest_y);
+
+	struct wlr_output *output =
+		wlr_output_layout_output_at(layout, dest_x, dest_y);
+
+	if (output == NULL) {
+		return;
+	}
+
+	int width = 0, height = 0;
+	wlr_output_effective_resolution(output, &width, &height);
+
+	// the output box expressed in the coordinate system of the toplevel parent
+	// of the popup
+	struct wlr_box output_toplevel_sx_box = {
+		.x = output->lx - view->x,
+		.y = output->ly - view->y,
+		.width = width,
+		.height = height
+	};
+
+	wlr_xdg_popup_unconstrain_from_box(
+			popup->wlr_popup, &output_toplevel_sx_box);
+}
+
 static struct roots_xdg_popup *popup_create(struct roots_view *view,
 		struct wlr_xdg_popup *wlr_popup) {
 	struct roots_xdg_popup *popup =
@@ -66,6 +119,9 @@ static struct roots_xdg_popup *popup_create(struct roots_view *view,
 	wl_signal_add(&wlr_popup->base->events.unmap, &popup->unmap);
 	popup->new_popup.notify = popup_handle_new_popup;
 	wl_signal_add(&wlr_popup->base->events.new_popup, &popup->new_popup);
+
+	popup_unconstrain(popup);
+
 	return popup;
 }
 

--- a/types/wlr_layer_shell.c
+++ b/types/wlr_layer_shell.c
@@ -137,7 +137,7 @@ static void layer_surface_handle_get_popup(struct wl_client *client,
 	struct wlr_layer_surface *parent =
 		layer_surface_from_resource(layer_resource);
 	struct wlr_xdg_surface *popup_surface =
-		wlr_xdg_surface_from_resource(popup_resource);
+		wlr_xdg_surface_from_popup_resource(popup_resource);
 
 	assert(popup_surface->role == WLR_XDG_SURFACE_ROLE_POPUP);
 	struct wlr_xdg_popup *popup = popup_surface->popup;

--- a/types/wlr_layer_shell.c
+++ b/types/wlr_layer_shell.c
@@ -142,7 +142,7 @@ static void layer_surface_handle_get_popup(struct wl_client *client,
 	assert(popup_surface->role == WLR_XDG_SURFACE_ROLE_POPUP);
 	struct wlr_xdg_popup *popup = popup_surface->popup;
 	popup->parent = parent->surface;
-	popup->geometry = wlr_xdg_popup_get_geometry(popup);
+	popup->geometry = wlr_xdg_positioner_get_geometry(&popup->positioner);
 	wl_list_insert(&parent->popups, &popup->link);
 	wlr_signal_emit_safe(&parent->events.new_popup, popup);
 }

--- a/types/wlr_layer_shell.c
+++ b/types/wlr_layer_shell.c
@@ -142,7 +142,6 @@ static void layer_surface_handle_get_popup(struct wl_client *client,
 	assert(popup_surface->role == WLR_XDG_SURFACE_ROLE_POPUP);
 	struct wlr_xdg_popup *popup = popup_surface->popup;
 	popup->parent = parent->surface;
-	popup->geometry = wlr_xdg_positioner_get_geometry(&popup->positioner);
 	wl_list_insert(&parent->popups, &popup->link);
 	wlr_signal_emit_safe(&parent->events.new_popup, popup);
 }

--- a/types/wlr_xdg_shell.c
+++ b/types/wlr_xdg_shell.c
@@ -605,6 +605,8 @@ static void xdg_surface_handle_get_popup(struct wl_client *client,
 	// positioner properties
 	memcpy(&surface->popup->positioner, &positioner->attrs,
 		sizeof(struct wlr_xdg_positioner));
+	surface->popup->geometry =
+		wlr_xdg_positioner_get_geometry(&positioner->attrs);
 
 	wl_resource_set_implementation(surface->popup->resource,
 		&xdg_popup_implementation, surface,
@@ -612,8 +614,6 @@ static void xdg_surface_handle_get_popup(struct wl_client *client,
 
 	if (parent) {
 		surface->popup->parent = parent->surface;
-		surface->popup->geometry =
-			wlr_xdg_positioner_get_geometry(&positioner->attrs);
 		wl_list_insert(&parent->popups, &surface->popup->link);
 		wlr_signal_emit_safe(&parent->events.new_popup, surface->popup);
 	}

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -486,8 +486,6 @@ struct wlr_box wlr_xdg_positioner_v6_get_geometry(
 		return geometry;
 	}
 
-	// TODO: add compositor policy configuration and the code here
-
 	return geometry;
 }
 


### PR DESCRIPTION
- Extend the example client to allow to close the popup and handle mouse input
- Send frame_done events so surface updates work
- Damage popups

TODO (in followups): 
- [ ] handle popup with popups using surface_iterators
- [ ] handle subsurfaces
- [ ] handle grabs (including dismissing popups with grabs when losing focus, see xdg_popup.grab)