### PR TITLE
Fix hardware cursors scale & transform

### DIFF
--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -72,16 +72,20 @@ static void output_transform(struct wlr_output *_output,
 	output->wlr_output.transform = transform;
 }
 
-static bool output_set_cursor(struct wlr_output *_output,
-		struct wlr_texture *texture, int32_t hotspot_x, int32_t hotspot_y,
+static bool output_set_cursor(struct wlr_output *wlr_output,
+		struct wlr_texture *texture, int32_t scale,
+		enum wl_output_transform transform, int32_t hotspot_x, int32_t hotspot_y,
 		bool update_texture) {
-	struct wlr_wl_output *output =
-		(struct wlr_wl_output *)_output;
+	struct wlr_wl_output *output = (struct wlr_wl_output *)wlr_output;
 	struct wlr_wl_backend *backend = output->backend;
 
+	struct wlr_box hotspot = { .x = hotspot_x, .y = hotspot_y };
+	wlr_box_transform(&hotspot, wlr_output_transform_invert(wlr_output->transform),
+		output->cursor.width, output->cursor.height, &hotspot);
+
 	// TODO: use output->wlr_output.transform to transform pixels and hotpot
-	output->cursor.hotspot_x = hotspot_x;
-	output->cursor.hotspot_y = hotspot_y;
+	output->cursor.hotspot_x = hotspot.x;
+	output->cursor.hotspot_y = hotspot.y;
 
 	if (!update_texture) {
 		// Update hotspot without changing cursor image
@@ -98,6 +102,11 @@ static bool output_set_cursor(struct wlr_output *_output,
 	if (texture != NULL) {
 		int width, height;
 		wlr_texture_get_size(texture, &width, &height);
+		width = width * wlr_output->scale / scale;
+		height = height * wlr_output->scale / scale;
+
+		output->cursor.width = width;
+		output->cursor.height = height;
 
 		if (output->cursor.egl_window == NULL) {
 			output->cursor.egl_window =
@@ -110,12 +119,20 @@ static bool output_set_cursor(struct wlr_output *_output,
 
 		wlr_egl_make_current(&backend->egl, egl_surface, NULL);
 
+		struct wlr_box cursor_box = {
+			.width = width,
+			.height = height,
+		};
+
+		float projection[9];
+		wlr_matrix_projection(projection, width, height, wlr_output->transform);
+
 		float matrix[9];
-		wlr_matrix_projection(matrix, width, height, WL_OUTPUT_TRANSFORM_NORMAL);
+		wlr_matrix_project_box(matrix, &cursor_box, transform, 0, projection);
 
 		wlr_renderer_begin(backend->renderer, width, height);
 		wlr_renderer_clear(backend->renderer, (float[]){ 0.0, 0.0, 0.0, 0.0 });
-		wlr_render_texture(backend->renderer, texture, matrix, 0, 0, 1.0);
+		wlr_render_texture_with_matrix(backend->renderer, texture, matrix, 1.0);
 		wlr_renderer_end(backend->renderer);
 
 		wlr_egl_swap_buffers(&backend->egl, egl_surface, NULL);

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -55,6 +55,7 @@ struct wlr_wl_output {
 		struct wl_surface *surface;
 		struct wl_egl_window *egl_window;
 		int32_t hotspot_x, hotspot_y;
+		int32_t width, height;
 	} cursor;
 };
 

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -14,6 +14,7 @@ struct wlr_output_impl {
 	void (*transform)(struct wlr_output *output,
 		enum wl_output_transform transform);
 	bool (*set_cursor)(struct wlr_output *output, struct wlr_texture *texture,
+		int32_t scale, enum wl_output_transform transform,
 		int32_t hotspot_x, int32_t hotspot_y, bool update_texture);
 	bool (*move_cursor)(struct wlr_output *output, int x, int y);
 	void (*destroy)(struct wlr_output *output);


### PR DESCRIPTION
Test plan: try different combinations of output scale/transform, try compositor and client cursors, try clients that support HiDPI (e.g. GTK+) and clients that don't (e.g. Xwayland clients).

cc @Ongy @Timidger: this is a breaking change for the output implementation API.