### PR TITLE
rootston: add keybinding to toggle decoration mode

### DIFF
--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -39,6 +39,8 @@ struct roots_xdg_surface_v6 {
 	uint32_t pending_move_resize_configure_serial;
 };
 
+struct roots_xdg_toplevel_decoration;
+
 struct roots_xdg_surface {
 	struct roots_view *view;
 
@@ -54,6 +56,8 @@ struct roots_xdg_surface {
 	struct wl_listener surface_commit;
 
 	uint32_t pending_move_resize_configure_serial;
+
+	struct roots_xdg_toplevel_decoration *xdg_toplevel_decoration;
 };
 
 struct roots_xwayland_surface {

--- a/rootston/keyboard.c
+++ b/rootston/keyboard.c
@@ -133,6 +133,21 @@ static void keyboard_binding_execute(struct roots_keyboard *keyboard,
 		wl_list_for_each(output, &keyboard->input->server->desktop->outputs, link) {
 			wlr_output_enable(output->wlr_output, outputs_enabled);
 		}
+	} else if (strcmp(command, "toggle_decoration_mode") == 0) {
+		struct roots_view *focus = roots_seat_get_focus(seat);
+		if (focus != NULL && focus->type == ROOTS_XDG_SHELL_VIEW) {
+			struct roots_xdg_toplevel_decoration *decoration =
+				focus->roots_xdg_surface->xdg_toplevel_decoration;
+			if (decoration != NULL) {
+				enum wlr_xdg_toplevel_decoration_v1_mode mode =
+					decoration->wlr_decoration->current_mode;
+				mode = mode == WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE
+					? WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE
+					: WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE;
+				wlr_xdg_toplevel_decoration_v1_set_mode(
+					decoration->wlr_decoration, mode);
+			}
+		}
 	} else {
 		wlr_log(WLR_ERROR, "unknown binding command: %s", command);
 	}

--- a/rootston/xdg_shell.c
+++ b/rootston/xdg_shell.c
@@ -475,6 +475,7 @@ static void decoration_handle_destroy(struct wl_listener *listener,
 	struct roots_xdg_toplevel_decoration *decoration =
 		wl_container_of(listener, decoration, destroy);
 
+	decoration->surface->xdg_toplevel_decoration = NULL;
 	view_update_decorated(decoration->surface->view, false);
 	wl_list_remove(&decoration->destroy.link);
 	wl_list_remove(&decoration->request_mode.link);
@@ -523,6 +524,7 @@ void handle_xdg_toplevel_decoration(struct wl_listener *listener, void *data) {
 	}
 	decoration->wlr_decoration = wlr_decoration;
 	decoration->surface = xdg_surface;
+	xdg_surface->xdg_toplevel_decoration = decoration;
 
 	decoration->destroy.notify = decoration_handle_destroy;
 	wl_signal_add(&wlr_decoration->events.destroy, &decoration->destroy);


### PR DESCRIPTION
This is useful for `xdg-decoration` client devs to test decoration mode changes triggered server-side.

Test plan:
* Add `Ctrl+Shift+d = toggle_decoration_mode` to `rootston.ini`
* Open `rootston` and then spawn `build/examples/toplevel-decoration`
* Press the keybinding