### PR TITLE
xdg_shell popup: fix potential segv in handle_destroy

### DIFF
--- a/types/xdg_shell/wlr_xdg_popup.c
+++ b/types/xdg_shell/wlr_xdg_popup.c
@@ -186,7 +186,7 @@ static void xdg_popup_handle_destroy(struct wl_client *client,
 	struct wlr_xdg_surface *surface =
 		wlr_xdg_surface_from_popup_resource(resource);
 
-	if (!wl_list_empty(&surface->popups)) {
+	if (surface && !wl_list_empty(&surface->popups)) {
 		wl_resource_post_error(surface->client->resource,
 			XDG_WM_BASE_ERROR_NOT_THE_TOPMOST_POPUP,
 			"xdg_popup was destroyed while it was not the topmost popup");

--- a/types/xdg_shell/wlr_xdg_popup.c
+++ b/types/xdg_shell/wlr_xdg_popup.c
@@ -152,6 +152,9 @@ static void xdg_popup_handle_grab(struct wl_client *client,
 		wlr_xdg_surface_from_popup_resource(resource);
 	struct wlr_seat_client *seat_client =
 		wlr_seat_client_from_resource(seat_resource);
+	if (!surface) {
+		return;
+	}
 
 	if (surface->popup->committed) {
 		wl_resource_post_error(surface->popup->resource,

--- a/types/xdg_shell_v6/wlr_xdg_popup_v6.c
+++ b/types/xdg_shell_v6/wlr_xdg_popup_v6.c
@@ -214,7 +214,7 @@ static void xdg_popup_handle_destroy(struct wl_client *client,
 	struct wlr_xdg_surface_v6 *surface =
 		xdg_surface_from_xdg_popup_resource(resource);
 
-	if (!wl_list_empty(&surface->popups)) {
+	if (surface && !wl_list_empty(&surface->popups)) {
 		wl_resource_post_error(surface->client->resource,
 			ZXDG_SHELL_V6_ERROR_NOT_THE_TOPMOST_POPUP,
 			"xdg_popup was destroyed while it was not the topmost popup");

--- a/types/xdg_shell_v6/wlr_xdg_popup_v6.c
+++ b/types/xdg_shell_v6/wlr_xdg_popup_v6.c
@@ -174,6 +174,9 @@ static void xdg_popup_handle_grab(struct wl_client *client,
 		xdg_surface_from_xdg_popup_resource(resource);
 	struct wlr_seat_client *seat_client =
 		wlr_seat_client_from_resource(seat_resource);
+	if (!surface) {
+		return;
+	}
 
 	if (surface->popup->committed) {
 		wl_resource_post_error(surface->popup->resource,


### PR DESCRIPTION
surface could be NULL there if the popup had been made inert before... I think?