### PR TITLE
layer-shell: check if the surface is mapped in layer_surface_destroy()

### DIFF
--- a/types/wlr_layer_shell.c
+++ b/types/wlr_layer_shell.c
@@ -176,7 +176,9 @@ static void layer_surface_unmap(struct wlr_layer_surface *surface) {
 }
 
 static void layer_surface_destroy(struct wlr_layer_surface *surface) {
-	layer_surface_unmap(surface);
+	if (surface->configured && surface->mapped) {
+		layer_surface_unmap(surface);
+	}
 	wlr_signal_emit_safe(&surface->events.destroy, surface);
 	wl_resource_set_user_data(surface->resource, NULL);
 	wl_list_remove(&surface->surface_destroy_listener.link);


### PR DESCRIPTION
If the layer surface has been closed by the compositor, using `layer_surface_close()`, then the unmap event is emitted immediately. However, when the layer surface is later destroyed by the client, the compositor used to get a second unmap, which is fixed with this commit.

As discussed in IRC, there could be another way to fix this - by not emitting the unmap on in `layer_surface_close()`. However, there is still the possibility the client first unmaps by committing a `NULL` buffer and then destroying the surface, so the change in this PR is needed anyway.