### PR TITLE
Add support for discrete axis values and axis source

### DIFF
--- a/backend/libinput/pointer.c
+++ b/backend/libinput/pointer.c
@@ -126,8 +126,10 @@ void handle_pointer_axis(struct libinput_event *event,
 				wlr_event.orientation = WLR_AXIS_ORIENTATION_HORIZONTAL;
 				break;
 			}
-			wlr_event.delta = libinput_event_pointer_get_axis_value(
-					pevent, axies[i]);
+			wlr_event.delta =
+				libinput_event_pointer_get_axis_value(pevent, axies[i]);
+			wlr_event.delta_discrete =
+				libinput_event_pointer_get_axis_value_discrete(pevent, axies[i]);
 			wlr_signal_emit_safe(&wlr_dev->pointer->events.axis, &wlr_event);
 		}
 	}

--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -111,11 +111,14 @@ static void pointer_handle_axis(void *data, struct wl_pointer *wl_pointer,
 	struct wlr_event_pointer_axis event = {
 		.device = &pointer->input_device->wlr_input_device,
 		.delta = wl_fixed_to_double(value),
+		.delta_discrete = pointer->axis_discrete,
 		.orientation = axis,
 		.time_msec = time,
 		.source = pointer->axis_source,
 	};
 	wlr_signal_emit_safe(&pointer->wlr_pointer.events.axis, &event);
+
+	pointer->axis_discrete = 0;
 }
 
 static void pointer_handle_frame(void *data, struct wl_pointer *wl_pointer) {
@@ -140,7 +143,13 @@ static void pointer_handle_axis_stop(void *data, struct wl_pointer *wl_pointer,
 
 static void pointer_handle_axis_discrete(void *data, struct wl_pointer *wl_pointer,
 		uint32_t axis, int32_t discrete) {
+	struct wlr_wl_backend *backend = data;
+	struct wlr_wl_pointer *pointer = backend->current_pointer;
+	if (pointer == NULL) {
+		return;
+	}
 
+	pointer->axis_discrete = discrete;
 }
 
 static const struct wl_pointer_listener pointer_listener = {

--- a/backend/x11/input_device.c
+++ b/backend/x11/input_device.c
@@ -73,13 +73,15 @@ void handle_x11_input_event(struct wlr_x11_backend *x11,
 
 		if (ev->detail == XCB_BUTTON_INDEX_4 ||
 				ev->detail == XCB_BUTTON_INDEX_5) {
-			double delta = (ev->detail == XCB_BUTTON_INDEX_4 ? -15 : 15);
+			int32_t delta_discrete = ev->detail == XCB_BUTTON_INDEX_4 ? -1 : 1;
 			struct wlr_event_pointer_axis axis = {
 				.device = &output->pointer_dev,
 				.time_msec = ev->time,
 				.source = WLR_AXIS_SOURCE_WHEEL,
 				.orientation = WLR_AXIS_ORIENTATION_VERTICAL,
-				.delta = delta,
+				// 15 is a typical value libinput sends for one scroll
+				.delta = delta_discrete * 15,
+				.delta_discrete = delta_discrete,
 			};
 			wlr_signal_emit_safe(&output->pointer.events.axis, &axis);
 			x11->time = ev->time;

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -72,6 +72,7 @@ struct wlr_wl_pointer {
 	struct wlr_wl_input_device *input_device;
 	struct wl_pointer *wl_pointer;
 	enum wlr_axis_source axis_source;
+	int32_t axis_discrete;
 	struct wlr_wl_output *output;
 
 	struct wl_listener output_destroy;

--- a/include/wlr/types/wlr_pointer.h
+++ b/include/wlr/types/wlr_pointer.h
@@ -58,6 +58,7 @@ struct wlr_event_pointer_axis {
 	enum wlr_axis_source source;
 	enum wlr_axis_orientation orientation;
 	double delta;
+	int32_t delta_discrete;
 };
 
 #endif

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -60,7 +60,8 @@ struct wlr_pointer_grab_interface {
 	uint32_t (*button)(struct wlr_seat_pointer_grab *grab, uint32_t time,
 			uint32_t button, uint32_t state);
 	void (*axis)(struct wlr_seat_pointer_grab *grab, uint32_t time,
-			enum wlr_axis_orientation orientation, double value);
+			enum wlr_axis_orientation orientation, double value,
+			int32_t value_discrete);
 	void (*cancel)(struct wlr_seat_pointer_grab *grab);
 };
 
@@ -300,7 +301,8 @@ uint32_t wlr_seat_pointer_send_button(struct wlr_seat *wlr_seat, uint32_t time,
  * grabs.
  **/
 void wlr_seat_pointer_send_axis(struct wlr_seat *wlr_seat, uint32_t time,
-		enum wlr_axis_orientation orientation, double value);
+		enum wlr_axis_orientation orientation, double value,
+		int32_t value_discrete);
 
 /**
  * Start a grab of the pointer of this seat. The grabber is responsible for
@@ -341,7 +343,8 @@ uint32_t wlr_seat_pointer_notify_button(struct wlr_seat *wlr_seat,
  * Notify the seat of an axis event.
  */
 void wlr_seat_pointer_notify_axis(struct wlr_seat *wlr_seat, uint32_t time,
-		enum wlr_axis_orientation orientation, double value);
+		enum wlr_axis_orientation orientation, double value,
+		int32_t value_discrete);
 
 /**
  * Whether or not the pointer has a grab other than the default grab.

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -61,7 +61,7 @@ struct wlr_pointer_grab_interface {
 			uint32_t button, uint32_t state);
 	void (*axis)(struct wlr_seat_pointer_grab *grab, uint32_t time,
 			enum wlr_axis_orientation orientation, double value,
-			int32_t value_discrete);
+			int32_t value_discrete, enum wlr_axis_source source);
 	void (*cancel)(struct wlr_seat_pointer_grab *grab);
 };
 
@@ -302,7 +302,7 @@ uint32_t wlr_seat_pointer_send_button(struct wlr_seat *wlr_seat, uint32_t time,
  **/
 void wlr_seat_pointer_send_axis(struct wlr_seat *wlr_seat, uint32_t time,
 		enum wlr_axis_orientation orientation, double value,
-		int32_t value_discrete);
+		int32_t value_discrete, enum wlr_axis_source source);
 
 /**
  * Start a grab of the pointer of this seat. The grabber is responsible for
@@ -344,7 +344,7 @@ uint32_t wlr_seat_pointer_notify_button(struct wlr_seat *wlr_seat,
  */
 void wlr_seat_pointer_notify_axis(struct wlr_seat *wlr_seat, uint32_t time,
 		enum wlr_axis_orientation orientation, double value,
-		int32_t value_discrete);
+		int32_t value_discrete, enum wlr_axis_source source);
 
 /**
  * Whether or not the pointer has a grab other than the default grab.

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -313,7 +313,7 @@ void roots_cursor_handle_button(struct roots_cursor *cursor,
 void roots_cursor_handle_axis(struct roots_cursor *cursor,
 		struct wlr_event_pointer_axis *event) {
 	wlr_seat_pointer_notify_axis(cursor->seat->seat, event->time_msec,
-		event->orientation, event->delta, event->delta_discrete);
+		event->orientation, event->delta, event->delta_discrete, event->source);
 }
 
 void roots_cursor_handle_touch_down(struct roots_cursor *cursor,

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -313,7 +313,7 @@ void roots_cursor_handle_button(struct roots_cursor *cursor,
 void roots_cursor_handle_axis(struct roots_cursor *cursor,
 		struct wlr_event_pointer_axis *event) {
 	wlr_seat_pointer_notify_axis(cursor->seat->seat, event->time_msec,
-		event->orientation, event->delta);
+		event->orientation, event->delta, event->delta_discrete);
 }
 
 void roots_cursor_handle_touch_down(struct roots_cursor *cursor,

--- a/types/data_device/wlr_drag.c
+++ b/types/data_device/wlr_drag.c
@@ -192,7 +192,7 @@ static uint32_t drag_handle_pointer_button(struct wlr_seat_pointer_grab *grab,
 
 static void drag_handle_pointer_axis(struct wlr_seat_pointer_grab *grab,
 		uint32_t time, enum wlr_axis_orientation orientation, double value,
-		int32_t value_discrete) {
+		int32_t value_discrete, enum wlr_axis_source source) {
 	// This space is intentionally left blank
 }
 

--- a/types/data_device/wlr_drag.c
+++ b/types/data_device/wlr_drag.c
@@ -191,7 +191,8 @@ static uint32_t drag_handle_pointer_button(struct wlr_seat_pointer_grab *grab,
 }
 
 static void drag_handle_pointer_axis(struct wlr_seat_pointer_grab *grab,
-		uint32_t time, enum wlr_axis_orientation orientation, double value) {
+		uint32_t time, enum wlr_axis_orientation orientation, double value,
+		int32_t value_discrete) {
 	// This space is intentionally left blank
 }
 

--- a/types/seat/wlr_seat_pointer.c
+++ b/types/seat/wlr_seat_pointer.c
@@ -25,8 +25,10 @@ static uint32_t default_pointer_button(struct wlr_seat_pointer_grab *grab,
 }
 
 static void default_pointer_axis(struct wlr_seat_pointer_grab *grab,
-		uint32_t time, enum wlr_axis_orientation orientation, double value) {
-	wlr_seat_pointer_send_axis(grab->seat, time, orientation, value);
+		uint32_t time, enum wlr_axis_orientation orientation, double value,
+		int32_t value_discrete) {
+	wlr_seat_pointer_send_axis(grab->seat, time, orientation, value,
+		value_discrete);
 }
 
 static void default_pointer_cancel(struct wlr_seat_pointer_grab *grab) {
@@ -224,7 +226,8 @@ uint32_t wlr_seat_pointer_send_button(struct wlr_seat *wlr_seat, uint32_t time,
 }
 
 void wlr_seat_pointer_send_axis(struct wlr_seat *wlr_seat, uint32_t time,
-		enum wlr_axis_orientation orientation, double value) {
+		enum wlr_axis_orientation orientation, double value,
+		int32_t value_discrete) {
 	struct wlr_seat_client *client = wlr_seat->pointer_state.focused_client;
 	if (client == NULL) {
 		return;
@@ -236,11 +239,18 @@ void wlr_seat_pointer_send_axis(struct wlr_seat *wlr_seat, uint32_t time,
 			continue;
 		}
 
+		uint32_t version = wl_resource_get_version(resource);
+
 		if (value) {
+			if (value_discrete &&
+					version >= WL_POINTER_AXIS_DISCRETE_SINCE_VERSION) {
+				wl_pointer_send_axis_discrete(resource, orientation,
+					value_discrete);
+			}
+
 			wl_pointer_send_axis(resource, time, orientation,
 				wl_fixed_from_double(value));
-		} else if (wl_resource_get_version(resource) >=
-				WL_POINTER_AXIS_STOP_SINCE_VERSION) {
+		} else if (version >= WL_POINTER_AXIS_STOP_SINCE_VERSION) {
 			wl_pointer_send_axis_stop(resource, time, orientation);
 		}
 		pointer_send_frame(resource);
@@ -304,10 +314,11 @@ uint32_t wlr_seat_pointer_notify_button(struct wlr_seat *wlr_seat,
 }
 
 void wlr_seat_pointer_notify_axis(struct wlr_seat *wlr_seat, uint32_t time,
-		enum wlr_axis_orientation orientation, double value) {
+		enum wlr_axis_orientation orientation, double value,
+		int32_t value_discrete) {
 	clock_gettime(CLOCK_MONOTONIC, &wlr_seat->last_event);
 	struct wlr_seat_pointer_grab *grab = wlr_seat->pointer_state.grab;
-	grab->interface->axis(grab, time, orientation, value);
+	grab->interface->axis(grab, time, orientation, value, value_discrete);
 }
 
 bool wlr_seat_pointer_has_grab(struct wlr_seat *seat) {

--- a/types/wlr_wl_shell.c
+++ b/types/wlr_wl_shell.c
@@ -94,9 +94,9 @@ static void shell_pointer_grab_cancel(struct wlr_seat_pointer_grab *grab) {
 
 static void shell_pointer_grab_axis(struct wlr_seat_pointer_grab *grab,
 		uint32_t time, enum wlr_axis_orientation orientation, double value,
-		int32_t value_discrete) {
+		int32_t value_discrete, enum wlr_axis_source source) {
 	wlr_seat_pointer_send_axis(grab->seat, time, orientation, value,
-		value_discrete);
+		value_discrete, source);
 }
 
 static const struct wlr_pointer_grab_interface shell_pointer_grab_impl = {

--- a/types/wlr_wl_shell.c
+++ b/types/wlr_wl_shell.c
@@ -93,8 +93,10 @@ static void shell_pointer_grab_cancel(struct wlr_seat_pointer_grab *grab) {
 }
 
 static void shell_pointer_grab_axis(struct wlr_seat_pointer_grab *grab,
-		uint32_t time, enum wlr_axis_orientation orientation, double value) {
-	wlr_seat_pointer_send_axis(grab->seat, time, orientation, value);
+		uint32_t time, enum wlr_axis_orientation orientation, double value,
+		int32_t value_discrete) {
+	wlr_seat_pointer_send_axis(grab->seat, time, orientation, value,
+		value_discrete);
 }
 
 static const struct wlr_pointer_grab_interface shell_pointer_grab_impl = {

--- a/types/wlr_xdg_shell.c
+++ b/types/wlr_xdg_shell.c
@@ -78,9 +78,9 @@ static uint32_t xdg_pointer_grab_button(struct wlr_seat_pointer_grab *grab,
 
 static void xdg_pointer_grab_axis(struct wlr_seat_pointer_grab *grab,
 		uint32_t time, enum wlr_axis_orientation orientation, double value,
-		int32_t value_discrete) {
+		int32_t value_discrete, enum wlr_axis_source source) {
 	wlr_seat_pointer_send_axis(grab->seat, time, orientation, value,
-		value_discrete);
+		value_discrete, source);
 }
 
 static void xdg_pointer_grab_cancel(struct wlr_seat_pointer_grab *grab) {

--- a/types/wlr_xdg_shell.c
+++ b/types/wlr_xdg_shell.c
@@ -77,8 +77,10 @@ static uint32_t xdg_pointer_grab_button(struct wlr_seat_pointer_grab *grab,
 }
 
 static void xdg_pointer_grab_axis(struct wlr_seat_pointer_grab *grab,
-		uint32_t time, enum wlr_axis_orientation orientation, double value) {
-	wlr_seat_pointer_send_axis(grab->seat, time, orientation, value);
+		uint32_t time, enum wlr_axis_orientation orientation, double value,
+		int32_t value_discrete) {
+	wlr_seat_pointer_send_axis(grab->seat, time, orientation, value,
+		value_discrete);
 }
 
 static void xdg_pointer_grab_cancel(struct wlr_seat_pointer_grab *grab) {

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -88,9 +88,9 @@ static uint32_t xdg_pointer_grab_button(struct wlr_seat_pointer_grab *grab,
 
 static void xdg_pointer_grab_axis(struct wlr_seat_pointer_grab *grab,
 		uint32_t time, enum wlr_axis_orientation orientation, double value,
-		int32_t value_discrete) {
+		int32_t value_discrete, enum wlr_axis_source source) {
 	wlr_seat_pointer_send_axis(grab->seat, time, orientation, value,
-		value_discrete);
+		value_discrete, source);
 }
 
 static void xdg_pointer_grab_cancel(struct wlr_seat_pointer_grab *grab) {

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -87,8 +87,10 @@ static uint32_t xdg_pointer_grab_button(struct wlr_seat_pointer_grab *grab,
 }
 
 static void xdg_pointer_grab_axis(struct wlr_seat_pointer_grab *grab,
-		uint32_t time, enum wlr_axis_orientation orientation, double value) {
-	wlr_seat_pointer_send_axis(grab->seat, time, orientation, value);
+		uint32_t time, enum wlr_axis_orientation orientation, double value,
+		int32_t value_discrete) {
+	wlr_seat_pointer_send_axis(grab->seat, time, orientation, value,
+		value_discrete);
 }
 
 static void xdg_pointer_grab_cancel(struct wlr_seat_pointer_grab *grab) {


### PR DESCRIPTION
Test plan: `env WAYLAND_DEBUG=1 weston-clickdot` and check that `axis_discrete` and `axis_source` events are sent. Note that not all hardware supports this.

cc @Ongy @Timidger: this requires changes in your libraries and compositors.