### PR TITLE
Tablet grabs

### DIFF
--- a/include/wlr/types/wlr_tablet_v2.h
+++ b/include/wlr/types/wlr_tablet_v2.h
@@ -10,6 +10,14 @@
 /* This can probably be even lower,the tools don't have a lot of buttons */
 #define WLR_TABLET_V2_TOOL_BUTTONS_CAP 16
 
+struct wlr_tablet_pad_v2_grab_interface;
+
+struct wlr_tablet_pad_v2_grab {
+	const struct wlr_tablet_pad_v2_grab_interface *interface;
+	struct wlr_tablet_v2_tablet_pad *pad;
+	void *data;
+};
+
 struct wlr_tablet_client_v2;
 struct wlr_tablet_tool_client_v2;
 struct wlr_tablet_pad_client_v2;
@@ -70,6 +78,8 @@ struct wlr_tablet_v2_tablet_pad {
 	struct wl_listener pad_destroy;
 
 	struct wlr_tablet_pad_client_v2 *current_client;
+	struct wlr_tablet_pad_v2_grab *grab;
+	struct wlr_tablet_pad_v2_grab default_grab;
 
 	struct {
 		struct wl_signal button_feedback; // struct wlr_tablet_v2_event_feedback
@@ -155,7 +165,7 @@ void wlr_send_tablet_v2_tablet_pad_button(
 	struct wlr_tablet_v2_tablet_pad *pad, size_t button,
 	uint32_t time, enum zwp_tablet_pad_v2_button_state state);
 
-void wlr_send_tablet_v2_tablet_pad_strip( struct wlr_tablet_v2_tablet_pad *pad,
+void wlr_send_tablet_v2_tablet_pad_strip(struct wlr_tablet_v2_tablet_pad *pad,
 	uint32_t strip, double position, bool finger, uint32_t time);
 void wlr_send_tablet_v2_tablet_pad_ring(struct wlr_tablet_v2_tablet_pad *pad,
 	uint32_t ring, double position, bool finger, uint32_t time);
@@ -165,6 +175,56 @@ uint32_t wlr_send_tablet_v2_tablet_pad_leave(struct wlr_tablet_v2_tablet_pad *pa
 
 uint32_t wlr_send_tablet_v2_tablet_pad_mode(struct wlr_tablet_v2_tablet_pad *pad,
 	size_t group, uint32_t mode, uint32_t time);
+
+
+uint32_t wlr_tablet_v2_tablet_pad_notify_enter(
+	struct wlr_tablet_v2_tablet_pad *pad,
+	struct wlr_tablet_v2_tablet *tablet,
+	struct wlr_surface *surface);
+
+void wlr_tablet_v2_tablet_pad_notify_button(
+	struct wlr_tablet_v2_tablet_pad *pad, size_t button,
+	uint32_t time, enum zwp_tablet_pad_v2_button_state state);
+
+void wlr_tablet_v2_tablet_pad_notify_strip(
+	struct wlr_tablet_v2_tablet_pad *pad,
+	uint32_t strip, double position, bool finger, uint32_t time);
+void wlr_tablet_v2_tablet_pad_notify_ring(
+	struct wlr_tablet_v2_tablet_pad *pad,
+	uint32_t ring, double position, bool finger, uint32_t time);
+
+uint32_t wlr_tablet_v2_tablet_pad_notify_leave(
+	struct wlr_tablet_v2_tablet_pad *pad, struct wlr_surface *surface);
+
+uint32_t wlr_tablet_v2_tablet_pad_notify_mode(
+	struct wlr_tablet_v2_tablet_pad *pad,
+	size_t group, uint32_t mode, uint32_t time);
+
+struct wlr_tablet_pad_v2_grab_interface {
+	uint32_t (*enter)(
+		struct wlr_tablet_pad_v2_grab *grab,
+		struct wlr_tablet_v2_tablet *tablet,
+		struct wlr_surface *surface);
+
+	void (*button)(struct wlr_tablet_pad_v2_grab *grab,size_t button,
+		uint32_t time, enum zwp_tablet_pad_v2_button_state state);
+
+	void (*strip)(struct wlr_tablet_pad_v2_grab *grab,
+		uint32_t strip, double position, bool finger, uint32_t time);
+	void (*ring)(struct wlr_tablet_pad_v2_grab *grab,
+		uint32_t ring, double position, bool finger, uint32_t time);
+
+	uint32_t (*leave)(struct wlr_tablet_pad_v2_grab *grab,
+		struct wlr_surface *surface);
+
+	uint32_t (*mode)(struct wlr_tablet_pad_v2_grab *grab,
+		size_t group, uint32_t mode, uint32_t time);
+
+	void (*cancel)(struct wlr_tablet_pad_v2_grab *grab);
+};
+
+void wlr_tablet_v2_end_grab(struct wlr_tablet_v2_tablet_pad *pad);
+void wlr_tablet_v2_start_grab(struct wlr_tablet_v2_tablet_pad *pad, struct wlr_tablet_pad_v2_grab *grab);
 
 bool wlr_surface_accepts_tablet_v2(struct wlr_tablet_v2_tablet *tablet,
 	struct wlr_surface *surface);

--- a/include/wlr/types/wlr_tablet_v2.h
+++ b/include/wlr/types/wlr_tablet_v2.h
@@ -240,6 +240,9 @@ struct wlr_tablet_tool_v2_grab_interface {
 void wlr_tablet_tool_v2_start_grab(struct wlr_tablet_v2_tablet_tool *tool, struct wlr_tablet_tool_v2_grab *grab);
 void wlr_tablet_tool_v2_end_grab(struct wlr_tablet_v2_tablet_tool *tool);
 
+void wlr_tablet_tool_v2_start_implicit_grab(struct wlr_tablet_v2_tablet_tool *tool);
+
+
 uint32_t wlr_send_tablet_v2_tablet_pad_enter(
 	struct wlr_tablet_v2_tablet_pad *pad,
 	struct wlr_tablet_v2_tablet *tablet,

--- a/include/wlr/types/wlr_tablet_v2.h
+++ b/include/wlr/types/wlr_tablet_v2.h
@@ -18,6 +18,14 @@ struct wlr_tablet_pad_v2_grab {
 	void *data;
 };
 
+struct wlr_tablet_tool_v2_grab_interface;
+
+struct wlr_tablet_tool_v2_grab {
+	const struct wlr_tablet_tool_v2_grab_interface *interface;
+	struct wlr_tablet_v2_tablet_tool *tool;
+	void *data;
+};
+
 struct wlr_tablet_client_v2;
 struct wlr_tablet_tool_client_v2;
 struct wlr_tablet_pad_client_v2;
@@ -53,6 +61,9 @@ struct wlr_tablet_v2_tablet_tool {
 	struct wlr_tablet_tool_client_v2 *current_client;
 	struct wlr_surface *focused_surface;
 	struct wl_listener surface_destroy;
+
+	struct wlr_tablet_tool_v2_grab *grab;
+	struct wlr_tablet_tool_v2_grab default_grab;
 
 	uint32_t proximity_serial;
 	bool is_down;
@@ -155,6 +166,79 @@ void wlr_send_tablet_v2_tablet_tool_proximity_out(
 void wlr_send_tablet_v2_tablet_tool_button(
 	struct wlr_tablet_v2_tablet_tool *tool, uint32_t button,
 	enum zwp_tablet_pad_v2_button_state state);
+
+
+
+void wlr_tablet_v2_tablet_tool_notify_proximity_in(
+	struct wlr_tablet_v2_tablet_tool *tool,
+	struct wlr_tablet_v2_tablet *tablet,
+	struct wlr_surface *surface);
+
+void wlr_tablet_v2_tablet_tool_notify_down(struct wlr_tablet_v2_tablet_tool *tool);
+void wlr_tablet_v2_tablet_tool_notify_up(struct wlr_tablet_v2_tablet_tool *tool);
+
+void wlr_tablet_v2_tablet_tool_notify_motion(
+	struct wlr_tablet_v2_tablet_tool *tool, double x, double y);
+
+void wlr_tablet_v2_tablet_tool_notify_pressure(
+	struct wlr_tablet_v2_tablet_tool *tool, double pressure);
+
+void wlr_tablet_v2_tablet_tool_notify_distance(
+	struct wlr_tablet_v2_tablet_tool *tool, double distance);
+
+void wlr_tablet_v2_tablet_tool_notify_tilt(
+	struct wlr_tablet_v2_tablet_tool *tool, double x, double y);
+
+void wlr_tablet_v2_tablet_tool_notify_rotation(
+	struct wlr_tablet_v2_tablet_tool *tool, double degrees);
+
+void wlr_tablet_v2_tablet_tool_notify_slider(
+	struct wlr_tablet_v2_tablet_tool *tool, double position);
+
+void wlr_tablet_v2_tablet_tool_notify_wheel(
+	struct wlr_tablet_v2_tablet_tool *tool, double degrees, int32_t clicks);
+
+void wlr_tablet_v2_tablet_tool_notify_proximity_out(
+	struct wlr_tablet_v2_tablet_tool *tool);
+
+void wlr_tablet_v2_tablet_tool_notify_button(
+	struct wlr_tablet_v2_tablet_tool *tool, uint32_t button,
+	enum zwp_tablet_pad_v2_button_state state);
+
+
+struct wlr_tablet_tool_v2_grab_interface {
+	void (*proximity_in)(
+		struct wlr_tablet_tool_v2_grab *grab,
+		struct wlr_tablet_v2_tablet *tablet,
+		struct wlr_surface *surface);
+
+	void (*down)(struct wlr_tablet_tool_v2_grab *grab);
+	void (*up)(struct wlr_tablet_tool_v2_grab *grab);
+
+	void (*motion)(struct wlr_tablet_tool_v2_grab *grab, double x, double y);
+
+	void (*pressure)(struct wlr_tablet_tool_v2_grab *grab, double pressure);
+
+	void (*distance)(struct wlr_tablet_tool_v2_grab *grab, double distance);
+
+	void (*tilt)(struct wlr_tablet_tool_v2_grab *grab, double x, double y);
+
+	void (*rotation)(struct wlr_tablet_tool_v2_grab *grab, double degrees);
+
+	void (*slider)(struct wlr_tablet_tool_v2_grab *grab, double position);
+
+	void (*wheel)(struct wlr_tablet_tool_v2_grab *grab, double degrees, int32_t clicks);
+
+	void (*proximity_out)(struct wlr_tablet_tool_v2_grab *grab);
+
+	void (*button)(
+		struct wlr_tablet_tool_v2_grab *grab, uint32_t button,
+		enum zwp_tablet_pad_v2_button_state state);
+	void (*cancel)(struct wlr_tablet_tool_v2_grab *grab);
+};
+
+void wlr_tablet_tool_v2_start_grab(struct wlr_tablet_v2_tablet_tool *tool, struct wlr_tablet_tool_v2_grab *grab);
+void wlr_tablet_tool_v2_end_grab(struct wlr_tablet_v2_tablet_tool *tool);
 
 uint32_t wlr_send_tablet_v2_tablet_pad_enter(
 	struct wlr_tablet_v2_tablet_pad *pad,

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -209,6 +209,7 @@ static void handle_tool_tip(struct wl_listener *listener, void *data) {
 
 	if (event->state == WLR_TABLET_TOOL_TIP_DOWN) {
 		wlr_tablet_v2_tablet_tool_notify_down(roots_tool->tablet_v2_tool);
+		wlr_tablet_tool_v2_start_implicit_grab(roots_tool->tablet_v2_tool);
 	} else {
 		wlr_tablet_v2_tablet_tool_notify_up(roots_tool->tablet_v2_tool);
 	}

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -763,7 +763,7 @@ static void handle_tablet_pad_ring(struct wl_listener *listener, void *data) {
 		wl_container_of(listener, pad, ring);
 	struct wlr_event_tablet_pad_ring *event = data;
 
-	wlr_send_tablet_v2_tablet_pad_ring(pad->tablet_v2_pad,
+	wlr_tablet_v2_tablet_pad_notify_ring(pad->tablet_v2_pad,
 		event->ring, event->position,
 		event->source == WLR_TABLET_PAD_RING_SOURCE_FINGER,
 		event->time_msec);
@@ -774,7 +774,7 @@ static void handle_tablet_pad_strip(struct wl_listener *listener, void *data) {
 		wl_container_of(listener, pad, strip);
 	struct wlr_event_tablet_pad_strip *event = data;
 
-	wlr_send_tablet_v2_tablet_pad_strip(pad->tablet_v2_pad,
+	wlr_tablet_v2_tablet_pad_notify_strip(pad->tablet_v2_pad,
 		event->strip, event->position,
 		event->source == WLR_TABLET_PAD_STRIP_SOURCE_FINGER,
 		event->time_msec);
@@ -785,10 +785,10 @@ static void handle_tablet_pad_button(struct wl_listener *listener, void *data) {
 		wl_container_of(listener, pad, button);
 	struct wlr_event_tablet_pad_button *event = data;
 
-	wlr_send_tablet_v2_tablet_pad_mode(pad->tablet_v2_pad,
+	wlr_tablet_v2_tablet_pad_notify_mode(pad->tablet_v2_pad,
 		event->group, event->mode, event->time_msec);
 
-	wlr_send_tablet_v2_tablet_pad_button(pad->tablet_v2_pad,
+	wlr_tablet_v2_tablet_pad_notify_button(pad->tablet_v2_pad,
 		event->button, event->time_msec,
 		(enum zwp_tablet_pad_v2_button_state)event->state);
 }
@@ -1173,7 +1173,7 @@ void roots_seat_set_focus(struct roots_seat *seat, struct roots_view *view) {
 		struct roots_tablet_pad *pad;
 		wl_list_for_each(pad, &seat->tablet_pads, link) {
 			if (pad->tablet) {
-				wlr_send_tablet_v2_tablet_pad_enter(pad->tablet_v2_pad, pad->tablet->tablet_v2, view->wlr_surface);
+				wlr_tablet_v2_tablet_pad_notify_enter(pad->tablet_v2_pad, pad->tablet->tablet_v2, view->wlr_surface);
 			}
 		}
 	} else {

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -129,21 +129,21 @@ static void handle_tablet_tool_position(struct roots_cursor *cursor,
 	struct roots_tablet_tool *roots_tool = tool->data;
 	
 	if (!surface) {
-		wlr_send_tablet_v2_tablet_tool_proximity_out(roots_tool->tablet_v2_tool);
+		wlr_tablet_v2_tablet_tool_notify_proximity_out(roots_tool->tablet_v2_tool);
 		/* XXX: TODO: Fallback pointer semantics */
 		return;
 	}
 	
 	if (!wlr_surface_accepts_tablet_v2(tablet->tablet_v2, surface)) {
-		wlr_send_tablet_v2_tablet_tool_proximity_out(roots_tool->tablet_v2_tool);
+		wlr_tablet_v2_tablet_tool_notify_proximity_out(roots_tool->tablet_v2_tool);
 		/* XXX: TODO: Fallback pointer semantics */
 		return;
 	}
 
-	wlr_send_tablet_v2_tablet_tool_proximity_in(roots_tool->tablet_v2_tool,
+	wlr_tablet_v2_tablet_tool_notify_proximity_in(roots_tool->tablet_v2_tool,
 		tablet->tablet_v2, surface);
 
-	wlr_send_tablet_v2_tablet_tool_motion(roots_tool->tablet_v2_tool, sx, sy);
+	wlr_tablet_v2_tablet_tool_notify_motion(roots_tool->tablet_v2_tool, sx, sy);
 }
 
 static void handle_tool_axis(struct wl_listener *listener, void *data) {
@@ -169,32 +169,32 @@ static void handle_tool_axis(struct wl_listener *listener, void *data) {
 		event->x, event->y, event->dx, event->dy);
 
 	if (event->updated_axes & WLR_TABLET_TOOL_AXIS_PRESSURE) {
-		wlr_send_tablet_v2_tablet_tool_pressure(
+		wlr_tablet_v2_tablet_tool_notify_pressure(
 			roots_tool->tablet_v2_tool, event->pressure);
 	}
 
 	if (event->updated_axes & WLR_TABLET_TOOL_AXIS_DISTANCE) {
-		wlr_send_tablet_v2_tablet_tool_distance(
+		wlr_tablet_v2_tablet_tool_notify_distance(
 			roots_tool->tablet_v2_tool, event->distance);
 	}
 
 	if (event->updated_axes & (WLR_TABLET_TOOL_AXIS_TILT_X | WLR_TABLET_TOOL_AXIS_TILT_Y)) {
-		wlr_send_tablet_v2_tablet_tool_tilt(
+		wlr_tablet_v2_tablet_tool_notify_tilt(
 			roots_tool->tablet_v2_tool, event->tilt_x, event->tilt_y);
 	}
 
 	if (event->updated_axes & WLR_TABLET_TOOL_AXIS_ROTATION) {
-		wlr_send_tablet_v2_tablet_tool_rotation(
+		wlr_tablet_v2_tablet_tool_notify_rotation(
 			roots_tool->tablet_v2_tool, event->rotation);
 	}
 
 	if (event->updated_axes & WLR_TABLET_TOOL_AXIS_SLIDER) {
-		wlr_send_tablet_v2_tablet_tool_slider(
+		wlr_tablet_v2_tablet_tool_notify_slider(
 			roots_tool->tablet_v2_tool, event->slider);
 	}
 
 	if (event->updated_axes & WLR_TABLET_TOOL_AXIS_WHEEL) {
-		wlr_send_tablet_v2_tablet_tool_wheel(
+		wlr_tablet_v2_tablet_tool_notify_wheel(
 			roots_tool->tablet_v2_tool, event->wheel_delta, 0);
 	}
 }
@@ -208,9 +208,9 @@ static void handle_tool_tip(struct wl_listener *listener, void *data) {
 	struct roots_tablet_tool *roots_tool = event->tool->data;
 
 	if (event->state == WLR_TABLET_TOOL_TIP_DOWN) {
-		wlr_send_tablet_v2_tablet_tool_down(roots_tool->tablet_v2_tool);
+		wlr_tablet_v2_tablet_tool_notify_down(roots_tool->tablet_v2_tool);
 	} else {
-		wlr_send_tablet_v2_tablet_tool_up(roots_tool->tablet_v2_tool);
+		wlr_tablet_v2_tablet_tool_notify_up(roots_tool->tablet_v2_tool);
 	}
 }
 
@@ -235,7 +235,7 @@ static void handle_tool_button(struct wl_listener *listener, void *data) {
 	struct wlr_event_tablet_tool_button *event = data;
 	struct roots_tablet_tool *roots_tool = event->tool->data;
 
-	wlr_send_tablet_v2_tablet_tool_button(roots_tool->tablet_v2_tool,
+	wlr_tablet_v2_tablet_tool_notify_button(roots_tool->tablet_v2_tool,
 		(enum zwp_tablet_pad_v2_button_state)event->button,
 		(enum zwp_tablet_pad_v2_button_state)event->state);
 }

--- a/types/tablet_v2/wlr_tablet_v2_pad.c
+++ b/types/tablet_v2/wlr_tablet_v2_pad.c
@@ -11,7 +11,7 @@
 #include <wlr/types/wlr_tablet_v2.h>
 #include <wlr/util/log.h>
 
-static struct wlr_tablet_pad_v2_grab_interface default_pad_interface;
+static struct wlr_tablet_pad_v2_grab_interface default_pad_grab_interface;
 
 struct tablet_pad_auxiliary_user_data {
 	struct wlr_tablet_pad_client_v2 *pad;
@@ -368,7 +368,7 @@ struct wlr_tablet_v2_tablet_pad *wlr_tablet_pad_create(
 	if (!pad) {
 		return NULL;
 	}
-	pad->default_grab.interface = &default_pad_interface;
+	pad->default_grab.interface = &default_pad_grab_interface;
 	pad->default_grab.pad = pad;
 	pad->grab = &pad->default_grab;
 
@@ -631,10 +631,8 @@ void wlr_tablet_v2_start_grab(struct wlr_tablet_v2_tablet_pad *pad,
 		struct wlr_tablet_pad_v2_grab *prev = pad->grab;
 		grab->pad = pad;
 		pad->grab = grab;
-		if (prev) {
-			if (prev->interface->cancel) {
-				prev->interface->cancel(prev);
-			}
+		if (prev && prev->interface->cancel) {
+			prev->interface->cancel(prev);
 		}
 	}
 }
@@ -685,7 +683,7 @@ static void default_pad_cancel(struct wlr_tablet_pad_v2_grab *grab) {
 	// Do nothing, the default cancel can be ignored.
 }
 
-static struct wlr_tablet_pad_v2_grab_interface default_pad_interface  = {
+static struct wlr_tablet_pad_v2_grab_interface default_pad_grab_interface  = {
 	.enter = default_pad_enter,
 	.button = default_pad_button,
 	.strip = default_pad_strip,

--- a/types/tablet_v2/wlr_tablet_v2_pad.c
+++ b/types/tablet_v2/wlr_tablet_v2_pad.c
@@ -476,9 +476,9 @@ void wlr_send_tablet_v2_tablet_pad_button(
 
 void wlr_send_tablet_v2_tablet_pad_strip(struct wlr_tablet_v2_tablet_pad *pad,
 		uint32_t strip, double position, bool finger, uint32_t time) {
-	if (!pad->current_client &&
-			pad->current_client->strips &&
-			pad->current_client->strips[strip]) {
+	if (!pad->current_client ||
+			!pad->current_client->strips ||
+			!pad->current_client->strips[strip]) {
 		return;
 	}
 	struct wl_resource *resource = pad->current_client->strips[strip];

--- a/types/tablet_v2/wlr_tablet_v2_pad.c
+++ b/types/tablet_v2/wlr_tablet_v2_pad.c
@@ -11,6 +11,8 @@
 #include <wlr/types/wlr_tablet_v2.h>
 #include <wlr/util/log.h>
 
+static struct wlr_tablet_pad_v2_grab_interface default_pad_interface;
+
 struct tablet_pad_auxiliary_user_data {
 	struct wlr_tablet_pad_client_v2 *pad;
 	size_t index;
@@ -366,6 +368,9 @@ struct wlr_tablet_v2_tablet_pad *wlr_tablet_pad_create(
 	if (!pad) {
 		return NULL;
 	}
+	pad->default_grab.interface = &default_pad_interface;
+	pad->default_grab.pad = pad;
+	pad->grab = &pad->default_grab;
 
 	pad->group_count = wl_list_length(&wlr_pad->groups);
 	pad->groups = calloc(pad->group_count, sizeof(int));
@@ -564,3 +569,128 @@ bool wlr_surface_accepts_tablet_v2(struct wlr_tablet_v2_tablet *tablet,
 
 	return false;
 }
+
+
+uint32_t wlr_tablet_v2_tablet_pad_notify_enter(
+	struct wlr_tablet_v2_tablet_pad *pad,
+	struct wlr_tablet_v2_tablet *tablet,
+	struct wlr_surface *surface) {
+	if (pad->grab && pad->grab->interface->enter) {
+		return pad->grab->interface->enter(pad->grab, tablet, surface);
+	}
+
+	return 0;
+}
+
+void wlr_tablet_v2_tablet_pad_notify_button(
+	struct wlr_tablet_v2_tablet_pad *pad, size_t button,
+	uint32_t time, enum zwp_tablet_pad_v2_button_state state) {
+	if (pad->grab && pad->grab->interface->button) {
+		pad->grab->interface->button(pad->grab, button, time, state);
+	}
+}
+
+void wlr_tablet_v2_tablet_pad_notify_strip(
+	struct wlr_tablet_v2_tablet_pad *pad,
+	uint32_t strip, double position, bool finger, uint32_t time) {
+	if (pad->grab && pad->grab->interface->strip) {
+		pad->grab->interface->strip(pad->grab, strip, position, finger, time);
+	}
+}
+
+void wlr_tablet_v2_tablet_pad_notify_ring(
+	struct wlr_tablet_v2_tablet_pad *pad,
+	uint32_t ring, double position, bool finger, uint32_t time) {
+	if (pad->grab && pad->grab->interface->ring) {
+		pad->grab->interface->ring(pad->grab, ring, position, finger, time);
+	}
+}
+
+uint32_t wlr_tablet_v2_tablet_pad_notify_leave(
+	struct wlr_tablet_v2_tablet_pad *pad, struct wlr_surface *surface) {
+	if (pad->grab && pad->grab->interface->leave) {
+		return pad->grab->interface->leave(pad->grab, surface);
+	}
+
+	return 0;
+}
+
+uint32_t wlr_tablet_v2_tablet_pad_notify_mode(
+	struct wlr_tablet_v2_tablet_pad *pad,
+	size_t group, uint32_t mode, uint32_t time) {
+	if (pad->grab && pad->grab->interface->mode) {
+		return pad->grab->interface->mode(pad->grab, group, mode, time);
+	}
+
+	return 0;
+}
+
+void wlr_tablet_v2_start_grab(struct wlr_tablet_v2_tablet_pad *pad,
+		struct wlr_tablet_pad_v2_grab *grab) {
+	if (grab != &pad->default_grab) {
+		struct wlr_tablet_pad_v2_grab *prev = pad->grab;
+		grab->pad = pad;
+		pad->grab = grab;
+		if (prev) {
+			if (prev->interface->cancel) {
+				prev->interface->cancel(prev);
+			}
+		}
+	}
+}
+
+void wlr_tablet_v2_end_grab(struct wlr_tablet_v2_tablet_pad *pad) {
+	struct wlr_tablet_pad_v2_grab *grab = pad->grab;
+	if (grab && grab != &pad->default_grab) {
+		pad->grab = &pad->default_grab;
+		if (grab->interface->cancel) {
+			grab->interface->cancel(grab);
+		}
+	}
+}
+
+static uint32_t default_pad_enter(
+		struct wlr_tablet_pad_v2_grab *grab,
+		struct wlr_tablet_v2_tablet *tablet,
+		struct wlr_surface *surface) {
+	return wlr_send_tablet_v2_tablet_pad_enter(grab->pad, tablet, surface);
+}
+
+static void default_pad_button(struct wlr_tablet_pad_v2_grab *grab,size_t button,
+		uint32_t time, enum zwp_tablet_pad_v2_button_state state) {
+	wlr_send_tablet_v2_tablet_pad_button(grab->pad, button, time, state);
+}
+
+static void default_pad_strip(struct wlr_tablet_pad_v2_grab *grab,
+		uint32_t strip, double position, bool finger, uint32_t time) {
+	wlr_send_tablet_v2_tablet_pad_strip(grab->pad, strip, position, finger, time);
+}
+
+static void default_pad_ring(struct wlr_tablet_pad_v2_grab *grab,
+		uint32_t ring, double position, bool finger, uint32_t time) {
+	wlr_send_tablet_v2_tablet_pad_ring(grab->pad, ring, position, finger, time);
+}
+
+static uint32_t default_pad_leave(struct wlr_tablet_pad_v2_grab *grab,
+		struct wlr_surface *surface) {
+	return wlr_send_tablet_v2_tablet_pad_leave(grab->pad, surface);
+}
+
+static uint32_t default_pad_mode(struct wlr_tablet_pad_v2_grab *grab,
+		size_t group, uint32_t mode, uint32_t time) {
+	return wlr_send_tablet_v2_tablet_pad_mode(grab->pad, group, mode, time);
+}
+
+static void default_pad_cancel(struct wlr_tablet_pad_v2_grab *grab) {
+	// Do nothing, the default cancel can be ignored.
+}
+
+static struct wlr_tablet_pad_v2_grab_interface default_pad_interface  = {
+	.enter = default_pad_enter,
+	.button = default_pad_button,
+	.strip = default_pad_strip,
+	.ring = default_pad_ring,
+	.leave = default_pad_leave,
+	.mode = default_pad_mode,
+	.cancel = default_pad_cancel,
+};

--- a/types/tablet_v2/wlr_tablet_v2_tool.c
+++ b/types/tablet_v2/wlr_tablet_v2_tool.c
@@ -12,7 +12,7 @@
 #include <wlr/types/wlr_tablet_v2.h>
 #include <wlr/util/log.h>
 
-static const struct wlr_tablet_tool_v2_grab_interface default_tool_interface;
+static const struct wlr_tablet_tool_v2_grab_interface default_tool_grab_interface;
 
 static const struct wlr_surface_role tablet_tool_cursor_surface_role = {
 	.name = "wp_tablet_tool-cursor",
@@ -209,7 +209,7 @@ struct wlr_tablet_v2_tablet_tool *wlr_tablet_tool_create(
 	tool->wlr_tool = wlr_tool;
 	wl_list_init(&tool->clients);
 	tool->default_grab.tool = tool;
-	tool->default_grab.interface = &default_tool_interface;
+	tool->default_grab.interface = &default_tool_grab_interface;
 	tool->grab = &tool->default_grab;
 
 
@@ -602,7 +602,8 @@ void wlr_tablet_v2_tablet_tool_notify_button(
 	}
 }
 
-void wlr_tablet_tool_v2_start_grab(struct wlr_tablet_v2_tablet_tool *tool, struct wlr_tablet_tool_v2_grab *grab) {
+void wlr_tablet_tool_v2_start_grab(struct wlr_tablet_v2_tablet_tool *tool,
+		struct wlr_tablet_tool_v2_grab *grab) {
 	wlr_tablet_tool_v2_end_grab(tool);
 	tool->grab = grab;
 }
@@ -630,7 +631,7 @@ static void default_tool_up(struct wlr_tablet_tool_v2_grab *grab) {
 }
 
 static void default_tool_motion(
-	struct wlr_tablet_tool_v2_grab *grab, double x, double y) {
+		struct wlr_tablet_tool_v2_grab *grab, double x, double y) {
 	wlr_send_tablet_v2_tablet_tool_motion(grab->tool, x, y);
 }
 
@@ -678,7 +679,8 @@ static void default_tool_cancel(struct wlr_tablet_tool_v2_grab *grab) {
 	/* Do nothing. Default grab can't be canceled */
 }
 
-static const struct wlr_tablet_tool_v2_grab_interface default_tool_interface = {
+static const struct wlr_tablet_tool_v2_grab_interface
+		default_tool_grab_interface = {
 	.proximity_in = default_tool_proximity_in,
 	.down = default_tool_down,
 	.up = default_tool_up,
@@ -779,7 +781,8 @@ static void implicit_tool_cancel(struct wlr_tablet_tool_v2_grab *grab) {
 	free(grab);
 }
 
-const struct wlr_tablet_tool_v2_grab_interface implicit_tool_interface = {
+static const struct wlr_tablet_tool_v2_grab_interface
+		implicit_tool_grab_interface = {
 	.proximity_in = implicit_tool_proximity_in,
 	.down = implicit_tool_down,
 	.up = implicit_tool_up,
@@ -796,11 +799,11 @@ const struct wlr_tablet_tool_v2_grab_interface implicit_tool_interface = {
 };
 
 static bool tool_has_implicit_grab(struct wlr_tablet_v2_tablet_tool *tool) {
-	return tool->grab->interface == &implicit_tool_interface;
+	return tool->grab->interface == &implicit_tool_grab_interface;
 }
 
-void wlr_tablet_tool_v2_start_implicit_grab(struct wlr_tablet_v2_tablet_tool *tool) {
-	/* Durr */
+void wlr_tablet_tool_v2_start_implicit_grab(
+		struct wlr_tablet_v2_tablet_tool *tool) {
 	if (tool_has_implicit_grab(tool) || !tool->focused_surface) {
 		return;
 	}
@@ -816,7 +819,7 @@ void wlr_tablet_tool_v2_start_implicit_grab(struct wlr_tablet_v2_tablet_tool *to
 		return;
 	}
 
-	grab->interface = &implicit_tool_interface;
+	grab->interface = &implicit_tool_grab_interface;
 	grab->tool = tool;
 	struct implicit_grab_state *state = calloc(1, sizeof(struct implicit_grab_state));
 	if (!state) {

--- a/types/tablet_v2/wlr_tablet_v2_tool.c
+++ b/types/tablet_v2/wlr_tablet_v2_tool.c
@@ -389,11 +389,11 @@ void wlr_send_tablet_v2_tablet_tool_proximity_out(
 		if (tool->is_down) {
 			zwp_tablet_tool_v2_send_up(tool->current_client->resource);
 		}
-		zwp_tablet_tool_v2_send_proximity_out(tool->current_client->resource);
 		if (tool->current_client->frame_source) {
 			wl_event_source_remove(tool->current_client->frame_source);
 			send_tool_frame(tool->current_client);
 		}
+		zwp_tablet_tool_v2_send_proximity_out(tool->current_client->resource);
 
 		tool->current_client = NULL;
 		tool->focused_surface = NULL;


### PR DESCRIPTION
Add grabs to the tablet-v2 input device structs.

Also use the tablet-tool grab to implement the logic to *not* change focus when a button is held or the tip is pressed down.

* ~Currently buttons aren't tracked, only the tip works for now.~

Testplan:

Use an application that gives feedback on tablet-tools (e.g. the example client in https://github.com/Ongy/wlroots/tree/tablet-v2-example) [which I should merge at some point] and start two instances.
Hold pen over 1 window and connect tip. Move over other and notice that focus stays with the first.

Release pen over 2nd window and focus should be updated automatically (though no rotate/tilt/pressure/motion etc.)