### PR TITLE
contributing: move wl_resource_set_user_data() right before free()

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -334,9 +334,9 @@ static void subsurface_destroy(struct wlr_subsurface *subsurface) {
 		return;
 	}
 
-	wl_resource_set_user_data(subsurface->resource, NULL);
-
 	…
+
+	wl_resource_set_user_data(subsurface->resource, NULL);
 	free(subsurface);
 }
 


### PR DESCRIPTION
`free()` will invalidate the user data field contents, so it makes sense to group these together. We shouldn't call `wl_resource_set_user_data` before emitting the destroy event.