### PR TITLE
backend/wayland: fix keyboard keys not pressed/released when focus changes

### DIFF
--- a/include/wlr/types/wlr_keyboard.h
+++ b/include/wlr/types/wlr_keyboard.h
@@ -89,7 +89,7 @@ enum wlr_key_state {
 struct wlr_event_keyboard_key {
 	uint32_t time_msec;
 	uint32_t keycode;
-	bool update_state;
+	bool update_state; // if backend doesn't update modifiers on its own
 	enum wlr_key_state state;
 };
 


### PR DESCRIPTION
Test plan: using the Wayland backend, open `weston-eventdemo` in rootston. In the outer compositor, change focus from the rootston window to another window using keybindings, and back. All keys should be released when rootston looses focus, and pressed again when focusing rootston again.

See #1024