### PR TITLE
xdg-shell(-v6): add set_title and set_app_id toplevel signals

### DIFF
--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -119,6 +119,8 @@ struct wlr_xdg_toplevel {
 		struct wl_signal request_resize;
 		struct wl_signal request_show_window_menu;
 		struct wl_signal set_parent;
+		struct wl_signal set_title;
+		struct wl_signal set_app_id;
 	} events;
 };
 

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -127,6 +127,8 @@ struct wlr_xdg_toplevel_v6 {
 		struct wl_signal request_resize;
 		struct wl_signal request_show_window_menu;
 		struct wl_signal set_parent;
+		struct wl_signal set_title;
+		struct wl_signal set_app_id;
 	} events;
 };
 

--- a/types/xdg_shell/wlr_xdg_toplevel.c
+++ b/types/xdg_shell/wlr_xdg_toplevel.c
@@ -234,6 +234,7 @@ static void xdg_toplevel_handle_set_title(struct wl_client *client,
 
 	free(surface->toplevel->title);
 	surface->toplevel->title = tmp;
+	wlr_signal_emit_safe(&surface->toplevel->events.set_title, surface);
 }
 
 static void xdg_toplevel_handle_set_app_id(struct wl_client *client,
@@ -249,6 +250,7 @@ static void xdg_toplevel_handle_set_app_id(struct wl_client *client,
 
 	free(surface->toplevel->app_id);
 	surface->toplevel->app_id = tmp;
+	wlr_signal_emit_safe(&surface->toplevel->events.set_app_id, surface);
 }
 
 static void xdg_toplevel_handle_show_window_menu(struct wl_client *client,
@@ -471,6 +473,8 @@ void create_xdg_toplevel(struct wlr_xdg_surface *xdg_surface,
 	wl_signal_init(&xdg_surface->toplevel->events.request_resize);
 	wl_signal_init(&xdg_surface->toplevel->events.request_show_window_menu);
 	wl_signal_init(&xdg_surface->toplevel->events.set_parent);
+	wl_signal_init(&xdg_surface->toplevel->events.set_title);
+	wl_signal_init(&xdg_surface->toplevel->events.set_app_id);
 
 	xdg_surface->role = WLR_XDG_SURFACE_ROLE_TOPLEVEL;
 	xdg_surface->toplevel->base = xdg_surface;

--- a/types/xdg_shell_v6/wlr_xdg_toplevel_v6.c
+++ b/types/xdg_shell_v6/wlr_xdg_toplevel_v6.c
@@ -57,6 +57,7 @@ static void xdg_toplevel_handle_set_title(struct wl_client *client,
 
 	free(surface->toplevel->title);
 	surface->toplevel->title = tmp;
+	wlr_signal_emit_safe(&surface->toplevel->events.set_title, surface);
 }
 
 static void xdg_toplevel_handle_set_app_id(struct wl_client *client,
@@ -71,6 +72,7 @@ static void xdg_toplevel_handle_set_app_id(struct wl_client *client,
 
 	free(surface->toplevel->app_id);
 	surface->toplevel->app_id = tmp;
+	wlr_signal_emit_safe(&surface->toplevel->events.set_app_id, surface);
 }
 
 static void xdg_toplevel_handle_show_window_menu(struct wl_client *client,
@@ -441,6 +443,8 @@ void create_xdg_toplevel_v6(struct wlr_xdg_surface_v6 *xdg_surface,
 	wl_signal_init(&xdg_surface->toplevel->events.request_resize);
 	wl_signal_init(&xdg_surface->toplevel->events.request_show_window_menu);
 	wl_signal_init(&xdg_surface->toplevel->events.set_parent);
+	wl_signal_init(&xdg_surface->toplevel->events.set_title);
+	wl_signal_init(&xdg_surface->toplevel->events.set_app_id);
 
 	xdg_surface->role = WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL;
 	xdg_surface->toplevel->base = xdg_surface;


### PR DESCRIPTION
This is useful for example when rendering decorations

I haven't tested much, because I'm not aware of any clients that change app_id. But I successfully managed to get title updates from gedit, so I think it should work fine.