### PR TITLE
rootston: destroy xwayland before all clients

### DIFF
--- a/rootston/main.c
+++ b/rootston/main.c
@@ -72,6 +72,9 @@ int main(int argc, char **argv) {
 	}
 
 	wl_display_run(server.wl_display);
+#ifdef WLR_HAS_XWAYLAND
+	wlr_xwayland_destroy(server.desktop->xwayland);
+#endif
 	wl_display_destroy_clients(server.wl_display);
 	wl_display_destroy(server.wl_display);
 	return 0;


### PR DESCRIPTION
Destroying all clients disconnects the xwayland client, and
xwayland automatically restarts when disconnected.

Fixes #1026