### PR TITLE
output: always use hardware cursors if available

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -537,8 +537,8 @@ static void drm_connector_transform(struct wlr_output *output,
 }
 
 static bool drm_connector_set_cursor(struct wlr_output *output,
-		const uint8_t *buf, int32_t stride, uint32_t width, uint32_t height,
-		int32_t hotspot_x, int32_t hotspot_y, bool update_pixels) {
+		struct wlr_texture *texture, int32_t hotspot_x, int32_t hotspot_y,
+		bool update_texture) {
 	struct wlr_drm_connector *conn = (struct wlr_drm_connector *)output;
 	struct wlr_drm_backend *drm = (struct wlr_drm_backend *)output->backend;
 	struct wlr_drm_renderer *renderer = &drm->renderer;
@@ -566,11 +566,6 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 		w = ret ? 64 : w;
 		ret = drmGetCap(drm->fd, DRM_CAP_CURSOR_HEIGHT, &h);
 		h = ret ? 64 : h;
-
-		if (width > w || height > h) {
-			wlr_log(L_INFO, "Cursor too large (max %dx%d)", (int)w, (int)h);
-			return false;
-		}
 
 		if (!init_drm_surface(&plane->surf, renderer, w, h,
 				GBM_FORMAT_ARGB8888, 0)) {
@@ -612,14 +607,22 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 		wlr_output_update_needs_swap(output);
 	}
 
-	if (!update_pixels) {
+	if (!update_texture) {
 		// Don't update cursor image
 		return true;
 	}
 
-	plane->cursor_enabled = buf != NULL;
+	plane->cursor_enabled = false;
+	if (texture != NULL) {
+		int width, height;
+		wlr_texture_get_size(texture, &width, &height);
 
-	if (buf != NULL) {
+		if (width > (int)plane->surf.width || height > (int)plane->surf.height) {
+			wlr_log(L_ERROR, "Cursor too large (max %dx%d)",
+				(int)plane->surf.width, (int)plane->surf.height);
+			return false;
+		}
+
 		uint32_t bo_width = gbm_bo_get_width(plane->cursor_bo);
 		uint32_t bo_height = gbm_bo_get_height(plane->cursor_bo);
 
@@ -635,13 +638,6 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 
 		struct wlr_renderer *rend = plane->surf.renderer->wlr_rend;
 
-		struct wlr_texture *texture = wlr_texture_from_pixels(rend,
-			WL_SHM_FORMAT_ARGB8888, stride, width, height, buf);
-		if (texture == NULL) {
-			wlr_log(L_ERROR, "Unable to create texture");
-			return false;
-		}
-
 		wlr_renderer_begin(rend, plane->surf.width, plane->surf.height);
 		wlr_renderer_clear(rend, (float[]){ 0.0, 0.0, 0.0, 0.0 });
 		wlr_render_texture(rend, texture, plane->matrix, 0, 0, 1.0f);
@@ -652,8 +648,9 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 
 		swap_drm_surface_buffers(&plane->surf, NULL);
 
-		wlr_texture_destroy(texture);
 		gbm_bo_unmap(plane->cursor_bo, bo_data);
+
+		plane->cursor_enabled = true;
 	}
 
 	if (!drm->session->active) {

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -164,8 +164,16 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display,
 		goto error_registry;
 	}
 
+	static EGLint config_attribs[] = {
+		EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+		EGL_RED_SIZE, 1,
+		EGL_GREEN_SIZE, 1,
+		EGL_BLUE_SIZE, 1,
+		EGL_ALPHA_SIZE, 1,
+		EGL_NONE,
+	};
 	if (!wlr_egl_init(&backend->egl, EGL_PLATFORM_WAYLAND_EXT,
-			backend->remote_display, NULL, WL_SHM_FORMAT_ARGB8888)) {
+			backend->remote_display, config_attribs, WL_SHM_FORMAT_ARGB8888)) {
 		wlr_log(L_ERROR, "Could not initialize EGL");
 		goto error_egl;
 	}

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -40,25 +40,22 @@ struct wlr_wl_output {
 	struct wlr_output wlr_output;
 
 	struct wlr_wl_backend *backend;
+	struct wl_list link;
+
 	struct wl_surface *surface;
+	struct wl_callback *frame_callback;
 	struct zxdg_surface_v6 *xdg_surface;
 	struct zxdg_toplevel_v6 *xdg_toplevel;
 	struct wl_egl_window *egl_window;
-	struct wl_callback *frame_callback;
-
-	struct {
-		struct wl_shm_pool *pool;
-		void *buffer; // actually a (client-side) struct wl_buffer *
-		uint32_t buf_size;
-		uint8_t *data;
-		struct wl_surface *surface;
-		int32_t hotspot_x, hotspot_y;
-	} cursor;
+	EGLSurface egl_surface;
 
 	uint32_t enter_serial;
 
-	void *egl_surface;
-	struct wl_list link;
+	struct {
+		struct wl_surface *surface;
+		struct wl_egl_window *egl_window;
+		int32_t hotspot_x, hotspot_y;
+	} cursor;
 };
 
 struct wlr_wl_input_device {

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -13,9 +13,8 @@ struct wlr_output_impl {
 		int32_t height, int32_t refresh);
 	void (*transform)(struct wlr_output *output,
 		enum wl_output_transform transform);
-	bool (*set_cursor)(struct wlr_output *output, const uint8_t *buf,
-		int32_t stride, uint32_t width, uint32_t height,
-		int32_t hotspot_x, int32_t hotspot_y, bool update_pixels);
+	bool (*set_cursor)(struct wlr_output *output, struct wlr_texture *texture,
+		int32_t hotspot_x, int32_t hotspot_y, bool update_texture);
 	bool (*move_cursor)(struct wlr_output *output, int x, int y);
 	void (*destroy)(struct wlr_output *output);
 	bool (*make_current)(struct wlr_output *output, int *buffer_age);


### PR DESCRIPTION
This changes the `wlr_output_impl.set_cursor` function to take a
`wlr_texture` instead of a byte buffer. This simplifies the
DRM and Wayland backends since they were creating textures from
the byte buffer anyway.

With this commit, performance should be improved when moving the
cursor since outputs don't need to be re-rendered anymore.

Test plan: check that client cursors work on the DRM and Wayland backends.

Fixes #281