### PR TITLE
Fix GLES2 renderer to use glGetUniformLocations locations

### DIFF
--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -32,11 +32,37 @@ struct wlr_gles2_renderer {
 	const char *exts_str;
 
 	struct {
-		GLuint quad;
-		GLuint ellipse;
-		GLuint tex_rgba;
-		GLuint tex_rgbx;
-		GLuint tex_ext;
+		struct {
+			GLuint program;
+			GLint proj;
+			GLint color;
+		} quad;
+		struct {
+			GLuint program;
+			GLint proj;
+			GLint color;
+		} ellipse;
+		struct {
+			GLuint program;
+			GLint proj;
+			GLint invert_y;
+			GLint tex;
+			GLint alpha;
+		} tex_rgba;
+		struct  {
+			GLuint program;
+			GLint proj;
+			GLint invert_y;
+			GLint tex;
+			GLint alpha;
+		} tex_rgbx;
+		struct  {
+			GLuint program;
+			GLint proj;
+			GLint invert_y;
+			GLint tex;
+			GLint alpha;
+		} tex_ext;
 	} shaders;
 
 	uint32_t viewport_width, viewport_height;

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -25,6 +25,14 @@ struct wlr_gles2_pixel_format {
 	bool has_alpha;
 };
 
+struct wlr_gles2_tex_shader {
+	GLuint program;
+	GLint proj;
+	GLint invert_y;
+	GLint tex;
+	GLint alpha;
+};
+
 struct wlr_gles2_renderer {
 	struct wlr_renderer wlr_renderer;
 
@@ -42,27 +50,9 @@ struct wlr_gles2_renderer {
 			GLint proj;
 			GLint color;
 		} ellipse;
-		struct {
-			GLuint program;
-			GLint proj;
-			GLint invert_y;
-			GLint tex;
-			GLint alpha;
-		} tex_rgba;
-		struct  {
-			GLuint program;
-			GLint proj;
-			GLint invert_y;
-			GLint tex;
-			GLint alpha;
-		} tex_rgbx;
-		struct  {
-			GLuint program;
-			GLint proj;
-			GLint invert_y;
-			GLint tex;
-			GLint alpha;
-		} tex_ext;
+		struct wlr_gles2_tex_shader tex_rgba;
+		struct wlr_gles2_tex_shader tex_rgbx;
+		struct wlr_gles2_tex_shader tex_ext;
 	} shaders;
 
 	uint32_t viewport_width, viewport_height;

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -118,38 +118,22 @@ static bool gles2_render_texture_with_matrix(struct wlr_renderer *wlr_renderer,
 	struct wlr_gles2_texture *texture =
 		get_gles2_texture_in_context(wlr_texture);
 
-	GLuint prog = 0;
+	struct wlr_gles2_tex_shader *shader = NULL;
 	GLenum target = 0;
-	GLint proj_loc = 0;
-	GLint invert_y_loc = 0;
-	GLint tex_loc = 0;
-	GLint alpha_loc = 0;
 
 	switch (texture->type) {
 	case WLR_GLES2_TEXTURE_GLTEX:
 	case WLR_GLES2_TEXTURE_WL_DRM_GL:
 		if (texture->has_alpha) {
-			prog = renderer->shaders.tex_rgba.program;
-			proj_loc = renderer->shaders.tex_rgba.proj;
-			invert_y_loc = renderer->shaders.tex_rgba.invert_y;
-			tex_loc = renderer->shaders.tex_rgba.tex;
-			alpha_loc = renderer->shaders.tex_rgba.alpha;
+			shader = &renderer->shaders.tex_rgba;
 		} else {
-			prog = renderer->shaders.tex_rgbx.program;
-			proj_loc = renderer->shaders.tex_rgbx.proj;
-			invert_y_loc = renderer->shaders.tex_rgbx.invert_y;
-			tex_loc = renderer->shaders.tex_rgbx.tex;
-			alpha_loc = renderer->shaders.tex_rgbx.alpha;
+			shader = &renderer->shaders.tex_rgbx;
 		}
 		target = GL_TEXTURE_2D;
 		break;
 	case WLR_GLES2_TEXTURE_WL_DRM_EXT:
 	case WLR_GLES2_TEXTURE_DMABUF:
-		prog = renderer->shaders.tex_ext.program;
-		proj_loc = renderer->shaders.tex_ext.proj;
-		invert_y_loc = renderer->shaders.tex_ext.invert_y;
-		tex_loc = renderer->shaders.tex_ext.tex;
-		alpha_loc = renderer->shaders.tex_ext.alpha;
+		shader = &renderer->shaders.tex_ext;
 		target = GL_TEXTURE_EXTERNAL_OES;
 		break;
 	}
@@ -169,12 +153,12 @@ static bool gles2_render_texture_with_matrix(struct wlr_renderer *wlr_renderer,
 	glTexParameteri(target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 	glTexParameteri(target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
-	glUseProgram(prog);
+	glUseProgram(shader->program);
 
-	glUniformMatrix3fv(proj_loc, 1, GL_FALSE, transposition);
-	glUniform1i(invert_y_loc, texture->inverted_y);
-	glUniform1f(alpha_loc, alpha);
-	glUniform1i(tex_loc, 0);
+	glUniformMatrix3fv(shader->proj, 1, GL_FALSE, transposition);
+	glUniform1i(shader->invert_y, texture->inverted_y);
+	glUniform1i(shader->tex, 0);
+	glUniform1f(shader->alpha, alpha);
 
 	draw_quad();
 


### PR DESCRIPTION
This is needed as uniform locations are driver implementation-specific and glGetUniformLocation should be normally used according to OpenGL (ES) specification.

I tested this to work on Gemini PDA with Mali graphics proprietary driver and custom hwcomposer backend.