### PR TITLE
surface: fix double wl_buffer.release events

### DIFF
--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -325,19 +325,12 @@ static void surface_damage_subsurfaces(struct wlr_subsurface *subsurface) {
 	}
 }
 
-static void surface_apply_damage(struct wlr_surface *surface,
-		bool invalid_buffer) {
+static void surface_apply_damage(struct wlr_surface *surface) {
 	struct wl_resource *resource = surface->current->buffer;
 	if (resource == NULL) {
 		// NULL commit
 		wlr_buffer_unref(surface->buffer);
 		surface->buffer = NULL;
-		return;
-	}
-
-	if (surface->buffer != NULL && !surface->buffer->released &&
-			!invalid_buffer) {
-		// The buffer is still the same, no need to re-upload
 		return;
 	}
 
@@ -376,7 +369,9 @@ static void surface_commit_pending(struct wlr_surface *surface) {
 
 	surface_move_state(surface, surface->pending, surface->current);
 
-	surface_apply_damage(surface, invalid_buffer);
+	if (invalid_buffer) {
+		surface_apply_damage(surface);
+	}
 
 	// commit subsurface order
 	struct wlr_subsurface *subsurface;


### PR DESCRIPTION
Prior to this commit, we re-uploaded the buffer even if a new one
wasn't attached. After uploading, we send wl_buffer.release. So,
this sequence of requests resulted in a double release:

    surface.attach(buffer, 0, 0)
    surface.commit()
    <- buffer.release()
    surface.commit()
    <- buffer.release()

Test plan: open Gedit, click on a button to open a popup. Crashes Gedit before this commit with:

```
(gedit:28185): Gdk-WARNING **: 12:33:31.056: (gdkwindow-wayland.c:797):buffer_release_callback: runtime check failed: (impl->staging_cairo_surface != cairo_surface)
```