### PR TITLE
Check for libavutil/hwcontext_drm.h

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -5,6 +5,10 @@ libavutil = dependency('libavutil', required: false)
 libavcodec = dependency('libavcodec', required: false)
 libavformat = dependency('libavformat', required: false)
 
+if not cc.has_header('libavutil/hwcontext_drm.h', dependencies: libavutil)
+    libavutil = disabler()
+endif
+
 executable('simple', 'simple.c', dependencies: wlroots)
 executable('pointer', 'pointer.c', dependencies: wlroots)
 executable('touch', 'touch.c', 'cat.c', dependencies: wlroots)

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,9 +1,10 @@
 threads = dependency('threads')
 wayland_cursor = dependency('wayland-cursor')
 
-libavutil = dependency('libavutil', required: false)
-libavcodec = dependency('libavcodec', required: false)
-libavformat = dependency('libavformat', required: false)
+# These versions correspond to ffmpeg 4.0
+libavutil = dependency('libavutil', version: '>=56.14.100', required: false)
+libavcodec = dependency('libavcodec', version: '>=58.18.100', required: false)
+libavformat = dependency('libavformat', version: '>=58.12.100', required: false)
 
 if not cc.has_header('libavutil/hwcontext_drm.h', dependencies: libavutil)
     libavutil = disabler()

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
 	'c',
 	version: '0.0.1',
 	license: 'MIT',
-	meson_version: '>=0.43.0',
+	meson_version: '>=0.44.0',
 	default_options: [
 		'c_std=c11',
 		'warning_level=2',


### PR DESCRIPTION
This is an optional feature of libavutil, so this will cause a build failure if it's not present (e.g. on Debian/Ubuntu).
Bumps the minimum meson version for the disabler object.