### PR TITLE
Use correct prinf format specifiers for ssize_t

### DIFF
--- a/xwayland/selection/incoming.c
+++ b/xwayland/selection/incoming.c
@@ -31,7 +31,7 @@ static int xwm_data_source_write(int fd, uint32_t mask, void *data) {
 		return 1;
 	}
 
-	wlr_log(L_DEBUG, "wrote %ld (chunk size %ld) of %d bytes",
+	wlr_log(L_DEBUG, "wrote %zd (chunk size %zd) of %d bytes",
 		transfer->property_start + len,
 		len, xcb_get_property_value_length(transfer->property_reply));
 

--- a/xwayland/selection/outgoing.c
+++ b/xwayland/selection/outgoing.c
@@ -96,7 +96,7 @@ static int xwm_data_source_read(int fd, uint32_t mask, void *data) {
 		goto error_out;
 	}
 
-	wlr_log(L_DEBUG, "read %ld bytes (available %zu, mask 0x%x)", len,
+	wlr_log(L_DEBUG, "read %zd bytes (available %zu, mask 0x%x)", len,
 		available, mask);
 
 	transfer->source_data.size = current + len;


### PR DESCRIPTION
This unbreaks the build on armhf that otherwise fails like

    ../xwayland/selection/incoming.c: In function 'xwm_data_source_write':
    ../include/wlr/util/log.h:34:17: error: format '%ld' expects argument of type 'long int', but argument 6 has type 'ssize_t {aka int}' [-Werror=format=]
      _wlr_log(verb, "[%s:%d] " fmt, wlr_strip_path(__FILE__), __LINE__, ##__VA_ARGS__)
                     ^
    ../xwayland/selection/incoming.c:34:2: note: in expansion of macro 'wlr_log'
      wlr_log(L_DEBUG, "wrote %zd (chunk size %ld) of %d bytes",
      ^~~~~~~
    ../xwayland/selection/incoming.c:34:44: note: format string is defined here
      wlr_log(L_DEBUG, "wrote %zd (chunk size %ld) of %d bytes",
                                              ~~^
                                              %d