### PR TITLE
Fix double-free in the rotation.c example.

### DIFF
--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -268,6 +268,5 @@ int main(int argc, char *argv[]) {
 	wl_display_run(display);
 
 	wlr_texture_destroy(state.cat_texture);
-	wlr_renderer_destroy(state.renderer);
 	wl_display_destroy(display);
 }


### PR DESCRIPTION
The wl_display_destroy function already destroys the backend's renderer.
Freeing it by hand causes a segmentation fault.