### PR TITLE
Fix atti assert in wlr_egl_init

### DIFF
--- a/render/egl.c
+++ b/render/egl.c
@@ -190,7 +190,7 @@ bool wlr_egl_init(struct wlr_egl *egl, EGLenum platform, void *remote_display,
 	}
 
 	attribs[atti++] = EGL_NONE;
-	assert(atti < sizeof(attribs)/sizeof(attribs[0]));
+	assert(atti <= sizeof(attribs)/sizeof(attribs[0]));
 
 	egl->context = eglCreateContext(egl->display, egl->config,
 		EGL_NO_CONTEXT, attribs);


### PR DESCRIPTION
If `request_high_priority` is `true`, then `atti` will be `5` in the assert. Since `5` is not less than `5` (`sizeof(attribs)/sizeof(attribs[0])`), the assert fails and sway does not start.

This changes the assert to be less than or equal to.