### PR TITLE
use-after-free fixes (xdg_shell popups, primary selection source, xwm parents)

### DIFF
--- a/types/wlr_primary_selection.c
+++ b/types/wlr_primary_selection.c
@@ -229,9 +229,9 @@ void wlr_seat_set_primary_selection(struct wlr_seat *seat,
 	}
 
 	if (seat->primary_selection_source) {
+		wl_list_remove(&seat->primary_selection_source_destroy.link);
 		seat->primary_selection_source->cancel(seat->primary_selection_source);
 		seat->primary_selection_source = NULL;
-		wl_list_remove(&seat->primary_selection_source_destroy.link);
 	}
 
 	seat->primary_selection_source = source;

--- a/types/xdg_shell/wlr_xdg_surface.c
+++ b/types/xdg_shell/wlr_xdg_surface.c
@@ -415,6 +415,12 @@ void destroy_xdg_surface(struct wlr_xdg_surface *surface) {
 
 	wlr_signal_emit_safe(&surface->events.destroy, surface);
 
+	struct wlr_xdg_popup *popup_state, *next;
+	wl_list_for_each_safe(popup_state, next, &surface->popups, link) {
+		xdg_popup_send_popup_done(popup_state->resource);
+		destroy_xdg_popup(popup_state->base);
+	}
+
 	switch (surface->role) {
 	case WLR_XDG_SURFACE_ROLE_TOPLEVEL:
 		destroy_xdg_toplevel(surface);

--- a/types/xdg_shell_v6/wlr_xdg_surface_v6.c
+++ b/types/xdg_shell_v6/wlr_xdg_surface_v6.c
@@ -100,6 +100,12 @@ void destroy_xdg_surface_v6(struct wlr_xdg_surface_v6 *surface) {
 
 	wlr_signal_emit_safe(&surface->events.destroy, surface);
 
+	struct wlr_xdg_popup_v6 *popup_state, *next;
+	wl_list_for_each_safe(popup_state, next, &surface->popups, link) {
+		zxdg_popup_v6_send_popup_done(popup_state->resource);
+		destroy_xdg_popup_v6(popup_state->base);
+	}
+
 	switch (surface->role) {
 	case WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL:
 		destroy_xdg_toplevel_v6(surface);

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -294,6 +294,12 @@ static void xwayland_surface_destroy(
 	wl_list_remove(&xsurface->link);
 	wl_list_remove(&xsurface->parent_link);
 
+	struct wlr_xwayland_surface *child, *next;
+	wl_list_for_each_safe(child, next, &xsurface->children, parent_link) {
+		wl_list_remove(&child->parent_link);
+		wl_list_init(&child->parent_link);
+	}
+
 	if (xsurface->surface_id) {
 		wl_list_remove(&xsurface->unpaired_link);
 	}


### PR DESCRIPTION
see individual commits:
 - popups and their parent surface (happens with submenus in konsole)
 - primary selection (happens when overwriting selection in e.g. urxvt)
 - xwm parents/children (happens when closing gimp)