### PR TITLE
xdg-shell: end pointer and keyboard grab at the same time

### DIFF
--- a/types/xdg_shell/wlr_xdg_popup.c
+++ b/types/xdg_shell/wlr_xdg_popup.c
@@ -13,6 +13,7 @@ static void xdg_pointer_grab_end(struct wlr_seat_pointer_grab *grab) {
 	}
 
 	wlr_seat_pointer_end_grab(grab->seat);
+	wlr_seat_keyboard_end_grab(grab->seat);
 }
 
 static void xdg_pointer_grab_enter(struct wlr_seat_pointer_grab *grab,
@@ -78,7 +79,7 @@ static void xdg_keyboard_grab_modifiers(struct wlr_seat_keyboard_grab *grab,
 }
 
 static void xdg_keyboard_grab_cancel(struct wlr_seat_keyboard_grab *grab) {
-	wlr_seat_keyboard_end_grab(grab->seat);
+	wlr_seat_pointer_end_grab(grab->seat);
 }
 
 static const struct wlr_keyboard_grab_interface xdg_keyboard_grab_impl = {

--- a/types/xdg_shell_v6/wlr_xdg_popup_v6.c
+++ b/types/xdg_shell_v6/wlr_xdg_popup_v6.c
@@ -23,6 +23,7 @@ static void xdg_pointer_grab_end(struct wlr_seat_pointer_grab *grab) {
 	}
 
 	wlr_seat_pointer_end_grab(grab->seat);
+	wlr_seat_keyboard_end_grab(grab->seat);
 }
 
 static void xdg_pointer_grab_enter(struct wlr_seat_pointer_grab *grab,
@@ -88,7 +89,7 @@ static void xdg_keyboard_grab_modifiers(struct wlr_seat_keyboard_grab *grab,
 }
 
 static void xdg_keyboard_grab_cancel(struct wlr_seat_keyboard_grab *grab) {
-	wlr_seat_keyboard_end_grab(grab->seat);
+	wlr_seat_pointer_end_grab(grab->seat);
 }
 
 static const struct wlr_keyboard_grab_interface xdg_keyboard_grab_impl = {


### PR DESCRIPTION
Related to #1054 

When you click on another surface during a popup grab, it should end both the keyboard grab and the pointer grab at the same time so that the popup closes when you switch focus (it didn't do that before).