### PR TITLE
xdg-shells: add a set_parent signal to toplevel surfaces

### DIFF
--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -118,6 +118,7 @@ struct wlr_xdg_toplevel {
 		struct wl_signal request_move;
 		struct wl_signal request_resize;
 		struct wl_signal request_show_window_menu;
+		struct wl_signal set_parent;
 	} events;
 };
 

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -126,6 +126,7 @@ struct wlr_xdg_toplevel_v6 {
 		struct wl_signal request_move;
 		struct wl_signal request_resize;
 		struct wl_signal request_show_window_menu;
+		struct wl_signal set_parent;
 	} events;
 };
 

--- a/types/xdg_shell/wlr_xdg_toplevel.c
+++ b/types/xdg_shell/wlr_xdg_toplevel.c
@@ -218,6 +218,7 @@ static void xdg_toplevel_handle_set_parent(struct wl_client *client,
 	}
 
 	surface->toplevel->parent = parent;
+	wlr_signal_emit_safe(&surface->toplevel->events.set_parent, surface);
 }
 
 static void xdg_toplevel_handle_set_title(struct wl_client *client,
@@ -464,6 +465,7 @@ void create_xdg_toplevel(struct wlr_xdg_surface *xdg_surface,
 	wl_signal_init(&xdg_surface->toplevel->events.request_move);
 	wl_signal_init(&xdg_surface->toplevel->events.request_resize);
 	wl_signal_init(&xdg_surface->toplevel->events.request_show_window_menu);
+	wl_signal_init(&xdg_surface->toplevel->events.set_parent);
 
 	xdg_surface->role = WLR_XDG_SURFACE_ROLE_TOPLEVEL;
 	xdg_surface->toplevel->base = xdg_surface;

--- a/types/xdg_shell_v6/wlr_xdg_toplevel_v6.c
+++ b/types/xdg_shell_v6/wlr_xdg_toplevel_v6.c
@@ -42,6 +42,7 @@ static void xdg_toplevel_handle_set_parent(struct wl_client *client,
 	}
 
 	surface->toplevel->parent = parent;
+	wlr_signal_emit_safe(&surface->toplevel->events.set_parent, surface);
 }
 
 static void xdg_toplevel_handle_set_title(struct wl_client *client,
@@ -434,6 +435,7 @@ void create_xdg_toplevel_v6(struct wlr_xdg_surface_v6 *xdg_surface,
 	wl_signal_init(&xdg_surface->toplevel->events.request_move);
 	wl_signal_init(&xdg_surface->toplevel->events.request_resize);
 	wl_signal_init(&xdg_surface->toplevel->events.request_show_window_menu);
+	wl_signal_init(&xdg_surface->toplevel->events.set_parent);
 
 	xdg_surface->role = WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL;
 	xdg_surface->toplevel->base = xdg_surface;


### PR DESCRIPTION
Can be used in sway for auto-floating dialogues and similar and to properly position such transient windows relative to their parent.
