### PR TITLE
FIX: Suprocess loops endlessly when the control socket closes.

### DIFF
--- a/backend/session/direct-ipc.c
+++ b/backend/session/direct-ipc.c
@@ -130,7 +130,7 @@ static void communicate(int sock) {
 	int drm_fd = -1;
 	bool running = true;
 
-	while (running && recv_msg(sock, &drm_fd, &msg, sizeof(msg)) >= 0) {
+	while (running && recv_msg(sock, &drm_fd, &msg, sizeof(msg)) > 0) {
 		switch (msg.type) {
 		case MSG_OPEN:
 			errno = 0;


### PR DESCRIPTION
recvmsg(3) returns 0 if the connection partner has shut down its socket.
The communicate function considered 0 a successful message, though, and
keeps calling recvmsg(3) again and again.