### PR TITLE
wlr_surface_get_root_surface: walk up parent

### DIFF
--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -956,7 +956,7 @@ struct wlr_surface *wlr_surface_get_root_surface(struct wlr_surface *surface) {
 	while (wlr_surface_is_subsurface(surface)) {
 		struct wlr_subsurface *subsurface =
 			wlr_subsurface_from_surface(surface);
-		surface = subsurface->surface;
+		surface = subsurface->parent;
 	}
 	return surface;
 }


### PR DESCRIPTION
This would dead-loop and never walk up if called on a subsurface.

This came up with firefox, this function would just freeze up everything at some point, if I understand the semantics of `root_surface` correctly it makes more sense to walk up to the parent.