### PR TITLE
Split eglSwapBuffersWithDamage feature detection

### DIFF
--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -16,12 +16,12 @@ struct wlr_egl {
 	const char *exts_str;
 
 	struct {
-		bool bind_wayland_display;
-		bool buffer_age;
-		bool dmabuf_import_modifiers;
-		bool dmabuf_import;
-		bool image_base;
-		bool swap_buffers_with_damage;
+		bool bind_wayland_display_wl;
+		bool buffer_age_ext;
+		bool image_dmabuf_import_modifiers_ext;
+		bool image_dmabuf_import_ext;
+		bool image_base_khr;
+		bool swap_buffers_with_damage_ext;
 		bool swap_buffers_with_damage_khr;
 	} exts;
 

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -22,6 +22,7 @@ struct wlr_egl {
 		bool dmabuf_import;
 		bool image_base;
 		bool swap_buffers_with_damage;
+		bool swap_buffers_with_damage_khr;
 	} exts;
 
 	struct wl_display *wl_display;

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -210,7 +210,7 @@ struct wlr_texture *wlr_gles2_texture_from_dmabuf(struct wlr_egl *egl,
 		return NULL;
 	}
 
-	if (!egl->exts.dmabuf_import) {
+	if (!egl->exts.image_dmabuf_import_ext) {
 		wlr_log(L_ERROR, "Cannot create DMA-BUF texture: EGL extension "
 			"unavailable");
 		return NULL;


### PR DESCRIPTION
Detecting whether` eglSwapBuffersWithDamageEXT` or `eglSwapBuffersWithDamageKHR` is used should be based on the extension string, not only on the availability of the function.