### PR TITLE
wlr_seat destroy: fix use-after-free after primary selection source cancel

### DIFF
--- a/types/seat/wlr_seat.c
+++ b/types/seat/wlr_seat.c
@@ -168,9 +168,9 @@ void wlr_seat_destroy(struct wlr_seat *seat) {
 		seat->selection_source = NULL;
 	}
 	if (seat->primary_selection_source) {
+		wl_list_remove(&seat->primary_selection_source_destroy.link);
 		seat->primary_selection_source->cancel(seat->primary_selection_source);
 		seat->primary_selection_source = NULL;
-		wl_list_remove(&seat->primary_selection_source_destroy.link);
 	}
 
 	struct wlr_seat_client *client, *tmp;


### PR DESCRIPTION
The primary_selection_source_destroy list points to memory freed by
that cancel callback, so remove from list before freeing.

```
==14457==ERROR: AddressSanitizer: heap-use-after-free on address 0x60b0001410d0 at pc 0x7fe35dd227cf bp 0x7ffea83e7dd0 sp 0x7ffea83e7dc0
WRITE of size 8 at 0x60b0001410d0 thread T0
    #0 0x7fe35dd227ce in wl_list_remove ../util/signal.c:55
    #1 0x7fe35dccfcbf in wlr_seat_destroy ../types/seat/wlr_seat.c:173
    #2 0x7fe35dccfff5 in handle_display_destroy ../types/seat/wlr_seat.c:196
    #3 0x7fe35da1af8f in wl_priv_signal_emit src/wayland-server.c:2024
    #4 0x7fe35da1b6ca in wl_display_destroy src/wayland-server.c:1092
    #5 0x41e958 in main ../rootston/main.c:79
    #6 0x7fe35cbbe18a in __libc_start_main ../csu/libc-start.c:308
    #7 0x406259 in _start (/home/shared/wayland/wlroots/build/rootston/rootston+0x406259)

0x60b0001410d0 is located 64 bytes inside of 112-byte region [0x60b000141090,0x60b000141100)
freed by thread T0 here:
    #0 0x7fe35e07a880 in __interceptor_free (/lib64/libasan.so.5+0xee880)
    #1 0x7fe35dc6e14a in primary_selection_source_cancel ../xwayland/selection/incoming.c:250
    #2 0x7fe35dccfc7c in wlr_seat_destroy ../types/seat/wlr_seat.c:171
    #3 0x7fe35dccfff5 in handle_display_destroy ../types/seat/wlr_seat.c:196
    #4 0x7fe35da1af8f in wl_priv_signal_emit src/wayland-server.c:2024

previously allocated by thread T0 here:
    #0 0x7fe35e07ae50 in calloc (/lib64/libasan.so.5+0xeee50)
    #1 0x7fe35dc6ec51 in xwm_selection_get_targets ../xwayland/selection/incoming.c:355
    #2 0x7fe35dc6f0f7 in xwm_handle_selection_notify ../xwayland/selection/incoming.c:402
    #3 0x7fe35dc73b16 in xwm_handle_selection_event ../xwayland/selection/selection.c:124
    #4 0x7fe35dc81522 in x11_event_handler ../xwayland/xwm.c:1154
    #5 0x7fe35da1cf01 in wl_event_loop_dispatch src/event-loop.c:641
```
(once again, it's in wl_list_remove, so need my hack or valgrind)