### PR TITLE
surface: don't release wl_drm and linux-dmabuf buffers early

### DIFF
--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -394,6 +394,10 @@ static void surface_apply_damage(struct wlr_surface *surface,
 		}
 
 		wl_shm_buffer_end_access(buf);
+
+		// We've uploaded the wl_shm_buffer data to the GPU, we won't access the
+		// wl_buffer anymore
+		surface_state_release_buffer(surface->current);
 	} else if (invalid_buffer || reupload_buffer) {
 		wlr_texture_destroy(surface->texture);
 
@@ -409,9 +413,10 @@ static void surface_apply_damage(struct wlr_surface *surface,
 			surface->texture = NULL;
 			wlr_log(L_ERROR, "Unknown buffer handle attached");
 		}
-	}
 
-	surface_state_release_buffer(surface->current);
+		// Don't release the wl_buffer yet: since the texture is shared with the
+		// client, we'll access the wl_buffer when rendering
+	}
 }
 
 static void surface_commit_pending(struct wlr_surface *surface) {


### PR DESCRIPTION
For wl_drm and linux-dmabuf buffers, release now happens in `surface_move_state`.

Test plan: start mpv with `WAYLAND_DEBUG=1`.

Background: https://github.com/swaywm/wlroots/issues/1046#issuecomment-395433065