### PR TITLE
layer-shell: Fix crash when cursor is intially outside any output

### DIFF
--- a/rootston/layer_shell.c
+++ b/rootston/layer_shell.c
@@ -395,8 +395,18 @@ void handle_layer_shell_surface(struct wl_listener *listener, void *data) {
 			wlr_output_layout_output_at(desktop->layout,
 					seat->cursor->cursor->x,
 					seat->cursor->cursor->y);
-		assert(output); // And this one
-		layer_surface->output = output;
+		if (!output) {
+			wlr_log(L_ERROR, "Couldn't find output at (%.0f,%.0f)",
+				seat->cursor->cursor->x,
+				seat->cursor->cursor->y);
+			output = wlr_output_layout_get_center_output(desktop->layout);
+		}
+		if (output) {
+			layer_surface->output = output;
+		} else {
+			wlr_layer_surface_close(layer_surface);
+			return;
+		}
 	}
 
 	roots_surface->surface_commit.notify = handle_surface_commit;

--- a/types/wlr_layer_shell.c
+++ b/types/wlr_layer_shell.c
@@ -287,7 +287,9 @@ static void handle_wlr_surface_committed(struct wlr_surface *wlr_surface,
 		surface->added = true;
 		wlr_signal_emit_safe(&surface->shell->events.new_surface,
 				surface);
-		assert(surface->output);
+		// either the compositor found a suitable output or it must
+		// have closed the surface
+		assert(surface->output || surface->closed);
 	}
 	if (surface->configured && wlr_surface_has_buffer(surface->surface) &&
 			!surface->mapped) {


### PR DESCRIPTION
On the X11 backend the cursor position might be outside the output
window so no output is returned leading to the assert to trigger. Use
sane fallback instead of crashing.