### PR TITLE
examples/dmabuf-capture: move encoding to a separate thread

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -47,6 +47,7 @@ if libavutil.found() and libavcodec.found() and libavformat.found()
 	executable(
 		'dmabuf-capture',
 		'dmabuf-capture.c',
-		dependencies: [wayland_client, wlr_protos, libavutil, libavcodec, libavformat, wlroots]
+		dependencies: [wayland_client, wlr_protos, libavutil, libavcodec,
+				libavformat, wlroots, threads ]
 	)
 endif


### PR DESCRIPTION
Drop new frames if too slow. Speeds up encoding significantly, even with vaapi.