### PR TITLE
xwayland: make utility windows unmanaged again

### DIFF
--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -1643,6 +1643,7 @@ bool wlr_xwayland_surface_is_unmanaged(
 		NET_WM_WINDOW_TYPE_POPUP_MENU,
 		NET_WM_WINDOW_TYPE_SPLASH,
 		NET_WM_WINDOW_TYPE_TOOLTIP,
+		NET_WM_WINDOW_TYPE_UTILITY,
 	};
 
 	for (size_t i = 0; i < sizeof(needles) / sizeof(needles[0]); ++i) {


### PR DESCRIPTION
7f70d244a9802207c258bd5da6d4ada5eb15484a made utility windows
managed, because it made sense according to the spec. Turns out
Firefox uses them for popups.