### PR TITLE
surface: remove wlr_surface.texture

### DIFF
--- a/include/wlr/types/wlr_buffer.h
+++ b/include/wlr/types/wlr_buffer.h
@@ -8,8 +8,15 @@
  * A client buffer.
  */
 struct wlr_buffer {
-	struct wl_resource *resource; // can be NULL
-	struct wlr_texture *texture; // can be NULL
+	/**
+	 * The buffer resource, if any. Will be NULL if the client destroys it.
+	 */
+	struct wl_resource *resource;
+	/**
+	 * The buffer's texture, if any. A buffer will not have a texture if the
+	 * client destroys the buffer before it has been released.
+	 */
+	struct wlr_texture *texture;
 	bool released;
 	size_t n_refs;
 

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -69,8 +69,13 @@ struct wlr_subsurface {
 struct wlr_surface {
 	struct wl_resource *resource;
 	struct wlr_renderer *renderer;
+	/**
+	 * The surface's buffer, if any. A surface has an attached buffer when it
+	 * commits with a non-null buffer in its pending state. A surface will not
+	 * have a buffer if it has never committed one, has committed a null buffer,
+	 * or something went wrong with uploading the buffer.
+	 */
 	struct wlr_buffer *buffer;
-	struct wlr_texture *texture;
 	struct wlr_surface_state *current, *pending;
 	const char *role; // the lifetime-bound role or null
 
@@ -124,6 +129,13 @@ int wlr_surface_set_role(struct wlr_surface *surface, const char *role,
  * committed a null buffer, or something went wrong with uploading the buffer.
  */
 bool wlr_surface_has_buffer(struct wlr_surface *surface);
+
+/**
+ * Get the texture of the buffer currently attached to this surface. Returns
+ * NULL if no buffer is currently attached or if something went wrong with
+ * uploading the buffer.
+ */
+struct wlr_texture *wlr_surface_get_texture(struct wlr_surface *surface);
 
 /**
  * Create a new subsurface resource with the provided new ID. If `resource_list`

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -189,7 +189,8 @@ static void render_surface(struct wlr_surface *surface, int sx, int sy,
 	struct roots_output *output = data->output;
 	float rotation = data->layout.rotation;
 
-	if (!wlr_surface_has_buffer(surface)) {
+	struct wlr_texture *texture = wlr_surface_get_texture(surface);
+	if (texture == NULL) {
 		return;
 	}
 
@@ -230,8 +231,7 @@ static void render_surface(struct wlr_surface *surface, int sx, int sy,
 	pixman_box32_t *rects = pixman_region32_rectangles(&damage, &nrects);
 	for (int i = 0; i < nrects; ++i) {
 		scissor_output(output, &rects[i]);
-		wlr_render_texture_with_matrix(renderer, surface->texture, matrix,
-			data->alpha);
+		wlr_render_texture_with_matrix(renderer, texture, matrix, data->alpha);
 	}
 
 damage_finish:

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -367,7 +367,8 @@ static void output_fullscreen_surface_render(struct wlr_output *output,
 	struct wlr_renderer *renderer = wlr_backend_get_renderer(output->backend);
 	assert(renderer);
 
-	if (!wlr_surface_has_buffer(surface)) {
+	struct wlr_texture *texture = wlr_surface_get_texture(surface);
+	if (texture == NULL) {
 		wlr_renderer_clear(renderer, (float[]){0, 0, 0, 1});
 		return;
 	}
@@ -386,8 +387,7 @@ static void output_fullscreen_surface_render(struct wlr_output *output,
 	for (int i = 0; i < nrects; ++i) {
 		output_scissor(output, &rects[i]);
 		wlr_renderer_clear(renderer, (float[]){0, 0, 0, 1});
-		wlr_render_texture_with_matrix(surface->renderer, surface->texture,
-			matrix, 1.0f);
+		wlr_render_texture_with_matrix(surface->renderer, texture, matrix, 1.0f);
 	}
 	wlr_renderer_scissor(renderer, NULL);
 
@@ -418,7 +418,7 @@ static void output_cursor_render(struct wlr_output_cursor *cursor,
 
 	struct wlr_texture *texture = cursor->texture;
 	if (cursor->surface != NULL) {
-		texture = cursor->surface->texture;
+		texture = wlr_surface_get_texture(cursor->surface);
 	}
 	if (texture == NULL) {
 		return;
@@ -700,7 +700,7 @@ static bool output_cursor_attempt_hardware(struct wlr_output_cursor *cursor) {
 	enum wl_output_transform transform = WL_OUTPUT_TRANSFORM_NORMAL;
 	struct wlr_texture *texture = cursor->texture;
 	if (cursor->surface != NULL) {
-		texture = cursor->surface->texture;
+		texture = wlr_surface_get_texture(cursor->surface);
 		scale = cursor->surface->current->scale;
 		transform = cursor->surface->current->transform;
 	}

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -332,7 +332,6 @@ static void surface_apply_damage(struct wlr_surface *surface,
 		// NULL commit
 		wlr_buffer_unref(surface->buffer);
 		surface->buffer = NULL;
-		surface->texture = NULL;
 		return;
 	}
 
@@ -362,7 +361,6 @@ static void surface_apply_damage(struct wlr_surface *surface,
 
 	wlr_buffer_unref(surface->buffer);
 	surface->buffer = NULL;
-	surface->texture = NULL;
 
 	struct wlr_buffer *buffer = wlr_buffer_create(surface->renderer, resource);
 	if (buffer == NULL) {
@@ -371,7 +369,6 @@ static void surface_apply_damage(struct wlr_surface *surface,
 	}
 
 	surface->buffer = buffer;
-	surface->texture = buffer->texture;
 }
 
 static void surface_commit_pending(struct wlr_surface *surface) {
@@ -660,8 +657,15 @@ struct wlr_surface *wlr_surface_create(struct wl_client *client,
 	return surface;
 }
 
+struct wlr_texture *wlr_surface_get_texture(struct wlr_surface *surface) {
+	if (surface->buffer == NULL) {
+		return NULL;
+	}
+	return surface->buffer->texture;
+}
+
 bool wlr_surface_has_buffer(struct wlr_surface *surface) {
-	return surface->texture != NULL;
+	return wlr_surface_get_texture(surface) != NULL;
 }
 
 int wlr_surface_set_role(struct wlr_surface *surface, const char *role,


### PR DESCRIPTION
The texture is managed by the surface's wlr_buffer now. In
particular, the buffer can destroy the texture early if it becomes
invalid.

cc @ongy @Timidger @ammen99: this is a breaking change.