### PR TITLE
Remove symbol versioning from DSO

### DIFF
--- a/wlroots.syms
+++ b/wlroots.syms
@@ -1,4 +1,4 @@
-WLROOTS_0_0_0 {
+{
 	global:
 		wlr_*;
 		_wlr_log;


### PR DESCRIPTION
This removes GNU symbol versioning from the dynamic shared object.

Note that this still uses the GNU version file. The alternative would be to use `-export-symbols symfile` (which requires to explicitly list all symbols) or `-export-symbols-regex regex` (which makes it necessary to use a regex instead of simple wildcards, but may be not that bad if we ignore `wlr_signal_emit_safe`'s case and go with something like `^_?wlr_.*`). See for instance https://gitlab.com/axil/gnutls/commit/6c2512405eabc83fe64b72ca81d4c1989a9e0e22