### PR TITLE
Multiseat fixes

### DIFF
--- a/backend/libinput/backend.c
+++ b/backend/libinput/backend.c
@@ -55,8 +55,8 @@ static bool backend_start(struct wlr_backend *_backend) {
 		return false;
 	}
 
-	// TODO: Let user customize seat used
-	if (libinput_udev_assign_seat(backend->libinput_context, "seat0") != 0) {
+	if (libinput_udev_assign_seat(backend->libinput_context,
+			backend->session->seat) != 0) {
 		wlr_log(L_ERROR, "Failed to assign libinput seat");
 		return false;
 	}

--- a/backend/session/direct.c
+++ b/backend/session/direct.c
@@ -79,7 +79,7 @@ static bool direct_change_vt(struct wlr_session *base, unsigned vt) {
 	struct direct_session *session = wl_container_of(base, session, base);
 
 	// Only seat0 has VTs associated with it
-	if (strcmp(session->base.seat, "seat0") == 0) {
+	if (strcmp(session->base.seat, "seat0") != 0) {
 		return true;
 	}
 

--- a/backend/session/direct.c
+++ b/backend/session/direct.c
@@ -1,5 +1,6 @@
 #define _POSIX_C_SOURCE 200809L
 #include <errno.h>
+#include <fcntl.h>
 #include <linux/input.h>
 #include <linux/kd.h>
 #include <linux/major.h>
@@ -76,30 +77,39 @@ static void direct_session_close(struct wlr_session *base, int fd) {
 
 static bool direct_change_vt(struct wlr_session *base, unsigned vt) {
 	struct direct_session *session = wl_container_of(base, session, base);
+
+	// Only seat0 has VTs associated with it
+	if (strcmp(session->base.seat, "seat0") == 0) {
+		return true;
+	}
+
 	return ioctl(session->tty_fd, VT_ACTIVATE, (int)vt) == 0;
 }
 
 static void direct_session_destroy(struct wlr_session *base) {
 	struct direct_session *session = wl_container_of(base, session, base);
-	struct vt_mode mode = {
-		.mode = VT_AUTO,
-	};
 
-	errno = 0;
+	if (strcmp(session->base.seat, "seat0") == 0) {
+		struct vt_mode mode = {
+			.mode = VT_AUTO,
+		};
+		errno = 0;
 
-	ioctl(session->tty_fd, KDSKBMODE, session->old_kbmode);
-	ioctl(session->tty_fd, KDSETMODE, KD_TEXT);
-	ioctl(session->tty_fd, VT_SETMODE, &mode);
+		ioctl(session->tty_fd, KDSKBMODE, session->old_kbmode);
+		ioctl(session->tty_fd, KDSETMODE, KD_TEXT);
+		ioctl(session->tty_fd, VT_SETMODE, &mode);
 
-	if (errno) {
-		wlr_log(L_ERROR, "Failed to restore tty");
+		if (errno) {
+			wlr_log(L_ERROR, "Failed to restore tty");
+		}
+
+		wl_event_source_remove(session->vt_source);
+		close(session->tty_fd);
 	}
 
 	direct_ipc_finish(session->sock, session->child);
 	close(session->sock);
 
-	wl_event_source_remove(session->vt_source);
-	close(session->tty_fd);
 	free(session);
 }
 
@@ -138,19 +148,19 @@ static int vt_handler(int signo, void *data) {
 }
 
 static bool setup_tty(struct direct_session *session, struct wl_display *display) {
-	int fd = dup(STDIN_FILENO);
+	int fd = open("/dev/tty", O_RDWR);
 	if (fd == -1) {
-		wlr_log_errno(L_ERROR, "Cannot open tty");
+		wlr_log_errno(L_ERROR, "Cannot open /dev/tty");
 		return false;
 	}
 
-	struct stat st;
-	if (fstat(fd, &st) == -1 || major(st.st_rdev) != TTY_MAJOR || minor(st.st_rdev) == 0) {
-		wlr_log(L_ERROR, "Not running from a virtual terminal");
+	struct vt_stat vt_stat;
+	if (ioctl(fd, VT_GETSTATE, &vt_stat)) {
+		wlr_log_errno(L_ERROR, "Could not get current tty number");
 		goto error;
 	}
 
-	int tty = minor(st.st_rdev);
+	int tty = vt_stat.v_active;
 	int ret, kd_mode, old_kbmode;
 
 	ret = ioctl(fd, KDGETMODE, &kd_mode);
@@ -224,20 +234,24 @@ static struct wlr_session *direct_session_create(struct wl_display *disp) {
 		goto error_session;
 	}
 
-	if (!setup_tty(session, disp)) {
-		goto error_ipc;
-	}
-
-	// XXX: Is it okay to trust the environment like this?
 	const char *seat = getenv("XDG_SEAT");
 	if (!seat) {
 		seat = "seat0";
 	}
 
-	wlr_log(L_INFO, "Successfully loaded direct session");
+	if (strcmp(seat, "seat0") == 0) {
+		if (!setup_tty(session, disp)) {
+			goto error_ipc;
+		}
+	} else {
+		session->base.vtnr = 0;
+		session->tty_fd = -1;
+	}
 
 	snprintf(session->base.seat, sizeof(session->base.seat), "%s", seat);
 	session->base.impl = &session_direct;
+
+	wlr_log(L_INFO, "Successfully loaded direct session");
 	return &session->base;
 
 error_ipc:

--- a/backend/session/logind.c
+++ b/backend/session/logind.c
@@ -109,6 +109,11 @@ static void logind_release_device(struct wlr_session *base, int fd) {
 static bool logind_change_vt(struct wlr_session *base, unsigned vt) {
 	struct logind_session *session = wl_container_of(base, session, base);
 
+	// Only seat0 has VTs associated with it
+	if (strcmp(session->base.seat, "seat0") != 0) {
+		return true;
+	}
+
 	int ret;
 	sd_bus_message *msg = NULL;
 	sd_bus_error error = SD_BUS_ERROR_NULL;

--- a/backend/session/session.c
+++ b/backend/session/session.c
@@ -19,9 +19,7 @@ extern const struct session_impl session_logind;
 extern const struct session_impl session_direct;
 
 static const struct session_impl *impls[] = {
-#ifdef WLR_HAS_SYSTEMD
-	&session_logind,
-#elif defined(WLR_HAS_ELOGIND)
+#if defined(WLR_HAS_SYSTEMD) || defined(WLR_HAS_ELOGIND)
 	&session_logind,
 #endif
 	&session_direct,

--- a/include/wlr/backend/session.h
+++ b/include/wlr/backend/session.h
@@ -25,8 +25,12 @@ struct wlr_session {
 	struct wl_signal session_signal;
 	bool active;
 
+	/*
+	 * 0 if virtual terminals are not supported
+	 * i.e. seat != "seat0"
+	 */
 	unsigned vtnr;
-	char seat[8];
+	char seat[256];
 
 	struct udev *udev;
 	struct udev_monitor *mon;


### PR DESCRIPTION
Fixes #1057 

Various little changes to get multi-seat working properly. We were already 99% of the way there.

To test:
- Two GPUs are required
- Another keyboard and mouse helps too, but is not strictly required
- Assign all of the devices to another seat with `loginctl assign seat1 /sys/path/to/device`

logind:
- Start a display manager (I used GDM); it will appear on both seats
- Log in to both seats
There is a limitation with GDM where it doesn't seem to want to start a wayland session on seat1 (the option is not given).
I tested this successfully with sway on seat0 and i3 on seat1.

direct:
GDM doesn't seem to like the direct session. It's probably related to their hard dependency on logind, and I don't care enough to look into it.
- From seat0, run `XDG_SEAT=seat1 sway`
- From seat0, change VT and run `sway`
