### PR TITLE
Apply opaque regions to surfaces' current state

### DIFF
--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -258,6 +258,7 @@ static void surface_move_state(struct wlr_surface *surface,
 	}
 	if ((next->invalid & WLR_SURFACE_INVALID_OPAQUE_REGION)) {
 		// TODO: process buffer
+		pixman_region32_copy(&state->opaque, &next->opaque);
 		pixman_region32_clear(&next->opaque);
 	}
 	if ((next->invalid & WLR_SURFACE_INVALID_INPUT_REGION)) {


### PR DESCRIPTION
This change is needed to allow https://github.com/swaywm/sway/pull/2182 to see the opaque region in the current state.

I admit I'm a little confused by the property `invalid`. I assume it denotes the fields which are dirty and should be copied into the current state.