### PR TITLE
Close fd's obtained from logind

### DIFF
--- a/backend/session/logind.c
+++ b/backend/session/logind.c
@@ -104,6 +104,7 @@ static void logind_release_device(struct wlr_session *base, int fd) {
 
 	sd_bus_error_free(&error);
 	sd_bus_message_unref(msg);
+	close(fd);
 }
 
 static bool logind_change_vt(struct wlr_session *base, unsigned vt) {


### PR DESCRIPTION
Might be a fix for #1090.

Test plan:
* Start rootston with DRM & logind backend.
* Observe that rootston has fds open for /dev/input/event*.
* Switch to another TTY and back.
* Observe that on master those fds have doubled. Another set of fds is added each time libinput is suspended and resumed. This is no longer the case with this patch.