### PR TITLE
box: fix wlr_box_intersection

### DIFF
--- a/types/wlr_box.c
+++ b/types/wlr_box.c
@@ -46,8 +46,8 @@ bool wlr_box_intersection(const struct wlr_box *box_a,
 
 	int x1 = fmax(box_a->x, box_b->x);
 	int y1 = fmax(box_a->y, box_b->y);
-	int x2 = fmin(box_a->x + box_a->width - 1, box_b->x + box_b->width - 1);
-	int y2 = fmin(box_a->y + box_a->height - 1, box_b->y + box_b->height - 1);
+	int x2 = fmin(box_a->x + box_a->width, box_b->x + box_b->width);
+	int y2 = fmin(box_a->y + box_a->height, box_b->y + box_b->height);
 
 	dest->x = x1;
 	dest->y = y1;


### PR DESCRIPTION
`x2` and `y2` were computed as inclusive bounds, and then the size was computed with a subtraction on inclusive bounds. To compute a size you need to do a subtraction between an inclusive bound and an exclusive bound. This PR changes `x2` and `y2` to be exclusive bounds instead.

Fixes https://github.com/swaywm/wlroots/issues/1042