### PR TITLE
render: introduce wlr_multi_renderer

### DIFF
--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -166,10 +166,6 @@ struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
 		goto error_event;
 	}
 
-	if (!wlr_egl_bind_display(&drm->renderer.egl, display)) {
-		wlr_log(L_INFO, "Failed to bind egl/wl display");
-	}
-
 	drm->display_destroy.notify = handle_display_destroy;
 	wl_display_add_destroy_listener(display, &drm->display_destroy);
 

--- a/backend/multi/backend.c
+++ b/backend/multi/backend.c
@@ -4,6 +4,7 @@
 #include <wlr/backend/drm.h>
 #include <wlr/backend/interface.h>
 #include <wlr/backend/session.h>
+#include <wlr/render/multi.h>
 #include <wlr/util/log.h>
 #include "backend/multi.h"
 #include "util/signal.h"
@@ -55,14 +56,7 @@ static void multi_backend_destroy(struct wlr_backend *wlr_backend) {
 static struct wlr_renderer *multi_backend_get_renderer(
 		struct wlr_backend *backend) {
 	struct wlr_multi_backend *multi = (struct wlr_multi_backend *)backend;
-	struct subbackend_state *sub;
-	wl_list_for_each(sub, &multi->backends, link) {
-		struct wlr_renderer *rend = wlr_backend_get_renderer(sub->backend);
-		if (rend != NULL) {
-			return rend;
-		}
-	}
-	return NULL;
+	return multi->renderer;
 }
 
 struct wlr_backend_impl backend_impl = {
@@ -82,6 +76,12 @@ struct wlr_backend *wlr_multi_backend_create(struct wl_display *display) {
 		calloc(1, sizeof(struct wlr_multi_backend));
 	if (!backend) {
 		wlr_log(L_ERROR, "Backend allocation failed");
+		return NULL;
+	}
+
+	backend->renderer = wlr_multi_renderer_create();
+	if (backend->renderer == NULL) {
+		free(backend);
 		return NULL;
 	}
 
@@ -119,8 +119,8 @@ static void handle_subbackend_destroy(struct wl_listener *listener,
 	subbackend_state_destroy(state);
 }
 
-static struct subbackend_state *multi_backend_get_subbackend(struct wlr_multi_backend *multi,
-		struct wlr_backend *backend) {
+static struct subbackend_state *multi_backend_get_subbackend(
+		struct wlr_multi_backend *multi, struct wlr_backend *backend) {
 	struct subbackend_state *sub = NULL;
 	wl_list_for_each(sub, &multi->backends, link) {
 		if (sub->backend == backend) {
@@ -150,6 +150,11 @@ void wlr_multi_backend_add(struct wlr_backend *_multi,
 	sub->backend = backend;
 	sub->container = &multi->backend;
 
+	struct wlr_renderer *renderer = wlr_backend_get_renderer(backend);
+	if (renderer != NULL) {
+		wlr_multi_renderer_add(multi->renderer, renderer);
+	}
+
 	wl_signal_add(&backend->events.destroy, &sub->destroy);
 	sub->destroy.notify = handle_subbackend_destroy;
 
@@ -169,7 +174,6 @@ void wlr_multi_backend_remove(struct wlr_backend *_multi,
 
 	struct subbackend_state *sub =
 		multi_backend_get_subbackend(multi, backend);
-
 	if (sub) {
 		wlr_signal_emit_safe(&multi->events.backend_remove, backend);
 		subbackend_state_destroy(sub);

--- a/backend/multi/backend.c
+++ b/backend/multi/backend.c
@@ -48,6 +48,8 @@ static void multi_backend_destroy(struct wlr_backend *wlr_backend) {
 		wlr_backend_destroy(sub->backend);
 	}
 
+	wlr_renderer_destroy(backend->renderer);
+
 	// Destroy this backend only after removing all sub-backends
 	wlr_signal_emit_safe(&wlr_backend->events.destroy, backend);
 	free(backend);

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -177,7 +177,6 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display,
 		wlr_log(L_ERROR, "Could not initialize EGL");
 		goto error_egl;
 	}
-	wlr_egl_bind_display(&backend->egl, backend->local_display);
 
 	backend->renderer = wlr_gles2_renderer_create(&backend->egl);
 	if (backend->renderer == NULL) {

--- a/include/backend/multi.h
+++ b/include/backend/multi.h
@@ -9,6 +9,7 @@
 struct wlr_multi_backend {
 	struct wlr_backend backend;
 
+	struct wlr_renderer *renderer;
 	struct wl_list backends;
 
 	struct wl_listener display_destroy;

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -66,6 +66,8 @@ struct wlr_gles2_texture {
 		GLuint gl_tex;
 		struct wl_resource *wl_drm;
 	};
+
+	struct wl_listener egl_destroy;
 };
 
 const struct wlr_gles2_pixel_format *get_gles2_format_from_wl(

--- a/include/render/multi.h
+++ b/include/render/multi.h
@@ -1,0 +1,39 @@
+#ifndef RENDERER_MULTI_H
+#define RENDERER_MULTI_H
+
+#include <wayland-util.h>
+#include <wlr/render/multi.h>
+
+struct wlr_multi_renderer_child {
+	struct wlr_renderer *renderer;
+	struct wl_list link; // wlr_multi_renderer::children
+
+	struct wl_listener destroy;
+};
+
+struct wlr_multi_renderer {
+	struct wlr_renderer renderer;
+
+	struct wl_list children; // wlr_multi_renderer_child::link
+};
+
+struct wlr_multi_texture_child {
+	struct wlr_renderer *renderer;
+	struct wlr_texture *texture;
+	struct wl_list link; // wlr_multi_texture::children
+
+	struct wl_listener renderer_destroy;
+};
+
+struct wlr_multi_texture {
+	struct wlr_texture texture;
+	int32_t width, height;
+
+	struct wl_list children; // wlr_multi_texture_child::link
+};
+
+struct wlr_multi_texture *multi_texture_create();
+void multi_texture_add(struct wlr_multi_texture *texture,
+	struct wlr_texture *child, struct wlr_renderer *child_renderer);
+
+#endif

--- a/include/render/multi.h
+++ b/include/render/multi.h
@@ -21,8 +21,6 @@ struct wlr_multi_texture_child {
 	struct wlr_renderer *renderer;
 	struct wlr_texture *texture;
 	struct wl_list link; // wlr_multi_texture::children
-
-	struct wl_listener renderer_destroy;
 };
 
 struct wlr_multi_texture {

--- a/include/render/multi.h
+++ b/include/render/multi.h
@@ -21,6 +21,8 @@ struct wlr_multi_texture_child {
 	struct wlr_renderer *renderer;
 	struct wlr_texture *texture;
 	struct wl_list link; // wlr_multi_texture::children
+
+	struct wl_listener destroy;
 };
 
 struct wlr_multi_texture {

--- a/include/render/multi.h
+++ b/include/render/multi.h
@@ -20,6 +20,8 @@ struct wlr_multi_renderer {
 	enum wl_shm_format *formats;
 	size_t formats_len;
 
+	struct wl_display *wl_display;
+
 	struct wl_list children; // wlr_multi_renderer_child::link
 };
 
@@ -41,5 +43,6 @@ struct wlr_multi_texture {
 struct wlr_multi_texture *multi_texture_create();
 void multi_texture_add(struct wlr_multi_texture *texture,
 	struct wlr_texture *child, struct wlr_renderer *child_renderer);
+void multi_texture_update_size(struct wlr_multi_texture *texture);
 
 #endif

--- a/include/render/multi.h
+++ b/include/render/multi.h
@@ -4,8 +4,11 @@
 #include <wayland-util.h>
 #include <wlr/render/multi.h>
 
+struct wlr_multi_renderer;
+
 struct wlr_multi_renderer_child {
 	struct wlr_renderer *renderer;
+	struct wlr_multi_renderer *parent;
 	struct wl_list link; // wlr_multi_renderer::children
 
 	struct wl_listener destroy;
@@ -13,6 +16,9 @@ struct wlr_multi_renderer_child {
 
 struct wlr_multi_renderer {
 	struct wlr_renderer renderer;
+
+	enum wl_shm_format *formats;
+	size_t formats_len;
 
 	struct wl_list children; // wlr_multi_renderer_child::link
 };

--- a/include/wlr/backend/multi.h
+++ b/include/wlr/backend/multi.h
@@ -7,6 +7,8 @@
 /**
  * Creates a multi-backend. Multi-backends wrap an arbitrary number of backends
  * and aggregate their new_output/new_input signals.
+ *
+ * The renderer of a multi-backend is guaranteed to be a multi-renderer.
  */
 struct wlr_backend *wlr_multi_backend_create(struct wl_display *display);
 /**

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -52,7 +52,7 @@ void wlr_egl_finish(struct wlr_egl *egl);
 bool wlr_egl_bind_wl_display(struct wlr_egl *egl, struct wl_display *display);
 
 /**
- * Returns a surface for the given native window
+ * Returns a surface for the given native window.
  * The window must match the remote display the wlr_egl was created with.
  */
 EGLSurface wlr_egl_create_surface(struct wlr_egl *egl, void *window);
@@ -94,14 +94,27 @@ int wlr_egl_get_dmabuf_modifiers(struct wlr_egl *egl, int format,
  */
 bool wlr_egl_destroy_image(struct wlr_egl *egl, EGLImageKHR image);
 
+/**
+ * Makes the EGL context current. If `buffer_age` is not NULL, sets it to the
+ * current buffer age, or -1 if unknown.
+ */
 bool wlr_egl_make_current(struct wlr_egl *egl, EGLSurface surface,
 	int *buffer_age);
 
+/**
+ * Checks if the EGL context is the current one.
+ */
 bool wlr_egl_is_current(struct wlr_egl *egl);
 
+/**
+ * Swaps buffers. The buffer damage is optional.
+ */
 bool wlr_egl_swap_buffers(struct wlr_egl *egl, EGLSurface surface,
 	pixman_region32_t *damage);
 
+/**
+ * Destroys the EGL surface.
+ */
 bool wlr_egl_destroy_surface(struct wlr_egl *egl, EGLSurface surface);
 
 #endif

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -45,11 +45,11 @@ bool wlr_egl_init(struct wlr_egl *egl, EGLenum platform, void *remote_display,
 void wlr_egl_finish(struct wlr_egl *egl);
 
 /**
- * Binds the given display to the EGL instance.
- * This will allow clients to create EGL surfaces from wayland ones and render
- * to it.
+ * Binds the given wl_display to the EGL instance. This will allow clients to
+ * create EGL surfaces from Wayland ones and render to it via the deprecated
+ * wl_drm interface.
  */
-bool wlr_egl_bind_display(struct wlr_egl *egl, struct wl_display *local_display);
+bool wlr_egl_bind_wl_display(struct wlr_egl *egl, struct wl_display *display);
 
 /**
  * Returns a surface for the given native window

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -24,6 +24,10 @@ struct wlr_egl {
 	} egl_exts;
 
 	struct wl_display *wl_display;
+
+	struct {
+		struct wl_signal destroy;
+	} events;
 };
 
 // TODO: Allocate and return a wlr_egl

--- a/include/wlr/render/gles2.h
+++ b/include/wlr/render/gles2.h
@@ -4,12 +4,17 @@
 #include <wlr/backend.h>
 #include <wlr/render/wlr_renderer.h>
 
+/**
+ * A GLES2 renderer. The renderer and all textures are destroyed when the
+ * wlr_egl is.
+ */
+
 struct wlr_egl;
 
 struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_egl *egl);
 
 struct wlr_texture *wlr_gles2_texture_from_pixels(struct wlr_egl *egl,
-	enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width, uint32_t height,
+	enum wl_shm_format fmt, uint32_t stride, uint32_t width, uint32_t height,
 	const void *data);
 struct wlr_texture *wlr_gles2_texture_from_wl_drm(struct wlr_egl *egl,
 	struct wl_resource *data);

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -41,6 +41,8 @@ struct wlr_renderer_impl {
 		void *data);
 	bool (*format_supported)(struct wlr_renderer *renderer,
 		enum wl_shm_format fmt);
+	void (*bind_wl_display)(struct wlr_renderer *renderer,
+		struct wl_display *display);
 	struct wlr_texture *(*texture_from_pixels)(struct wlr_renderer *renderer,
 		enum wl_shm_format fmt, uint32_t stride, uint32_t width,
 		uint32_t height, const void *data);

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -24,7 +24,7 @@ struct wlr_renderer_impl {
 		const float color[static 4], const float matrix[static 9]);
 	void (*render_ellipse_with_matrix)(struct wlr_renderer *renderer,
 		const float color[static 4], const float matrix[static 9]);
-	const enum wl_shm_format *(*formats)(
+	const enum wl_shm_format *(*get_formats)(
 		struct wlr_renderer *renderer, size_t *len);
 	bool (*resource_is_wl_drm_buffer)(struct wlr_renderer *renderer,
 		struct wl_resource *resource);
@@ -57,7 +57,7 @@ void wlr_renderer_init(struct wlr_renderer *renderer,
 struct wlr_texture_impl {
 	void (*get_size)(struct wlr_texture *texture, int *width, int *height);
 	bool (*write_pixels)(struct wlr_texture *texture,
-		enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width,
+		enum wl_shm_format fmt, uint32_t stride, uint32_t width,
 		uint32_t height, uint32_t src_x, uint32_t src_y, uint32_t dst_x,
 		uint32_t dst_y, const void *data);
 	void (*destroy)(struct wlr_texture *texture);

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -12,6 +12,22 @@
 #include <wlr/types/wlr_output.h>
 
 struct wlr_renderer_impl {
+	const enum wl_shm_format *(*get_formats)(
+		struct wlr_renderer *renderer, size_t *len);
+	bool (*format_supported)(struct wlr_renderer *renderer,
+		enum wl_shm_format fmt);
+	struct wlr_texture *(*texture_from_pixels)(struct wlr_renderer *renderer,
+		enum wl_shm_format fmt, uint32_t stride, uint32_t width,
+		uint32_t height, const void *data);
+	bool (*read_pixels)(struct wlr_renderer *renderer, enum wl_shm_format fmt,
+		uint32_t stride, uint32_t width, uint32_t height,
+		uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y,
+		void *data);
+	void (*bind_wl_display)(struct wlr_renderer *renderer,
+		struct wl_display *display);
+	void (*destroy)(struct wlr_renderer *renderer);
+
+	// Rendering functions
 	void (*begin)(struct wlr_renderer *renderer, uint32_t width,
 		uint32_t height);
 	void (*end)(struct wlr_renderer *renderer);
@@ -24,33 +40,23 @@ struct wlr_renderer_impl {
 		const float color[static 4], const float matrix[static 9]);
 	void (*render_ellipse_with_matrix)(struct wlr_renderer *renderer,
 		const float color[static 4], const float matrix[static 9]);
-	const enum wl_shm_format *(*get_formats)(
-		struct wlr_renderer *renderer, size_t *len);
+
+	// wl_drm functions
 	bool (*resource_is_wl_drm_buffer)(struct wlr_renderer *renderer,
 		struct wl_resource *resource);
 	void (*wl_drm_buffer_get_size)(struct wlr_renderer *renderer,
 		struct wl_resource *buffer, int *width, int *height);
+	struct wlr_texture *(*texture_from_wl_drm)(struct wlr_renderer *renderer,
+		struct wl_resource *buffer);
+
+	// DMA-BUF functions
 	bool (*check_import_dmabuf)(struct wlr_renderer *renderer,
 		struct wlr_dmabuf_buffer *dmabuf);
 	int (*get_dmabuf_formats)(struct wlr_renderer *renderer, int **formats);
 	int (*get_dmabuf_modifiers)(struct wlr_renderer *renderer, int format,
 		uint64_t **modifiers);
-	bool (*read_pixels)(struct wlr_renderer *renderer, enum wl_shm_format fmt,
-		uint32_t stride, uint32_t width, uint32_t height,
-		uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y,
-		void *data);
-	bool (*format_supported)(struct wlr_renderer *renderer,
-		enum wl_shm_format fmt);
-	void (*bind_wl_display)(struct wlr_renderer *renderer,
-		struct wl_display *display);
-	struct wlr_texture *(*texture_from_pixels)(struct wlr_renderer *renderer,
-		enum wl_shm_format fmt, uint32_t stride, uint32_t width,
-		uint32_t height, const void *data);
-	struct wlr_texture *(*texture_from_wl_drm)(struct wlr_renderer *renderer,
-		struct wl_resource *data);
 	struct wlr_texture *(*texture_from_dmabuf)(struct wlr_renderer *renderer,
 		struct wlr_dmabuf_buffer_attribs *attribs);
-	void (*destroy)(struct wlr_renderer *renderer);
 };
 
 void wlr_renderer_init(struct wlr_renderer *renderer,

--- a/include/wlr/render/multi.h
+++ b/include/wlr/render/multi.h
@@ -4,6 +4,19 @@
 #include <wlr/backend.h>
 #include <wlr/render/wlr_renderer.h>
 
+/**
+ * A multi-renderer wraps an arbitrary number of renderers and uploads textures
+ * to all of them. A multi-renderer cannot be used to render. Textures created
+ * by a multi-renderer are guaranteed to be multi-textures. The set of formats
+ * supported by multi-renderers is restricted to the formats supported by all
+ * their children.
+ *
+ * A multi-texture wraps an arbitrary number of textures uploaded to different
+ * renderers. Multi-textures cannot be used directly: the texture suitable for
+ * the renderer currently rendering must be obtained with
+ * `wlr_multi_texture_get_child`.
+ */
+
 struct wlr_renderer *wlr_multi_renderer_create();
 void wlr_multi_renderer_add(struct wlr_renderer *renderer,
 	struct wlr_renderer *child);

--- a/include/wlr/render/multi.h
+++ b/include/wlr/render/multi.h
@@ -14,6 +14,7 @@ bool wlr_renderer_is_multi(struct wlr_renderer *renderer);
 
 struct wlr_texture *wlr_multi_texture_get_child(struct wlr_texture *texture,
 	struct wlr_renderer *child_renderer);
+bool wlr_multi_texture_is_empty(struct wlr_texture *texture);
 bool wlr_texture_is_multi(struct wlr_texture *texture);
 
 #endif

--- a/include/wlr/render/multi.h
+++ b/include/wlr/render/multi.h
@@ -1,0 +1,19 @@
+#ifndef WLR_RENDER_MULTI_H
+#define WLR_RENDER_MULTI_H
+
+#include <wlr/backend.h>
+#include <wlr/render/wlr_renderer.h>
+
+struct wlr_renderer *wlr_multi_renderer_create();
+void wlr_multi_renderer_add(struct wlr_renderer *renderer,
+	struct wlr_renderer *child);
+void wlr_multi_renderer_remove(struct wlr_renderer *renderer,
+	struct wlr_renderer *child);
+bool wlr_multi_renderer_is_empty(struct wlr_renderer *renderer);
+bool wlr_renderer_is_multi(struct wlr_renderer *renderer);
+
+struct wlr_texture *wlr_multi_texture_get_child(struct wlr_texture *texture,
+	struct wlr_renderer *child_renderer);
+bool wlr_texture_is_multi(struct wlr_texture *texture);
+
+#endif

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -11,13 +11,27 @@ struct wlr_renderer_impl;
 struct wlr_renderer {
 	const struct wlr_renderer_impl *impl;
 
+	bool rendering;
+
 	struct {
 		struct wl_signal destroy;
 	} events;
 };
 
+/**
+ * Begins to render. All rendering operations must be called between
+ * `wlr_renderer_begin` and `wlr_renderer_end`.
+ *
+ * Textures must not be created during rendering.
+ */
 void wlr_renderer_begin(struct wlr_renderer *r, int width, int height);
+/**
+ * Ends rendering.
+ */
 void wlr_renderer_end(struct wlr_renderer *r);
+/**
+ * Clear the whole renderer buffer with the provided color.
+ */
 void wlr_renderer_clear(struct wlr_renderer *r, const float color[static 4]);
 /**
  * Defines a scissor box. Only pixels that lie within the scissor box can be

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -98,7 +98,10 @@ bool wlr_renderer_read_pixels(struct wlr_renderer *r, enum wl_shm_format fmt,
  */
 bool wlr_renderer_format_supported(struct wlr_renderer *r,
 	enum wl_shm_format fmt);
-void wlr_renderer_init_wl_shm(struct wlr_renderer *r,
+/**
+ * Advertizes supported formats on the provided wl_display.
+ */
+void wlr_renderer_init_wl_display(struct wlr_renderer *r,
 	struct wl_display *display);
 /**
  * Destroys this wlr_renderer. Textures must be destroyed separately.

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -103,6 +103,9 @@ bool wlr_renderer_check_import_dmabuf(struct wlr_renderer *renderer,
 /**
  * Reads out of pixels of the currently bound surface into data. `stride` is in
  * bytes.
+ *
+ * This function can only be called after `wlr_renderer_begin` and before
+ * swapping buffers.
  */
 bool wlr_renderer_read_pixels(struct wlr_renderer *r, enum wl_shm_format fmt,
 	uint32_t stride, uint32_t width, uint32_t height,

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -85,18 +85,18 @@ bool wlr_renderer_resource_is_wl_drm_buffer(struct wlr_renderer *renderer,
 void wlr_renderer_wl_drm_buffer_get_size(struct wlr_renderer *renderer,
 	struct wl_resource *buffer, int *width, int *height);
 /**
- * Get the available dmabuf formats
+ * Get the available dmabuf formats.
  */
 int wlr_renderer_get_dmabuf_formats(struct wlr_renderer *renderer,
 	int **formats);
 /**
- * Get the available dmabuf modifiers for a given format
+ * Get the available dmabuf modifiers for a given format.
  */
 int wlr_renderer_get_dmabuf_modifiers(struct wlr_renderer *renderer, int format,
 	uint64_t **modifiers);
 /**
  * Try to import the given dmabuf. On success return true false otherwise.
- * If this succeeds the dmabuf can be used for rendering on a texture
+ * If this succeeds the dmabuf can be used for rendering on a texture.
  */
 bool wlr_renderer_check_import_dmabuf(struct wlr_renderer *renderer,
 	struct wlr_dmabuf_buffer *dmabuf);

--- a/include/wlr/render/wlr_texture.h
+++ b/include/wlr/render/wlr_texture.h
@@ -23,7 +23,7 @@ struct wlr_texture {
  * texture is mutable.
  */
 struct wlr_texture *wlr_texture_from_pixels(struct wlr_renderer *renderer,
-	enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width, uint32_t height,
+	enum wl_shm_format fmt, uint32_t stride, uint32_t width, uint32_t height,
 	const void *data);
 
 /**

--- a/include/wlr/render/wlr_texture.h
+++ b/include/wlr/render/wlr_texture.h
@@ -12,6 +12,10 @@ struct wlr_texture_impl;
 
 struct wlr_texture {
 	const struct wlr_texture_impl *impl;
+
+	struct {
+		struct wl_signal destroy;
+	} events;
 };
 
 /**

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -89,6 +89,7 @@ struct wlr_surface {
 	// wlr_subsurface::parent_pending_link
 	struct wl_list subsurface_pending_list;
 
+	struct wl_listener texture_destroy;
 	struct wl_listener renderer_destroy;
 
 	void *data;

--- a/render/egl.c
+++ b/render/egl.c
@@ -205,14 +205,14 @@ void wlr_egl_finish(struct wlr_egl *egl) {
 
 	eglMakeCurrent(EGL_NO_DISPLAY, EGL_NO_SURFACE, EGL_NO_SURFACE,
 		EGL_NO_CONTEXT);
-	wlr_egl_bind_display(egl, NULL);
+	wlr_egl_bind_wl_display(egl, NULL);
 
 	eglDestroyContext(egl->display, egl->context);
 	eglTerminate(egl->display);
 	eglReleaseThread();
 }
 
-bool wlr_egl_bind_display(struct wlr_egl *egl, struct wl_display *display) {
+bool wlr_egl_bind_wl_display(struct wlr_egl *egl, struct wl_display *display) {
 	if (egl->wl_display == display) {
 		return true;
 	}
@@ -227,6 +227,8 @@ bool wlr_egl_bind_display(struct wlr_egl *egl, struct wl_display *display) {
 
 	if (result) {
 		egl->wl_display = display;
+	} else {
+		wlr_log(L_ERROR, "Failed to bind wl_display to EGL");
 	}
 	return result;
 }

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -280,7 +280,14 @@ static bool gles2_read_pixels(struct wlr_renderer *wlr_renderer,
 
 static bool gles2_format_supported(struct wlr_renderer *wlr_renderer,
 		enum wl_shm_format wl_fmt) {
+	gles2_get_renderer(wlr_renderer);
 	return get_gles2_format_from_wl(wl_fmt) != NULL;
+}
+
+static void gles2_bind_wl_display(struct wlr_renderer *wlr_renderer,
+		struct wl_display *display) {
+	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
+	wlr_egl_bind_wl_display(renderer->egl, display);
 }
 
 static struct wlr_texture *gles2_texture_from_pixels(
@@ -342,6 +349,7 @@ static const struct wlr_renderer_impl renderer_impl = {
 	.check_import_dmabuf = gles2_check_import_dmabuf,
 	.read_pixels = gles2_read_pixels,
 	.format_supported = gles2_format_supported,
+	.bind_wl_display = gles2_bind_wl_display,
 	.texture_from_pixels = gles2_texture_from_pixels,
 	.texture_from_wl_drm = gles2_texture_from_wl_drm,
 	.texture_from_dmabuf = gles2_texture_from_dmabuf,

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -198,7 +198,7 @@ static void gles2_render_ellipse_with_matrix(struct wlr_renderer *wlr_renderer,
 	POP_GLES2_DEBUG;
 }
 
-static const enum wl_shm_format *gles2_renderer_formats(
+static const enum wl_shm_format *gles2_renderer_get_formats(
 		struct wlr_renderer *wlr_renderer, size_t *len) {
 	return get_gles2_formats(len);
 }
@@ -334,7 +334,7 @@ static const struct wlr_renderer_impl renderer_impl = {
 	.render_texture_with_matrix = gles2_render_texture_with_matrix,
 	.render_quad_with_matrix = gles2_render_quad_with_matrix,
 	.render_ellipse_with_matrix = gles2_render_ellipse_with_matrix,
-	.formats = gles2_renderer_formats,
+	.get_formats = gles2_renderer_get_formats,
 	.resource_is_wl_drm_buffer = gles2_resource_is_wl_drm_buffer,
 	.wl_drm_buffer_get_size = gles2_wl_drm_buffer_get_size,
 	.get_dmabuf_formats = gles2_get_dmabuf_formats,

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -40,8 +40,10 @@ static bool gles2_texture_write_pixels(struct wlr_texture *wlr_texture,
 		enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width,
 		uint32_t height, uint32_t src_x, uint32_t src_y, uint32_t dst_x,
 		uint32_t dst_y, const void *data) {
-	struct wlr_gles2_texture *texture =
-		get_gles2_texture_in_context(wlr_texture);
+	struct wlr_gles2_texture *texture = gles2_get_texture(wlr_texture);
+	if (!wlr_egl_is_current(texture->egl)) {
+		wlr_egl_make_current(texture->egl, EGL_NO_SURFACE, NULL);
+	}
 
 	if (texture->type != WLR_GLES2_TEXTURE_GLTEX) {
 		wlr_log(L_ERROR, "Cannot write pixels to immutable texture");
@@ -108,7 +110,9 @@ static const struct wlr_texture_impl texture_impl = {
 struct wlr_texture *wlr_gles2_texture_from_pixels(struct wlr_egl *egl,
 		enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width,
 		uint32_t height, const void *data) {
-	assert(wlr_egl_is_current(egl));
+	if (!wlr_egl_is_current(egl)) {
+		wlr_egl_make_current(egl, EGL_NO_SURFACE, NULL);
+	}
 
 	const struct wlr_gles2_pixel_format *fmt = get_gles2_format_from_wl(wl_fmt);
 	if (fmt == NULL) {

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -170,7 +170,9 @@ struct wlr_texture *wlr_gles2_texture_from_pixels(struct wlr_egl *egl,
 
 struct wlr_texture *wlr_gles2_texture_from_wl_drm(struct wlr_egl *egl,
 		struct wl_resource *data) {
-	assert(wlr_egl_is_current(egl));
+	if (!wlr_egl_is_current(egl)) {
+		wlr_egl_make_current(egl, EGL_NO_SURFACE, NULL);
+	}
 
 	if (!glEGLImageTargetTexture2DOES) {
 		return NULL;
@@ -221,7 +223,9 @@ struct wlr_texture *wlr_gles2_texture_from_wl_drm(struct wlr_egl *egl,
 
 struct wlr_texture *wlr_gles2_texture_from_dmabuf(struct wlr_egl *egl,
 		struct wlr_dmabuf_buffer_attribs *attribs) {
-	assert(wlr_egl_is_current(egl));
+	if (!wlr_egl_is_current(egl)) {
+		wlr_egl_make_current(egl, EGL_NO_SURFACE, NULL);
+	}
 
 	if (!glEGLImageTargetTexture2DOES) {
 		return NULL;

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -83,6 +83,8 @@ static void gles2_texture_destroy(struct wlr_texture *wlr_texture) {
 
 	struct wlr_gles2_texture *texture = gles2_get_texture(wlr_texture);
 
+	wl_list_remove(&texture->egl_destroy.link);
+
 	wlr_egl_make_current(texture->egl, EGL_NO_SURFACE, NULL);
 
 	PUSH_GLES2_DEBUG;
@@ -107,6 +109,29 @@ static const struct wlr_texture_impl texture_impl = {
 	.destroy = gles2_texture_destroy,
 };
 
+static void texture_handle_egl_destroy(struct wl_listener *listener,
+		void *data) {
+	struct wlr_gles2_texture *texture =
+		wl_container_of(listener, texture, egl_destroy);
+	wlr_texture_destroy(&texture->wlr_texture);
+}
+
+static struct wlr_gles2_texture *texture_create(struct wlr_egl *egl) {
+	struct wlr_gles2_texture *texture =
+		calloc(1, sizeof(struct wlr_gles2_texture));
+	if (texture == NULL) {
+		wlr_log(L_ERROR, "Allocation failed");
+		return NULL;
+	}
+	wlr_texture_init(&texture->wlr_texture, &texture_impl);
+	texture->egl = egl;
+
+	wl_signal_add(&egl->events.destroy, &texture->egl_destroy);
+	texture->egl_destroy.notify = texture_handle_egl_destroy;
+
+	return texture;
+}
+
 struct wlr_texture *wlr_gles2_texture_from_pixels(struct wlr_egl *egl,
 		enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width,
 		uint32_t height, const void *data) {
@@ -120,14 +145,10 @@ struct wlr_texture *wlr_gles2_texture_from_pixels(struct wlr_egl *egl,
 		return NULL;
 	}
 
-	struct wlr_gles2_texture *texture =
-		calloc(1, sizeof(struct wlr_gles2_texture));
+	struct wlr_gles2_texture *texture = texture_create(egl);
 	if (texture == NULL) {
-		wlr_log(L_ERROR, "Allocation failed");
 		return NULL;
 	}
-	wlr_texture_init(&texture->wlr_texture, &texture_impl);
-	texture->egl = egl;
 	texture->width = width;
 	texture->height = height;
 	texture->type = WLR_GLES2_TEXTURE_GLTEX;
@@ -155,14 +176,10 @@ struct wlr_texture *wlr_gles2_texture_from_wl_drm(struct wlr_egl *egl,
 		return NULL;
 	}
 
-	struct wlr_gles2_texture *texture =
-		calloc(1, sizeof(struct wlr_gles2_texture));
+	struct wlr_gles2_texture *texture = texture_create(egl);
 	if (texture == NULL) {
-		wlr_log(L_ERROR, "Allocation failed");
 		return NULL;
 	}
-	wlr_texture_init(&texture->wlr_texture, &texture_impl);
-	texture->egl = egl;
 	texture->wl_drm = data;
 
 	EGLint fmt;
@@ -216,14 +233,10 @@ struct wlr_texture *wlr_gles2_texture_from_dmabuf(struct wlr_egl *egl,
 		return NULL;
 	}
 
-	struct wlr_gles2_texture *texture =
-		calloc(1, sizeof(struct wlr_gles2_texture));
+	struct wlr_gles2_texture *texture = texture_create(egl);
 	if (texture == NULL) {
-		wlr_log(L_ERROR, "Allocation failed");
 		return NULL;
 	}
-	wlr_texture_init(&texture->wlr_texture, &texture_impl);
-	texture->egl = egl;
 	texture->width = attribs->width;
 	texture->height = attribs->height;
 	texture->type = WLR_GLES2_TEXTURE_DMABUF;

--- a/render/meson.build
+++ b/render/meson.build
@@ -15,6 +15,8 @@ lib_wlr_render = static_library(
 		'gles2/shaders.c',
 		'gles2/texture.c',
 		'gles2/util.c',
+		'multi/renderer.c',
+		'multi/texture.c',
 		'wlr_renderer.c',
 		'wlr_texture.c',
 	),

--- a/render/multi/renderer.c
+++ b/render/multi/renderer.c
@@ -1,0 +1,130 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <wlr/render/interface.h>
+#include <wlr/util/log.h>
+#include "render/multi.h"
+
+static struct wlr_multi_renderer *renderer_get_multi(
+		struct wlr_renderer *wlr_renderer) {
+	assert(wlr_renderer_is_multi(wlr_renderer));
+	return (struct wlr_multi_renderer *)wlr_renderer;
+}
+
+static void renderer_attempt_render() {
+	assert(false); // Multi renderer can only be used to create textures
+}
+
+static bool renderer_attempt_render_texture(struct wlr_renderer *wlr_renderer,
+		struct wlr_texture *texture, const float matrix[static 9],
+		float alpha) {
+	renderer_attempt_render();
+	return false;
+}
+
+static const enum wl_shm_format *renderer_get_formats(
+		struct wlr_renderer *wlr_renderer, size_t *len) {
+	struct wlr_multi_renderer *renderer = renderer_get_multi(wlr_renderer);
+
+	// TODO
+	struct wlr_multi_renderer_child *child;
+	wl_list_for_each(child, &renderer->children, link) {
+		return wlr_renderer_get_formats(child->renderer, len);
+	}
+
+	*len = 0;
+	return NULL;
+}
+
+static bool renderer_format_supported(struct wlr_renderer *wlr_renderer,
+		enum wl_shm_format fmt) {
+	struct wlr_multi_renderer *renderer = renderer_get_multi(wlr_renderer);
+
+	struct wlr_multi_renderer_child *child;
+	wl_list_for_each(child, &renderer->children, link) {
+		if (!wlr_renderer_format_supported(child->renderer, fmt)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static struct wlr_texture *renderer_texture_from_pixels(
+		struct wlr_renderer *wlr_renderer, enum wl_shm_format fmt,
+		uint32_t stride, uint32_t width, uint32_t height, const void *data) {
+	struct wlr_multi_renderer *renderer = renderer_get_multi(wlr_renderer);
+
+	if (wl_list_empty(&renderer->children)) {
+		return NULL;
+	}
+
+	struct wlr_multi_texture *texture = multi_texture_create();
+	if (texture == NULL) {
+		return NULL;
+	}
+	texture->width = width;
+	texture->height = height;
+
+	struct wlr_multi_renderer_child *child;
+	wl_list_for_each(child, &renderer->children, link) {
+		struct wlr_texture *wlr_texture_child = wlr_texture_from_pixels(
+			child->renderer, fmt, stride, width, height, data);
+		if (wlr_texture_child == NULL) {
+			wlr_texture_destroy(&texture->texture);
+			return NULL;
+		}
+
+		multi_texture_add(texture, wlr_texture_child, child->renderer);
+	}
+
+	return &texture->texture;
+}
+
+static const struct wlr_renderer_impl renderer_impl = {
+	.begin = renderer_attempt_render,
+	.clear = renderer_attempt_render,
+	.scissor = renderer_attempt_render,
+	.render_texture_with_matrix = renderer_attempt_render_texture,
+	.render_quad_with_matrix = renderer_attempt_render,
+	.render_ellipse_with_matrix = renderer_attempt_render,
+	.get_formats = renderer_get_formats,
+	.format_supported = renderer_format_supported,
+	.texture_from_pixels = renderer_texture_from_pixels,
+};
+
+struct wlr_renderer *wlr_multi_renderer_create() {
+	struct wlr_multi_renderer *renderer =
+		calloc(1, sizeof(struct wlr_multi_renderer));
+	if (renderer == NULL) {
+		return NULL;
+	}
+	wl_list_init(&renderer->children);
+	wlr_renderer_init(&renderer->renderer, &renderer_impl);
+	return &renderer->renderer;
+}
+
+void wlr_multi_renderer_add(struct wlr_renderer *wlr_renderer,
+		struct wlr_renderer *wlr_child) {
+	struct wlr_multi_renderer *renderer = renderer_get_multi(wlr_renderer);
+
+	struct wlr_multi_renderer_child *child =
+		calloc(1, sizeof(struct wlr_multi_renderer_child));
+	if (child == NULL) {
+		wlr_log(L_ERROR, "Allocation failed");
+		return;
+	}
+	child->renderer = wlr_child;
+
+	wl_list_insert(&renderer->children, &child->link);
+
+	// TODO: destroy listener
+}
+
+void wlr_multi_renderer_remove(struct wlr_renderer *renderer,
+	struct wlr_renderer *child);
+
+bool wlr_multi_renderer_is_empty(struct wlr_renderer *renderer);
+
+bool wlr_renderer_is_multi(struct wlr_renderer *wlr_renderer) {
+	return wlr_renderer->impl == &renderer_impl;
+}

--- a/render/multi/renderer.c
+++ b/render/multi/renderer.c
@@ -80,19 +80,12 @@ static struct wlr_texture *renderer_texture_from_pixels(
 	return &texture->texture;
 }
 
-static void renderer_child_destroy(struct wlr_multi_renderer_child *child) {
-	wl_list_remove(&child->destroy.link);
-	wl_list_remove(&child->link);
-	free(child);
-}
-
 static void renderer_destroy(struct wlr_renderer *wlr_renderer) {
 	struct wlr_multi_renderer *renderer = renderer_get_multi(wlr_renderer);
 
 	struct wlr_multi_renderer_child *child, *tmp;
 	wl_list_for_each_safe(child, tmp, &renderer->children, link) {
 		wlr_renderer_destroy(child->renderer);
-		renderer_child_destroy(child);
 	}
 
 	free(renderer);
@@ -120,6 +113,12 @@ struct wlr_renderer *wlr_multi_renderer_create() {
 	wl_list_init(&renderer->children);
 	wlr_renderer_init(&renderer->renderer, &renderer_impl);
 	return &renderer->renderer;
+}
+
+static void renderer_child_destroy(struct wlr_multi_renderer_child *child) {
+	wl_list_remove(&child->destroy.link);
+	wl_list_remove(&child->link);
+	free(child);
 }
 
 static void multi_renderer_child_handle_destroy(struct wl_listener *listener,

--- a/render/multi/texture.c
+++ b/render/multi/texture.c
@@ -97,6 +97,16 @@ void multi_texture_add(struct wlr_multi_texture *texture,
 	child->destroy.notify = texture_handle_destroy;
 }
 
+void multi_texture_update_size(struct wlr_multi_texture *texture) {
+	assert(!wl_list_empty(&texture->children));
+
+	struct wlr_multi_texture_child *child;
+	wl_list_for_each(child, &texture->children, link) {
+		wlr_texture_get_size(child->texture, &texture->width, &texture->height);
+		break;
+	}
+}
+
 struct wlr_texture *wlr_multi_texture_get_child(struct wlr_texture *wlr_texture,
 		struct wlr_renderer *child_renderer) {
 	struct wlr_multi_texture *texture = texture_get_multi(wlr_texture);

--- a/render/multi/texture.c
+++ b/render/multi/texture.c
@@ -1,0 +1,88 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <wlr/render/interface.h>
+#include <wlr/util/log.h>
+#include "render/multi.h"
+
+static const struct wlr_texture_impl texture_impl;
+
+bool wlr_texture_is_multi(struct wlr_texture *wlr_texture) {
+	return wlr_texture->impl == &texture_impl;
+}
+
+static struct wlr_multi_texture *texture_get_multi(
+		struct wlr_texture *wlr_texture) {
+	assert(wlr_texture_is_multi(wlr_texture));
+	return (struct wlr_multi_texture *)wlr_texture;
+}
+
+static void texture_get_size(struct wlr_texture *wlr_texture, int *width,
+		int *height) {
+	struct wlr_multi_texture *texture = texture_get_multi(wlr_texture);
+	*width = texture->width;
+	*height = texture->height;
+}
+
+static bool texture_write_pixels(struct wlr_texture *wlr_texture,
+		enum wl_shm_format fmt, uint32_t stride, uint32_t width,
+		uint32_t height, uint32_t src_x, uint32_t src_y, uint32_t dst_x,
+		uint32_t dst_y, const void *data) {
+	struct wlr_multi_texture *texture = texture_get_multi(wlr_texture);
+
+	struct wlr_multi_texture_child *child;
+	wl_list_for_each(child, &texture->children, link) {
+		if (!wlr_texture_write_pixels(child->texture, fmt, stride, width,
+				height, src_x, src_y, dst_x, dst_y, data)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static const struct wlr_texture_impl texture_impl = {
+	.get_size = texture_get_size,
+	.write_pixels = texture_write_pixels,
+	// TODO: destroy
+};
+
+struct wlr_multi_texture *multi_texture_create() {
+	struct wlr_multi_texture *texture =
+		calloc(1, sizeof(struct wlr_multi_texture));
+	if (texture == NULL) {
+		return NULL;
+	}
+	wlr_texture_init(&texture->texture, &texture_impl);
+	wl_list_init(&texture->children);
+	return texture;
+}
+
+void multi_texture_add(struct wlr_multi_texture *texture,
+		struct wlr_texture *wlr_child, struct wlr_renderer *child_renderer) {
+	struct wlr_multi_texture_child *child =
+		calloc(1, sizeof(struct wlr_multi_texture_child));
+	if (child == NULL) {
+		wlr_log(L_ERROR, "Allocation failed");
+		return;
+	}
+	child->texture = wlr_child;
+	child->renderer = child_renderer;
+
+	// TODO: renderer_destroy
+
+	wl_list_insert(&texture->children, &child->link);
+}
+
+struct wlr_texture *wlr_multi_texture_get_child(struct wlr_texture *wlr_texture,
+		struct wlr_renderer *child_renderer) {
+	struct wlr_multi_texture *texture = texture_get_multi(wlr_texture);
+
+	struct wlr_multi_texture_child *child;
+	wl_list_for_each(child, &texture->children, link) {
+		if (child->renderer == child_renderer) {
+			return child->texture;
+		}
+	}
+
+	return NULL;
+}

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -38,20 +38,28 @@ void wlr_renderer_destroy(struct wlr_renderer *r) {
 }
 
 void wlr_renderer_begin(struct wlr_renderer *r, int width, int height) {
+	assert(!r->rendering);
+
 	r->impl->begin(r, width, height);
+	r->rendering = true;
 }
 
 void wlr_renderer_end(struct wlr_renderer *r) {
+	assert(r->rendering);
+
 	if (r->impl->end) {
 		r->impl->end(r);
 	}
+	r->rendering = false;
 }
 
 void wlr_renderer_clear(struct wlr_renderer *r, const float color[static 4]) {
+	assert(r->rendering);
 	r->impl->clear(r, color);
 }
 
 void wlr_renderer_scissor(struct wlr_renderer *r, struct wlr_box *box) {
+	assert(r->rendering);
 	r->impl->scissor(r, box);
 }
 
@@ -70,6 +78,7 @@ bool wlr_render_texture(struct wlr_renderer *r, struct wlr_texture *texture,
 bool wlr_render_texture_with_matrix(struct wlr_renderer *r,
 		struct wlr_texture *texture, const float matrix[static 9],
 		float alpha) {
+	assert(r->rendering);
 	return r->impl->render_texture_with_matrix(r, texture, matrix, alpha);
 }
 
@@ -84,6 +93,7 @@ void wlr_render_rect(struct wlr_renderer *r, const struct wlr_box *box,
 
 void wlr_render_quad_with_matrix(struct wlr_renderer *r,
 		const float color[static 4], const float matrix[static 9]) {
+	assert(r->rendering);
 	r->impl->render_quad_with_matrix(r, color, matrix);
 }
 
@@ -98,6 +108,7 @@ void wlr_render_ellipse(struct wlr_renderer *r, const struct wlr_box *box,
 
 void wlr_render_ellipse_with_matrix(struct wlr_renderer *r,
 		const float color[static 4], const float matrix[static 9]) {
+	assert(r->rendering);
 	r->impl->render_ellipse_with_matrix(r, color, matrix);
 }
 

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -15,7 +15,7 @@ void wlr_renderer_init(struct wlr_renderer *renderer,
 	assert(impl->render_texture_with_matrix);
 	assert(impl->render_quad_with_matrix);
 	assert(impl->render_ellipse_with_matrix);
-	assert(impl->formats);
+	assert(impl->get_formats);
 	assert(impl->format_supported);
 	assert(impl->texture_from_pixels);
 	renderer->impl = impl;
@@ -99,7 +99,7 @@ void wlr_render_ellipse_with_matrix(struct wlr_renderer *r,
 
 const enum wl_shm_format *wlr_renderer_get_formats(
 		struct wlr_renderer *r, size_t *len) {
-	return r->impl->formats(r, len);
+	return r->impl->get_formats(r, len);
 }
 
 bool wlr_renderer_resource_is_wl_drm_buffer(struct wlr_renderer *r,

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -24,9 +24,13 @@ void wlr_renderer_init(struct wlr_renderer *renderer,
 }
 
 void wlr_renderer_destroy(struct wlr_renderer *r) {
+	if (r == NULL) {
+		return;
+	}
+
 	wlr_signal_emit_safe(&r->events.destroy, r);
 
-	if (r && r->impl && r->impl->destroy) {
+	if (r->impl && r->impl->destroy) {
 		r->impl->destroy(r);
 	} else {
 		free(r);

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -162,7 +162,7 @@ bool wlr_renderer_format_supported(struct wlr_renderer *r,
 	return r->impl->format_supported(r, fmt);
 }
 
-void wlr_renderer_init_wl_shm(struct wlr_renderer *r,
+void wlr_renderer_init_wl_display(struct wlr_renderer *r,
 		struct wl_display *display) {
 	if (wl_display_init_shm(display)) {
 		wlr_log(L_ERROR, "Failed to initialize shm");
@@ -181,5 +181,9 @@ void wlr_renderer_init_wl_shm(struct wlr_renderer *r,
 				formats[i] != WL_SHM_FORMAT_XRGB8888) {
 			wl_display_add_shm_format(display, formats[i]);
 		}
+	}
+
+	if (r->impl->bind_wl_display) {
+		r->impl->bind_wl_display(r, display);
 	}
 }

--- a/render/wlr_texture.c
+++ b/render/wlr_texture.c
@@ -3,16 +3,25 @@
 #include <stdlib.h>
 #include <wlr/render/interface.h>
 #include <wlr/render/wlr_texture.h>
+#include "util/signal.h"
 
 void wlr_texture_init(struct wlr_texture *texture,
 		const struct wlr_texture_impl *impl) {
 	assert(impl->get_size);
 	assert(impl->write_pixels);
 	texture->impl = impl;
+
+	wl_signal_init(&texture->events.destroy);
 }
 
 void wlr_texture_destroy(struct wlr_texture *texture) {
-	if (texture && texture->impl && texture->impl->destroy) {
+	if (texture == NULL) {
+		return;
+	}
+
+	wlr_signal_emit_safe(&texture->events.destroy, texture);
+
+	if (texture->impl && texture->impl->destroy) {
 		texture->impl->destroy(texture);
 	} else {
 		free(texture);

--- a/rootston/main.c
+++ b/rootston/main.c
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
 	assert(server.renderer);
 	server.data_device_manager =
 		wlr_data_device_manager_create(server.wl_display);
-	wlr_renderer_init_wl_shm(server.renderer, server.wl_display);
+	wlr_renderer_init_wl_display(server.renderer, server.wl_display);
 	server.desktop = desktop_create(&server, server.config);
 	server.input = input_create(&server, server.config);
 

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -10,6 +10,7 @@
 #include <wlr/types/wlr_wl_shell.h>
 #include <wlr/types/wlr_xdg_shell_v6.h>
 #include <wlr/types/wlr_xdg_shell.h>
+#include <wlr/render/multi.h>
 #include <wlr/util/log.h>
 #include <wlr/util/region.h>
 #include "rootston/config.h"
@@ -208,6 +209,10 @@ static void render_surface(struct wlr_surface *surface, int sx, int sy,
 		return;
 	}
 
+	struct wlr_texture *texture =
+		wlr_multi_texture_get_child(surface->texture, renderer);
+	assert(texture);
+
 	struct wlr_box rotated;
 	wlr_box_rotated_bounds(&box, rotation, &rotated);
 
@@ -231,8 +236,7 @@ static void render_surface(struct wlr_surface *surface, int sx, int sy,
 	pixman_box32_t *rects = pixman_region32_rectangles(&damage, &nrects);
 	for (int i = 0; i < nrects; ++i) {
 		scissor_output(output, &rects[i]);
-		wlr_render_texture_with_matrix(renderer, surface->texture, matrix,
-			data->alpha);
+		wlr_render_texture_with_matrix(renderer, texture, matrix, data->alpha);
 	}
 
 damage_finish:

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -6,6 +6,7 @@
 #include <time.h>
 #include <wayland-server.h>
 #include <wlr/interfaces/wlr_output.h>
+#include <wlr/render/multi.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_matrix.h>
@@ -372,6 +373,12 @@ static void output_fullscreen_surface_render(struct wlr_output *output,
 		return;
 	}
 
+	struct wlr_texture *texture = surface->texture;
+	if (wlr_texture_is_multi(texture)) {
+		texture = wlr_multi_texture_get_child(texture, renderer);
+		assert(texture);
+	}
+
 	struct wlr_box box;
 	output_fullscreen_surface_get_box(output, surface, &box);
 
@@ -386,7 +393,7 @@ static void output_fullscreen_surface_render(struct wlr_output *output,
 	for (int i = 0; i < nrects; ++i) {
 		output_scissor(output, &rects[i]);
 		wlr_renderer_clear(renderer, (float[]){0, 0, 0, 0});
-		wlr_render_texture_with_matrix(surface->renderer, surface->texture, matrix, 1.0f);
+		wlr_render_texture_with_matrix(surface->renderer, texture, matrix, 1.0f);
 	}
 	wlr_renderer_scissor(renderer, NULL);
 
@@ -418,6 +425,10 @@ static void output_cursor_render(struct wlr_output_cursor *cursor,
 	struct wlr_texture *texture = cursor->texture;
 	if (cursor->surface != NULL) {
 		texture = cursor->surface->texture;
+	}
+	if (texture && wlr_texture_is_multi(texture)) {
+		texture = wlr_multi_texture_get_child(texture, renderer);
+		assert(texture);
 	}
 	if (texture == NULL) {
 		return;

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -498,6 +498,12 @@ bool wlr_output_swap_buffers(struct wlr_output *output, struct timespec *when,
 	}
 
 	if (pixman_region32_not_empty(&render_damage)) {
+		struct wlr_renderer *renderer =
+			wlr_backend_get_renderer(output->backend);
+		assert(renderer);
+
+		wlr_renderer_begin(renderer, output->width, output->height);
+
 		if (output->fullscreen_surface != NULL) {
 			output_fullscreen_surface_render(output, output->fullscreen_surface,
 				when, &render_damage);
@@ -511,6 +517,8 @@ bool wlr_output_swap_buffers(struct wlr_output *output, struct timespec *when,
 			}
 			output_cursor_render(cursor, when, &render_damage);
 		}
+
+		wlr_renderer_end(renderer);
 	}
 
 	// Transform damage into renderer coordinates, ie. upside down

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -714,9 +714,17 @@ static void output_cursor_update_visible(struct wlr_output_cursor *cursor) {
 }
 
 static bool output_cursor_attempt_hardware(struct wlr_output_cursor *cursor) {
+	struct wlr_renderer *renderer =
+		wlr_backend_get_renderer(cursor->output->backend);
+	assert(renderer);
+
 	struct wlr_texture *texture = cursor->texture;
 	if (cursor->surface != NULL) {
 		texture = cursor->surface->texture;
+		if (texture && wlr_texture_is_multi(texture)) {
+			texture = wlr_multi_texture_get_child(texture, renderer);
+			assert(texture);
+		}
 	}
 
 	struct wlr_output_cursor *hwcur = cursor->output->hardware_cursor;


### PR DESCRIPTION
I started #906, and then realized there are a lot of issues trying to import/export lazily because switching EGL contexts is required when exporting and importing. So hopefully this PR will make #906 easier to implement.

This introduces `wlr_multi_renderer`, which is similar to `wlr_multi_backend`. The `wlr_multi_backend` now creates a `wlr_multi_renderer` which creates textures on all renderers. When rendering a texture, the compositor must use `wlr_multi_texture_get_child` to get the texture for a specific renderer from a `wlr_multi_texture`.

In the future, it will be possible to optimize this multi renderer with DMA-BUF and the master/slave mechnism explained in #778.

`wlr_multi_renderer` was needed anyway for backend hotplugging (because you don't want to create surfaces with a renderer that could go away).

You can try to run rootston on this branch, you'll get two outputs: one Wayland output and one X11 output. Cursor input is a bit messed up, but rendering works!

- [x] Create textures from pixel buffers
- [x] Create textures from wl-drm
- [x] Create textures from DMA-BUF
- [x] Properly destroy textures
- [x] Properly destroy renderer
- [x] ~~Investigate why using `wlr_egl_bind_display` multiple times fails on shutdown~~

Follow-up issues:
- Hotplugging doesn't work if it changes the set of available formats
- ~~Input events on the Wayland and X11 backends are messed up (#925, fixed by #930)~~
- Allow the headless backend to re-use an existing renderer (see #778)
- Use DMA-BUF to share textures between backends (see #778)

Fixes #778