### PR TITLE
Normalise scroll values

### DIFF
--- a/backend/libinput/pointer.c
+++ b/backend/libinput/pointer.c
@@ -95,9 +95,9 @@ static enum wlr_axis_source axis_source_to_wlr(
 		return WLR_AXIS_SOURCE_CONTINUOUS;
 	case LIBINPUT_POINTER_AXIS_SOURCE_WHEEL_TILT:
 		return WLR_AXIS_SOURCE_WHEEL_TILT;
-	default:
-		abort();
 	}
+
+	abort();
 }
 
 static enum wlr_axis_orientation axis_orientation_to_wlr(
@@ -107,9 +107,9 @@ static enum wlr_axis_orientation axis_orientation_to_wlr(
 		return WLR_AXIS_ORIENTATION_VERTICAL;
 	case LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL:
 		return WLR_AXIS_ORIENTATION_HORIZONTAL;
-	default:
-		abort();
 	}
+
+	abort();
 }
 
 static double normalize_axis(struct libinput_event_pointer *pevent,

--- a/backend/libinput/pointer.c
+++ b/backend/libinput/pointer.c
@@ -150,18 +150,18 @@ void handle_pointer_axis(struct libinput_event *event,
 		.source = axis_source_to_wlr(source),
 	};
 
-	enum libinput_pointer_axis axies[] = {
+	enum libinput_pointer_axis axes[] = {
 		LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL,
 		LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL,
 	};
 
-	for (size_t i = 0; i < sizeof(axies) / sizeof(axies[0]); ++i) {
-		if (!libinput_event_pointer_has_axis(pevent, axies[i])) {
+	for (size_t i = 0; i < sizeof(axes) / sizeof(axes[0]); ++i) {
+		if (!libinput_event_pointer_has_axis(pevent, axes[i])) {
 			continue;
 		}
 
-		wlr_event.orientation = axis_orientation_to_wlr(axies[i]);
-		wlr_event.delta = normalize_axis(pevent, source, axies[i]);
+		wlr_event.orientation = axis_orientation_to_wlr(axes[i]);
+		wlr_event.delta = normalize_axis(pevent, source, axes[i]);
 
 		wlr_signal_emit_safe(&wlr_dev->pointer->events.axis, &wlr_event);
 	}


### PR DESCRIPTION
Fixes #848 

Apparently Xwayland will accumulate the scroll amount between events, and each 10 "units" of scroll send one X11 scroll event.
Since libinput was sending 15 units per mouse scroll for me, 2 actual scrolls would end up as 3 X11 scrolls.

You can see the weston fix here: https://github.com/wayland-project/weston/blob/master/libweston/libinput-device.c#L184

I also took the liberty of cleaning up the libinput axis function a bit.