### PR TITLE
Introduce wlr_buffer

### DIFF
--- a/include/wlr/types/wlr_buffer.h
+++ b/include/wlr/types/wlr_buffer.h
@@ -1,0 +1,36 @@
+#ifndef WLR_TYPES_WLR_BUFFER_H
+#define WLR_TYPES_WLR_BUFFER_H
+
+#include <pixman.h>
+#include <wayland-server.h>
+
+struct wlr_buffer {
+	struct wl_resource *resource;
+	struct wlr_texture *texture;
+	bool released;
+	size_t n_refs;
+
+	struct wl_listener resource_destroy;
+};
+
+struct wlr_renderer;
+
+// Checks if a resource is a wl_buffer.
+bool wlr_resource_is_buffer(struct wl_resource *resource);
+// Returns the buffer size.
+bool wlr_buffer_get_resource_size(struct wl_resource *resource,
+	struct wlr_renderer *renderer, int *width, int *height);
+
+// Uploads the texture to the GPU and references it.
+struct wlr_buffer *wlr_buffer_create(struct wlr_renderer *renderer,
+	struct wl_resource *resource);
+// References and unreferences the buffer.
+void wlr_buffer_ref(struct wlr_buffer *buffer);
+void wlr_buffer_unref(struct wlr_buffer *buffer);
+// Tries to update the texture in the provided buffer. This destroys `buffer`
+// and returns a new buffer.
+// Fails if `buffer->n_refs` > 1 or if the texture isn't mutable.
+struct wlr_buffer *wlr_buffer_apply_damage(struct wlr_buffer *buffer,
+	struct wl_resource *resource, pixman_region32_t *damage);
+
+#endif

