### PR TITLE
Fix xcb/xkb swap in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,15 @@ Install dependencies:
 
 If you choose to enable X11 support:
 
-* xkb
-* xkb-composite
-* xkb-xfixes
-* xkb-image
-* xkb-render
+* xcb
+* xcb-composite
+* xcb-xfixes
+* xcb-image
+* xcb-render
 * x11-xcb
 * xcb-errors (optional, for improved error reporting)
 * x11-icccm (optional, for improved Xwayland introspection)
-* xkb-xcb (optional, for improved keyboard handling on the X11 backend)
+* xcb-xkb (optional, for improved keyboard handling on the X11 backend)
 
 Run these commands:
 


### PR DESCRIPTION
Self explanitory fix for the README. Grep makes this appear to be the only place this mixup occurs.