### PR TITLE
Bail from setting gamma on destroyed resource

### DIFF
--- a/types/wlr_gamma_control.c
+++ b/types/wlr_gamma_control.c
@@ -51,6 +51,10 @@ static void gamma_control_set_gamma(struct wl_client *client,
 	struct wlr_gamma_control *gamma_control =
 		gamma_control_from_resource(gamma_control_resource);
 
+	if (gamma_control == NULL) {
+		return;
+	}
+
 	if (red->size != green->size || red->size != blue->size) {
 		wl_resource_post_error(gamma_control_resource,
 			GAMMA_CONTROL_ERROR_INVALID_GAMMA,


### PR DESCRIPTION
Using redshift-wayland, I occasionally see segfault when unplugging an output. It appears that `gamma_control_set_gamma` receives a `wlr_gamma_control` resource that has already been destroyed. This seems like it must be a bug in redshift, though I haven't yet tracked down exactly what is happening.

If I've misunderstood how the communication happens and it shouldn't be possible to receive one of these, should this instead be an assert?

Traceback and null `gamma_control` returned by `gamma_control_from_resource` (sorry about the lack of debug symbols in sway):
```
>> coredumpctl gdb sway
Journal file /var/log/journal/d0fa6cf37e9f4d1586e8336642604c5d/system@00056c1c68a546c2-8d69904309b2d3d6.journal~ is truncated, ignoring file.
           PID: 2334 (sway)
           UID: 1000 (vil)
           GID: 1001 (vil)
        Signal: 11 (SEGV)
     Timestamp: Sun 2018-07-08 11:49:44 EDT (52min ago)
  Command Line: sway
    Executable: /usr/bin/sway
 Control Group: /user.slice/user-1000.slice/session-c4.scope
          Unit: session-c4.scope
         Slice: user-1000.slice
       Session: c4
     Owner UID: 1000 (vil)
       Boot ID: 11ee99ebfba6418c9e3e266fad1f80e9
    Machine ID: d0fa6cf37e9f4d1586e8336642604c5d
      Hostname: sayaka
       Storage: /var/lib/systemd/coredump/core.sway.1000.11ee99ebfba6418c9e3e266fad1f80e9.2334.1531064984000000.lz4
       Message: Process 2334 (sway) of user 1000 dumped core.
                
                Stack trace of thread 2334:
                #0  0x00007fd8b4eee260 gamma_control_set_gamma (libwlroots.so.0)
                #1  0x00007fd8b23e81c8 ffi_call_unix64 (libffi.so.6)
                #2  0x00007fd8b23e7c2a ffi_call (libffi.so.6)
                #3  0x00007fd8b512fa2f n/a (libwayland-server.so.0)
                #4  0x00007fd8b512bf29 n/a (libwayland-server.so.0)
                #5  0x00007fd8b512da42 wl_event_loop_dispatch (libwayland-server.so.0)
                #6  0x00007fd8b512c14c wl_display_run (libwayland-server.so.0)
                #7  0x0000562d3cd1792d n/a (sway)
                #8  0x00007fd8b449f06b __libc_start_main (libc.so.6)
                #9  0x0000562d3cd17b3a n/a (sway)
                
                Stack trace of thread 2343:
                #0  0x00007fd8b426affc pthread_cond_wait@@GLIBC_2.3.2 (libpthread.so.0)
                #1  0x00007fd8ac66c124 n/a (i965_dri.so)
                #2  0x00007fd8ac66be18 n/a (i965_dri.so)
                #3  0x00007fd8b4265075 start_thread (libpthread.so.0)
                #4  0x00007fd8b457453f __clone (libc.so.6)

GNU gdb (GDB) 8.1
Copyright (C) 2018 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-pc-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from /usr/bin/sway...(no debugging symbols found)...done.
[New LWP 2334]
[New LWP 2343]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/usr/lib/libthread_db.so.1".
Core was generated by `sway'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007fd8b4eee260 in gamma_control_set_gamma (client=<optimized out>, 
    gamma_control_resource=0x562d3ec1f8c0, red=0x562d3ee57390, green=0x562d3ee573a8, 
    blue=0x562d3ee573c0) at ../types/wlr_gamma_control.c:66
66	../types/wlr_gamma_control.c: No such file or directory.
[Current thread is 1 (Thread 0x7fd8b70fa9c0 (LWP 2334))]
(gdb) info locals
gamma_control = 0x0
size = 256
r = 0x562d3ee573e4
g = 0x562d3ee575e8
b = 0x562d3ee577ec
(gdb) 
```