### PR TITLE
seat: allow clients to bind to seat multiple times

### DIFF
--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -13,11 +13,11 @@
  * managed by wlr_seat; some may be NULL.
  */
 struct wlr_seat_client {
-	struct wl_resource *wl_resource;
 	struct wl_client *client;
 	struct wlr_seat *seat;
 
 	// lists of wl_resource
+	struct wl_list wl_resources;
 	struct wl_list pointers;
 	struct wl_list keyboards;
 	struct wl_list touches;

--- a/types/data_device/wlr_drag.c
+++ b/types/data_device/wlr_drag.c
@@ -44,7 +44,7 @@ static void drag_set_focus(struct wlr_drag *drag,
 
 	if (!drag->source &&
 			wl_resource_get_client(surface->resource) !=
-			wl_resource_get_client(drag->seat_client->wl_resource)) {
+			drag->seat_client->client) {
 		return;
 	}
 


### PR DESCRIPTION
This lets clients bind to a seat multiple times by re-using the existing
wlr_seat_client whenever a duplicate request happens.
Previously, an independant wlr_seat_client would be created and only
events from one would be processed.

Fixes #1023.

~~FWIW I'm not 100% happy with the style (new_seat_client bool and the need for a new function in the API, and that function's name), but at least it seems to work.~~
Cc @ongy @Timidger as API changes, even if I didn't need to change anything to rootston/sway, it's just a ~~new helper function~~ change in the `wlr_seat_client` struct