### PR TITLE
xwayland: preserve the PATH variable

### DIFF
--- a/xwayland/xwayland.c
+++ b/xwayland/xwayland.c
@@ -103,6 +103,7 @@ static void exec_xwayland(struct wlr_xwayland *wlr_xwayland) {
 	}
 
 	const char *xdg_runtime = getenv("XDG_RUNTIME_DIR");
+	const char *path_var = getenv("PATH");
 	if (!xdg_runtime) {
 		wlr_log(L_ERROR, "XDG_RUNTIME_DIR is not set");
 		_exit(EXIT_FAILURE);
@@ -113,6 +114,7 @@ static void exec_xwayland(struct wlr_xwayland *wlr_xwayland) {
 		_exit(EXIT_FAILURE);
 	}
 	setenv("XDG_RUNTIME_DIR", xdg_runtime, true);
+	setenv("PATH", path_var, true);
 	char wayland_socket_str[16];
 	snprintf(wayland_socket_str, sizeof(wayland_socket_str), "%d", wlr_xwayland->wl_fd[1]);
 	setenv("WAYLAND_SOCKET", wayland_socket_str, true);


### PR DESCRIPTION
Some systems don't have xwayland in /usr/bin, but in other paths. 
wlroots was unable to find Xwayland binaries outside of standard locations