### PR TITLE
fix: add stack update on focus change

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,7 +236,7 @@ error_session:
 ## Wayland protocol implementation
 
 Each protocol generally lives in a file with the same name, usually containing
-at leats one struct for each interface in the protocol. For instance,
+at least one struct for each interface in the protocol. For instance,
 `xdg_shell` lives in `types/wlr_xdg_shell.h` and has a `wlr_xdg_surface` struct.
 
 ### Globals

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -228,13 +228,13 @@ static void xwm_send_focus_window(struct wlr_xwm *xwm,
 		// if the surface doesn't allow the focus request, we will send him
 		// only the take focus event. It will get the focus by itself.
 		xwm_send_wm_message(xsurface, &message_data, XCB_EVENT_MASK_NO_EVENT);
-		return;
 	}
+	else {
+		xwm_send_wm_message(xsurface, &message_data, XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT);
 
-	xwm_send_wm_message(xsurface, &message_data, XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT);
-
-	xcb_set_input_focus(xwm->xcb_conn, XCB_INPUT_FOCUS_POINTER_ROOT,
-		xsurface->window_id, XCB_CURRENT_TIME);
+		xcb_set_input_focus(xwm->xcb_conn, XCB_INPUT_FOCUS_POINTER_ROOT,
+			xsurface->window_id, XCB_CURRENT_TIME);
+	}
 
 	uint32_t values[1];
 	values[0] = XCB_STACK_MODE_ABOVE;

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -228,8 +228,7 @@ static void xwm_send_focus_window(struct wlr_xwm *xwm,
 		// if the surface doesn't allow the focus request, we will send him
 		// only the take focus event. It will get the focus by itself.
 		xwm_send_wm_message(xsurface, &message_data, XCB_EVENT_MASK_NO_EVENT);
-	}
-	else {
+	} else {
 		xwm_send_wm_message(xsurface, &message_data, XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT);
 
 		xcb_set_input_focus(xwm->xcb_conn, XCB_INPUT_FOCUS_POINTER_ROOT,


### PR DESCRIPTION
Enable the stack update again for focus changes on non-focusable views.

I introduced this bug earlier in #1100.