### PR TITLE
Unbreak xvfb

### DIFF
--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -264,6 +264,7 @@ struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
 		wlr_log(WLR_ERROR, "Could not create event source");
 		goto error_display;
 	}
+	wl_event_source_check(x11->event_source);
 
 	x11->screen = xcb_setup_roots_iterator(xcb_get_setup(x11->xcb_conn)).data;
 

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -258,7 +258,7 @@ struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
 
 	int fd = xcb_get_file_descriptor(x11->xcb_conn);
 	struct wl_event_loop *ev = wl_display_get_event_loop(display);
-	int events = WL_EVENT_READABLE | WL_EVENT_ERROR | WL_EVENT_HANGUP;
+	uint32_t events = WL_EVENT_READABLE | WL_EVENT_ERROR | WL_EVENT_HANGUP;
 	x11->event_source = wl_event_loop_add_fd(ev, fd, events, x11_event, x11);
 	if (!x11->event_source) {
 		wlr_log(WLR_ERROR, "Could not create event source");

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -47,8 +47,16 @@ static bool output_set_custom_mode(struct wlr_output *wlr_output,
 	output_set_refresh(&output->wlr_output, refresh);
 
 	const uint32_t values[] = { width, height };
-	xcb_configure_window(x11->xcb_conn, output->win,
+	xcb_void_cookie_t cookie = xcb_configure_window_checked(x11->xcb_conn, output->win,
 		XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT, values);
+
+	xcb_generic_error_t *error;
+	if ((error = xcb_request_check(x11->xcb_conn, cookie))) {
+		wlr_log(WLR_ERROR, "Could not set window size to %dx%d\n", width, height);
+		free(error);
+		return false;
+	}
+
 	return true;
 }
 


### PR DESCRIPTION
x11: make sure event source is drained
    
 Otherwise running under Xvfb will not deliver any events. This results in e.g. weston-info reporting a 0x0 window size (which results in all sorts of problems) plus some other minor cleanups.
