### PR TITLE
Add missing dependency libinput to types/meson.build

### DIFF
--- a/types/meson.build
+++ b/types/meson.build
@@ -57,5 +57,5 @@ lib_wlr_types = static_library(
 		'wlr_screencopy_v1.c',
 	),
 	include_directories: wlr_inc,
-	dependencies: [pixman, xkbcommon, wayland_server, wlr_protos],
+	dependencies: [pixman, xkbcommon, wayland_server, wlr_protos, libinput],
 )


### PR DESCRIPTION
The file `types/tablet_v2/wlr_tablet_v2.c` includes `libinput.h`, and therefore depends on `libinput`. This fixes a compilation error on some systems that is caused by `libinput.h` not being in the include path.