### PR TITLE
xdg-output: don't send no-op updates

### DIFF
--- a/include/wlr/types/wlr_xdg_output.h
+++ b/include/wlr/types/wlr_xdg_output.h
@@ -10,6 +10,9 @@ struct wlr_xdg_output {
 
 	struct wlr_output_layout_output *layout_output;
 
+	int32_t x, y;
+	int32_t width, height;
+
 	struct wl_listener destroy;
 };
 


### PR DESCRIPTION
To begin with, no-op updates are unnecessary, so this patch is an
improvement on its own.

Then, this fixes hotplugging issues with xwayland. xwayland waits
for both wl_output and xdg_output to send a "done" event. However,
it doesn't handle well desynchronized "done" updates: if xdg-output
sends "done" twice, the second one will wait for the next wl_output
"done" event. This is an issue when the first is a no-op and the
second is a real update: the second isn't applied. I've considered
patching xwayland instead, but it seems pretty complicated.