### PR TITLE
render/egl: add wlr_egl_destroy_surface

### DIFF
--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -79,9 +79,7 @@ bool wlr_drm_surface_init(struct wlr_drm_surface *surf,
 		}
 		gbm_surface_destroy(surf->gbm);
 	}
-	if (surf->egl) {
-		wlr_egl_destroy_surface(&surf->renderer->egl, surf->egl);
-	}
+	wlr_egl_destroy_surface(&surf->renderer->egl, surf->egl);
 
 	surf->gbm = gbm_surface_create(renderer->gbm, width, height,
 		format, GBM_BO_USE_RENDERING | flags);
@@ -117,9 +115,7 @@ void wlr_drm_surface_finish(struct wlr_drm_surface *surf) {
 		gbm_surface_release_buffer(surf->gbm, surf->back);
 	}
 
-	if (surf->egl) {
-		wlr_egl_destroy_surface(&surf->renderer->egl, surf->egl);
-	}
+	wlr_egl_destroy_surface(&surf->renderer->egl, surf->egl);
 	if (surf->gbm) {
 		gbm_surface_destroy(surf->gbm);
 	}

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -80,7 +80,7 @@ bool wlr_drm_surface_init(struct wlr_drm_surface *surf,
 		gbm_surface_destroy(surf->gbm);
 	}
 	if (surf->egl) {
-		eglDestroySurface(surf->renderer->egl.display, surf->egl);
+		wlr_egl_destroy_surface(&surf->renderer->egl, surf->egl);
 	}
 
 	surf->gbm = gbm_surface_create(renderer->gbm, width, height,
@@ -118,7 +118,7 @@ void wlr_drm_surface_finish(struct wlr_drm_surface *surf) {
 	}
 
 	if (surf->egl) {
-		eglDestroySurface(surf->renderer->egl.display, surf->egl);
+		wlr_egl_destroy_surface(&surf->renderer->egl, surf->egl);
 	}
 	if (surf->gbm) {
 		gbm_surface_destroy(surf->gbm);

--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -29,9 +29,7 @@ static bool output_set_custom_mode(struct wlr_output *wlr_output, int32_t width,
 		refresh = HEADLESS_DEFAULT_REFRESH;
 	}
 
-	if (output->egl_surface) {
-		wlr_egl_destroy_surface(&backend->egl, output->egl_surface);
-	}
+	wlr_egl_destroy_surface(&backend->egl, output->egl_surface);
 
 	output->egl_surface = egl_create_surface(&backend->egl, width, height);
 	if (output->egl_surface == EGL_NO_SURFACE) {

--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -30,7 +30,7 @@ static bool output_set_custom_mode(struct wlr_output *wlr_output, int32_t width,
 	}
 
 	if (output->egl_surface) {
-		eglDestroySurface(backend->egl.display, output->egl_surface);
+		wlr_egl_destroy_surface(&backend->egl, output->egl_surface);
 	}
 
 	output->egl_surface = egl_create_surface(&backend->egl, width, height);
@@ -73,7 +73,7 @@ static void output_destroy(struct wlr_output *wlr_output) {
 
 	wl_event_source_remove(output->frame_timer);
 
-	eglDestroySurface(output->backend->egl.display, output->egl_surface);
+	wlr_egl_destroy_surface(&output->backend->egl, output->egl_surface);
 	free(output);
 }
 

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -184,7 +184,7 @@ static void wlr_wl_output_destroy(struct wlr_output *wlr_output) {
 		wl_callback_destroy(output->frame_callback);
 	}
 
-	eglDestroySurface(output->backend->egl.display, output->surface);
+	wlr_egl_destroy_surface(&output->backend->egl, output->egl_surface);
 	wl_egl_window_destroy(output->egl_window);
 	zxdg_toplevel_v6_destroy(output->xdg_toplevel);
 	zxdg_surface_v6_destroy(output->xdg_surface);

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -61,7 +61,7 @@ static void output_destroy(struct wlr_output *wlr_output) {
 
 	wl_list_remove(&output->link);
 	wl_event_source_remove(output->frame_timer);
-	eglDestroySurface(x11->egl.display, output->surf);
+	wlr_egl_destroy_surface(&x11->egl, output->surf);
 	xcb_destroy_window(x11->xcb_conn, output->win);
 	xcb_flush(x11->xcb_conn);
 	free(output);

--- a/examples/layer-shell.c
+++ b/examples/layer-shell.c
@@ -188,9 +188,8 @@ static void xdg_popup_configure(void *data, struct xdg_popup *xdg_popup,
 	}
 }
 
-static void popup_destroy()
-{
-	eglDestroySurface(egl.display, popup_egl_surface);
+static void popup_destroy() {
+	wlr_egl_destroy_surface(&egl, popup_egl_surface);
 	wl_egl_window_destroy(popup_egl_window);
 	xdg_popup_destroy(popup);
 	wl_surface_destroy(popup_wl_surface);
@@ -262,7 +261,7 @@ static void layer_surface_configure(void *data,
 
 static void layer_surface_closed(void *data,
 		struct zwlr_layer_surface_v1 *surface) {
-	eglDestroySurface(egl.display, egl_surface);
+	wlr_egl_destroy_surface(&egl, egl_surface);
 	wl_egl_window_destroy(egl_window);
 	zwlr_layer_surface_v1_destroy(surface);
 	wl_surface_destroy(wl_surface);

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -98,4 +98,6 @@ bool wlr_egl_is_current(struct wlr_egl *egl);
 bool wlr_egl_swap_buffers(struct wlr_egl *egl, EGLSurface surface,
 	pixman_region32_t *damage);
 
+void wlr_egl_destroy_surface(struct wlr_egl *egl, EGLSurface surface);
+
 #endif

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -98,6 +98,6 @@ bool wlr_egl_is_current(struct wlr_egl *egl);
 bool wlr_egl_swap_buffers(struct wlr_egl *egl, EGLSurface surface,
 	pixman_region32_t *damage);
 
-void wlr_egl_destroy_surface(struct wlr_egl *egl, EGLSurface surface);
+bool wlr_egl_destroy_surface(struct wlr_egl *egl, EGLSurface surface);
 
 #endif

--- a/render/egl.c
+++ b/render/egl.c
@@ -225,9 +225,10 @@ bool wlr_egl_destroy_image(struct wlr_egl *egl, EGLImage image) {
 	if (!eglDestroyImageKHR) {
 		return false;
 	}
-
-	eglDestroyImageKHR(egl->display, image);
-	return true;
+	if (!image) {
+		return true;
+	}
+	return eglDestroyImageKHR(egl->display, image);
 }
 
 EGLSurface wlr_egl_create_surface(struct wlr_egl *egl, void *window) {
@@ -500,6 +501,9 @@ int wlr_egl_get_dmabuf_modifiers(struct wlr_egl *egl,
 	return num;
 }
 
-void wlr_egl_destroy_surface(struct wlr_egl *egl, EGLSurface surface) {
-	eglDestroySurface(egl->display, surface);
+bool wlr_egl_destroy_surface(struct wlr_egl *egl, EGLSurface surface) {
+	if (!surface) {
+		return true;
+	}
+	return eglDestroySurface(egl->display, surface);
 }

--- a/render/egl.c
+++ b/render/egl.c
@@ -499,3 +499,7 @@ int wlr_egl_get_dmabuf_modifiers(struct wlr_egl *egl,
 	}
 	return num;
 }
+
+void wlr_egl_destroy_surface(struct wlr_egl *egl, EGLSurface surface) {
+	eglDestroySurface(egl->display, surface);
+}

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -88,10 +88,7 @@ static void gles2_texture_destroy(struct wlr_texture *wlr_texture) {
 	if (texture->image_tex) {
 		glDeleteTextures(1, &texture->image_tex);
 	}
-	if (texture->image) {
-		assert(eglDestroyImageKHR);
-		wlr_egl_destroy_image(texture->egl, texture->image);
-	}
+	wlr_egl_destroy_image(texture->egl, texture->image);
 
 	if (texture->type == WLR_GLES2_TEXTURE_GLTEX) {
 		glDeleteTextures(1, &texture->gl_tex);


### PR DESCRIPTION
This also fixes the `eglDestroySurface` error under the Wayland backend.