### PR TITLE
drag-icon map and unmap fixes

### DIFF
--- a/include/rootston/seat.h
+++ b/include/rootston/seat.h
@@ -58,7 +58,7 @@ struct roots_drag_icon {
 	double x, y;
 
 	struct wl_listener surface_commit;
-	struct wl_listener map;
+	struct wl_listener unmap;
 	struct wl_listener destroy;
 };
 

--- a/include/rootston/seat.h
+++ b/include/rootston/seat.h
@@ -58,6 +58,7 @@ struct roots_drag_icon {
 	double x, y;
 
 	struct wl_listener surface_commit;
+	struct wl_listener map;
 	struct wl_listener unmap;
 	struct wl_listener destroy;
 };

--- a/include/wlr/types/wlr_data_device.h
+++ b/include/wlr/types/wlr_data_device.h
@@ -88,6 +88,7 @@ struct wlr_drag_icon {
 	int32_t sx, sy;
 
 	struct {
+		struct wl_signal map;
 		struct wl_signal unmap;
 		struct wl_signal destroy;
 	} events;

--- a/include/wlr/types/wlr_data_device.h
+++ b/include/wlr/types/wlr_data_device.h
@@ -88,7 +88,7 @@ struct wlr_drag_icon {
 	int32_t sx, sy;
 
 	struct {
-		struct wl_signal map; // emitted when mapped or unmapped
+		struct wl_signal unmap;
 		struct wl_signal destroy;
 	} events;
 

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -263,10 +263,10 @@ static void roots_drag_icon_handle_surface_commit(struct wl_listener *listener,
 	roots_drag_icon_damage_whole(icon);
 }
 
-static void roots_drag_icon_handle_map(struct wl_listener *listener,
+static void roots_drag_icon_handle_unmap(struct wl_listener *listener,
 		void *data) {
 	struct roots_drag_icon *icon =
-		wl_container_of(listener, icon, map);
+		wl_container_of(listener, icon, unmap);
 	roots_drag_icon_damage_whole(icon);
 }
 
@@ -278,7 +278,7 @@ static void roots_drag_icon_handle_destroy(struct wl_listener *listener,
 
 	wl_list_remove(&icon->link);
 	wl_list_remove(&icon->surface_commit.link);
-	wl_list_remove(&icon->map.link);
+	wl_list_remove(&icon->unmap.link);
 	wl_list_remove(&icon->destroy.link);
 	free(icon);
 }
@@ -297,8 +297,8 @@ static void roots_seat_handle_new_drag_icon(struct wl_listener *listener,
 
 	icon->surface_commit.notify = roots_drag_icon_handle_surface_commit;
 	wl_signal_add(&wlr_drag_icon->surface->events.commit, &icon->surface_commit);
-	icon->map.notify = roots_drag_icon_handle_map;
-	wl_signal_add(&wlr_drag_icon->events.map, &icon->map);
+	icon->unmap.notify = roots_drag_icon_handle_unmap;
+	wl_signal_add(&wlr_drag_icon->events.unmap, &icon->unmap);
 	icon->destroy.notify = roots_drag_icon_handle_destroy;
 	wl_signal_add(&wlr_drag_icon->events.destroy, &icon->destroy);
 

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -263,6 +263,13 @@ static void roots_drag_icon_handle_surface_commit(struct wl_listener *listener,
 	roots_drag_icon_damage_whole(icon);
 }
 
+static void roots_drag_icon_handle_map(struct wl_listener *listener,
+		void *data) {
+	struct roots_drag_icon *icon =
+		wl_container_of(listener, icon, map);
+	roots_drag_icon_damage_whole(icon);
+}
+
 static void roots_drag_icon_handle_unmap(struct wl_listener *listener,
 		void *data) {
 	struct roots_drag_icon *icon =
@@ -299,6 +306,8 @@ static void roots_seat_handle_new_drag_icon(struct wl_listener *listener,
 	wl_signal_add(&wlr_drag_icon->surface->events.commit, &icon->surface_commit);
 	icon->unmap.notify = roots_drag_icon_handle_unmap;
 	wl_signal_add(&wlr_drag_icon->events.unmap, &icon->unmap);
+	icon->map.notify = roots_drag_icon_handle_map;
+	wl_signal_add(&wlr_drag_icon->events.map, &icon->map);
 	icon->destroy.notify = roots_drag_icon_handle_destroy;
 	wl_signal_add(&wlr_drag_icon->events.destroy, &icon->destroy);
 

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -260,6 +260,7 @@ static void roots_drag_icon_handle_surface_commit(struct wl_listener *listener,
 		void *data) {
 	struct roots_drag_icon *icon =
 		wl_container_of(listener, icon, surface_commit);
+	roots_drag_icon_update_position(icon);
 	roots_drag_icon_damage_whole(icon);
 }
 
@@ -312,6 +313,8 @@ static void roots_seat_handle_new_drag_icon(struct wl_listener *listener,
 	wl_signal_add(&wlr_drag_icon->events.destroy, &icon->destroy);
 
 	wl_list_insert(&seat->drag_icons, &icon->link);
+
+	roots_drag_icon_update_position(icon);
 }
 
 void roots_drag_icon_update_position(struct roots_drag_icon *icon) {

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -261,7 +261,6 @@ static void roots_drag_icon_handle_surface_commit(struct wl_listener *listener,
 	struct roots_drag_icon *icon =
 		wl_container_of(listener, icon, surface_commit);
 	roots_drag_icon_update_position(icon);
-	roots_drag_icon_damage_whole(icon);
 }
 
 static void roots_drag_icon_handle_map(struct wl_listener *listener,

--- a/types/data_device/wlr_drag.c
+++ b/types/data_device/wlr_drag.c
@@ -100,12 +100,12 @@ static void drag_set_focus(struct wlr_drag *drag,
 
 static void drag_icon_set_mapped(struct wlr_drag_icon *icon, bool mapped) {
 	if (mapped && !icon->mapped) {
+		icon->mapped = true;
 		wlr_signal_emit_safe(&icon->events.map, icon);
 	} else if (!mapped && icon->mapped) {
+		icon->mapped = false;
 		wlr_signal_emit_safe(&icon->events.unmap, icon);
 	}
-
-	icon->mapped = mapped;
 }
 
 static void drag_end(struct wlr_drag *drag) {

--- a/types/data_device/wlr_drag.c
+++ b/types/data_device/wlr_drag.c
@@ -98,6 +98,16 @@ static void drag_set_focus(struct wlr_drag *drag,
 	wlr_signal_emit_safe(&drag->events.focus, drag);
 }
 
+static void drag_icon_set_mapped(struct wlr_drag_icon *icon, bool mapped) {
+	if (mapped && !icon->mapped) {
+		wlr_signal_emit_safe(&icon->events.map, icon);
+	} else if (!mapped && icon->mapped) {
+		wlr_signal_emit_safe(&icon->events.unmap, icon);
+	}
+
+	icon->mapped = mapped;
+}
+
 static void drag_end(struct wlr_drag *drag) {
 	if (!drag->cancelling) {
 		drag->cancelling = true;
@@ -115,9 +125,8 @@ static void drag_end(struct wlr_drag *drag) {
 		drag_set_focus(drag, NULL, 0, 0);
 
 		if (drag->icon) {
-			drag->icon->mapped = false;
 			wl_list_remove(&drag->icon_destroy.link);
-			wlr_signal_emit_safe(&drag->icon->events.unmap, drag->icon);
+			drag_icon_set_mapped(drag->icon, false);
 		}
 
 		wlr_signal_emit_safe(&drag->events.destroy, drag);
@@ -310,9 +319,10 @@ static void drag_handle_drag_source_destroy(struct wl_listener *listener,
 
 
 static void drag_icon_destroy(struct wlr_drag_icon *icon) {
-	if (!icon) {
+	if (icon == NULL) {
 		return;
 	}
+	drag_icon_set_mapped(icon, false);
 	wlr_signal_emit_safe(&icon->events.destroy, icon);
 	wlr_surface_set_role_committed(icon->surface, NULL, NULL);
 	wl_list_remove(&icon->surface_destroy.link);
@@ -333,6 +343,8 @@ static void drag_icon_handle_surface_commit(struct wlr_surface *surface,
 	struct wlr_drag_icon *icon = role_data;
 	icon->sx += icon->surface->current->sx;
 	icon->sy += icon->surface->current->sy;
+
+	drag_icon_set_mapped(icon, wlr_surface_has_buffer(surface));
 }
 
 static void drag_icon_handle_seat_client_destroy(struct wl_listener *listener,
@@ -355,8 +367,8 @@ static struct wlr_drag_icon *drag_icon_create(
 	icon->client = client;
 	icon->is_pointer = is_pointer;
 	icon->touch_id = touch_id;
-	icon->mapped = true;
 
+	wl_signal_init(&icon->events.map);
 	wl_signal_init(&icon->events.unmap);
 	wl_signal_init(&icon->events.destroy);
 
@@ -371,6 +383,10 @@ static struct wlr_drag_icon *drag_icon_create(
 
 	wl_list_insert(&client->seat->drag_icons, &icon->link);
 	wlr_signal_emit_safe(&client->seat->events.new_drag_icon, icon);
+
+	if (wlr_surface_has_buffer(icon_surface)) {
+		drag_icon_set_mapped(icon, true);
+	}
 
 	return icon;
 }

--- a/types/data_device/wlr_drag.c
+++ b/types/data_device/wlr_drag.c
@@ -117,7 +117,7 @@ static void drag_end(struct wlr_drag *drag) {
 		if (drag->icon) {
 			drag->icon->mapped = false;
 			wl_list_remove(&drag->icon_destroy.link);
-			wlr_signal_emit_safe(&drag->icon->events.map, drag->icon);
+			wlr_signal_emit_safe(&drag->icon->events.unmap, drag->icon);
 		}
 
 		wlr_signal_emit_safe(&drag->events.destroy, drag);
@@ -357,7 +357,7 @@ static struct wlr_drag_icon *drag_icon_create(
 	icon->touch_id = touch_id;
 	icon->mapped = true;
 
-	wl_signal_init(&icon->events.map);
+	wl_signal_init(&icon->events.unmap);
 	wl_signal_init(&icon->events.destroy);
 
 	wl_signal_add(&icon->surface->events.destroy, &icon->surface_destroy);


### PR DESCRIPTION
The event is only emitted on unmap, so I renamed it to `unmap`. I don't like the old approach of emitting both map/unmap on the same event because it's inconsistent with the shell behavior. (I wrote this code and it just confused me).

Do we want to have a `map` event? We used to have one, right?

Reviewing to see if we need to `unmap` in other places.