### PR TITLE
wlr_linux_dmabuf: Fix printf conversion specifiers on armhf

### DIFF
--- a/types/wlr_linux_dmabuf.c
+++ b/types/wlr_linux_dmabuf.c
@@ -101,7 +101,8 @@ static void params_add(struct wl_client *client,
 	if (buffer->has_modifier && modifier != buffer->attributes.modifier) {
 		wl_resource_post_error(params_resource,
 			ZWP_LINUX_BUFFER_PARAMS_V1_ERROR_INVALID_FORMAT,
-			"sent modifier %lu for plane %u, expected modifier %lu like other planes",
+			"sent modifier %" PRIu64 " for plane %u, expected"
+			" modifier %" PRIu64 " like other planes",
 			modifier, plane_idx, buffer->attributes.modifier);
 		close(fd);
 		return;


### PR DESCRIPTION
The printf conversion specifiers in a call to wl_resource_post_error
do not specify the type correctly on armhf:

../types/wlr_linux_dmabuf.c: In function 'params_add':
../types/wlr_linux_dmabuf.c:104:21: error: format '%lu' expects argument of type 'long unsigned int', but argument 4 has type 'uint64_t {aka long long unsigned int}' [-Werror=format=]
    "sent modifier %lu for plane %u, expected modifier %lu like other planes",
                   ~~^
                   %llu

To fix this, we use standard printf conversion specifier macros from
inttypes.h.