### PR TITLE
Add options to exclude rootston and examples at compilation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -205,7 +205,9 @@ if get_option('enable-rootston')
 	subdir('rootston')
 endif
 
-subdir('examples')
+if get_option('enable-examples')
+	subdir('examples')
+endif
 
 pkgconfig = import('pkgconfig')
 pkgconfig.generate(

--- a/meson.build
+++ b/meson.build
@@ -201,7 +201,10 @@ summary = [
 message('\n'.join(summary))
 
 
-subdir('rootston')
+if get_option('enable-rootston')
+	subdir('rootston')
+endif
+
 subdir('examples')
 
 pkgconfig = import('pkgconfig')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,3 +5,4 @@ option('enable-xcb_errors', type: 'combo', choices: ['auto', 'true', 'false'], v
 option('enable-xwayland', type: 'boolean', value: true, description: 'Enable support X11 applications')
 option('enable-x11_backend', type: 'boolean', value: true, description: 'Enable X11 backend')
 option('enable-rootston', type: 'boolean', value: true, description: 'Build the rootston example compositor')
+option('enable-examples', type: 'boolean', value: true, description: 'Build example applications')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,3 +4,4 @@ option('enable-elogind', type: 'combo', choices: ['auto', 'true', 'false'], valu
 option('enable-xcb_errors', type: 'combo', choices: ['auto', 'true', 'false'], value: 'auto', description: 'Use xcb-errors util library')
 option('enable-xwayland', type: 'boolean', value: true, description: 'Enable support X11 applications')
 option('enable-x11_backend', type: 'boolean', value: true, description: 'Enable X11 backend')
+option('enable-rootston', type: 'boolean', value: true, description: 'Build the rootston example compositor')


### PR DESCRIPTION
This PR adds two commits which add more fine-grained control of what is actually compiled.
Both rootston and the examples are not needed to run wlroots and sway (or any other compositor) and need not be compiled in those cases.