### PR TITLE
output-damage: limit the number of damaged rectangles

### DIFF
--- a/include/wlr/types/wlr_output_damage.h
+++ b/include/wlr/types/wlr_output_damage.h
@@ -23,6 +23,7 @@
  */
 struct wlr_output_damage {
 	struct wlr_output *output;
+	int max_rects; // max number of damaged rectangles
 
 	pixman_region32_t current; // in output-local coordinates
 


### PR DESCRIPTION
Test plan: set the limit to 1, open htop on gnome-terminal.

The current value is kind of arbitrary, it just roughly reflects what GTK+ does.

Fixes #949