### PR TITLE
Remove redundant roots_seat_remove_device function

### DIFF
--- a/include/rootston/seat.h
+++ b/include/rootston/seat.h
@@ -94,9 +94,6 @@ void roots_seat_destroy(struct roots_seat *seat);
 void roots_seat_add_device(struct roots_seat *seat,
 		struct wlr_input_device *device);
 
-void roots_seat_remove_device(struct roots_seat *seat,
-		struct wlr_input_device *device);
-
 void roots_seat_configure_cursor(struct roots_seat *seat);
 
 void roots_seat_configure_xcursor(struct roots_seat *seat);


### PR DESCRIPTION
This function is unimplemented and is redundant because all devices added
with roots_seat_add_device get destruction handlers assigned already.

This fixes #998.