### PR TITLE
rootston: focus newly-created surfaces

### DIFF
--- a/include/rootston/cursor.h
+++ b/include/rootston/cursor.h
@@ -80,4 +80,7 @@ void roots_cursor_handle_tool_tip(struct roots_cursor *cursor,
 void roots_cursor_handle_request_set_cursor(struct roots_cursor *cursor,
 		struct wlr_seat_pointer_request_set_cursor_event *event);
 
+void roots_cursor_update_position(struct roots_cursor *cursor,
+		uint32_t time);
+
 #endif

--- a/include/rootston/input.h
+++ b/include/rootston/input.h
@@ -32,4 +32,6 @@ struct roots_seat *input_get_seat(struct roots_input *input, char *name);
 
 struct roots_seat *input_last_active_seat(struct roots_input *input);
 
+void input_update_cursor_focus(struct roots_input *input);
+
 #endif

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -423,6 +423,7 @@ struct roots_subsurface *subsurface_create(struct roots_view *view,
 	view_child_init(&subsurface->view_child, view, wlr_subsurface->surface);
 	subsurface->destroy.notify = subsurface_handle_destroy;
 	wl_signal_add(&wlr_subsurface->events.destroy, &subsurface->destroy);
+	input_update_cursor_focus(view->desktop->server->input);
 	return subsurface;
 }
 
@@ -468,6 +469,7 @@ void view_map(struct roots_view *view, struct wlr_surface *surface) {
 
 	wl_list_insert(&view->desktop->views, &view->link);
 	view_damage_whole(view);
+	input_update_cursor_focus(view->desktop->server->input);
 }
 
 void view_unmap(struct roots_view *view) {

--- a/rootston/input.c
+++ b/rootston/input.c
@@ -1,5 +1,7 @@
+#define _POSIX_C_SOURCE 199309L
 #include <assert.h>
 #include <stdlib.h>
+#include <time.h>
 #include <wayland-server.h>
 #include <wlr/backend/libinput.h>
 #include <wlr/config.h>
@@ -125,4 +127,17 @@ bool input_view_has_focus(struct roots_input *input, struct roots_view *view) {
 	}
 
 	return false;
+}
+
+static inline int64_t timespec_to_msec(const struct timespec *a) {
+	return (int64_t)a->tv_sec * 1000 + a->tv_nsec / 1000000;
+}
+
+void input_update_cursor_focus(struct roots_input *input) {
+	struct roots_seat *seat;
+	struct timespec now;
+	wl_list_for_each(seat, &input->seats, link) {
+		clock_gettime(CLOCK_MONOTONIC, &now);
+		roots_cursor_update_position(seat->cursor, timespec_to_msec(&now));
+	}
 }

--- a/rootston/layer_shell.c
+++ b/rootston/layer_shell.c
@@ -291,7 +291,10 @@ static void handle_map(struct wl_listener *listener, void *data) {
 static void handle_unmap(struct wl_listener *listener, void *data) {
 	struct roots_layer_surface *layer = wl_container_of(
 			listener, layer, unmap);
+	struct wlr_output *wlr_output = layer->layer_surface->output;
+	struct roots_output *output = wlr_output->data;
 	unmap(layer->layer_surface);
+	input_update_cursor_focus(output->desktop->server->input);
 }
 
 static void popup_handle_map(struct wl_listener *listener, void *data) {
@@ -303,6 +306,7 @@ static void popup_handle_map(struct wl_listener *listener, void *data) {
 	int oy = popup->wlr_popup->geometry.y + layer->geo.y;
 	output_damage_whole_local_surface(output, popup->wlr_popup->base->surface,
 		ox, oy, 0);
+	input_update_cursor_focus(output->desktop->server->input);
 }
 
 static void popup_handle_unmap(struct wl_listener *listener, void *data) {

--- a/rootston/xdg_shell.c
+++ b/rootston/xdg_shell.c
@@ -6,6 +6,7 @@
 #include <wlr/types/wlr_surface.h>
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/util/log.h>
+#include "rootston/cursor.h"
 #include "rootston/desktop.h"
 #include "rootston/input.h"
 #include "rootston/server.h"
@@ -33,6 +34,7 @@ static void popup_handle_destroy(struct wl_listener *listener, void *data) {
 static void popup_handle_map(struct wl_listener *listener, void *data) {
 	struct roots_xdg_popup *popup = wl_container_of(listener, popup, map);
 	view_damage_whole(popup->view_child.view);
+	input_update_cursor_focus(popup->view_child.view->desktop->server->input);
 }
 
 static void popup_handle_unmap(struct wl_listener *listener, void *data) {

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -34,6 +34,7 @@ static void popup_handle_map(struct wl_listener *listener, void *data) {
 	struct roots_xdg_popup_v6 *popup =
 		wl_container_of(listener, popup, map);
 	view_damage_whole(popup->view_child.view);
+	input_update_cursor_focus(popup->view_child.view->desktop->server->input);
 }
 
 static void popup_handle_unmap(struct wl_listener *listener, void *data) {


### PR DESCRIPTION
Whenever a new surface is created, we have to update the cursor focus,
even if there's no input event. So, we generate one motion event, and
reuse the code to update the proper cursor focus. We need to do this
for all surface roles - toplevels, popups, subsurfaces.

Fixes #1162

How to test: There are many ways to test, for example open an app and don't move the cursor. The cursor surface should change (and the view should get cursor focus). Or open weston-terminal, right click, hold the button and don't move the mouse - the first menu item should be highlighted.

Further work:
1. I'm not sure, but maybe we should do the same when a surface is unmapped?
2. Port this to sway - it doesn't handle cursor focus properly either