--- a/include/wlr/types/wlr_buffer.h
+++ b/include/wlr/types/wlr_buffer.h
@@ -36,7 +36,7 @@ struct wlr_buffer *wlr_buffer_create(struct wlr_renderer *renderer,
 /**
  * Reference the buffer.
  */
-void wlr_buffer_ref(struct wlr_buffer *buffer);
+struct wlr_buffer *wlr_buffer_ref(struct wlr_buffer *buffer);
 /**
  * Unreference the buffer. After this call, `buffer` may not be accessed
  * anymore.

--- a/include/wlr/types/wlr_buffer.h
+++ b/include/wlr/types/wlr_buffer.h
@@ -4,9 +4,12 @@
 #include <pixman.h>
 #include <wayland-server.h>
 
+/**
+ * A client buffer.
+ */
 struct wlr_buffer {
-	struct wl_resource *resource;
-	struct wlr_texture *texture;
+	struct wl_resource *resource; // can be NULL
+	struct wlr_texture *texture; // can be NULL
 	bool released;
 	size_t n_refs;
 
@@ -15,21 +18,38 @@ struct wlr_buffer {
 
 struct wlr_renderer;
 
-// Checks if a resource is a wl_buffer.
+/**
+ * Check if a resource is a wl_buffer resource.
+ */
 bool wlr_resource_is_buffer(struct wl_resource *resource);
-// Returns the buffer size.
+/**
+ * Get the size of a wl_buffer resource.
+ */
 bool wlr_buffer_get_resource_size(struct wl_resource *resource,
 	struct wlr_renderer *renderer, int *width, int *height);
 
-// Uploads the texture to the GPU and references it.
+/**
+ * Upload a buffer to the GPU and reference it.
+ */
 struct wlr_buffer *wlr_buffer_create(struct wlr_renderer *renderer,
 	struct wl_resource *resource);
-// References and unreferences the buffer.
+/**
+ * Reference the buffer.
+ */
 void wlr_buffer_ref(struct wlr_buffer *buffer);
+/**
+ * Unreference the buffer. After this call, `buffer` may not be accessed
+ * anymore.
+ */
 void wlr_buffer_unref(struct wlr_buffer *buffer);
-// Tries to update the texture in the provided buffer. This destroys `buffer`
-// and returns a new buffer.
-// Fails if `buffer->n_refs` > 1 or if the texture isn't mutable.
+/**
+ * Try to update the buffer's content. On success, returns the updated buffer
+ * and destroys the provided `buffer`. On error, `buffer` is intact and NULL is
+ * returned.
+ *
+ * Fails if there's more than one reference to the buffer or if the texture
+ * isn't mutable.
+ */
 struct wlr_buffer *wlr_buffer_apply_damage(struct wlr_buffer *buffer,
 	struct wl_resource *resource, pixman_region32_t *damage);
 

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -69,6 +69,7 @@ struct wlr_subsurface {
 struct wlr_surface {
 	struct wl_resource *resource;
 	struct wlr_renderer *renderer;
+	struct wlr_buffer *buffer;
 	struct wlr_texture *texture;
 	struct wlr_surface_state *current, *pending;
 	const char *role; // the lifetime-bound role or null

--- a/types/meson.build
+++ b/types/meson.build
@@ -20,6 +20,7 @@ lib_wlr_types = static_library(
 		'xdg_shell_v6/wlr_xdg_surface_v6.c',
 		'xdg_shell_v6/wlr_xdg_toplevel_v6.c',
 		'wlr_box.c',
+		'wlr_buffer.c',
 		'wlr_compositor.c',
 		'wlr_cursor.c',
 		'wlr_gamma_control.c',

--- a/types/wlr_buffer.c
+++ b/types/wlr_buffer.c
@@ -105,8 +105,9 @@ struct wlr_buffer *wlr_buffer_create(struct wlr_renderer *renderer,
 	return buffer;
 }
 
-void wlr_buffer_ref(struct wlr_buffer *buffer) {
+struct wlr_buffer *wlr_buffer_ref(struct wlr_buffer *buffer) {
 	buffer->n_refs++;
+	return buffer;
 }
 
 void wlr_buffer_unref(struct wlr_buffer *buffer) {

--- a/types/wlr_buffer.c
+++ b/types/wlr_buffer.c
@@ -1,0 +1,186 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <wlr/types/wlr_buffer.h>
+#include <wlr/types/wlr_linux_dmabuf.h>
+#include <wlr/render/wlr_renderer.h>
+#include <wlr/util/log.h>
+
+bool wlr_resource_is_buffer(struct wl_resource *resource) {
+	return strcmp(wl_resource_get_class(resource), wl_buffer_interface.name) == 0;
+}
+
+bool wlr_buffer_get_resource_size(struct wl_resource *resource,
+		struct wlr_renderer *renderer, int *width, int *height) {
+	assert(wlr_resource_is_buffer(resource));
+
+	struct wl_shm_buffer *shm_buf = wl_shm_buffer_get(resource);
+	if (shm_buf != NULL) {
+		*width = wl_shm_buffer_get_width(shm_buf);
+		*height = wl_shm_buffer_get_height(shm_buf);
+	} else if (wlr_renderer_resource_is_wl_drm_buffer(renderer,
+			resource)) {
+		wlr_renderer_wl_drm_buffer_get_size(renderer, resource,
+			width, height);
+	} else if (wlr_dmabuf_resource_is_buffer(resource)) {
+		struct wlr_dmabuf_buffer *dmabuf =
+			wlr_dmabuf_buffer_from_buffer_resource(resource);
+		*width = dmabuf->attributes.width;
+		*height = dmabuf->attributes.height;
+	} else {
+		*width = *height = 0;
+		return false;
+	}
+
+	return true;
+}
+
+
+static void buffer_resource_handle_destroy(struct wl_listener *listener,
+		void *data) {
+	struct wlr_buffer *buffer =
+		wl_container_of(listener, buffer, resource_destroy);
+	wl_list_remove(&buffer->resource_destroy.link);
+	wl_list_init(&buffer->resource_destroy.link);
+	buffer->resource = NULL;
+
+	if (!buffer->released) {
+		// The texture becomes invalid
+		wlr_texture_destroy(buffer->texture);
+		buffer->texture = NULL;
+	}
+}
+
+struct wlr_buffer *wlr_buffer_create(struct wlr_renderer *renderer,
+		struct wl_resource *resource) {
+	assert(wlr_resource_is_buffer(resource));
+
+	struct wlr_texture *texture = NULL;
+	bool released = false;
+
+	struct wl_shm_buffer *shm_buf = wl_shm_buffer_get(resource);
+	if (shm_buf != NULL) {
+		enum wl_shm_format fmt = wl_shm_buffer_get_format(shm_buf);
+		int32_t stride = wl_shm_buffer_get_stride(shm_buf);
+		int32_t width = wl_shm_buffer_get_width(shm_buf);
+		int32_t height = wl_shm_buffer_get_height(shm_buf);
+
+		wl_shm_buffer_begin_access(shm_buf);
+		void *data = wl_shm_buffer_get_data(shm_buf);
+		texture = wlr_texture_from_pixels(renderer, fmt, stride,
+			width, height, data);
+		wl_shm_buffer_end_access(shm_buf);
+
+		// We have uploaded the data, we don't need to access the wl_buffer
+		// anymore
+		wl_buffer_send_release(resource);
+		released = true;
+	} else if (wlr_renderer_resource_is_wl_drm_buffer(renderer, resource)) {
+		texture = wlr_texture_from_wl_drm(renderer, resource);
+	} else if (wlr_dmabuf_resource_is_buffer(resource)) {
+		struct wlr_dmabuf_buffer *dmabuf =
+			wlr_dmabuf_buffer_from_buffer_resource(resource);
+		texture = wlr_texture_from_dmabuf(renderer, &dmabuf->attributes);
+	} else {
+		wlr_log(L_ERROR, "Cannot upload texture: unknown buffer type");
+		return NULL;
+	}
+
+	if (texture == NULL) {
+		wlr_log(L_ERROR, "Failed to upload texture");
+		return NULL;
+	}
+
+	struct wlr_buffer *buffer = calloc(1, sizeof(struct wlr_buffer));
+	if (buffer == NULL) {
+		return NULL;
+	}
+	buffer->resource = resource;
+	buffer->texture = texture;
+	buffer->released = released;
+	buffer->n_refs = 1;
+
+	wl_resource_add_destroy_listener(resource, &buffer->resource_destroy);
+	buffer->resource_destroy.notify = buffer_resource_handle_destroy;
+
+	return buffer;
+}
+
+void wlr_buffer_ref(struct wlr_buffer *buffer) {
+	buffer->n_refs++;
+}
+
+void wlr_buffer_unref(struct wlr_buffer *buffer) {
+	if (buffer == NULL) {
+		return;
+	}
+
+	assert(buffer->n_refs > 0);
+	buffer->n_refs--;
+	if (buffer->n_refs > 0) {
+		return;
+	}
+
+	if (!buffer->released && buffer->resource != NULL) {
+		wl_buffer_send_release(buffer->resource);
+	}
+
+	wl_list_remove(&buffer->resource_destroy.link);
+	wlr_texture_destroy(buffer->texture);
+	free(buffer);
+}
+
+struct wlr_buffer *wlr_buffer_apply_damage(struct wlr_buffer *buffer,
+		struct wl_resource *resource, pixman_region32_t *damage) {
+	assert(wlr_resource_is_buffer(resource));
+
+	if (buffer->n_refs > 1) {
+		// Someone else still has a reference to the buffer
+		return NULL;
+	}
+
+	struct wl_shm_buffer *shm_buf = wl_shm_buffer_get(resource);
+	if (shm_buf == NULL) {
+		// Uploading only damaged regions only works for wl_shm buffers
+		return NULL;
+	}
+
+	enum wl_shm_format fmt = wl_shm_buffer_get_format(shm_buf);
+	int32_t stride = wl_shm_buffer_get_stride(shm_buf);
+	int32_t width = wl_shm_buffer_get_width(shm_buf);
+	int32_t height = wl_shm_buffer_get_height(shm_buf);
+
+	int32_t texture_width, texture_height;
+	wlr_texture_get_size(buffer->texture, &texture_width, &texture_height);
+	if (width != texture_width || height != texture_height) {
+		return NULL;
+	}
+
+	wl_shm_buffer_begin_access(shm_buf);
+	void *data = wl_shm_buffer_get_data(shm_buf);
+
+	int n;
+	pixman_box32_t *rects = pixman_region32_rectangles(damage, &n);
+	for (int i = 0; i < n; ++i) {
+		pixman_box32_t *r = &rects[i];
+		if (!wlr_texture_write_pixels(buffer->texture, fmt, stride,
+				r->x2 - r->x1, r->y2 - r->y1, r->x1, r->y1,
+				r->x1, r->y1, data)) {
+			wl_shm_buffer_end_access(shm_buf);
+			return NULL;
+		}
+	}
+
+	wl_shm_buffer_end_access(shm_buf);
+
+	// We have uploaded the data, we don't need to access the wl_buffer
+	// anymore
+	wl_buffer_send_release(resource);
+
+	wl_list_remove(&buffer->resource_destroy.link);
+	wl_resource_add_destroy_listener(resource, &buffer->resource_destroy);
+	buffer->resource_destroy.notify = buffer_resource_handle_destroy;
+
+	buffer->resource = resource;
+	buffer->released = true;
+	return buffer;
+}


### PR DESCRIPTION
This PR introduces `wlr_buffer`, as discussed in https://github.com/swaywm/wlroots/issues/1046#issuecomment-395679806.

`wlr_buffer`s are ref-counted and hold a texture. When they are destroyed, the `wl_buffer` is released and the texture is destroyed.

A compositor can reference the buffer when it needs to:

```c
struct wlr_buffer *buffer = wlr_buffer_ref(surface->buffer);

// Use buffer->texture (can be NULL if client destroys the buffer)

wlr_buffer_unref(buffer);
```

@ammen99 Can you provide some feedback? Would this approach work for you?

- [ ] We probably want to get rid of `wlr_surface.texture`
- [ ] Listen for renderer destroy

Fixes #1046