### PR TITLE
Fix gcc maybe-uninitialized in wlr_cursor apply_output_transform

### DIFF
--- a/types/wlr_cursor.c
+++ b/types/wlr_cursor.c
@@ -332,7 +332,7 @@ static void handle_pointer_motion(struct wl_listener *listener, void *data) {
 
 static void apply_output_transform(double *x, double *y,
 		enum wl_output_transform transform) {
-	double dx, dy;
+	double dx = *x, dy = *y;
 	double width = 1.0, height = 1.0;
 
 	switch (transform) {


### PR DESCRIPTION
Fix this weird gcc warning, same as #946, but it was closed.