### PR TITLE
compositor: redesign how resources are managed

### DIFF
--- a/include/wlr/types/wlr_region.h
+++ b/include/wlr/types/wlr_region.h
@@ -6,9 +6,11 @@
 struct wl_resource;
 
 /*
- * Implements the given resource as region.
+ * Creates a new region resource with the provided new ID. If `resource_list` is
+ * non-NULL, adds the region's resource to the list.
  */
-struct wl_resource *wlr_region_create(struct wl_client *client, uint32_t id);
+struct wl_resource *wlr_region_create(struct wl_client *client,
+	uint32_t version, uint32_t id, struct wl_list *resource_list);
 
 pixman_region32_t *wlr_region_from_resource(struct wl_resource *resource);
 

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -80,10 +80,6 @@ struct wlr_surface {
 		struct wl_signal destroy;
 	} events;
 
-	// destroy listener used by compositor
-	struct wl_listener compositor_listener;
-	void *compositor_data;
-
 	// surface commit callback for the role that runs before all others
 	void (*role_committed)(struct wlr_surface *surface, void *role_data);
 	void *role_data;
@@ -102,8 +98,14 @@ typedef void (*wlr_surface_iterator_func_t)(struct wlr_surface *surface,
 	int sx, int sy, void *data);
 
 struct wlr_renderer;
-struct wlr_surface *wlr_surface_create(struct wl_resource *res,
-		struct wlr_renderer *renderer);
+
+/**
+ * Create a new surface resource with the provided new ID. If `resource_list`
+ * is non-NULL, adds the surface's resource to the list.
+ */
+struct wlr_surface *wlr_surface_create(struct wl_client *client,
+		uint32_t version, uint32_t id, struct wlr_renderer *renderer,
+		struct wl_list *resource_list);
 
 /**
  * Set the lifetime role for this surface. Returns 0 on success or -1 if the
@@ -121,10 +123,12 @@ int wlr_surface_set_role(struct wlr_surface *surface, const char *role,
 bool wlr_surface_has_buffer(struct wlr_surface *surface);
 
 /**
- * Create the subsurface implementation for this surface.
+ * Create a new subsurface resource with the provided new ID. If `resource_list`
+ * is non-NULL, adds the subsurface's resource to the list.
  */
-struct wlr_subsurface *wlr_surface_make_subsurface(struct wlr_surface *surface,
-		struct wlr_surface *parent, uint32_t id);
+struct wlr_subsurface *wlr_subsurface_create(struct wlr_surface *surface,
+		struct wlr_surface *parent, uint32_t version, uint32_t id,
+		struct wl_list *resource_list);
 
 /**
  * Get the root of the subsurface tree for this surface.

--- a/types/wlr_region.c
+++ b/types/wlr_region.c
@@ -34,29 +34,40 @@ static const struct wl_region_interface region_impl = {
 
 static void region_handle_resource_destroy(struct wl_resource *resource) {
 	pixman_region32_t *reg = wlr_region_from_resource(resource);
+
+	wl_list_remove(wl_resource_get_link(resource));
+
 	pixman_region32_fini(reg);
 	free(reg);
-
-	// Set by wlr_compositor
-	wl_list_remove(wl_resource_get_link(resource));
 }
 
-struct wl_resource *wlr_region_create(struct wl_client *client, uint32_t id) {
+struct wl_resource *wlr_region_create(struct wl_client *client,
+		uint32_t version, uint32_t id, struct wl_list *resource_list) {
 	pixman_region32_t *region = calloc(1, sizeof(pixman_region32_t));
 	if (region == NULL) {
+		wl_client_post_no_memory(client);
 		return NULL;
 	}
 
 	pixman_region32_init(region);
 
 	struct wl_resource *region_resource = wl_resource_create(client,
-		&wl_region_interface, 1, id);
+		&wl_region_interface, version, id);
 	if (region_resource == NULL) {
 		free(region);
+		wl_client_post_no_memory(client);
 		return NULL;
 	}
 	wl_resource_set_implementation(region_resource, &region_impl, region,
 		region_handle_resource_destroy);
+
+	struct wl_list *resource_link = wl_resource_get_link(region_resource);
+	if (resource_list != NULL) {
+		wl_list_insert(resource_list, resource_link);
+	} else {
+		wl_list_init(resource_link);
+	}
+
 	return region_resource;
 }
 


### PR DESCRIPTION
All public resource creators now take a new ID for the resource
and an optional list where the resource link is added. When the
resource is destroyed it is its own responsibility to remove
itself from the list. This removes the need for the caller to add
a destroy listener.

This commit fixes a few segfaults with resources not removed from
the list when destroyed.