### PR TITLE
Fix WLR_DIRECTION enums

### DIFF
--- a/include/wlr/types/wlr_output_layout.h
+++ b/include/wlr/types/wlr_output_layout.h
@@ -105,9 +105,9 @@ struct wlr_output *wlr_output_layout_get_center_output(
 		struct wlr_output_layout *layout);
 
 enum wlr_direction {
-	WLR_DIRECTION_UP = 0,
-	WLR_DIRECTION_DOWN = 1,
-	WLR_DIRECTION_LEFT = 2,
+	WLR_DIRECTION_UP = 1,
+	WLR_DIRECTION_DOWN = 2,
+	WLR_DIRECTION_LEFT = 3,
 	WLR_DIRECTION_RIGHT = 4,
 };
 


### PR DESCRIPTION
Having 0 as an enum value causes wlr_output_layout_adjacent_output() to
never match WLR_DIRECTION_UP.

See here: https://github.com/swaywm/wlroots/blob/31857c9ed40a6bf34273b0459d2aa604642d1807/types/wlr_output_layout.c#L458

To test:

* In sway, have two outputs arranged vertically.
* With focus on the bottom output, do `focus up`