### PR TITLE
Add wlr_input_device.output_name

### DIFF
--- a/backend/libinput/events.c
+++ b/backend/libinput/events.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 200809L
 #include <assert.h>
 #include <libinput.h>
 #include <stdlib.h>
@@ -48,6 +49,10 @@ static struct wlr_input_device *allocate_device(
 	struct wlr_input_device *wlr_dev = &wlr_libinput_dev->wlr_input_device;
 	libinput_device_get_size(libinput_dev,
 			&wlr_dev->width_mm, &wlr_dev->height_mm);
+	const char *output_name = libinput_device_get_output_name(libinput_dev);
+	if (output_name != NULL) {
+		wlr_dev->output_name = strdup(output_name);
+	}
 	wl_list_insert(wlr_devices, &wlr_dev->link);
 	wlr_libinput_dev->handle = libinput_dev;
 	libinput_device_ref(libinput_dev);

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -288,6 +288,7 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *_backend) {
 		wlr_log_errno(L_ERROR, "Could not create output surface");
 		goto error;
 	}
+	wl_surface_set_user_data(output->surface, output);
 	output->xdg_surface =
 		zxdg_shell_v6_get_xdg_surface(backend->shell, output->surface);
 	if (!output->xdg_surface) {

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -20,7 +20,7 @@ static struct wl_callback_listener frame_listener;
 
 static void surface_frame_callback(void *data, struct wl_callback *cb,
 		uint32_t time) {
-	struct wlr_wl_backend_output *output = data;
+	struct wlr_wl_output *output = data;
 	assert(output);
 	wl_callback_destroy(cb);
 	output->frame_callback = NULL;
@@ -34,7 +34,7 @@ static struct wl_callback_listener frame_listener = {
 
 static bool output_set_custom_mode(struct wlr_output *_output,
 		int32_t width, int32_t height, int32_t refresh) {
-	struct wlr_wl_backend_output *output = (struct wlr_wl_backend_output *)_output;
+	struct wlr_wl_output *output = (struct wlr_wl_output *)_output;
 	wl_egl_window_resize(output->egl_window, width, height, 0, 0);
 	wlr_output_update_custom_mode(&output->wlr_output, width, height, 0);
 	return true;
@@ -42,16 +42,16 @@ static bool output_set_custom_mode(struct wlr_output *_output,
 
 static bool output_make_current(struct wlr_output *wlr_output,
 		int *buffer_age) {
-	struct wlr_wl_backend_output *output =
-		(struct wlr_wl_backend_output *)wlr_output;
+	struct wlr_wl_output *output =
+		(struct wlr_wl_output *)wlr_output;
 	return wlr_egl_make_current(&output->backend->egl, output->egl_surface,
 		buffer_age);
 }
 
 static bool output_swap_buffers(struct wlr_output *wlr_output,
 		pixman_region32_t *damage) {
-	struct wlr_wl_backend_output *output =
-		(struct wlr_wl_backend_output *)wlr_output;
+	struct wlr_wl_output *output =
+		(struct wlr_wl_output *)wlr_output;
 
 	if (output->frame_callback != NULL) {
 		wlr_log(L_ERROR, "Skipping buffer swap");
@@ -67,15 +67,15 @@ static bool output_swap_buffers(struct wlr_output *wlr_output,
 
 static void output_transform(struct wlr_output *_output,
 		enum wl_output_transform transform) {
-	struct wlr_wl_backend_output *output = (struct wlr_wl_backend_output *)_output;
+	struct wlr_wl_output *output = (struct wlr_wl_output *)_output;
 	output->wlr_output.transform = transform;
 }
 
 static bool output_set_cursor(struct wlr_output *_output,
 		const uint8_t *buf, int32_t stride, uint32_t width, uint32_t height,
 		int32_t hotspot_x, int32_t hotspot_y, bool update_pixels) {
-	struct wlr_wl_backend_output *output =
-		(struct wlr_wl_backend_output *)_output;
+	struct wlr_wl_output *output =
+		(struct wlr_wl_output *)_output;
 	struct wlr_wl_backend *backend = output->backend;
 
 	// TODO: use output->wlr_output.transform to transform pixels and hotpot
@@ -100,7 +100,7 @@ static bool output_set_cursor(struct wlr_output *_output,
 	}
 
 	if (!backend->shm || !backend->pointer) {
-		wlr_log(L_INFO, "cannot set cursor, no shm or pointer");
+		wlr_log(L_INFO, "cannot set cursor: no wl_shm or wl_pointer");
 		return false;
 	}
 
@@ -158,8 +158,8 @@ static bool output_set_cursor(struct wlr_output *_output,
 }
 
 static void output_destroy(struct wlr_output *wlr_output) {
-	struct wlr_wl_backend_output *output =
-		(struct wlr_wl_backend_output *)wlr_output;
+	struct wlr_wl_output *output =
+		(struct wlr_wl_output *)wlr_output;
 	if (output == NULL) {
 		return;
 	}
@@ -192,7 +192,7 @@ static void output_destroy(struct wlr_output *wlr_output) {
 	free(output);
 }
 
-void update_wl_output_cursor(struct wlr_wl_backend_output *output) {
+void update_wl_output_cursor(struct wlr_wl_output *output) {
 	if (output->backend->pointer && output->enter_serial) {
 		wl_pointer_set_cursor(output->backend->pointer, output->enter_serial,
 			output->cursor.surface, output->cursor.hotspot_x,
@@ -221,7 +221,7 @@ bool wlr_output_is_wl(struct wlr_output *wlr_output) {
 
 static void xdg_surface_handle_configure(void *data, struct zxdg_surface_v6 *xdg_surface,
 		uint32_t serial) {
-	struct wlr_wl_backend_output *output = data;
+	struct wlr_wl_output *output = data;
 	assert(output && output->xdg_surface == xdg_surface);
 
 	zxdg_surface_v6_ack_configure(xdg_surface, serial);
@@ -235,7 +235,7 @@ static struct zxdg_surface_v6_listener xdg_surface_listener = {
 
 static void xdg_toplevel_handle_configure(void *data, struct zxdg_toplevel_v6 *xdg_toplevel,
 		int32_t width, int32_t height, struct wl_array *states) {
-	struct wlr_wl_backend_output *output = data;
+	struct wlr_wl_output *output = data;
 	assert(output && output->xdg_toplevel == xdg_toplevel);
 
 	if (width == 0 && height == 0) {
@@ -247,7 +247,7 @@ static void xdg_toplevel_handle_configure(void *data, struct zxdg_toplevel_v6 *x
 }
 
 static void xdg_toplevel_handle_close(void *data, struct zxdg_toplevel_v6 *xdg_toplevel) {
-	struct wlr_wl_backend_output *output = data;
+	struct wlr_wl_output *output = data;
 	assert(output && output->xdg_toplevel == xdg_toplevel);
 
 	wlr_output_destroy((struct wlr_output *)output);
@@ -266,9 +266,9 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *_backend) {
 		return NULL;
 	}
 
-	struct wlr_wl_backend_output *output;
-	if (!(output = calloc(sizeof(struct wlr_wl_backend_output), 1))) {
-		wlr_log(L_ERROR, "Failed to allocate wlr_wl_backend_output");
+	struct wlr_wl_output *output;
+	if (!(output = calloc(sizeof(struct wlr_wl_output), 1))) {
+		wlr_log(L_ERROR, "Failed to allocate wlr_wl_output");
 		return NULL;
 	}
 	wlr_output_init(&output->wlr_output, &backend->backend, &output_impl,
@@ -336,7 +336,13 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *_backend) {
 
 	wl_list_insert(&backend->outputs, &output->link);
 	wlr_output_update_enabled(wlr_output, true);
+
 	wlr_signal_emit_safe(&backend->backend.events.new_output, wlr_output);
+
+	if (backend->pointer != NULL) {
+		create_wl_pointer(backend->pointer, output);
+	}
+
 	return wlr_output;
 
 error:

--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -14,104 +14,79 @@
 #include "util/signal.h"
 
 static void pointer_handle_enter(void *data, struct wl_pointer *wl_pointer,
-		uint32_t serial, struct wl_surface *surface, wl_fixed_t surface_x,
-		wl_fixed_t surface_y) {
-	struct wlr_input_device *dev = data;
-	struct wlr_wl_input_device *wlr_wl_dev = (struct wlr_wl_input_device *)dev;
-	assert(dev && dev->pointer);
-	struct wlr_wl_pointer *wlr_wl_pointer = (struct wlr_wl_pointer *)dev->pointer;
-	struct wlr_wl_backend_output *output =
-		get_wl_output_for_surface(wlr_wl_dev->backend, surface);
-	if (!output) {
-		// GNOME sends a pointer enter when the surface is being destroyed
+		uint32_t serial, struct wl_surface *surface, wl_fixed_t sx,
+		wl_fixed_t sy) {
+	struct wlr_wl_pointer *pointer = data;
+	if (pointer->output->surface != surface) {
 		return;
 	}
-	if (wlr_wl_pointer->current_output) {
-		wl_list_remove(&wlr_wl_pointer->output_destroy_listener.link);
-	}
-	wl_signal_add(&output->wlr_output.events.destroy,
-		&wlr_wl_pointer->output_destroy_listener);
-	wlr_wl_pointer->current_output = output;
-	output->enter_serial = serial;
-	update_wl_output_cursor(output);
+
+	pointer->output->enter_serial = serial;
+	update_wl_output_cursor(pointer->output);
 }
 
 static void pointer_handle_leave(void *data, struct wl_pointer *wl_pointer,
 		uint32_t serial, struct wl_surface *surface) {
-	struct wlr_input_device *dev = data;
-	assert(dev && dev->pointer);
-	struct wlr_wl_pointer *wlr_wl_pointer = (struct wlr_wl_pointer *)dev->pointer;
-	if (wlr_wl_pointer->current_output) {
-		wlr_wl_pointer->current_output->enter_serial = 0;
-		wlr_wl_pointer->current_output = NULL;
-	}
-}
-
-static void pointer_handle_motion(void *data, struct wl_pointer *wl_pointer,
-		uint32_t time, wl_fixed_t surface_x, wl_fixed_t surface_y) {
-	struct wlr_input_device *dev = data;
-	assert(dev && dev->pointer);
-	struct wlr_wl_pointer *wlr_wl_pointer =
-		(struct wlr_wl_pointer *)dev->pointer;
-	if (!wlr_wl_pointer->current_output) {
-		wlr_log(L_DEBUG, "pointer motion event without current output");
+	struct wlr_wl_pointer *pointer = data;
+	if (pointer->output->surface != surface) {
 		return;
 	}
 
-	struct wlr_output *wlr_output = &wlr_wl_pointer->current_output->wlr_output;
+	pointer->output->enter_serial = 0;
+}
 
-	struct wlr_box box = {
-		.x = wl_fixed_to_int(surface_x),
-		.y = wl_fixed_to_int(surface_y),
-	};
-	wlr_box_transform(&box, wlr_output->transform, wlr_output->width,
-		wlr_output->height, &box);
-	box.x /= wlr_output->scale;
-	box.y /= wlr_output->scale;
+static void pointer_handle_motion(void *data, struct wl_pointer *wl_pointer,
+		uint32_t time, wl_fixed_t sx, wl_fixed_t sy) {
+	struct wlr_wl_pointer *pointer = data;
+	if (pointer->output->enter_serial == 0) {
+		return;
+	}
 
-	struct wlr_box layout_box;
-	get_wl_output_layout_box(wlr_wl_pointer->current_output->backend,
-		&layout_box);
+	int output_width, output_height;
+	wlr_output_effective_resolution(&pointer->output->wlr_output,
+		&output_width, &output_height);
 
-	double ox = wlr_output->lx / (double)layout_box.width;
-	double oy = wlr_output->ly / (double)layout_box.height;
-
-	struct wlr_event_pointer_motion_absolute wlr_event = {
-		.device = dev,
+	struct wlr_event_pointer_motion_absolute event = {
+		.device = &pointer->input_device->wlr_input_device,
 		.time_msec = time,
-		.x = box.x / (double)layout_box.width + ox,
-		.y = box.y / (double)layout_box.height + oy,
+		.x = (double)wl_fixed_to_int(sx) / output_width,
+		.y = (double)wl_fixed_to_int(sy) / output_height,
 	};
-
-	wlr_signal_emit_safe(&dev->pointer->events.motion_absolute, &wlr_event);
+	wlr_log(L_DEBUG, "motion: %f,%f", event.x, event.y);
+	wlr_signal_emit_safe(&pointer->wlr_pointer.events.motion_absolute, &event);
 }
 
 static void pointer_handle_button(void *data, struct wl_pointer *wl_pointer,
 		uint32_t serial, uint32_t time, uint32_t button, uint32_t state) {
-	struct wlr_input_device *dev = data;
-	assert(dev && dev->pointer);
+	struct wlr_wl_pointer *pointer = data;
+	if (pointer->output->enter_serial == 0) {
+		return;
+	}
 
-	struct wlr_event_pointer_button wlr_event;
-	wlr_event.device = dev;
-	wlr_event.button = button;
-	wlr_event.state = state;
-	wlr_event.time_msec = time;
-	wlr_signal_emit_safe(&dev->pointer->events.button, &wlr_event);
+	struct wlr_event_pointer_button event = {
+		.device = &pointer->input_device->wlr_input_device,
+		.button = button,
+		.state = state,
+		.time_msec = time,
+	};
+	wlr_signal_emit_safe(&pointer->wlr_pointer.events.button, &event);
 }
 
 static void pointer_handle_axis(void *data, struct wl_pointer *wl_pointer,
 		uint32_t time, uint32_t axis, wl_fixed_t value) {
-	struct wlr_input_device *dev = data;
-	assert(dev && dev->pointer);
-	struct wlr_wl_pointer *wlr_wl_pointer = (struct wlr_wl_pointer *)dev->pointer;
+	struct wlr_wl_pointer *pointer = data;
+	if (pointer->output->enter_serial == 0) {
+		return;
+	}
 
-	struct wlr_event_pointer_axis wlr_event;
-	wlr_event.device = dev;
-	wlr_event.delta = wl_fixed_to_double(value);
-	wlr_event.orientation = axis;
-	wlr_event.time_msec = time;
-	wlr_event.source = wlr_wl_pointer->axis_source;
-	wlr_signal_emit_safe(&dev->pointer->events.axis, &wlr_event);
+	struct wlr_event_pointer_axis event = {
+		.device = &pointer->input_device->wlr_input_device,
+		.delta = wl_fixed_to_double(value),
+		.orientation = axis,
+		.time_msec = time,
+		.source = pointer->axis_source,
+	};
+	wlr_signal_emit_safe(&pointer->wlr_pointer.events.axis, &event);
 }
 
 static void pointer_handle_frame(void *data, struct wl_pointer *wl_pointer) {
@@ -120,11 +95,12 @@ static void pointer_handle_frame(void *data, struct wl_pointer *wl_pointer) {
 
 static void pointer_handle_axis_source(void *data, struct wl_pointer *wl_pointer,
 		uint32_t axis_source) {
-	struct wlr_input_device *dev = data;
-	assert(dev && dev->pointer);
-	struct wlr_wl_pointer *wlr_wl_pointer = (struct wlr_wl_pointer *)dev->pointer;
+	struct wlr_wl_pointer *pointer = data;
+	if (pointer->output->enter_serial == 0) {
+		return;
+	}
 
-	wlr_wl_pointer->axis_source = axis_source;
+	pointer->axis_source = axis_source;
 }
 
 static void pointer_handle_axis_stop(void *data, struct wl_pointer *wl_pointer,
@@ -146,7 +122,7 @@ static const struct wl_pointer_listener pointer_listener = {
 	.frame = pointer_handle_frame,
 	.axis_source = pointer_handle_axis_source,
 	.axis_stop = pointer_handle_axis_stop,
-	.axis_discrete = pointer_handle_axis_discrete
+	.axis_discrete = pointer_handle_axis_discrete,
 };
 
 static void keyboard_handle_keymap(void *data, struct wl_keyboard *wl_keyboard,
@@ -204,43 +180,104 @@ static void input_device_destroy(struct wlr_input_device *wlr_dev) {
 	if (dev->resource) {
 		wl_proxy_destroy(dev->resource);
 	}
+	wl_list_remove(&dev->wlr_input_device.link);
 	free(dev);
 }
 
 static struct wlr_input_device_impl input_device_impl = {
-	.destroy = input_device_destroy
+	.destroy = input_device_destroy,
 };
 
 bool wlr_input_device_is_wl(struct wlr_input_device *dev) {
 	return dev->impl == &input_device_impl;
 }
 
-static struct wlr_input_device *allocate_device(struct wlr_wl_backend *backend,
-		enum wlr_input_device_type type) {
-	struct wlr_wl_input_device *wlr_wl_dev;
-	if (!(wlr_wl_dev = calloc(1, sizeof(struct wlr_wl_input_device)))) {
+static struct wlr_wl_input_device *create_wl_input_device(
+		struct wlr_wl_backend *backend, enum wlr_input_device_type type) {
+	struct wlr_wl_input_device *dev =
+		calloc(1, sizeof(struct wlr_wl_input_device));
+	if (dev == NULL) {
 		wlr_log_errno(L_ERROR, "Allocation failed");
 		return NULL;
 	}
+	dev->backend = backend;
 
-	wlr_wl_dev->backend = backend;
+	struct wlr_input_device *wlr_dev = &dev->wlr_input_device;
 
-	int vendor = 0;
-	int product = 0;
+	unsigned int vendor = 0, product = 0;
 	const char *name = "wayland";
-	struct wlr_input_device *wlr_device = &wlr_wl_dev->wlr_input_device;
-	wlr_input_device_init(wlr_device, type, &input_device_impl,
-			name, vendor, product);
-	wl_list_insert(&backend->devices, &wlr_device->link);
-	return wlr_device;
+	wlr_input_device_init(wlr_dev, type, &input_device_impl, name, vendor,
+		product);
+	wl_list_insert(&backend->devices, &wlr_dev->link);
+	return dev;
 }
+
+static struct wlr_pointer_impl pointer_impl;
+
+struct wlr_wl_pointer *pointer_get_wl(struct wlr_pointer *wlr_pointer) {
+	assert(wlr_pointer->impl == &pointer_impl);
+	return (struct wlr_wl_pointer *)wlr_pointer;
+}
+
+static void pointer_destroy(struct wlr_pointer *wlr_pointer) {
+	struct wlr_wl_pointer *pointer = pointer_get_wl(wlr_pointer);
+	wl_list_remove(&pointer->output_destroy.link);
+	free(pointer);
+}
+
+static struct wlr_pointer_impl pointer_impl = {
+	.destroy = pointer_destroy,
+};
 
 static void pointer_handle_output_destroy(struct wl_listener *listener,
 		void *data) {
-	struct wlr_wl_pointer *wlr_wl_pointer =
-		wl_container_of(listener, wlr_wl_pointer, output_destroy_listener);
-	wlr_wl_pointer->current_output = NULL;
-	wl_list_remove(&wlr_wl_pointer->output_destroy_listener.link);
+	struct wlr_wl_pointer *pointer =
+		wl_container_of(listener, pointer, output_destroy);
+	wlr_input_device_destroy(&pointer->input_device->wlr_input_device);
+}
+
+void create_wl_pointer(struct wl_pointer *wl_pointer,
+		struct wlr_wl_output *output) {
+	struct wlr_wl_backend *backend = output->backend;
+
+	struct wlr_input_device *wlr_dev;
+	wl_list_for_each(wlr_dev, &output->backend->devices, link) {
+		if (wlr_dev->type != WLR_INPUT_DEVICE_POINTER) {
+			continue;
+		}
+		struct wlr_wl_pointer *pointer = pointer_get_wl(wlr_dev->pointer);
+		if (pointer->output == output) {
+			return;
+		}
+	}
+
+	struct wlr_wl_pointer *pointer = calloc(1, sizeof(struct wlr_wl_pointer));
+	if (pointer == NULL) {
+		wlr_log(L_ERROR, "Allocation failed");
+		return;
+	}
+	pointer->wl_pointer = wl_pointer;
+	pointer->output = output;
+
+	wl_signal_add(&output->wlr_output.events.destroy, &pointer->output_destroy);
+	pointer->output_destroy.notify = pointer_handle_output_destroy;
+
+	struct wlr_wl_input_device *dev =
+		create_wl_input_device(backend, WLR_INPUT_DEVICE_POINTER);
+	if (dev == NULL) {
+		free(pointer);
+		wlr_log(L_ERROR, "Allocation failed");
+		return;
+	}
+	wlr_dev = &dev->wlr_input_device;
+	pointer->input_device = dev;
+
+	wl_pointer_add_listener(wl_pointer, &pointer_listener, pointer);
+	wlr_dev->pointer = &pointer->wlr_pointer;
+	wlr_dev->output_name = strdup(output->wlr_output.name);
+	wlr_pointer_init(wlr_dev->pointer, &pointer_impl);
+
+	wlr_signal_emit_safe(&backend->backend.events.new_input, wlr_dev);
 }
 
 static void seat_handle_capabilities(void *data, struct wl_seat *wl_seat,
@@ -250,53 +287,36 @@ static void seat_handle_capabilities(void *data, struct wl_seat *wl_seat,
 
 	if ((caps & WL_SEAT_CAPABILITY_POINTER)) {
 		wlr_log(L_DEBUG, "seat %p offered pointer", (void*) wl_seat);
-		struct wlr_wl_pointer *wlr_wl_pointer;
-		if (!(wlr_wl_pointer = calloc(1, sizeof(struct wlr_wl_pointer)))) {
-			wlr_log(L_ERROR, "Unable to allocate wlr_wl_pointer");
-			return;
-		}
-		wlr_wl_pointer->output_destroy_listener.notify =
-			pointer_handle_output_destroy;
-
-		struct wlr_input_device *wlr_device;
-		if (!(wlr_device = allocate_device(backend, WLR_INPUT_DEVICE_POINTER))) {
-			free(wlr_wl_pointer);
-			wlr_log(L_ERROR, "Unable to allocate wlr_device for pointer");
-			return;
-		}
-		struct wlr_wl_input_device *wlr_wl_device =
-			(struct wlr_wl_input_device *)wlr_device;
 
 		struct wl_pointer *wl_pointer = wl_seat_get_pointer(wl_seat);
-		wl_pointer_add_listener(wl_pointer, &pointer_listener, wlr_device);
-		wlr_device->pointer = &wlr_wl_pointer->wlr_pointer;
-		wlr_pointer_init(wlr_device->pointer, NULL);
-		wlr_wl_device->resource = wl_pointer;
-		wlr_signal_emit_safe(&backend->backend.events.new_input, wlr_device);
 		backend->pointer = wl_pointer;
+
+		struct wlr_wl_output *output;
+		wl_list_for_each(output, &backend->outputs, link) {
+			create_wl_pointer(wl_pointer, output);
+		}
 	}
 	if ((caps & WL_SEAT_CAPABILITY_KEYBOARD)) {
 		wlr_log(L_DEBUG, "seat %p offered keyboard", (void*) wl_seat);
-		struct wlr_input_device *wlr_device = allocate_device(backend,
+		struct wlr_wl_input_device *dev = create_wl_input_device(backend,
 			WLR_INPUT_DEVICE_KEYBOARD);
-		if (!wlr_device) {
-			wlr_log(L_ERROR, "Unable to allocate wl_keyboard device");
+		if (dev == NULL) {
+			wlr_log(L_ERROR, "Allocation failed");
 			return;
 		}
-		wlr_device->keyboard = calloc(1, sizeof(struct wlr_keyboard));
-		if (!wlr_device->keyboard) {
-			free(wlr_device);
-			wlr_log(L_ERROR, "Unable to allocate wlr keyboard");
+		struct wlr_input_device *wlr_dev = &dev->wlr_input_device;
+		wlr_dev->keyboard = calloc(1, sizeof(struct wlr_keyboard));
+		if (!wlr_dev->keyboard) {
+			free(dev);
+			wlr_log(L_ERROR, "Allocation failed");
 			return;
 		}
-		wlr_keyboard_init(wlr_device->keyboard, NULL);
-		struct wlr_wl_input_device *wlr_wl_device =
-			(struct wlr_wl_input_device *)wlr_device;
+		wlr_keyboard_init(wlr_dev->keyboard, NULL);
 
 		struct wl_keyboard *wl_keyboard = wl_seat_get_keyboard(wl_seat);
-		wl_keyboard_add_listener(wl_keyboard, &keyboard_listener, wlr_device);
-		wlr_wl_device->resource = wl_keyboard;
-		wlr_signal_emit_safe(&backend->backend.events.new_input, wlr_device);
+		wl_keyboard_add_listener(wl_keyboard, &keyboard_listener, wlr_dev);
+		dev->resource = wl_keyboard;
+		wlr_signal_emit_safe(&backend->backend.events.new_input, wlr_dev);
 	}
 }
 

--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -63,7 +63,6 @@ static void pointer_handle_leave(void *data, struct wl_pointer *wl_pointer,
 	}
 
 	backend->current_pointer = NULL;
-	wlr_log(L_DEBUG, "leave %p", surface);
 }
 
 static void pointer_handle_motion(void *data, struct wl_pointer *wl_pointer,
@@ -74,6 +73,17 @@ static void pointer_handle_motion(void *data, struct wl_pointer *wl_pointer,
 		return;
 	}
 
+	struct wlr_output *wlr_output = &pointer->output->wlr_output;
+
+	struct wlr_box box = {
+		.x = wl_fixed_to_int(sx),
+		.y = wl_fixed_to_int(sy),
+	};
+	wlr_box_transform(&box, wlr_output->transform, wlr_output->width,
+		wlr_output->height, &box);
+	box.x /= wlr_output->scale;
+	box.y /= wlr_output->scale;
+
 	int output_width, output_height;
 	wlr_output_effective_resolution(&pointer->output->wlr_output,
 		&output_width, &output_height);
@@ -81,10 +91,9 @@ static void pointer_handle_motion(void *data, struct wl_pointer *wl_pointer,
 	struct wlr_event_pointer_motion_absolute event = {
 		.device = &pointer->input_device->wlr_input_device,
 		.time_msec = time,
-		.x = (double)wl_fixed_to_int(sx) / output_width,
-		.y = (double)wl_fixed_to_int(sy) / output_height,
+		.x = (double)box.x / output_width,
+		.y = (double)box.y / output_height,
 	};
-	wlr_log(L_DEBUG, "motion: %f,%f", event.x, event.y);
 	wlr_signal_emit_safe(&pointer->wlr_pointer.events.motion_absolute, &event);
 }
 

--- a/backend/x11/input_device.c
+++ b/backend/x11/input_device.c
@@ -33,14 +33,20 @@ static void x11_handle_pointer_position(struct wlr_x11_output *output,
 	struct wlr_x11_backend *x11 = output->x11;
 	struct wlr_output *wlr_output = &output->wlr_output;
 
+	struct wlr_box box = { .x = x, .y = y };
+	wlr_box_transform(&box, wlr_output->transform, wlr_output->width,
+		wlr_output->height, &box);
+	box.x /= wlr_output->scale;
+	box.y /= wlr_output->scale;
+
 	int output_width, output_height;
 	wlr_output_effective_resolution(wlr_output, &output_width, &output_height);
 
 	struct wlr_event_pointer_motion_absolute event = {
 		.device = &output->pointer_dev,
 		.time_msec = time,
-		.x = (double)x / output_width,
-		.y = (double)y / output_height,
+		.x = (double)box.x / output_width,
+		.y = (double)box.y / output_height,
 	};
 	wlr_signal_emit_safe(&output->pointer.events.motion_absolute, &event);
 

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -32,6 +32,7 @@ struct wlr_wl_backend {
 	struct wl_shm *shm;
 	struct wl_seat *seat;
 	struct wl_pointer *pointer;
+	struct wlr_wl_pointer *current_pointer;
 	char *seat_name;
 };
 

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -35,7 +35,7 @@ struct wlr_wl_backend {
 	char *seat_name;
 };
 
-struct wlr_wl_backend_output {
+struct wlr_wl_output {
 	struct wlr_output wlr_output;
 
 	struct wlr_wl_backend *backend;
@@ -47,7 +47,7 @@ struct wlr_wl_backend_output {
 
 	struct {
 		struct wl_shm_pool *pool;
-		void *buffer; // actually a (client-side) struct wl_buffer*
+		void *buffer; // actually a (client-side) struct wl_buffer *
 		uint32_t buf_size;
 		uint8_t *data;
 		struct wl_surface *surface;
@@ -69,17 +69,20 @@ struct wlr_wl_input_device {
 
 struct wlr_wl_pointer {
 	struct wlr_pointer wlr_pointer;
+
+	struct wlr_wl_input_device *input_device;
+	struct wl_pointer *wl_pointer;
 	enum wlr_axis_source axis_source;
-	struct wlr_wl_backend_output *current_output;
-	struct wl_listener output_destroy_listener;
+	struct wlr_wl_output *output;
+
+	struct wl_listener output_destroy;
 };
 
 void poll_wl_registry(struct wlr_wl_backend *backend);
-void update_wl_output_cursor(struct wlr_wl_backend_output *output);
-struct wlr_wl_backend_output *get_wl_output_for_surface(
-		struct wlr_wl_backend *backend, struct wl_surface *surface);
-void get_wl_output_layout_box(struct wlr_wl_backend *backend,
-		struct wlr_box *box);
+void update_wl_output_cursor(struct wlr_wl_output *output);
+struct wlr_wl_pointer *pointer_get_wl(struct wlr_pointer *wlr_pointer);
+void create_wl_pointer(struct wl_pointer *wl_pointer,
+	struct wlr_wl_output *output);
 
 extern const struct wl_seat_listener seat_listener;
 

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -24,6 +24,9 @@ struct wlr_x11_output {
 	xcb_window_t win;
 	EGLSurface surf;
 
+	struct wlr_pointer pointer;
+	struct wlr_input_device pointer_dev;
+
 	struct wl_event_source *frame_timer;
 	int frame_delay;
 };
@@ -42,9 +45,6 @@ struct wlr_x11_backend {
 
 	struct wlr_keyboard keyboard;
 	struct wlr_input_device keyboard_dev;
-
-	struct wlr_pointer pointer;
-	struct wlr_input_device pointer_dev;
 
 	struct wlr_egl egl;
 	struct wlr_renderer *renderer;
@@ -74,8 +74,6 @@ struct wlr_x11_backend {
 
 struct wlr_x11_output *get_x11_output_from_window_id(struct wlr_x11_backend *x11,
 	xcb_window_t window);
-void get_x11_output_layout_box(struct wlr_x11_backend *backend,
-	struct wlr_box *box);
 
 extern const struct wlr_keyboard_impl keyboard_impl;
 extern const struct wlr_pointer_impl pointer_impl;

--- a/include/wlr/backend/wayland.h
+++ b/include/wlr/backend/wayland.h
@@ -37,7 +37,7 @@ bool wlr_backend_is_wl(struct wlr_backend *backend);
 bool wlr_input_device_is_wl(struct wlr_input_device *device);
 
 /**
- * True if the given output is a wlr_wl_backend_output.
+ * True if the given output is a wlr_wl_output.
  */
 bool wlr_output_is_wl(struct wlr_output *output);
 

--- a/include/wlr/types/wlr_input_device.h
+++ b/include/wlr/types/wlr_input_device.h
@@ -11,7 +11,7 @@ enum wlr_input_device_type {
 	WLR_INPUT_DEVICE_POINTER,
 	WLR_INPUT_DEVICE_TOUCH,
 	WLR_INPUT_DEVICE_TABLET_TOOL,
-	WLR_INPUT_DEVICE_TABLET_PAD
+	WLR_INPUT_DEVICE_TABLET_PAD,
 };
 
 /* Note: these are circular dependencies */
@@ -27,10 +27,11 @@ struct wlr_input_device {
 	const struct wlr_input_device_impl *impl;
 
 	enum wlr_input_device_type type;
-	int vendor, product;
+	unsigned int vendor, product;
 	char *name;
 	// Or 0 if not applicable to this device
 	double width_mm, height_mm;
+	char *output_name;
 
 	/* wlr_input_device.type determines which of these is valid */
 	union {

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -141,10 +141,18 @@ static void seat_set_device_output_mappings(struct roots_seat *seat,
 		struct wlr_input_device *device, struct wlr_output *output) {
 	struct wlr_cursor *cursor = seat->cursor->cursor;
 	struct roots_config *config = seat->input->config;
-	struct roots_device_config *dconfig;
-	dconfig = roots_config_get_device(config, device);
-	if (dconfig && dconfig->mapped_output &&
-			strcmp(dconfig->mapped_output, output->name) == 0) {
+	struct roots_device_config *dconfig =
+		roots_config_get_device(config, device);
+
+	const char *mapped_output = NULL;
+	if (dconfig != NULL) {
+		mapped_output = dconfig->mapped_output;
+	}
+	if (mapped_output == NULL) {
+		mapped_output = device->output_name;
+	}
+
+	if (mapped_output && strcmp(mapped_output, output->name) == 0) {
 		wlr_cursor_map_input_to_output(cursor, device, output);
 	}
 }

--- a/types/wlr_input_device.c
+++ b/types/wlr_input_device.c
@@ -56,6 +56,7 @@ void wlr_input_device_destroy(struct wlr_input_device *dev) {
 		}
 	}
 	free(dev->name);
+	free(dev->output_name);
 	if (dev->impl && dev->impl->destroy) {
 		dev->impl->destroy(dev);
 	} else {


### PR DESCRIPTION
This allows the backend to suggest an output mapping for an input device. This is mainly used by the Wayland/X11 backends to suggest a mapping between pointers that give absolute events relative to one surface and the surface itself. This could be used by a backend capable of matching touchscreens to their output.

rootston will try to get a mapping from the config, and default to what the backend suggests.

This removes the nonsense layout coordinates conversions in the Wayland and X11 backends.

Test plan: try opening multiple outputs on the Wayland/X11 backends, check that input events are not messed up. Try adding scaling and transformations to outputs.

Fixes #925