### PR TITLE
update drm cursor matrix on set_transform

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -581,10 +581,10 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 			wlr_log_errno(L_ERROR, "Failed to create cursor bo");
 			return false;
 		}
-
-		wlr_matrix_projection(plane->matrix, plane->surf.width,
-			plane->surf.height, output->transform);
 	}
+
+	wlr_matrix_projection(plane->matrix, plane->surf.width,
+		plane->surf.height, output->transform);
 
 	struct wlr_box hotspot = { .x = hotspot_x, .y = hotspot_y };
 	wlr_box_transform(&hotspot, wlr_output_transform_invert(output->transform),


### PR DESCRIPTION
Updates the projection matrix for the cursor plane in the DRM backend,
when the output transform is changed, so new cursor are uploaded with
the correct transformation.

Testplan:
Get a setup that supports changing cursor transform during runtime, do it on DRM backend.
Before: Cursor transformation stays the way it was when the output was first set up (even new cursor)
After: Cursors are transformed properly

The *current* cursor set, when the transformation is applied may still be rotated the wrong way, since it's client owned and we do not have it anymore to update.