### PR TITLE
[WIP] wlr_primary_selection: Allow multiple offers per source

### DIFF
--- a/include/wlr/types/wlr_primary_selection.h
+++ b/include/wlr/types/wlr_primary_selection.h
@@ -24,7 +24,7 @@ struct wlr_primary_selection_source {
 	void (*cancel)(struct wlr_primary_selection_source *source);
 
 	// source status
-	struct wlr_primary_selection_offer *offer;
+	struct wl_list offers;
 	struct wlr_seat_client *seat_client;
 
 	struct {
@@ -37,6 +37,9 @@ struct wlr_primary_selection_source {
 struct wlr_primary_selection_offer {
 	struct wl_resource *resource;
 	struct wlr_primary_selection_source *source;
+
+	struct wl_resource *selection_device;
+	struct wl_list link; // wlr_primary_selection_source::offers
 
 	struct wl_listener source_destroy;
 

--- a/types/data_device/wlr_data_source.c
+++ b/types/data_device/wlr_data_source.c
@@ -34,14 +34,11 @@ struct wlr_data_offer *data_source_send_offer(struct wlr_data_source *source,
 	uint32_t version = wl_resource_get_version(
 		wl_resource_from_link(target->data_devices.next));
 
-	struct wlr_data_offer *offer =
-		data_offer_create(target->client, source, version);
-	if (offer == NULL) {
-		return NULL;
-	}
+	struct wlr_data_offer *offer;
 
 	struct wl_resource *target_resource;
 	wl_resource_for_each(target_resource, &target->data_devices) {
+		offer = data_offer_create(target->client, source, version);
 		wl_data_device_send_data_offer(target_resource, offer->resource);
 	}
 


### PR DESCRIPTION
Create as many offers as there are selection devices, so that we do
not send a client multiple times the same "new_id" offer (which
would make it crash)


Note something is weird with this and X11; once I've selected something in firefox then pastes to X11 do not work anymore (even from other wayland apps); I don't understand what though so could use some help with that.


Part of #1041 (this is not complete as it only does primary_selection, data_source needs a similar fix... but data source uses source->offer everywhere (like in drag n drop as well) so such an approach is going to be a royal pain)

Cc @aereaux as he said he would work on this a couple of weeks ago, if you want to take over please do (I can find something else to do :P); or if you just have thought about it and have an opinion it's welcome as well :)