### PR TITLE
Install generated protocols

### DIFF
--- a/include/wlr/types/wlr_layer_shell.h
+++ b/include/wlr/types/wlr_layer_shell.h
@@ -3,9 +3,9 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <wayland-server.h>
+#include <wlr/protocol/wlr-layer-shell-unstable-v1-protocol.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_surface.h>
-#include "wlr-layer-shell-unstable-v1-protocol.h"
 
 /**
  * wlr_layer_shell allows clients to arrange themselves in "layers" on the

--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -1,9 +1,9 @@
 #ifndef WLR_TYPES_WLR_XDG_SHELL_H
 #define WLR_TYPES_WLR_XDG_SHELL_H
+#include <wayland-server.h>
+#include <wlr/protocol/xdg-shell-protocol.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_seat.h>
-#include <wayland-server.h>
-#include "xdg-shell-protocol.h"
 
 struct wlr_xdg_shell {
 	struct wl_global *global;

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -2,9 +2,9 @@
 #define WLR_TYPES_WLR_XDG_SHELL_V6_H
 
 #include <wayland-server.h>
+#include <wlr/protocol/xdg-shell-unstable-v6-protocol.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_seat.h>
-#include "xdg-shell-unstable-v6-protocol.h"
 
 struct wlr_xdg_shell_v6 {
 	struct wl_global *global;

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -1,31 +1,13 @@
 wl_protocol_dir = wayland_protos.get_pkgconfig_variable('pkgdatadir')
 
-wayland_scanner = find_program('wayland-scanner')
-
-wayland_scanner_server = generator(
-	wayland_scanner,
-	output: '@BASENAME@-protocol.h',
-	arguments: ['server-header', '@INPUT@', '@OUTPUT@'],
-)
-
-# should check wayland_scanner's version, but it is hard to get
-if wayland_server.version().version_compare('>=1.14.91')
-	code_type = 'private-code'
-else
-	code_type = 'code'
+wl_scanner = find_program('wayland-scanner', required: false)
+if not wl_scanner.found()
+	wl_scanner_dep = dependency('wayland-scanner')
+	wl_scanner = find_program(wl_scanner_dep.get_pkgconfig_variable('wayland_scanner'))
 endif
 
-wayland_scanner_code = generator(
-	wayland_scanner,
-	output: '@BASENAME@-protocol.c',
-	arguments: [code_type, '@INPUT@', '@OUTPUT@'],
-)
-
-wayland_scanner_client = generator(
-	wayland_scanner,
-	output: '@BASENAME@-client-protocol.h',
-	arguments: ['client-header', '@INPUT@', '@OUTPUT@'],
-)
+wl_scanner_version = run_command(wl_scanner, '-v').stderr().strip().split(' ')[-1]
+code_type = wl_scanner_version.version_compare('>=1.14.91') ? 'public-code' : 'code'
 
 protocols = [
 	[wl_protocol_dir, 'stable/xdg-shell/xdg-shell.xml'],
@@ -62,13 +44,31 @@ wl_protos_headers = []
 
 foreach p : protocols
 	xml = join_paths(p)
-	wl_protos_src += wayland_scanner_code.process(xml)
-	wl_protos_headers += wayland_scanner_server.process(xml)
+	name = xml.split('/')[-1].split('.')[0]
+
+	wl_protos_src += custom_target(name + '-protocol.c',
+		input: xml,
+		output: '@BASENAME@-protocol.c',
+		command: [wl_scanner, code_type, '@INPUT@', '@OUTPUT@'],
+	)
+	wl_protos_headers += custom_target(name + '-protocol.h',
+		input: xml,
+		output: '@BASENAME@-protocol.h',
+		command: [wl_scanner, 'server-header', '@INPUT@', '@OUTPUT@'],
+		install: true,
+		install_dir: join_paths(get_option('includedir'), 'wlr/protocol'),
+	)
 endforeach
 
 foreach p : client_protocols
 	xml = join_paths(p)
-	wl_protos_headers += wayland_scanner_client.process(xml)
+	name = xml.split('/')[-1].split('.')[0]
+
+	wl_protos_headers += custom_target(name + '-client-protocol.h',
+		input: xml,
+		output: '@BASENAME@-client-protocol.h',
+		command: [wl_scanner, 'client-header', '@INPUT@', '@OUTPUT@'],
+	)
 endforeach
 
 lib_wl_protos = static_library('wl_protos', wl_protos_src + wl_protos_headers,
@@ -77,4 +77,10 @@ lib_wl_protos = static_library('wl_protos', wl_protos_src + wl_protos_headers,
 wlr_protos = declare_dependency(
 	link_with: lib_wl_protos,
 	sources: wl_protos_headers,
+)
+
+# Symbolic link so these appear as <wlr/protocol/foobar.h> for build
+meson.add_postconf_script('ln', '-s',
+	'../../protocol',
+	join_paths(meson.build_root(), 'include/wlr/protocol'),
 )


### PR DESCRIPTION
This installs the server protocols we generate as <wlr/protocol/name.h>.

This removes the weird requirement for the user to run wayland-scanner and set their include paths up in a very specific way to use some of our public headers. It's not really expected for users to include these headers directly, but the option is there if they want to.