### PR TITLE
fix check of EGL_WL_bind_wayland_display presence

### DIFF
--- a/render/egl.c
+++ b/render/egl.c
@@ -209,7 +209,7 @@ void wlr_egl_finish(struct wlr_egl *egl) {
 }
 
 bool wlr_egl_bind_display(struct wlr_egl *egl, struct wl_display *local_display) {
-	if (!eglBindWaylandDisplayWL) {
+	if (!egl->egl_exts.bind_wayland_display) {
 		return false;
 	}
 


### PR DESCRIPTION
Tested  on virtualbox with Fedora 28 guest, which does not have the `EGL_WL_bind_wayland_display` extension. The function pointer `eglBindWaylandDisplayWL `is non-null and causes a crash when used (SIGSEGV in `__strlen_avx2`).

Instead use `struct wlr_egl.egl_exts.bind_wayland_display` which is correctly set in `wlr_egl_init`, but not yet used...