### PR TITLE
[RFC] backends: implement custom EGL and renderer initialization

### DIFF
--- a/backend/backend.c
+++ b/backend/backend.c
@@ -72,8 +72,9 @@ static size_t parse_outputs_env(const char *name) {
 	return outputs;
 }
 
-static struct wlr_backend *attempt_wl_backend(struct wl_display *display) {
-	struct wlr_backend *backend = wlr_wl_backend_create(display, NULL);
+static struct wlr_backend *attempt_wl_backend(struct wl_display *display,
+		wlr_renderer_create_func_t create_renderer_func) {
+	struct wlr_backend *backend = wlr_wl_backend_create(display, NULL, create_renderer_func);
 	if (backend == NULL) {
 		return NULL;
 	}
@@ -88,8 +89,8 @@ static struct wlr_backend *attempt_wl_backend(struct wl_display *display) {
 
 #ifdef WLR_HAS_X11_BACKEND
 static struct wlr_backend *attempt_x11_backend(struct wl_display *display,
-		const char *x11_display) {
-	struct wlr_backend *backend = wlr_x11_backend_create(display, x11_display);
+		const char *x11_display, wlr_renderer_create_func_t create_renderer_func) {
+	struct wlr_backend *backend = wlr_x11_backend_create(display, x11_display, create_renderer_func);
 	if (backend == NULL) {
 		return NULL;
 	}
@@ -104,8 +105,8 @@ static struct wlr_backend *attempt_x11_backend(struct wl_display *display,
 #endif
 
 static struct wlr_backend *attempt_headless_backend(
-		struct wl_display *display) {
-	struct wlr_backend *backend = wlr_headless_backend_create(display);
+		struct wl_display *display, wlr_renderer_create_func_t create_renderer_func) {
+	struct wlr_backend *backend = wlr_headless_backend_create(display, create_renderer_func);
 	if (backend == NULL) {
 		return NULL;
 	}
@@ -119,7 +120,8 @@ static struct wlr_backend *attempt_headless_backend(
 }
 
 static struct wlr_backend *attempt_drm_backend(struct wl_display *display,
-		struct wlr_backend *backend, struct wlr_session *session) {
+		struct wlr_backend *backend, struct wlr_session *session,
+		wlr_renderer_create_func_t create_renderer_func) {
 	int gpus[8];
 	size_t num_gpus = wlr_session_find_gpus(session, 8, gpus);
 	struct wlr_backend *primary_drm = NULL;
@@ -127,7 +129,7 @@ static struct wlr_backend *attempt_drm_backend(struct wl_display *display,
 
 	for (size_t i = 0; i < num_gpus; ++i) {
 		struct wlr_backend *drm = wlr_drm_backend_create(display, session,
-			gpus[i], primary_drm);
+			gpus[i], primary_drm, create_renderer_func);
 		if (!drm) {
 			wlr_log(L_ERROR, "Failed to open DRM device %d", gpus[i]);
 			continue;
@@ -145,15 +147,15 @@ static struct wlr_backend *attempt_drm_backend(struct wl_display *display,
 
 static struct wlr_backend *attempt_backend_by_name(struct wl_display *display,
 		struct wlr_backend *backend, struct wlr_session **session,
-		const char *name) {
+		const char *name, wlr_renderer_create_func_t create_renderer_func) {
 	if (strcmp(name, "wayland") == 0) {
-		return attempt_wl_backend(display);
+		return attempt_wl_backend(display, create_renderer_func);
 #ifdef WLR_HAS_X11_BACKEND
 	} else if (strcmp(name, "x11") == 0) {
-		return attempt_x11_backend(display, NULL);
+		return attempt_x11_backend(display, NULL, create_renderer_func);
 #endif
 	} else if (strcmp(name, "headless") == 0) {
-		return attempt_headless_backend(display);
+		return attempt_headless_backend(display, create_renderer_func);
 	} else if (strcmp(name, "drm") == 0 || strcmp(name, "libinput") == 0) {
 		// DRM and libinput need a session
 		*session = wlr_session_create(display);
@@ -165,7 +167,7 @@ static struct wlr_backend *attempt_backend_by_name(struct wl_display *display,
 		if (strcmp(name, "libinput") == 0) {
 			return wlr_libinput_backend_create(display, *session);
 		} else {
-			return attempt_drm_backend(display, backend, *session);
+			return attempt_drm_backend(display, backend, *session, create_renderer_func);
 		}
 	}
 
@@ -173,7 +175,8 @@ static struct wlr_backend *attempt_backend_by_name(struct wl_display *display,
 	return NULL;
 }
 
-struct wlr_backend *wlr_backend_autocreate(struct wl_display *display) {
+struct wlr_backend *wlr_backend_autocreate(struct wl_display *display,
+		wlr_renderer_create_func_t create_renderer_func) {
 	struct wlr_backend *backend = wlr_multi_backend_create(display);
 	if (!backend) {
 		wlr_log(L_ERROR, "could not allocate multibackend");
@@ -195,7 +198,7 @@ struct wlr_backend *wlr_backend_autocreate(struct wl_display *display) {
 		char *name = strtok_r(names, ",", &saveptr);
 		while (name != NULL) {
 			struct wlr_backend *subbackend =
-				attempt_backend_by_name(display, backend, &session, name);
+				attempt_backend_by_name(display, backend, &session, name, create_renderer_func);
 			if (subbackend == NULL) {
 				wlr_log(L_ERROR, "failed to start backend '%s'", name);
 				wlr_backend_destroy(backend);
@@ -218,7 +221,8 @@ struct wlr_backend *wlr_backend_autocreate(struct wl_display *display) {
 
 	if (getenv("WAYLAND_DISPLAY") || getenv("_WAYLAND_DISPLAY") ||
 			getenv("WAYLAND_SOCKET")) {
-		struct wlr_backend *wl_backend = attempt_wl_backend(display);
+		struct wlr_backend *wl_backend = attempt_wl_backend(display,
+			create_renderer_func);
 		if (wl_backend) {
 			wlr_multi_backend_add(backend, wl_backend);
 			return backend;
@@ -229,7 +233,7 @@ struct wlr_backend *wlr_backend_autocreate(struct wl_display *display) {
 	const char *x11_display = getenv("DISPLAY");
 	if (x11_display) {
 		struct wlr_backend *x11_backend =
-			attempt_x11_backend(display, x11_display);
+			attempt_x11_backend(display, x11_display, create_renderer_func);
 		if (x11_backend) {
 			wlr_multi_backend_add(backend, x11_backend);
 			return backend;
@@ -255,7 +259,7 @@ struct wlr_backend *wlr_backend_autocreate(struct wl_display *display) {
 	wlr_multi_backend_add(backend, libinput);
 
 	struct wlr_backend *primary_drm =
-		attempt_drm_backend(display, backend, session);
+		attempt_drm_backend(display, backend, session, create_renderer_func);
 	if (!primary_drm) {
 		wlr_log(L_ERROR, "Failed to open any DRM device");
 		wlr_backend_destroy(libinput);

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -114,7 +114,8 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 }
 
 struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
-		struct wlr_session *session, int gpu_fd, struct wlr_backend *parent) {
+		struct wlr_session *session, int gpu_fd, struct wlr_backend *parent,
+		wlr_renderer_create_func_t create_renderer_func) {
 	assert(display && session && gpu_fd >= 0);
 	assert(!parent || wlr_backend_is_drm(parent));
 
@@ -161,7 +162,7 @@ struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
 		goto error_event;
 	}
 
-	if (!init_drm_renderer(drm, &drm->renderer)) {
+	if (!init_drm_renderer(drm, &drm->renderer, create_renderer_func)) {
 		wlr_log(L_ERROR, "Failed to initialize renderer");
 		goto error_event;
 	}

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -139,7 +139,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 }
 
 struct wlr_backend *wlr_wl_backend_create(struct wl_display *display,
-		const char *remote) {
+		const char *remote, wlr_renderer_create_func_t create_renderer_func) {
 	wlr_log(L_INFO, "Creating wayland backend");
 
 	struct wlr_wl_backend *backend = calloc(1, sizeof(struct wlr_wl_backend));
@@ -174,14 +174,14 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display,
 		EGL_ALPHA_SIZE, 1,
 		EGL_NONE,
 	};
-	if (!wlr_egl_init(&backend->egl, EGL_PLATFORM_WAYLAND_EXT,
-			backend->remote_display, config_attribs, WL_SHM_FORMAT_ARGB8888)) {
-		wlr_log(L_ERROR, "Could not initialize EGL");
-		goto error_egl;
-	}
-	wlr_egl_bind_display(&backend->egl, backend->local_display);
 
-	backend->renderer = wlr_gles2_renderer_create(&backend->egl);
+	if (!create_renderer_func) {
+		create_renderer_func = wlr_renderer_autocreate;
+	}
+
+	backend->renderer = create_renderer_func(&backend->egl, EGL_PLATFORM_WAYLAND_EXT,
+		backend->remote_display, config_attribs, WL_SHM_FORMAT_ARGB8888);
+
 	if (backend->renderer == NULL) {
 		wlr_log(L_ERROR, "Could not create renderer");
 		goto error_renderer;
@@ -193,8 +193,6 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display,
 	return &backend->backend;
 
 error_renderer:
-	wlr_egl_finish(&backend->egl);
-error_egl:
 	wl_registry_destroy(backend->registry);
 error_registry:
 	wl_display_disconnect(backend->remote_display);

--- a/examples/multi-pointer.c
+++ b/examples/multi-pointer.c
@@ -284,7 +284,7 @@ int main(int argc, char *argv[]) {
 		.clear_color = { 0.25f, 0.25f, 0.25f, 1 },
 		.display = display,
 	};
-	struct wlr_backend *wlr = wlr_backend_autocreate(display);
+	struct wlr_backend *wlr = wlr_backend_autocreate(display, NULL);
 	if (!wlr) {
 		exit(1);
 	}

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -261,7 +261,7 @@ int main(int argc, char *argv[]) {
 	state.layout = wlr_output_layout_create();
 	clock_gettime(CLOCK_MONOTONIC, &state.ts_last);
 
-	struct wlr_backend *wlr = wlr_backend_autocreate(display);
+	struct wlr_backend *wlr = wlr_backend_autocreate(display, NULL);
 	if (!wlr) {
 		exit(1);
 	}

--- a/examples/pointer.c
+++ b/examples/pointer.c
@@ -324,7 +324,7 @@ int main(int argc, char *argv[]) {
 		.display = display
 	};
 
-	struct wlr_backend *wlr = wlr_backend_autocreate(display);
+	struct wlr_backend *wlr = wlr_backend_autocreate(display, NULL);
 	if (!wlr) {
 		exit(1);
 	}

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -235,7 +235,7 @@ int main(int argc, char *argv[]) {
 	};
 	wl_list_init(&state.outputs);
 
-	struct wlr_backend *wlr = wlr_backend_autocreate(display);
+	struct wlr_backend *wlr = wlr_backend_autocreate(display, NULL);
 	if (!wlr) {
 		exit(1);
 	}

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -152,7 +152,7 @@ int main() {
 		.last_frame = { 0 },
 		.display = display
 	};
-	struct wlr_backend *wlr = wlr_backend_autocreate(display);
+	struct wlr_backend *wlr = wlr_backend_autocreate(display, NULL);
 	if (!wlr) {
 		exit(1);
 	}

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -349,7 +349,7 @@ int main(int argc, char *argv[]) {
 	};
 	wl_list_init(&state.tablet_pads);
 	wl_list_init(&state.tablet_tools);
-	struct wlr_backend *wlr = wlr_backend_autocreate(display);
+	struct wlr_backend *wlr = wlr_backend_autocreate(display, NULL);
 	if (!wlr) {
 		exit(1);
 	}

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -244,7 +244,7 @@ int main(int argc, char *argv[]) {
 	wl_list_init(&state.touch_points);
 	wl_list_init(&state.touch);
 
-	struct wlr_backend *wlr = wlr_backend_autocreate(display);
+	struct wlr_backend *wlr = wlr_backend_autocreate(display, NULL);
 	if (!wlr) {
 		exit(1);
 	}

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -5,6 +5,7 @@
 #include <gbm.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <wlr/backend.h>
 #include <wlr/render/wlr_renderer.h>
 
 struct wlr_drm_backend;
@@ -32,7 +33,7 @@ struct wlr_drm_surface {
 };
 
 bool init_drm_renderer(struct wlr_drm_backend *drm,
-	struct wlr_drm_renderer *renderer);
+	struct wlr_drm_renderer *renderer, wlr_renderer_create_func_t create_render);
 void finish_drm_renderer(struct wlr_drm_renderer *renderer);
 
 bool init_drm_surface(struct wlr_drm_surface *surf,

--- a/include/wlr/backend.h
+++ b/include/wlr/backend.h
@@ -20,12 +20,20 @@ struct wlr_backend {
 	} events;
 };
 
+typedef struct wlr_renderer *(*wlr_renderer_create_func_t)(struct wlr_egl *egl, EGLenum platform,
+	void *remote_display, EGLint *config_attribs, EGLint visual_id);
 /**
  * Automatically initializes the most suitable backend given the environment.
  * Will always return a multibackend. The backend is created but not started.
  * Returns NULL on failure.
+ *
+ * The compositor can request to initialize the backend's renderer by setting
+ * the create_render_func. The callback must initialize the given wlr_egl and
+ * return a valid wlr_renderer, or NULL if it has failed to initiaze it.
+ * Pass NULL as create_renderer_func to use the backend's default renderer.
  */
-struct wlr_backend *wlr_backend_autocreate(struct wl_display *display);
+struct wlr_backend *wlr_backend_autocreate(struct wl_display *display,
+	wlr_renderer_create_func_t create_renderer_func);
 /**
  * Start the backend. This may signal new_input or new_output immediately, but
  * may also wait until the display's event loop begins. Returns false on

--- a/include/wlr/backend/drm.h
+++ b/include/wlr/backend/drm.h
@@ -14,7 +14,8 @@
  * a DRM backend, other kinds of backends raise SIGABRT).
  */
 struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
-	struct wlr_session *session, int gpu_fd, struct wlr_backend *parent);
+	struct wlr_session *session, int gpu_fd, struct wlr_backend *parent,
+	wlr_renderer_create_func_t create_renderer_func);
 
 bool wlr_backend_is_drm(struct wlr_backend *backend);
 bool wlr_output_is_drm(struct wlr_output *output);

--- a/include/wlr/backend/headless.h
+++ b/include/wlr/backend/headless.h
@@ -9,7 +9,8 @@
  * Creates a headless backend. A headless backend has no outputs or inputs by
  * default.
  */
-struct wlr_backend *wlr_headless_backend_create(struct wl_display *display);
+struct wlr_backend *wlr_headless_backend_create(struct wl_display *display,
+	wlr_renderer_create_func_t create_renderer_func);
 /**
  * Create a new headless output backed by an in-memory EGL framebuffer. You can
  * read pixels from this framebuffer via wlr_renderer_read_pixels but it is

--- a/include/wlr/backend/wayland.h
+++ b/include/wlr/backend/wayland.h
@@ -16,7 +16,8 @@
  * to NULL for the default behaviour (WAYLAND_DISPLAY env variable or wayland-0
  * default)
  */
-struct wlr_backend *wlr_wl_backend_create(struct wl_display *display, const char *remote);
+struct wlr_backend *wlr_wl_backend_create(struct wl_display *display, const char *remote,
+	wlr_renderer_create_func_t create_renderer_func);
 
 /**
  * Adds a new output to this backend. You may remove outputs by destroying them.

--- a/include/wlr/backend/x11.h
+++ b/include/wlr/backend/x11.h
@@ -8,7 +8,7 @@
 #include <wlr/types/wlr_output.h>
 
 struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
-	const char *x11_display);
+	const char *x11_display, wlr_renderer_create_func_t create_renderer_func);
 struct wlr_output *wlr_x11_output_create(struct wlr_backend *backend);
 
 bool wlr_backend_is_x11(struct wlr_backend *backend);

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <wayland-server-protocol.h>
+#include <wlr/render/egl.h>
 #include <wlr/render/wlr_texture.h>
 #include <wlr/types/wlr_box.h>
 
@@ -15,6 +16,9 @@ struct wlr_renderer {
 		struct wl_signal destroy;
 	} events;
 };
+
+struct wlr_renderer *wlr_renderer_autocreate(struct wlr_egl *egl, EGLenum platform,
+	void *remote_display, EGLint *config_attribs, EGLint visual_id);
 
 void wlr_renderer_begin(struct wlr_renderer *r, int width, int height);
 void wlr_renderer_end(struct wlr_renderer *r);

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -4,6 +4,7 @@
 #include <wlr/render/interface.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_matrix.h>
+#include <wlr/render/gles2.h>
 #include <wlr/util/log.h>
 #include "util/signal.h"
 
@@ -178,4 +179,20 @@ void wlr_renderer_init_wl_shm(struct wlr_renderer *r,
 			wl_display_add_shm_format(display, formats[i]);
 		}
 	}
+}
+
+struct wlr_renderer *wlr_renderer_autocreate(struct wlr_egl *egl,
+		EGLenum platform, void *remote_display, EGLint *config_attribs, EGLint visual_id) {
+
+	if (!wlr_egl_init(egl, platform, remote_display, config_attribs, visual_id)) {
+		wlr_log(L_ERROR, "Could not initialize EGL");
+		return NULL;
+	}
+
+	struct wlr_renderer *renderer = wlr_gles2_renderer_create(egl);
+	if (!renderer) {
+		wlr_egl_finish(egl);
+	}
+
+	return renderer;
 }

--- a/rootston/main.c
+++ b/rootston/main.c
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
 	server.wl_event_loop = wl_display_get_event_loop(server.wl_display);
 	assert(server.config && server.wl_display && server.wl_event_loop);
 
-	server.backend = wlr_backend_autocreate(server.wl_display);
+	server.backend = wlr_backend_autocreate(server.wl_display, NULL);
 	if (server.backend == NULL) {
 		wlr_log(L_ERROR, "could not start backend");
 		return 1;


### PR DESCRIPTION
Compositors now have more control over how the backend creates its
renderer. Currently all backends create an EGL/GLES2 renderer, so
the necessary attributes for creating the context are passed to a
user-provided callback function. It is responsible for initializing the
provided `wlr_egl` and to return a renderer. On fail, return NULL.

Fixes #987 

Things I'm not sure about:
1) Where to place and how to name `wlr_backend_renderer_autocreate()` - should it be in `backend.c` or `wlr_renderer.c`?
2) Should we allow passing NULL to `wlr_backend_autocreate()` or force the user to specify `wlr_backend_renderer_autocreate` as renderer initialization function?
3) Example - is another example needed? Or maybe implement such a function in rootston to demonstrate how this is done?
4) Testing - I've tested rootston only with the default initialization, and my own compositor with custom initialization. 
5) The headless backend didn't need a GLES2 renderer, or at least it didn't fail without one. This PR currently forces it to have a render, should I fix this somehow?