### PR TITLE
Add relative outputs to wlr_output_layout

### DIFF
--- a/include/rootston/config.h
+++ b/include/rootston/config.h
@@ -10,13 +10,24 @@ struct roots_output_config {
 	char *name;
 	bool enable;
 	enum wl_output_transform transform;
-	int x, y;
 	float scale;
 	struct wl_list link;
 	struct {
 		int width, height;
 		float refresh_rate;
 	} mode;
+};
+
+struct roots_layout_config {
+	struct wl_list rules;
+};
+
+struct roots_layout_rule_config {
+	char *output_name;
+	struct wl_list link;
+	enum wlr_output_layout_output_configuration configuration;
+	char *reference_output;
+	int x, y;
 };
 
 struct roots_device_config {
@@ -68,6 +79,7 @@ struct roots_config {
 	struct wl_list keyboards;
 	struct wl_list cursors;
 
+	struct roots_layout_config layout;
 	char *config_path;
 	char *startup_cmd;
 	bool debug_damage_tracking;

--- a/include/rootston/desktop.h
+++ b/include/rootston/desktop.h
@@ -26,6 +26,7 @@
 #include "rootston/config.h"
 #include "rootston/output.h"
 #include "rootston/view.h"
+#include "rootston/layout.h"
 
 struct roots_desktop {
 	struct wl_list views; // roots_view::link
@@ -35,8 +36,8 @@ struct roots_desktop {
 
 	struct roots_server *server;
 	struct roots_config *config;
+	struct roots_layout *layout;
 
-	struct wlr_output_layout *layout;
 	struct wlr_xcursor_manager *xcursor_manager;
 
 	struct wlr_compositor *compositor;

--- a/include/rootston/layout.h
+++ b/include/rootston/layout.h
@@ -1,0 +1,29 @@
+#ifndef ROOTSTON_LAYOUT_H
+#define ROOTSTON_LAYOUT_H
+
+#include <wlr/types/wlr_output_layout.h>
+#include "rootston/config.h"
+#include "rootston/output.h"
+
+struct roots_layout_rule {
+	struct roots_layout_rule_config *config;
+	struct roots_output *output;
+	struct wl_list link;
+	bool configured;
+};
+
+struct roots_layout {
+	struct wlr_output_layout *wlr_layout;
+	struct roots_layout_config *current_config;
+	struct wl_list rules;
+};
+
+struct roots_layout* roots_layout_create(struct roots_layout_config *config);
+void roots_layout_destroy(struct roots_layout *layout);
+void roots_layout_add_output(struct roots_layout *layout,
+		struct roots_output *output);
+void roots_layout_remove_output(struct roots_layout *layout,
+		struct roots_output *output);
+void roots_layout_reflow(struct roots_layout *layout);
+
+#endif

--- a/include/wlr/types/wlr_output_layout.h
+++ b/include/wlr/types/wlr_output_layout.h
@@ -66,9 +66,6 @@ struct wlr_output *wlr_output_layout_output_at(struct wlr_output_layout *layout,
 void wlr_output_layout_add(struct wlr_output_layout *layout,
 		struct wlr_output *output, int lx, int ly);
 
-void wlr_output_layout_move(struct wlr_output_layout *layout,
-		struct wlr_output *output, int lx, int ly);
-
 void wlr_output_layout_remove(struct wlr_output_layout *layout,
 		struct wlr_output *output);
 

--- a/include/wlr/types/wlr_output_layout.h
+++ b/include/wlr/types/wlr_output_layout.h
@@ -23,10 +23,24 @@ struct wlr_output_layout {
 
 struct wlr_output_layout_output_state;
 
+enum wlr_output_layout_output_configuration {
+	WLR_OUTPUT_LAYOUT_OUTPUT_CONFIGURATION_FIXED,
+	WLR_OUTPUT_LAYOUT_OUTPUT_CONFIGURATION_AUTO,
+	WLR_OUTPUT_LAYOUT_OUTPUT_CONFIGURATION_RELATIVE_LEFT_OF,
+	WLR_OUTPUT_LAYOUT_OUTPUT_CONFIGURATION_RELATIVE_RIGHT_OF,
+	WLR_OUTPUT_LAYOUT_OUTPUT_CONFIGURATION_RELATIVE_BELOW,
+	WLR_OUTPUT_LAYOUT_OUTPUT_CONFIGURATION_RELATIVE_ABOVE,
+	WLR_OUTPUT_LAYOUT_OUTPUT_CONFIGURATION_RELATIVE_SAME_AS,
+};
+
 struct wlr_output_layout_output {
 	struct wlr_output *output;
 	int x, y;
+	enum wlr_output_layout_output_configuration configuration;
+	struct wlr_output_layout_output *reference;
+
 	struct wl_list link;
+
 	struct wlr_output_layout_output_state *state;
 
 	struct {
@@ -88,15 +102,27 @@ struct wlr_box *wlr_output_layout_get_box(
 		struct wlr_output_layout *layout, struct wlr_output *reference);
 
 /**
-* Add an auto configured output to the layout. This will place the output in a
-* sensible location in the layout. The coordinates of the output in the layout
-* may adjust dynamically when the layout changes. If the output is already in
-* the layout, it will become auto configured. If the position of the output is
-* set such as with `wlr_output_layout_move()`, the output will become manually
-* configured.
-*/
+ * Add an auto configured output to the layout. This will place the output in a
+ * sensible location in the layout. The coordinates of the output in the layout
+ * may adjust dynamically when the layout changes. If the output is already in
+ * the layout, it will become auto configured. Relative layouts are not supported
+ * with this kind of output.
+ */
 void wlr_output_layout_add_auto(struct wlr_output_layout *layout,
 		struct wlr_output *output);
+
+
+/**
+ * Add an auto configured output to the layout relative to another output.
+ * This will place the relative output next to the border of the reference
+ * output. The output layout will adjust dynamically to keep the relative
+ * output in this position when the absolute output changes coordinates.
+ * If the position of the relative output is set to absolute coordinates,
+ * it will become manually configured.
+*/
+void wlr_output_layout_add_relative(struct wlr_output_layout *layout,
+		struct wlr_output *output, struct wlr_output *reference,
+		enum wlr_output_layout_output_configuration configuration);
 
 /**
  * Get the output closest to the center of the layout extents.

--- a/include/wlr/types/wlr_output_layout.h
+++ b/include/wlr/types/wlr_output_layout.h
@@ -66,6 +66,9 @@ struct wlr_output *wlr_output_layout_output_at(struct wlr_output_layout *layout,
 void wlr_output_layout_add(struct wlr_output_layout *layout,
 		struct wlr_output *output, int lx, int ly);
 
+void wlr_output_layout_move(struct wlr_output_layout *layout,
+		struct wlr_output *output, int lx, int ly);
+
 void wlr_output_layout_remove(struct wlr_output_layout *layout,
 		struct wlr_output *output);
 

--- a/rootston/config.c
+++ b/rootston/config.c
@@ -243,7 +243,7 @@ static void config_handle_layout(struct roots_config *config, const char *name,
 	rule->output_name = strdup(name);
 
 	if (strcmp(mod_value, "fixed") == 0) {
-		mod_value = strtok_r(NULL, " ", &saveptr);
+		mod_value = strtok_r(NULL, ",", &saveptr);
 		rule->x = strtol(mod_value, NULL, 10);
 		mod_value = strtok_r(NULL, " ", &saveptr);
 		rule->y = strtol(mod_value, NULL, 10);

--- a/rootston/config.c
+++ b/rootston/config.c
@@ -239,46 +239,76 @@ static void config_handle_layout(struct roots_config *config, const char *name,
 
 	struct roots_layout_rule_config *rule =
 		calloc(1, sizeof(struct roots_layout_rule_config));
-	wl_list_insert(&lc->rules, &rule->link);
-	rule->output_name = strdup(name);
 
 	if (strcmp(mod_value, "fixed") == 0) {
 		mod_value = strtok_r(NULL, ",", &saveptr);
+		if (!mod_value) {
+			goto invalid_config;
+		}
 		rule->x = strtol(mod_value, NULL, 10);
 		mod_value = strtok_r(NULL, " ", &saveptr);
+		if (!mod_value) {
+			goto invalid_config;
+		}
 		rule->y = strtol(mod_value, NULL, 10);
 		rule->configuration =
 			WLR_OUTPUT_LAYOUT_OUTPUT_CONFIGURATION_FIXED;
+
 	} else if (strcmp(mod_value, "left-of") == 0) {
 		mod_value = strtok_r(NULL, " ", &saveptr);
+		if (!mod_value) {
+			goto invalid_config;
+		}
 		rule->reference_output = strdup(mod_value);
 		rule->configuration =
 			WLR_OUTPUT_LAYOUT_OUTPUT_CONFIGURATION_RELATIVE_LEFT_OF;
 	} else if (strcmp(mod_value, "right-of") == 0) {
 		mod_value = strtok_r(NULL, " ", &saveptr);
+		if (!mod_value) {
+			goto invalid_config;
+		}
 		rule->reference_output = strdup(mod_value);
 		rule->configuration =
 			WLR_OUTPUT_LAYOUT_OUTPUT_CONFIGURATION_RELATIVE_RIGHT_OF;
 	} else if (strcmp(mod_value, "below") == 0) {
 		mod_value = strtok_r(NULL, " ", &saveptr);
+		if (!mod_value) {
+			goto invalid_config;
+		}
 		rule->reference_output = strdup(mod_value);
 		rule->configuration =
 			WLR_OUTPUT_LAYOUT_OUTPUT_CONFIGURATION_RELATIVE_BELOW;
 	} else if (strcmp(mod_value, "above") == 0) {
 		mod_value = strtok_r(NULL, " ", &saveptr);
+		if (!mod_value) {
+			goto invalid_config;
+		}
 		rule->reference_output = strdup(mod_value);
 		rule->configuration =
 			WLR_OUTPUT_LAYOUT_OUTPUT_CONFIGURATION_RELATIVE_ABOVE;
 	} else if (strcmp(mod_value, "same-as") == 0) {
 		mod_value = strtok_r(NULL, " ", &saveptr);
+		if (!mod_value) {
+			goto invalid_config;
+		}
 		rule->reference_output = strdup(mod_value);
 		rule->configuration =
 			WLR_OUTPUT_LAYOUT_OUTPUT_CONFIGURATION_RELATIVE_SAME_AS;
 	} else {
-		wlr_log(L_ERROR, "got invalid input for layout: %s = %s", name, value);
+		goto invalid_config;
 	}
 
+	rule->output_name = strdup(name);
+	wl_list_insert(&lc->rules, &rule->link);
+
 	free(strstart);
+
+	return;
+
+invalid_config:
+	wlr_log(L_ERROR, "got invalid config for layout: %s = %s", name, value);
+	free(strstart);
+	free(rule);
 }
 
 static const char *output_prefix = "output:";

--- a/rootston/keyboard.c
+++ b/rootston/keyboard.c
@@ -13,6 +13,7 @@
 #include "rootston/input.h"
 #include "rootston/keyboard.h"
 #include "rootston/seat.h"
+#include "rootston/layout.h"
 
 static ssize_t pressed_keysyms_index(xkb_keysym_t *pressed_keysyms,
 		xkb_keysym_t keysym) {

--- a/rootston/layer_shell.c
+++ b/rootston/layer_shell.c
@@ -392,14 +392,14 @@ void handle_layer_shell_surface(struct wl_listener *listener, void *data) {
 		struct roots_seat *seat = input_last_active_seat(input);
 		assert(seat); // Technically speaking we should handle this case
 		struct wlr_output *output =
-			wlr_output_layout_output_at(desktop->layout,
+			wlr_output_layout_output_at(desktop->layout->wlr_layout,
 					seat->cursor->cursor->x,
 					seat->cursor->cursor->y);
 		if (!output) {
 			wlr_log(L_ERROR, "Couldn't find output at (%.0f,%.0f)",
 				seat->cursor->cursor->x,
 				seat->cursor->cursor->y);
-			output = wlr_output_layout_get_center_output(desktop->layout);
+			output = wlr_output_layout_get_center_output(desktop->layout->wlr_layout);
 		}
 		if (output) {
 			layer_surface->output = output;

--- a/rootston/layout.c
+++ b/rootston/layout.c
@@ -132,11 +132,25 @@ void roots_layout_remove_output(struct roots_layout *layout,
 	}
 }
 
+/*
+ * roots_layout_reflow makes sure that outputs that could not be properly
+ * configured, do not cause gaps or overlaps. First the extents of the
+ * outputs that are fully configured are calculated. These include outputs
+ * that have no active reference and are not fixed, and their children.
+ * The remaining unconfigured outputs are placed to the right of the fully
+ * configured outputs, taking into account that the unconfigred outputs
+ * can have children.
+ */
 void roots_layout_reflow(struct roots_layout *layout) {
 	int max_x = INT_MIN;
 	int max_x_y = 0;
+	// Configured is always initialized before use, since the first output
+	// in the layout is always fixed (rootston specifc, since it does not
+	// use auto outputs)
 	bool configured;
 
+	// XXX: requires specific ordering of the outputs in layout->outputs,
+	// specifically, output must follow their reference immediately.
 	struct wlr_output_layout_output *l_output;
 	wl_list_for_each(l_output, &layout->wlr_layout->outputs, link) {
 		if (l_output->configuration ==

--- a/rootston/layout.c
+++ b/rootston/layout.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <limits.h>
 #include <wlr/util/log.h>
+#include "rootston/output.h"
 #include "rootston/layout.h"
 
 static struct roots_layout_rule *get_rule(struct roots_layout *layout, char *name) {

--- a/rootston/layout.c
+++ b/rootston/layout.c
@@ -1,0 +1,232 @@
+#include <stdlib.h>
+#include <limits.h>
+#include <wlr/util/log.h>
+#include "rootston/layout.h"
+
+static struct roots_layout_rule *get_rule(struct roots_layout *layout, char *name) {
+	struct roots_layout_rule *rule;
+	wl_list_for_each(rule, &layout->rules, link) {
+		if (strcmp(name, rule->output->wlr_output->name) == 0) {
+			return rule;
+		}
+	}
+
+	return NULL;
+}
+
+struct roots_layout* roots_layout_create(struct roots_layout_config *config) {
+	struct roots_layout *layout = calloc(1, sizeof(struct roots_layout));
+
+	if (!layout) {
+		return NULL;
+	}
+
+	wl_list_init(&layout->rules);
+	layout->wlr_layout = wlr_output_layout_create();
+	layout->current_config = config;
+
+	return layout;
+}
+
+void roots_layout_destroy(struct roots_layout *layout) {
+	if (layout) {
+		struct roots_layout_rule *rule, *tmp;
+		wl_list_for_each_safe(rule, tmp, &layout->rules, link) {
+			wl_list_remove(&rule->link);
+			free(rule);
+		}
+
+		free(layout);
+	}
+}
+
+static void apply_rule(struct roots_layout *layout,
+		struct roots_layout_rule *rule) {
+
+	rule->configured = false;
+
+	if (rule->config) {
+		if (rule->config->configuration !=
+				WLR_OUTPUT_LAYOUT_OUTPUT_CONFIGURATION_FIXED) {
+			struct roots_layout_rule *ref =
+				get_rule(layout, rule->config->reference_output);
+			if (ref) {
+				wlr_output_layout_add_relative(layout->wlr_layout,
+						rule->output->wlr_output, ref->output->wlr_output,
+						rule->config->configuration);
+				rule->configured = true;
+			} else {
+				wlr_output_layout_add(layout->wlr_layout,
+						rule->output->wlr_output, 0, 0);
+			}
+		} else {
+			wlr_output_layout_add(layout->wlr_layout, rule->output->wlr_output,
+					rule->config->x, rule->config->y);
+			rule->configured = true;
+		}
+	} else {
+		wlr_output_layout_add(layout->wlr_layout,
+				rule->output->wlr_output, 0, 0);
+	}
+
+	struct roots_layout_rule *ref_rule;
+	wl_list_for_each(ref_rule, &layout->rules, link) {
+		if (!ref_rule->configured && ref_rule->config) {
+			if (strcmp(rule->output->wlr_output->name,
+						ref_rule->config->reference_output) == 0) {
+				wlr_output_layout_add_relative(layout->wlr_layout,
+						ref_rule->output->wlr_output, rule->output->wlr_output,
+						ref_rule->config->configuration);
+				ref_rule->configured = true;
+			}
+		}
+	}
+}
+
+void roots_layout_add_output(struct roots_layout *layout,
+		struct roots_output *output) {
+
+	struct roots_layout_rule *new_rule;
+
+	wl_list_for_each(new_rule, &layout->rules, link) {
+		if (new_rule->output == output) {
+			return;
+		}
+	}
+
+	new_rule = calloc(1, sizeof(struct roots_layout_rule));
+
+	if (!new_rule) {
+		wlr_log(L_ERROR, "Could not allocate layout rule");
+		return;
+	}
+
+	new_rule->output = output;
+
+	struct roots_layout_rule_config *c_rule;
+	wl_list_for_each(c_rule, &layout->current_config->rules, link) {
+		if (strcmp(output->wlr_output->name, c_rule->output_name) == 0) {
+			new_rule->config = c_rule;
+			break;
+		}
+	}
+
+	wl_list_insert(&layout->rules, &new_rule->link);
+	apply_rule(layout, new_rule);
+}
+
+void roots_layout_remove_output(struct roots_layout *layout,
+		struct roots_output *output) {
+	struct roots_layout_rule *rule, *tmp;
+
+	wl_list_for_each_safe(rule, tmp, &layout->rules, link) {
+		if (rule->output == output) {
+			wl_list_remove(&rule->link);
+			free(rule);
+		} else if (rule->config && rule->config->reference_output &&
+				strcmp(output->wlr_output->name,
+					rule->config->reference_output) == 0) {
+			rule->configured = false;
+		}
+	}
+}
+
+void roots_layout_reflow(struct roots_layout *layout) {
+	int max_x = INT_MIN;
+	int max_x_y = 0;
+	bool configured;
+
+	struct wlr_output_layout_output *l_output;
+	wl_list_for_each(l_output, &layout->wlr_layout->outputs, link) {
+		if (l_output->configuration ==
+				WLR_OUTPUT_LAYOUT_OUTPUT_CONFIGURATION_FIXED) {
+			struct roots_layout_rule *rule;
+			wl_list_for_each(rule, &layout->rules, link) {
+				if (rule->output->wlr_output == l_output->output) {
+					configured = rule->configured;
+					break;
+				}
+			}
+		}
+
+		if (configured) {
+			struct wlr_box *box =
+				wlr_output_layout_get_box(layout->wlr_layout, l_output->output);
+			if (max_x < box->x + box->width) {
+				max_x = box->x + box->width;
+				max_x_y = box->y;
+			}
+		}
+	}
+
+	if (max_x == INT_MIN) { // In case there are no configured layouts
+		max_x = 0;
+	}
+
+	struct wlr_output *unconfigured_output = NULL;
+	int auto_min_x = INT_MAX;
+	int auto_min_x_y = 0;
+	int auto_max_x = INT_MIN;
+	int auto_max_x_y = 0;
+
+	wl_list_for_each(l_output, &layout->wlr_layout->outputs, link) {
+		if (l_output->configuration ==
+				WLR_OUTPUT_LAYOUT_OUTPUT_CONFIGURATION_FIXED) {
+			if (unconfigured_output) {
+				struct wlr_box *box =
+					wlr_output_layout_get_box(layout->wlr_layout,
+							unconfigured_output);
+				wlr_output_layout_add(layout->wlr_layout, unconfigured_output,
+						box->x - auto_min_x + max_x,
+						box->y - auto_min_x_y + max_x_y);
+				max_x += auto_max_x - auto_min_x;
+				max_x_y += auto_max_x_y - auto_min_x_y;
+				auto_min_x = INT_MAX;
+				auto_min_x_y = 0;
+				auto_max_x = INT_MIN;
+				auto_max_x_y = 0;
+				unconfigured_output = NULL;
+			}
+			struct roots_layout_rule *rule;
+			wl_list_for_each(rule, &layout->rules, link) {
+				if (rule->output->wlr_output == l_output->output) {
+					configured = rule->configured;
+					if (!configured) {
+						unconfigured_output = l_output->output;
+					}
+					break;
+				}
+			}
+		}
+
+		if (!configured) {
+			struct wlr_box *box =
+				wlr_output_layout_get_box(layout->wlr_layout, l_output->output);
+			if (auto_max_x < box->x + box->width) {
+				auto_max_x = box->x + box->width;
+				auto_max_x_y = box->y;
+			}
+
+			if (auto_min_x > box->x) {
+				auto_min_x = box->x;
+				auto_min_x_y = box->y;
+			}
+		}
+	}
+
+	if (unconfigured_output) {
+		struct wlr_box *box =
+			wlr_output_layout_get_box(layout->wlr_layout,
+					unconfigured_output);
+		wlr_output_layout_add(layout->wlr_layout, unconfigured_output,
+				box->x - auto_min_x + max_x,
+				box->y - auto_min_x_y + max_x_y);
+		max_x += auto_max_x - auto_min_x;
+		max_x_y += auto_max_x_y - auto_min_x_y;
+	}
+
+	struct roots_layout_rule *rule;
+	wl_list_for_each(rule, &layout->rules, link) {
+		output_damage_whole(rule->output);
+	}
+}

--- a/rootston/meson.build
+++ b/rootston/meson.build
@@ -13,6 +13,7 @@ sources = [
 	'wl_shell.c',
 	'xdg_shell_v6.c',
 	'xdg_shell.c',
+	'layout.c'
 ]
 if get_option('enable-xwayland')
 	sources += ['xwayland.c']

--- a/rootston/rootston.ini.example
+++ b/rootston/rootston.ini.example
@@ -7,10 +7,6 @@ xwayland=false
 
 # Single output configuration. String after colon must match output's name.
 [output:VGA-1]
-# Set logical (layout) coordinates for this screen
-x = 1920
-y = 0
-
 # Screen transformation
 # possible values are:
 # '90', '180' or '270' - rotate output by specified angle clockwise
@@ -18,6 +14,14 @@ y = 0
 # 'flipped-90', 'flipped-180', 'flipped-270' - flip output horizontally
 #                                              and rotate by specified angle
 rotate = 90
+
+# Output position configuration
+[layout]
+# Put the output with name VGA-1 at (0,0)
+VGA-1 = fixed 0 0
+# Put the output with name VGA-2 to the left of the output with name VGA-1
+VGA-2 = left-of VGA-1
+# Other possibilities include : right-of, above, below, mirror
 
 [cursor]
 # Restrict cursor movements to single output

--- a/rootston/rootston.ini.example
+++ b/rootston/rootston.ini.example
@@ -18,7 +18,7 @@ rotate = 90
 # Output position configuration
 [layout]
 # Put the output with name VGA-1 at (0,0)
-VGA-1 = fixed 0 0
+VGA-1 = fixed 0,0
 # Put the output with name VGA-2 to the left of the output with name VGA-1
 VGA-2 = left-of VGA-1
 # Other possibilities include : right-of, above, below, mirror

--- a/rootston/rootston.ini.example
+++ b/rootston/rootston.ini.example
@@ -21,7 +21,7 @@ rotate = 90
 VGA-1 = fixed 0,0
 # Put the output with name VGA-2 to the left of the output with name VGA-1
 VGA-2 = left-of VGA-1
-# Other possibilities include : right-of, above, below, mirror
+# Other possibilities include: right-of, above, below, mirror
 
 [cursor]
 # Restrict cursor movements to single output

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -215,7 +215,7 @@ static void roots_seat_init_cursor(struct roots_seat *seat) {
 	seat->cursor->seat = seat;
 	struct wlr_cursor *wlr_cursor = seat->cursor->cursor;
 	struct roots_desktop *desktop = seat->input->server->desktop;
-	wlr_cursor_attach_output_layout(wlr_cursor, desktop->layout);
+	wlr_cursor_attach_output_layout(wlr_cursor, desktop->layout->wlr_layout);
 
 	roots_seat_configure_cursor(seat);
 	roots_seat_configure_xcursor(seat);
@@ -762,7 +762,7 @@ void roots_seat_set_focus(struct roots_seat *seat, struct roots_view *view) {
 			if (output->fullscreen_view &&
 					output->fullscreen_view != view &&
 					wlr_output_layout_intersects(
-						desktop->layout,
+						desktop->layout->wlr_layout,
 						output->wlr_output, &box)) {
 				view_set_fullscreen(output->fullscreen_view,
 						false, NULL);

--- a/rootston/xdg_shell.c
+++ b/rootston/xdg_shell.c
@@ -61,7 +61,7 @@ static void popup_unconstrain(struct roots_xdg_popup *popup) {
 	}
 
 	struct roots_view *view = popup->view_child.view;
-	struct wlr_output_layout *layout = view->desktop->layout;
+	struct wlr_output_layout *layout = view->desktop->layout->wlr_layout;
 	struct wlr_xdg_popup *wlr_popup = popup->wlr_popup;
 
 	int anchor_lx, anchor_ly;

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -63,7 +63,7 @@ static void popup_unconstrain(struct roots_xdg_popup_v6 *popup) {
 	}
 
 	struct roots_view *view = popup->view_child.view;
-	struct wlr_output_layout *layout = view->desktop->layout;
+	struct wlr_output_layout *layout = view->desktop->layout->wlr_layout;
 	struct wlr_xdg_popup_v6 *wlr_popup = popup->wlr_popup;
 
 	int anchor_lx, anchor_ly;

--- a/types/wlr_output_layout.c
+++ b/types/wlr_output_layout.c
@@ -105,10 +105,10 @@ static struct wlr_box *output_layout_output_get_box(
 static void output_layout_reconfigure(struct wlr_output_layout *layout) {
 
 	struct wlr_output_layout_output *l_output;
+	int max_x = INT_MIN;
+	int max_x_y = 0;
 
 	wl_list_for_each(l_output, &layout->outputs, link) {
-		int max_x = INT_MIN;
-		int max_x_y = INT_MIN;
 
 		struct wlr_box *box = output_layout_output_get_box(l_output);
 		struct wlr_box *ref_box;
@@ -142,12 +142,15 @@ static void output_layout_reconfigure(struct wlr_output_layout *layout) {
 			l_output->y = ref_box->y;
 			break;
 		case WLR_OUTPUT_LAYOUT_OUTPUT_CONFIGURATION_AUTO:
+			if (max_x == INT_MIN) {
+				max_x = 0;
+			}
 			l_output->x = max_x;
 			l_output->y = max_x_y;
 			break;
 		}
 
-		if (max_x < l_output->x + box->width) {
+		if (max_x < (l_output->x + box->width)) {
 			max_x = l_output->x + box->width;
 			max_x_y = l_output->y;
 		}
@@ -497,6 +500,7 @@ void wlr_output_layout_add_auto(struct wlr_output_layout *layout,
 		wl_list_remove(&l_output->link);
 	}
 
+	l_output->configuration = WLR_OUTPUT_LAYOUT_OUTPUT_CONFIGURATION_AUTO;
 	wl_list_insert(layout->outputs.prev, &l_output->link); // Insert at end
 	output_layout_reconfigure(layout);
 	wlr_output_create_global(output);

--- a/types/wlr_output_layout.c
+++ b/types/wlr_output_layout.c
@@ -287,6 +287,28 @@ void wlr_output_layout_add(struct wlr_output_layout *layout,
 	wlr_signal_emit_safe(&layout->events.add, l_output);
 }
 
+void wlr_output_layout_move(struct wlr_output_layout *layout,
+		struct wlr_output *output, int lx, int ly) {
+	struct wlr_output_layout_output *l_output =
+		wlr_output_layout_get(layout, output);
+
+	if (!l_output) {
+		wlr_log(L_ERROR, "output not found in this layout: %s", output->name);
+		return;
+	}
+
+	if (l_output->configuration !=
+				WLR_OUTPUT_LAYOUT_OUTPUT_CONFIGURATION_FIXED) {
+		relocate_output_with_children(layout, l_output, &layout->outputs);
+	}
+
+	l_output->x = lx;
+	l_output->y = ly;
+	l_output->configuration = WLR_OUTPUT_LAYOUT_OUTPUT_CONFIGURATION_FIXED;
+
+	output_layout_reconfigure(layout);
+}
+
 struct wlr_output_layout_output *wlr_output_layout_get(
 		struct wlr_output_layout *layout, struct wlr_output *reference) {
 	struct wlr_output_layout_output *l_output;

--- a/types/wlr_output_layout.c
+++ b/types/wlr_output_layout.c
@@ -117,6 +117,8 @@ static void output_layout_reconfigure(struct wlr_output_layout *layout) {
 		struct wlr_box *box = output_layout_output_get_box(l_output);
 		struct wlr_box *ref_box;
 
+		// Requires the outputs to be ordered such that outputs follow
+		// immediately after their parents
 		switch(l_output->configuration) {
 		case WLR_OUTPUT_LAYOUT_OUTPUT_CONFIGURATION_FIXED:
 			break;

--- a/types/wlr_output_layout.c
+++ b/types/wlr_output_layout.c
@@ -283,6 +283,7 @@ void wlr_output_layout_add(struct wlr_output_layout *layout,
 				WLR_OUTPUT_LAYOUT_OUTPUT_CONFIGURATION_FIXED) {
 		relocate_output_with_children(layout, l_output, &layout->outputs);
 	}
+
 	l_output->x = lx;
 	l_output->y = ly;
 	l_output->configuration = WLR_OUTPUT_LAYOUT_OUTPUT_CONFIGURATION_FIXED;
@@ -351,20 +352,6 @@ struct wlr_output *wlr_output_layout_output_at(struct wlr_output_layout *layout,
 		}
 	}
 	return NULL;
-}
-
-void wlr_output_layout_move(struct wlr_output_layout *layout,
-		struct wlr_output *output, int lx, int ly) {
-	struct wlr_output_layout_output *l_output =
-		wlr_output_layout_get(layout, output);
-	if (l_output) {
-		l_output->x = lx;
-		l_output->y = ly;
-		l_output->configuration = WLR_OUTPUT_LAYOUT_OUTPUT_CONFIGURATION_FIXED;
-		output_layout_reconfigure(layout);
-	} else {
-		wlr_log(L_ERROR, "output not found in this layout: %s", output->name);
-	}
 }
 
 void wlr_output_layout_remove(struct wlr_output_layout *layout,

--- a/types/wlr_output_layout.c
+++ b/types/wlr_output_layout.c
@@ -229,13 +229,6 @@ static struct wlr_output_layout_output *output_layout_output_create(
 	return l_output;
 }
 
-// Adapted from wl_list_for_each
-// Starts with wlr_ to avoid name conflicts
-#define wlr_wl_list_for_each_offset(pos, head, member, offset)			\
-	for (pos = wl_container_of((offset)->member.next, pos, member);	\
-	     &pos->member != (head);										\
-	     pos = wl_container_of(pos->member.next, pos, member))
-
 void relocate_output_with_children(struct wlr_output_layout *layout,
 		struct wlr_output_layout_output *output,
 		struct wl_list *ref) {
@@ -248,7 +241,10 @@ void relocate_output_with_children(struct wlr_output_layout *layout,
 		return;
 	}
 
-	wlr_wl_list_for_each_offset(child_output, &layout->outputs, link, output) {
+	for (child_output = wl_container_of((output)->link.next, output, link);
+			&output->link != &layout->outputs;
+			child_output =
+				wl_container_of((child_output)->link.next, output, link)) {
 		while (child_output->reference != parent_output) {
 			if (parent_output == output) {
 				goto move_outputs;
@@ -265,8 +261,6 @@ move_outputs:
 	output->link.prev = ref;
 	ref->next = &output->link;
 }
-
-#undef wlr_wl_list_for_each_offset
 
 void wlr_output_layout_add(struct wlr_output_layout *layout,
 		struct wlr_output *output, int lx, int ly) {


### PR DESCRIPTION
Introduces a way for compositors to create layouts with outputs that are relative to other outputs.
These relative outputs will update when the position or size of the reference ouput changes.
A rootston implementation is provided which
* allows relative outputs to be configured,
* makes sure that gaps do not occur when not all configured outputs are connected,
* makes sure that overlaps do not occur when outputs without configuration are connected.

See #550. 

API changes:
- ~~removed wlr_output_layout_move~~
- ~~wlr_output_layout_add_auto: changed behavior, ouputs added through this function do not adjust dynamically anymore.~~

cc @Ongy @Timidger 