### PR TITLE
Introduce wlr_xdg_surface_for_each_popup

### DIFF
--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -352,11 +352,19 @@ struct wlr_xdg_surface *wlr_xdg_surface_from_wlr_surface(
 void wlr_xdg_surface_get_geometry(struct wlr_xdg_surface *surface, struct wlr_box *box);
 
 /**
- * Call `iterator` on each surface in the xdg-surface tree, with the surface's
- * position relative to the root xdg-surface. The function is called from root to
- * leaves (in rendering order).
+ * Call `iterator` on each surface and popup in the xdg-surface tree, with the
+ * surface's position relative to the root xdg-surface. The function is called
+ * from root to leaves (in rendering order).
  */
 void wlr_xdg_surface_for_each_surface(struct wlr_xdg_surface *surface,
+	wlr_surface_iterator_func_t iterator, void *user_data);
+
+/**
+ * Call `iterator` on each popup in the xdg-surface tree, with the popup's
+ * position relative to the root xdg-surface. The function is called from root
+ * to leaves (in rendering order).
+ */
+void wlr_xdg_surface_for_each_popup(struct wlr_xdg_surface *surface,
 	wlr_surface_iterator_func_t iterator, void *user_data);
 
 #endif

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -329,11 +329,19 @@ struct wlr_xdg_surface_v6 *wlr_xdg_surface_v6_from_wlr_surface(
 void wlr_xdg_surface_v6_get_geometry(struct wlr_xdg_surface_v6 *surface, struct wlr_box *box);
 
 /**
- * Call `iterator` on each surface in the xdg-surface tree, with the surface's
- * position relative to the root xdg-surface. The function is called from root to
- * leaves (in rendering order).
+ * Call `iterator` on each surface and popup in the xdg-surface tree, with the
+ * surface's position relative to the root xdg-surface. The function is called
+ * from root to leaves (in rendering order).
  */
 void wlr_xdg_surface_v6_for_each_surface(struct wlr_xdg_surface_v6 *surface,
+	wlr_surface_iterator_func_t iterator, void *user_data);
+
+/**
+ * Call `iterator` on each popup in the xdg-surface tree, with the popup's
+ * position relative to the root xdg-surface. The function is called from root
+ * to leaves (in rendering order).
+ */
+void wlr_xdg_surface_v6_for_each_popup(struct wlr_xdg_surface_v6 *surface,
 	wlr_surface_iterator_func_t iterator, void *user_data);
 
 #endif

--- a/types/xdg_shell/wlr_xdg_surface.c
+++ b/types/xdg_shell/wlr_xdg_surface.c
@@ -557,9 +557,34 @@ static void xdg_surface_for_each_surface(struct wlr_xdg_surface *surface,
 	}
 }
 
+static void xdg_surface_for_each_popup(struct wlr_xdg_surface *surface,
+		int x, int y, wlr_surface_iterator_func_t iterator, void *user_data) {
+	struct wlr_xdg_popup *popup_state;
+	wl_list_for_each(popup_state, &surface->popups, link) {
+		struct wlr_xdg_surface *popup = popup_state->base;
+		if (!popup->configured) {
+			continue;
+		}
+
+		double popup_sx, popup_sy;
+		xdg_popup_get_position(popup_state, &popup_sx, &popup_sy);
+		iterator(popup->surface, x + popup_sx, y + popup_sy, user_data);
+
+		xdg_surface_for_each_popup(popup,
+			x + popup_sx,
+			y + popup_sy,
+			iterator, user_data);
+	}
+}
+
 void wlr_xdg_surface_for_each_surface(struct wlr_xdg_surface *surface,
 		wlr_surface_iterator_func_t iterator, void *user_data) {
 	xdg_surface_for_each_surface(surface, 0, 0, iterator, user_data);
+}
+
+void wlr_xdg_surface_for_each_popup(struct wlr_xdg_surface *surface,
+		wlr_surface_iterator_func_t iterator, void *user_data) {
+	xdg_surface_for_each_popup(surface, 0, 0, iterator, user_data);
 }
 
 void wlr_xdg_surface_get_geometry(struct wlr_xdg_surface *surface, struct wlr_box *box) {

--- a/types/xdg_shell_v6/wlr_xdg_surface_v6.c
+++ b/types/xdg_shell_v6/wlr_xdg_surface_v6.c
@@ -536,9 +536,34 @@ static void xdg_surface_v6_for_each_surface(struct wlr_xdg_surface_v6 *surface,
 	}
 }
 
+static void xdg_surface_v6_for_each_popup(struct wlr_xdg_surface_v6 *surface,
+		int x, int y, wlr_surface_iterator_func_t iterator, void *user_data) {
+	struct wlr_xdg_popup_v6 *popup_state;
+	wl_list_for_each(popup_state, &surface->popups, link) {
+		struct wlr_xdg_surface_v6 *popup = popup_state->base;
+		if (!popup->configured) {
+			continue;
+		}
+
+		double popup_sx, popup_sy;
+		xdg_popup_v6_get_position(popup_state, &popup_sx, &popup_sy);
+		iterator(popup->surface, x + popup_sx, y + popup_sy, user_data);
+
+		xdg_surface_v6_for_each_popup(popup,
+			x + popup_sx,
+			y + popup_sy,
+			iterator, user_data);
+	}
+}
+
 void wlr_xdg_surface_v6_for_each_surface(struct wlr_xdg_surface_v6 *surface,
 		wlr_surface_iterator_func_t iterator, void *user_data) {
 	xdg_surface_v6_for_each_surface(surface, 0, 0, iterator, user_data);
+}
+
+void wlr_xdg_surface_v6_for_each_popup(struct wlr_xdg_surface_v6 *surface,
+		wlr_surface_iterator_func_t iterator, void *user_data) {
+	xdg_surface_v6_for_each_popup(surface, 0, 0, iterator, user_data);
 }
 
 void wlr_xdg_surface_v6_get_geometry(struct wlr_xdg_surface_v6 *surface, struct wlr_box *box) {


### PR DESCRIPTION
It is common to want to iterate an xdg-surface's popups separately from the toplevel and subsurfaces. For example, popups are typically rendered on top of most other surfaces.

`wlr_xdg_surface_for_each_surface` continues to iterate both subsurfaces and popups to maintain backwards compatibility, <s>though it now iterates all the popups after all the subsurfaces rather than mixing them. Changing this back requires several lines of duplicated code, and I figured it's not likely to cause any issues.</s> This part has been reverted.