### PR TITLE
Add wlr_surface_get_geometry

### DIFF
--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -159,6 +159,14 @@ void wlr_surface_send_leave(struct wlr_surface *surface,
 void wlr_surface_send_frame_done(struct wlr_surface *surface,
 		const struct timespec *when);
 
+struct wlr_box;
+/**
+ * Get the bounding box that contains the surface and all subsurfaces in
+ * surface coordinates.
+ * X and y may be negative, if there are subsurfaces with negative position.
+ */
+void wlr_surface_get_extends(struct wlr_surface *surface, struct wlr_box *box);
+
 /**
  * Set a callback for surface commit that runs before all the other callbacks.
  * This is intended for use by the surface role.

--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -342,6 +342,15 @@ struct wlr_xdg_surface *wlr_xdg_surface_from_wlr_surface(
 		struct wlr_surface *surface);
 
 /**
+ * Get the surface geometry.
+ * This is either the geometry as set by the client, or defaulted to the bounds
+ * of the surface + the subsurfaces (as specified by the protocol).
+ *
+ * The x and y value can be <0
+ */
+void wlr_xdg_surface_get_geometry(struct wlr_xdg_surface *surface, struct wlr_box *box);
+
+/**
  * Call `iterator` on each surface in the xdg-surface tree, with the surface's
  * position relative to the root xdg-surface. The function is called from root to
  * leaves (in rendering order).

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -319,6 +319,15 @@ struct wlr_xdg_surface_v6 *wlr_xdg_surface_v6_from_wlr_surface(
 		struct wlr_surface *surface);
 
 /**
+ * Get the surface geometry.
+ * This is either the geometry as set by the client, or defaulted to the bounds
+ * of the surface + the subsurfaces (as specified by the protocol).
+ *
+ * The x and y value can be <0
+ */
+void wlr_xdg_surface_v6_get_geometry(struct wlr_xdg_surface_v6 *surface, struct wlr_box *box);
+
+/**
  * Call `iterator` on each surface in the xdg-surface tree, with the surface's
  * position relative to the root xdg-surface. The function is called from root to
  * leaves (in rendering order).

--- a/rootston/xdg_shell.c
+++ b/rootston/xdg_shell.c
@@ -132,14 +132,10 @@ static void get_size(const struct roots_view *view, struct wlr_box *box) {
 	assert(view->type == ROOTS_XDG_SHELL_VIEW);
 	struct wlr_xdg_surface *surface = view->xdg_surface;
 
-	if (surface->geometry.width > 0 && surface->geometry.height > 0) {
-		box->width = surface->geometry.width;
-		box->height = surface->geometry.height;
-	} else {
-		assert(surface->surface);
-		box->width = surface->surface->current->width;
-		box->height = surface->surface->current->height;
-	}
+	struct wlr_box geo_box;
+	wlr_xdg_surface_get_geometry(surface, &geo_box);
+	box->width = geo_box.width;
+	box->height = geo_box.height;
 }
 
 static void activate(struct roots_view *view, bool active) {

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -133,14 +133,10 @@ static void get_size(const struct roots_view *view, struct wlr_box *box) {
 	assert(view->type == ROOTS_XDG_SHELL_V6_VIEW);
 	struct wlr_xdg_surface_v6 *surface = view->xdg_surface_v6;
 
-	if (surface->geometry.width > 0 && surface->geometry.height > 0) {
-		box->width = surface->geometry.width;
-		box->height = surface->geometry.height;
-	} else {
-		assert(surface->surface);
-		box->width = surface->surface->current->width;
-		box->height = surface->surface->current->height;
-	}
+	struct wlr_box geo_box;
+	wlr_xdg_surface_v6_get_geometry(surface, &geo_box);
+	box->width = geo_box.width;
+	box->height = geo_box.height;
 }
 
 static void activate(struct roots_view *view, bool active) {


### PR DESCRIPTION
This function defaults and clips the xdg-surface geometry to the
bounding box of the surface + its subsurfaces, as specified by the
protocol spec.