### PR TITLE
Add wlr_surface.opaque_region

### DIFF
--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -56,6 +56,7 @@ void wlr_renderer_init(struct wlr_renderer *renderer,
 
 struct wlr_texture_impl {
 	void (*get_size)(struct wlr_texture *texture, int *width, int *height);
+	bool (*is_opaque)(struct wlr_texture *texture);
 	bool (*write_pixels)(struct wlr_texture *texture,
 		enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width,
 		uint32_t height, uint32_t src_x, uint32_t src_y, uint32_t dst_x,

--- a/include/wlr/render/wlr_texture.h
+++ b/include/wlr/render/wlr_texture.h
@@ -41,6 +41,11 @@ struct wlr_texture *wlr_texture_from_dmabuf(struct wlr_renderer *renderer,
 void wlr_texture_get_size(struct wlr_texture *texture, int *width, int *height);
 
 /**
+ * Returns true if this texture is using a fully opaque format.
+ */
+bool wlr_texture_is_opaque(struct wlr_texture *texture);
+
+/**
  * Update a texture with raw pixels. The texture must be mutable.
  */
 bool wlr_texture_write_pixels(struct wlr_texture *texture,

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -67,6 +67,12 @@ struct wlr_surface {
 	 */
 	pixman_region32_t buffer_damage;
 	/**
+	 * The current opaque region, in surface-local coordinates. It is clipped to
+	 * the surface bounds. If the surface's buffer is using a fully opaque
+	 * format, this is set to the whole surface.
+	 */
+	pixman_region32_t opaque_region;
+	/**
 	 * `current` contains the current, committed surface state. `pending`
 	 * accumulates state changes from the client between commits and shouldn't
 	 * be accessed by the compositor directly. `previous` contains the state of

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -36,6 +36,11 @@ static void gles2_texture_get_size(struct wlr_texture *wlr_texture, int *width,
 	*height = texture->height;
 }
 
+static bool gles2_texture_is_opaque(struct wlr_texture *wlr_texture) {
+	struct wlr_gles2_texture *texture = gles2_get_texture(wlr_texture);
+	return !texture->has_alpha;
+}
+
 static bool gles2_texture_write_pixels(struct wlr_texture *wlr_texture,
 		enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width,
 		uint32_t height, uint32_t src_x, uint32_t src_y, uint32_t dst_x,
@@ -129,6 +134,7 @@ static void gles2_texture_destroy(struct wlr_texture *wlr_texture) {
 
 static const struct wlr_texture_impl texture_impl = {
 	.get_size = gles2_texture_get_size,
+	.is_opaque = gles2_texture_is_opaque,
 	.write_pixels = gles2_texture_write_pixels,
 	.to_dmabuf = gles2_texture_to_dmabuf,
 	.destroy = gles2_texture_destroy,

--- a/render/wlr_texture.c
+++ b/render/wlr_texture.c
@@ -47,6 +47,13 @@ void wlr_texture_get_size(struct wlr_texture *texture, int *width,
 	return texture->impl->get_size(texture, width, height);
 }
 
+bool wlr_texture_is_opaque(struct wlr_texture *texture) {
+	if (!texture->impl->is_opaque) {
+		return false;
+	}
+	return texture->impl->is_opaque(texture);
+}
+
 bool wlr_texture_write_pixels(struct wlr_texture *texture,
 		enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width,
 		uint32_t height, uint32_t src_x, uint32_t src_y, uint32_t dst_x,


### PR DESCRIPTION
This is the enhanced opaque region:
* Clipped to the surface bounds
* Set to the whole surface if the texture is using a format without an alpha channel

Fixes #920