### PR TITLE
xwayland: handle override_redirect flag changes

### DIFF
--- a/include/wlr/xwayland.h
+++ b/include/wlr/xwayland.h
@@ -150,6 +150,7 @@ struct wlr_xwayland_surface {
 		struct wl_signal set_parent;
 		struct wl_signal set_pid;
 		struct wl_signal set_window_type;
+		struct wl_signal set_override_redirect;
 		struct wl_signal ping_timeout;
 	} events;
 
@@ -199,9 +200,6 @@ void wlr_xwayland_surface_set_fullscreen(struct wlr_xwayland_surface *surface,
 
 void wlr_xwayland_set_seat(struct wlr_xwayland *xwayland,
 	struct wlr_seat *seat);
-
-bool wlr_xwayland_surface_is_unmanaged(
-	const struct wlr_xwayland_surface *surface);
 
 bool wlr_surface_is_xwayland_surface(struct wlr_surface *surface);
 

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -127,13 +127,13 @@ static void handle_tablet_tool_position(struct roots_cursor *cursor,
 	struct wlr_surface *surface = desktop_surface_at(desktop,
 			cursor->cursor->x, cursor->cursor->y, &sx, &sy, &view);
 	struct roots_tablet_tool *roots_tool = tool->data;
-	
+
 	if (!surface) {
 		wlr_send_tablet_v2_tablet_tool_proximity_out(roots_tool->tablet_v2_tool);
 		/* XXX: TODO: Fallback pointer semantics */
 		return;
 	}
-	
+
 	if (!wlr_surface_accepts_tablet_v2(tablet->tablet_v2, surface)) {
 		wlr_send_tablet_v2_tablet_tool_proximity_out(roots_tool->tablet_v2_tool);
 		/* XXX: TODO: Fallback pointer semantics */
@@ -217,7 +217,7 @@ static void handle_tool_tip(struct wl_listener *listener, void *data) {
 static void handle_tablet_tool_destroy(struct wl_listener *listener, void *data) {
 	struct roots_tablet_tool *tool =
 		wl_container_of(listener, tool, tool_destroy);
-	
+
 	wl_list_remove(&tool->link);
 	wl_list_remove(&tool->tool_link);
 
@@ -1124,7 +1124,7 @@ void roots_seat_set_focus(struct roots_seat *seat, struct roots_view *view) {
 
 #ifdef WLR_HAS_XWAYLAND
 	if (view && view->type == ROOTS_XWAYLAND_VIEW &&
-			wlr_xwayland_surface_is_unmanaged(view->xwayland_surface)) {
+			view->xwayland_surface->override_redirect) {
 		return;
 	}
 #endif

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -241,8 +241,7 @@ static void xwm_send_focus_window(struct wlr_xwm *xwm,
 		XCB_CONFIG_WINDOW_STACK_MODE, values);
 }
 
-
-void xwm_surface_activate(struct wlr_xwm *xwm,
+static void xwm_surface_activate(struct wlr_xwm *xwm,
 		struct wlr_xwayland_surface *xsurface) {
 	if (xwm->focus_surface == xsurface ||
 			(xsurface && xsurface->override_redirect)) {


### PR DESCRIPTION
The override_redirect flag can change on configure notify and
on map notify. This adds an event to know when it changes.

This removes wlr_xwayland_surface_is_unmanaged which was wrongly
using the window type to decide whether the view should be
unmanaged.

A similar patch was proposed to Weston, but has never been
merged upstream [1].

[1]: https://patchwork.freedesktop.org/patch/211161/