### PR TITLE
Revert "rootston: Reap child processes"

### DIFF
--- a/rootston/main.c
+++ b/rootston/main.c
@@ -1,6 +1,5 @@
 #define _POSIX_C_SOURCE 200112L
 #include <assert.h>
-#include <signal.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <wayland-server.h>
@@ -16,11 +15,6 @@
 struct roots_server server = { 0 };
 
 int main(int argc, char **argv) {
-	if (signal(SIGCHLD, SIG_IGN) == SIG_ERR) {
-		wlr_log_errno(WLR_ERROR, "Unable to install SIGCHLD handler");
-		return 1;
-	}
-
 	wlr_log_init(WLR_DEBUG, NULL);
 	server.config = roots_config_create_from_args(argc, argv);
 	server.wl_display = wl_display_create();


### PR DESCRIPTION
This reverts commit b6ed1f29a4dbba93eb53c32ec5492db8ee1d9343.

This commit breaks xwayland.