### PR TITLE
Ignore clicks on un-focuseable things.

### DIFF
--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -273,7 +273,9 @@ static void roots_cursor_press_button(struct roots_cursor *cursor,
 			}
 			break;
 		case WLR_BUTTON_PRESSED:
-			roots_seat_set_focus(seat, view);
+			if (view) {
+				roots_seat_set_focus(seat, view);
+			}
 			if (surface && wlr_surface_is_layer_surface(surface)) {
 				struct wlr_layer_surface *layer =
 					wlr_layer_surface_from_wlr_surface(surface);

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -798,6 +798,7 @@ void roots_seat_set_focus(struct roots_seat *seat, struct roots_view *view) {
 
 	if (view == NULL) {
 		seat->cursor->mode = ROOTS_CURSOR_PASSTHROUGH;
+		wlr_seat_keyboard_clear_focus(seat->seat);
 		return;
 	}
 


### PR DESCRIPTION
This change is needed to fix edge cases in input methods using layer shells.

Input methods don't want to directly change the focus state of the compositor. With input method as non-interactive layer shell, clicking it would still remove the *active* status from an app, causing confusion when the input method clicks affect focus, like invoking a window switch.

First change fixes the inconsistency of removing focus when un-focuseable things were clicked. The second change makes focus stay where it was before.

This is required to support `virtual-keyboard-unstable-v1` in rootston.