### PR TITLE
xdg popup parent is now wlr_xdg_surface

### DIFF
--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -55,7 +55,7 @@ struct wlr_xdg_popup {
 
 	struct wl_resource *resource;
 	bool committed;
-	struct wlr_surface *parent;
+	struct wlr_xdg_surface *parent;
 	struct wlr_seat *seat;
 
 	// Position of the popup relative to the upper left corner of the window

--- a/types/wlr_layer_shell.c
+++ b/types/wlr_layer_shell.c
@@ -141,7 +141,7 @@ static void layer_surface_handle_get_popup(struct wl_client *client,
 
 	assert(popup_surface->role == WLR_XDG_SURFACE_ROLE_POPUP);
 	struct wlr_xdg_popup *popup = popup_surface->popup;
-	popup->parent = parent->surface;
+	popup->parent = wlr_xdg_surface_from_wlr_surface(parent->surface);
 	wl_list_insert(&parent->popups, &popup->link);
 	wlr_signal_emit_safe(&parent->events.new_popup, popup);
 }

--- a/types/xdg_shell/wlr_xdg_popup.c
+++ b/types/xdg_shell/wlr_xdg_popup.c
@@ -252,7 +252,7 @@ void create_xdg_popup(struct wlr_xdg_surface *xdg_surface,
 		wlr_xdg_positioner_get_geometry(&positioner->attrs);
 
 	if (parent) {
-		xdg_surface->popup->parent = parent->surface;
+		xdg_surface->popup->parent = wlr_xdg_surface_from_wlr_surface(parent->surface);
 		wl_list_insert(&parent->popups, &xdg_surface->popup->link);
 		wlr_signal_emit_safe(&parent->events.new_popup, xdg_surface->popup);
 	}
@@ -311,12 +311,11 @@ void wlr_xdg_popup_get_anchor_point(struct wlr_xdg_popup *popup,
 
 void wlr_xdg_popup_get_toplevel_coords(struct wlr_xdg_popup *popup,
 		int popup_sx, int popup_sy, int *toplevel_sx, int *toplevel_sy) {
-	struct wlr_xdg_surface *parent =
-		wlr_xdg_surface_from_wlr_surface(popup->parent);
+	struct wlr_xdg_surface *parent = popup->parent;
 	while (parent != NULL && parent->role == WLR_XDG_SURFACE_ROLE_POPUP) {
 		popup_sx += parent->popup->geometry.x;
 		popup_sy += parent->popup->geometry.y;
-		parent = wlr_xdg_surface_from_wlr_surface(parent->popup->parent);
+		parent = parent->popup->parent;
 	}
 	assert(parent);
 

--- a/types/xdg_shell/wlr_xdg_surface.c
+++ b/types/xdg_shell/wlr_xdg_surface.c
@@ -472,8 +472,7 @@ void wlr_xdg_surface_send_close(struct wlr_xdg_surface *surface) {
 
 static void xdg_popup_get_position(struct wlr_xdg_popup *popup,
 		double *popup_sx, double *popup_sy) {
-	struct wlr_xdg_surface *parent =
-		wlr_xdg_surface_from_wlr_surface(popup->parent);
+	struct wlr_xdg_surface *parent = popup->parent;
 	*popup_sx = parent->geometry.x + popup->geometry.x -
 		popup->base->geometry.x;
 	*popup_sy = parent->geometry.y + popup->geometry.y -


### PR DESCRIPTION
This is to make it the same as the v6 version. If you want the `wlr_surface` it's a field in the `wlr_xdg_surface` so while it's a breaking change it's not hard to get the previous behaviour.