### PR TITLE
Fix damage tracking debug mode

### DIFF
--- a/rootston/output.c
+++ b/rootston/output.c
@@ -517,6 +517,13 @@ static void render_output(struct roots_output *output) {
 renderer_end:
 	wlr_renderer_scissor(renderer, NULL);
 	wlr_renderer_end(renderer);
+
+	if (server->config->debug_damage_tracking) {
+		int width, height;
+		wlr_output_transformed_resolution(wlr_output, &width, &height);
+		pixman_region32_union_rect(&damage, &damage, 0, 0, width, height);
+	}
+
 	if (!wlr_output_damage_swap_buffers(output->damage, &now, &damage)) {
 		goto damage_finish;
 	}


### PR DESCRIPTION
This is a thing I've already done in sway, but not yet backported to rootston. I originally missed this bug because the parent compositor wasn't implementing damage tracking at that time.

Debugging damage tracking in Sway is a little bit hard because of frequent tree updates and bar repaints. It's usually easier to debug rootston.