### PR TITLE
[WIP] Remove usages of wlr_output_layout_get()

### DIFF
--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -76,10 +76,10 @@ static void animate_cat(struct sample_state *sample,
 
 	if (ur_collision && ul_collision && ll_collision && lr_collision) {
 		// oops we went off the screen somehow
-		struct wlr_box *box =
-			wlr_output_layout_get_box(sample->layout, output);
-		sample->x_offs = box->x + 20;
-		sample->y_offs = box->y + 20;
+		struct wlr_box box;
+		wlr_output_layout_get_box(sample->layout, output, &box);
+		sample->x_offs = box.x + 20;
+		sample->y_offs = box.y + 20;
 	} else if (ur_collision && ul_collision) {
 		sample->y_vel = fabs(sample->y_vel);
 	} else if (lr_collision && ll_collision) {

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -76,10 +76,10 @@ static void animate_cat(struct sample_state *sample,
 
 	if (ur_collision && ul_collision && ll_collision && lr_collision) {
 		// oops we went off the screen somehow
-		struct wlr_output_layout_output *l_output =
-			wlr_output_layout_get(sample->layout, output);
-		sample->x_offs = l_output->x + 20;
-		sample->y_offs = l_output->y + 20;
+		struct wlr_box *box =
+			wlr_output_layout_get_box(sample->layout, output);
+		sample->x_offs = box->x + 20;
+		sample->y_offs = box->y + 20;
 	} else if (ur_collision && ul_collision) {
 		sample->y_vel = fabs(sample->y_vel);
 	} else if (lr_collision && ll_collision) {

--- a/include/types/wlr_output_layout.h
+++ b/include/types/wlr_output_layout.h
@@ -3,27 +3,21 @@
 
 #include <wlr/types/wlr_output_layout.h>
 
-struct wlr_output_layout_output_state {
+struct wlr_output_layout_output {
 	struct wlr_output_layout *layout;
-	struct wlr_output_layout_output *l_output;
-
+	struct wlr_output *output;
+	int x, y;
+	struct wl_list link;
 	bool auto_configured;
+
+	struct {
+		struct wl_signal destroy;
+	} events;
 
 	struct wl_listener mode;
 	struct wl_listener scale;
 	struct wl_listener transform;
 	struct wl_listener output_destroy;
-};
-
-struct wlr_output_layout_output {
-	struct wlr_output *output;
-	int x, y;
-	struct wl_list link;
-	struct wlr_output_layout_output_state *state;
-
-	struct {
-		struct wl_signal destroy;
-	} events;
 };
 
 struct wlr_output_layout_output *wlr_output_layout_get(

--- a/include/types/wlr_output_layout.h
+++ b/include/types/wlr_output_layout.h
@@ -1,0 +1,32 @@
+#ifndef TYPES_WLR_OUTPUT_LAYOUT_H
+#define TYPES_WLR_OUTPUT_LAYOUT_H
+
+#include <wlr/types/wlr_output_layout.h>
+
+struct wlr_output_layout_output_state {
+	struct wlr_output_layout *layout;
+	struct wlr_output_layout_output *l_output;
+
+	bool auto_configured;
+
+	struct wl_listener mode;
+	struct wl_listener scale;
+	struct wl_listener transform;
+	struct wl_listener output_destroy;
+};
+
+struct wlr_output_layout_output {
+	struct wlr_output *output;
+	int x, y;
+	struct wl_list link;
+	struct wlr_output_layout_output_state *state;
+
+	struct {
+		struct wl_signal destroy;
+	} events;
+};
+
+struct wlr_output_layout_output *wlr_output_layout_get(
+		struct wlr_output_layout *layout, struct wlr_output *reference);
+
+#endif

--- a/include/wlr/types/wlr_output_layout.h
+++ b/include/wlr/types/wlr_output_layout.h
@@ -82,10 +82,11 @@ void wlr_output_layout_closest_point(struct wlr_output_layout *layout,
 /**
  * Get the box of the layout for the given reference output in layout
  * coordinates. If `reference` is NULL, the box will be for the extents of the
- * entire layout.
+ * entire layout. Returns false if the reference output is present and not in
+ * the layout or there are no outputs in the layout.
  */
-struct wlr_box *wlr_output_layout_get_box(
-		struct wlr_output_layout *layout, struct wlr_output *reference);
+bool wlr_output_layout_get_box(struct wlr_output_layout *layout,
+		struct wlr_output *reference, struct wlr_box *box);
 
 /**
 * Add an auto configured output to the layout. This will place the output in a

--- a/include/wlr/types/wlr_output_layout.h
+++ b/include/wlr/types/wlr_output_layout.h
@@ -21,19 +21,6 @@ struct wlr_output_layout {
 	void *data;
 };
 
-struct wlr_output_layout_output_state;
-
-struct wlr_output_layout_output {
-	struct wlr_output *output;
-	int x, y;
-	struct wl_list link;
-	struct wlr_output_layout_output_state *state;
-
-	struct {
-		struct wl_signal destroy;
-	} events;
-};
-
 /**
  * Creates a wlr_output_layout, which can be used to describing outputs in
  * physical space relative to one another, and perform various useful operations
@@ -42,9 +29,6 @@ struct wlr_output_layout_output {
 struct wlr_output_layout *wlr_output_layout_create();
 
 void wlr_output_layout_destroy(struct wlr_output_layout *layout);
-
-struct wlr_output_layout_output *wlr_output_layout_get(
-		struct wlr_output_layout *layout, struct wlr_output *reference);
 
 struct wlr_output *wlr_output_layout_output_at(struct wlr_output_layout *layout,
 		double lx, double ly);

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -341,14 +341,14 @@ bool view_center(struct roots_view *view) {
 		return false;
 	}
 
-	const struct wlr_output_layout_output *l_output =
-		wlr_output_layout_get(desktop->layout, output);
+	struct wlr_box *layout_box =
+        wlr_output_layout_get_box(desktop->layout, output);
 
 	int width, height;
 	wlr_output_effective_resolution(output, &width, &height);
 
-	double view_x = (double)(width - box.width) / 2 + l_output->x;
-	double view_y = (double)(height - box.height) / 2 + l_output->y;
+	double view_x = (double)(width - box.width) / 2 + layout_box->x;
+	double view_y = (double)(height - box.height) / 2 + layout_box->y;
 	view_move(view, view_x, view_y);
 
 	return true;

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -199,13 +199,13 @@ void view_arrange_maximized(struct roots_view *view) {
 
 	struct wlr_output *output = view_get_output(view);
 	struct roots_output *roots_output = output->data;
-	struct wlr_box *output_box =
-		wlr_output_layout_get_box(view->desktop->layout, output);
+	struct wlr_box output_box;
+	wlr_output_layout_get_box(view->desktop->layout, output, &output_box);
 	struct wlr_box usable_area;
 	memcpy(&usable_area, &roots_output->usable_area,
 			sizeof(struct wlr_box));
-	usable_area.x += output_box->x;
-	usable_area.y += output_box->y;
+	usable_area.x += output_box.x;
+	usable_area.y += output_box.y;
 
 	view_move_resize(view, usable_area.x, usable_area.y,
 			usable_area.width, usable_area.height);
@@ -274,10 +274,10 @@ void view_set_fullscreen(struct roots_view *view, bool fullscreen,
 		view->saved.width = view_box.width;
 		view->saved.height = view_box.height;
 
-		struct wlr_box *output_box =
-			wlr_output_layout_get_box(view->desktop->layout, output);
-		view_move_resize(view, output_box->x, output_box->y, output_box->width,
-			output_box->height);
+		struct wlr_box output_box;
+		wlr_output_layout_get_box(view->desktop->layout, output, &output_box);
+		view_move_resize(view, output_box.x, output_box.y, output_box.width,
+			output_box.height);
 		view_rotate(view, 0);
 
 		roots_output->fullscreen_view = view;
@@ -341,14 +341,14 @@ bool view_center(struct roots_view *view) {
 		return false;
 	}
 
-	struct wlr_box *layout_box =
-        wlr_output_layout_get_box(desktop->layout, output);
+	struct wlr_box layout_box;
+	wlr_output_layout_get_box(desktop->layout, output, &layout_box);
 
 	int width, height;
 	wlr_output_effective_resolution(output, &width, &height);
 
-	double view_x = (double)(width - box.width) / 2 + layout_box->x;
-	double view_y = (double)(height - box.height) / 2 + layout_box->y;
+	double view_x = (double)(width - box.width) / 2 + layout_box.x;
+	double view_y = (double)(height - box.height) / 2 + layout_box.y;
 	view_move(view, view_x, view_y);
 
 	return true;
@@ -717,10 +717,10 @@ static void handle_layout_change(struct wl_listener *listener, void *data) {
 		return;
 	}
 
-	struct wlr_box *center_output_box =
-		wlr_output_layout_get_box(desktop->layout, center_output);
-	double center_x = center_output_box->x + center_output_box->width/2;
-	double center_y = center_output_box->y + center_output_box->height/2;
+	struct wlr_box center_output_box;
+	wlr_output_layout_get_box(desktop->layout, center_output, &center_output_box);
+	double center_x = center_output_box.x + center_output_box.width/2;
+	double center_y = center_output_box.y + center_output_box.height/2;
 
 	struct roots_view *view;
 	wl_list_for_each(view, &desktop->views, link) {

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -402,8 +402,8 @@ static void render_output(struct roots_output *output) {
 
 	float clear_color[] = {0.25f, 0.25f, 0.25f, 1.0f};
 
-	const struct wlr_box *output_box =
-		wlr_output_layout_get_box(desktop->layout, wlr_output);
+	struct wlr_box output_box;
+	wlr_output_layout_get_box(desktop->layout, wlr_output, &output_box);
 
 	// Check if we can delegate the fullscreen surface to the output
 	if (output->fullscreen_view != NULL &&
@@ -413,10 +413,10 @@ static void render_output(struct roots_output *output) {
 		// Make sure the view is centered on screen
 		struct wlr_box view_box;
 		view_get_box(view, &view_box);
-		double view_x = (double)(output_box->width - view_box.width) / 2 +
-			output_box->x;
-		double view_y = (double)(output_box->height - view_box.height) / 2 +
-			output_box->y;
+		double view_x = (double)(output_box.width - view_box.width) / 2 +
+			output_box.x;
+		double view_y = (double)(output_box.height - view_box.height) / 2 +
+			output_box.y;
 		view_move(view, view_x, view_y);
 
 		if (has_standalone_surface(view)) {
@@ -468,9 +468,9 @@ static void render_output(struct roots_output *output) {
 		wlr_renderer_clear(renderer, clear_color);
 	}
 
-	render_layer(output, output_box, &data,
+	render_layer(output, &output_box, &data,
 			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]);
-	render_layer(output, output_box, &data,
+	render_layer(output, &output_box, &data,
 			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM]);
 
 	// If a view is fullscreen on this output, render it
@@ -502,7 +502,7 @@ static void render_output(struct roots_output *output) {
 			render_view(view, &data);
 		}
 		// Render top layer above shell views
-		render_layer(output, output_box, &data,
+		render_layer(output, &output_box, &data,
 				&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]);
 	}
 
@@ -511,7 +511,7 @@ static void render_output(struct roots_output *output) {
 	drag_icons_for_each_surface(server->input, render_surface, &data.layout,
 		&data);
 
-	render_layer(output, output_box, &data,
+	render_layer(output, &output_box, &data,
 			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]);
 
 renderer_end:
@@ -621,10 +621,10 @@ static void damage_whole_surface(struct wlr_surface *surface, int sx, int sy,
 
 void output_damage_whole_local_surface(struct roots_output *output,
 		struct wlr_surface *surface, double ox, double oy, float rotation) {
-	struct wlr_box *box =
-        wlr_output_layout_get_box(output->desktop->layout, output->wlr_output);
+	struct wlr_box box;
+	wlr_output_layout_get_box(output->desktop->layout, output->wlr_output, &box);
 	struct damage_data data = { .output = output };
-	surface_for_each_surface(surface, ox + box->x, oy + box->y, 0,
+	surface_for_each_surface(surface, ox + box.x, oy + box.y, 0,
 		&data.layout, damage_whole_surface, &data);
 }
 
@@ -703,10 +703,10 @@ static void damage_from_surface(struct wlr_surface *surface, int sx, int sy,
 
 void output_damage_from_local_surface(struct roots_output *output,
 		struct wlr_surface *surface, double ox, double oy, float rotation) {
-	struct wlr_box *box =
-        wlr_output_layout_get_box(output->desktop->layout, output->wlr_output);
+	struct wlr_box box;
+	wlr_output_layout_get_box(output->desktop->layout, output->wlr_output, &box);
 	struct damage_data data = { .output = output };
-	surface_for_each_surface(surface, ox + box->x, oy + box->y, 0,
+	surface_for_each_surface(surface, ox + box.x, oy + box.y, 0,
 		&data.layout, damage_from_surface, &data);
 }
 

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -621,10 +621,10 @@ static void damage_whole_surface(struct wlr_surface *surface, int sx, int sy,
 
 void output_damage_whole_local_surface(struct roots_output *output,
 		struct wlr_surface *surface, double ox, double oy, float rotation) {
-	struct wlr_output_layout_output *layout = wlr_output_layout_get(
-		output->desktop->layout, output->wlr_output);
+	struct wlr_box *box =
+        wlr_output_layout_get_box(output->desktop->layout, output->wlr_output);
 	struct damage_data data = { .output = output };
-	surface_for_each_surface(surface, ox + layout->x, oy + layout->y, 0,
+	surface_for_each_surface(surface, ox + box->x, oy + box->y, 0,
 		&data.layout, damage_whole_surface, &data);
 }
 
@@ -703,10 +703,10 @@ static void damage_from_surface(struct wlr_surface *surface, int sx, int sy,
 
 void output_damage_from_local_surface(struct roots_output *output,
 		struct wlr_surface *surface, double ox, double oy, float rotation) {
-	struct wlr_output_layout_output *layout = wlr_output_layout_get(
-		output->desktop->layout, output->wlr_output);
+	struct wlr_box *box =
+        wlr_output_layout_get_box(output->desktop->layout, output->wlr_output);
 	struct damage_data data = { .output = output };
-	surface_for_each_surface(surface, ox + layout->x, oy + layout->y, 0,
+	surface_for_each_surface(surface, ox + box->x, oy + box->y, 0,
 		&data.layout, damage_from_surface, &data);
 }
 

--- a/types/wlr_cursor.c
+++ b/types/wlr_cursor.c
@@ -9,6 +9,7 @@
 #include <wlr/types/wlr_output.h>
 #include <wlr/util/log.h>
 #include "util/signal.h"
+#include "types/wlr_output_layout.h"
 
 struct wlr_cursor_device {
 	struct wlr_cursor *cursor;

--- a/types/wlr_output_layout.c
+++ b/types/wlr_output_layout.c
@@ -7,21 +7,10 @@
 #include <wlr/types/wlr_output.h>
 #include <wlr/util/log.h>
 #include "util/signal.h"
+#include "types/wlr_output_layout.h"
 
 struct wlr_output_layout_state {
 	struct wlr_box _box; // should never be read directly, use the getter
-};
-
-struct wlr_output_layout_output_state {
-	struct wlr_output_layout *layout;
-	struct wlr_output_layout_output *l_output;
-
-	bool auto_configured;
-
-	struct wl_listener mode;
-	struct wl_listener scale;
-	struct wl_listener transform;
-	struct wl_listener output_destroy;
 };
 
 struct wlr_output_layout *wlr_output_layout_create(void) {

--- a/types/wlr_xdg_output.c
+++ b/types/wlr_xdg_output.c
@@ -6,6 +6,7 @@
 #include <wlr/types/wlr_xdg_output.h>
 #include <wlr/util/log.h>
 #include "xdg-output-unstable-v1-protocol.h"
+#include "types/wlr_output_layout.h"
 
 #define OUTPUT_MANAGER_VERSION 2
 


### PR DESCRIPTION
Getting the box works just as good.

Fixes #1013
Fixes #812

What do you think about changing `wlr_output_layout_get_box()` to accept a reference to the box as an output variable instead of returning a pointer? That seems to be what we've done in other places.