### PR TITLE
s/wlr_subsurface_from_surface/wlr_subsurface_from_wlr_surface/

### DIFF
--- a/include/wlr/types/wlr_compositor.h
+++ b/include/wlr/types/wlr_compositor.h
@@ -31,10 +31,11 @@ struct wlr_compositor {
 
 void wlr_compositor_destroy(struct wlr_compositor *wlr_compositor);
 struct wlr_compositor *wlr_compositor_create(struct wl_display *display,
-		struct wlr_renderer *renderer);
+	struct wlr_renderer *renderer);
 
 bool wlr_surface_is_subsurface(struct wlr_surface *surface);
 
-struct wlr_subsurface *wlr_subsurface_from_surface(struct wlr_surface *surface);
+struct wlr_subsurface *wlr_subsurface_from_wlr_surface(
+	struct wlr_surface *surface);
 
 #endif

--- a/types/wlr_compositor.c
+++ b/types/wlr_compositor.c
@@ -17,7 +17,7 @@ bool wlr_surface_is_subsurface(struct wlr_surface *surface) {
 		strcmp(surface->role, subsurface_role) == 0;
 }
 
-struct wlr_subsurface *wlr_subsurface_from_surface(
+struct wlr_subsurface *wlr_subsurface_from_wlr_surface(
 		struct wlr_surface *surface) {
 	assert(wlr_surface_is_subsurface(surface));
 	return (struct wlr_subsurface *)surface->role_data;
@@ -57,7 +57,7 @@ static void subcompositor_handle_get_subsurface(struct wl_client *client,
 	}
 
 	if (wlr_surface_is_subsurface(surface) &&
-			wlr_subsurface_from_surface(surface) != NULL) {
+			wlr_subsurface_from_wlr_surface(surface) != NULL) {
 		wl_resource_post_error(resource,
 			WL_SUBCOMPOSITOR_ERROR_BAD_SURFACE,
 			"%s%d: wl_surface@%d is already a sub-surface",

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -395,7 +395,7 @@ static bool subsurface_is_synchronized(struct wlr_subsurface *subsurface) {
 		if (!wlr_surface_is_subsurface(subsurface->parent)) {
 			break;
 		}
-		subsurface = wlr_subsurface_from_surface(subsurface->parent);
+		subsurface = wlr_subsurface_from_wlr_surface(subsurface->parent);
 	}
 
 	return false;
@@ -451,7 +451,7 @@ static void surface_commit(struct wl_client *client,
 
 	if (wlr_surface_is_subsurface(surface)) {
 		struct wlr_subsurface *subsurface =
-			wlr_subsurface_from_surface(surface);
+			wlr_subsurface_from_wlr_surface(surface);
 		subsurface_commit(subsurface);
 		return;
 	}
@@ -887,7 +887,7 @@ struct wlr_subsurface *wlr_subsurface_create(struct wlr_surface *surface,
 struct wlr_surface *wlr_surface_get_root_surface(struct wlr_surface *surface) {
 	while (wlr_surface_is_subsurface(surface)) {
 		struct wlr_subsurface *subsurface =
-			wlr_subsurface_from_surface(surface);
+			wlr_subsurface_from_wlr_surface(surface);
 		surface = subsurface->parent;
 	}
 	return surface;


### PR DESCRIPTION
This was the only x_from_wlr_surface function that lacked the wlr_ prefix,
let's have an API as uniform as possible.

Cc @ongy @Timidger @ammen99 as it is an API change