### PR TITLE
render: bind wl_drm in renderer

### DIFF
--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -166,10 +166,6 @@ struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
 		goto error_event;
 	}
 
-	if (!wlr_egl_bind_display(&drm->renderer.egl, display)) {
-		wlr_log(L_INFO, "Failed to bind egl/wl display");
-	}
-
 	drm->display_destroy.notify = handle_display_destroy;
 	wl_display_add_destroy_listener(display, &drm->display_destroy);
 

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -177,7 +177,6 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display,
 		wlr_log(L_ERROR, "Could not initialize EGL");
 		goto error_egl;
 	}
-	wlr_egl_bind_display(&backend->egl, backend->local_display);
 
 	backend->renderer = wlr_gles2_renderer_create(&backend->egl);
 	if (backend->renderer == NULL) {

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -49,6 +49,8 @@ struct wlr_renderer_impl {
 	struct wlr_texture *(*texture_from_dmabuf)(struct wlr_renderer *renderer,
 		struct wlr_dmabuf_buffer_attribs *attribs);
 	void (*destroy)(struct wlr_renderer *renderer);
+	void (*init_wl_display)(struct wlr_renderer *renderer,
+		struct wl_display *wl_display);
 };
 
 void wlr_renderer_init(struct wlr_renderer *renderer,

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -98,8 +98,8 @@ bool wlr_renderer_read_pixels(struct wlr_renderer *r, enum wl_shm_format fmt,
  */
 bool wlr_renderer_format_supported(struct wlr_renderer *r,
 	enum wl_shm_format fmt);
-void wlr_renderer_init_wl_shm(struct wlr_renderer *r,
-	struct wl_display *display);
+void wlr_renderer_init_wl_display(struct wlr_renderer *r,
+	struct wl_display *wl_display);
 /**
  * Destroys this wlr_renderer. Textures must be destroyed separately.
  */

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -304,6 +304,15 @@ static struct wlr_texture *gles2_texture_from_dmabuf(
 	return wlr_gles2_texture_from_dmabuf(renderer->egl, attribs);
 }
 
+static void gles2_init_wl_display(struct wlr_renderer *wlr_renderer,
+		struct wl_display *wl_display) {
+	struct wlr_gles2_renderer *renderer =
+		gles2_get_renderer_in_context(wlr_renderer);
+	if (!wlr_egl_bind_display(renderer->egl, wl_display)) {
+		wlr_log(L_INFO, "failed to bind wl_display to EGL");
+	}
+}
+
 static void gles2_destroy(struct wlr_renderer *wlr_renderer) {
 	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
 
@@ -345,6 +354,7 @@ static const struct wlr_renderer_impl renderer_impl = {
 	.texture_from_pixels = gles2_texture_from_pixels,
 	.texture_from_wl_drm = gles2_texture_from_wl_drm,
 	.texture_from_dmabuf = gles2_texture_from_dmabuf,
+	.init_wl_display = gles2_init_wl_display,
 };
 
 void push_gles2_marker(const char *file, const char *func) {

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -158,9 +158,9 @@ bool wlr_renderer_format_supported(struct wlr_renderer *r,
 	return r->impl->format_supported(r, fmt);
 }
 
-void wlr_renderer_init_wl_shm(struct wlr_renderer *r,
-		struct wl_display *display) {
-	if (wl_display_init_shm(display)) {
+void wlr_renderer_init_wl_display(struct wlr_renderer *r,
+		struct wl_display *wl_display) {
+	if (wl_display_init_shm(wl_display)) {
 		wlr_log(L_ERROR, "Failed to initialize shm");
 		return;
 	}
@@ -173,9 +173,14 @@ void wlr_renderer_init_wl_shm(struct wlr_renderer *r,
 	}
 
 	for (size_t i = 0; i < len; ++i) {
+		// These formats are already added by default
 		if (formats[i] != WL_SHM_FORMAT_ARGB8888 &&
 				formats[i] != WL_SHM_FORMAT_XRGB8888) {
-			wl_display_add_shm_format(display, formats[i]);
+			wl_display_add_shm_format(wl_display, formats[i]);
 		}
+	}
+
+	if (r->impl->init_wl_display) {
+		r->impl->init_wl_display(r, wl_display);
 	}
 }

--- a/rootston/main.c
+++ b/rootston/main.c
@@ -31,7 +31,7 @@ int main(int argc, char **argv) {
 	assert(server.renderer);
 	server.data_device_manager =
 		wlr_data_device_manager_create(server.wl_display);
-	wlr_renderer_init_wl_shm(server.renderer, server.wl_display);
+	wlr_renderer_init_wl_display(server.renderer, server.wl_display);
 	server.desktop = desktop_create(&server, server.config);
 	server.input = input_create(&server, server.config);
 


### PR DESCRIPTION
This adds wl_drm support to the X11 and headless backends.

cc @Ongy @Timidger: this renames `wlr_renderer_init_wl_shm` to `wlr_renderer_init_wl_display`