### PR TITLE
session: load GPU devices even if they have zero connectors

### DIFF
--- a/backend/session/session.c
+++ b/backend/session/session.c
@@ -220,17 +220,9 @@ static int open_if_kms(struct wlr_session *restrict session, const char *restric
 		goto out_fd;
 	}
 
-	if (res->count_crtcs <= 0 || res->count_connectors <= 0 ||
-		res->count_encoders <= 0) {
-
-		goto out_res;
-	}
-
 	drmModeFreeResources(res);
 	return fd;
 
-out_res:
-	drmModeFreeResources(res);
 out_fd:
 	wlr_session_close_file(session, fd);
 	return -1;


### PR DESCRIPTION
On some systems (most notably laptops with two GPUs) there are GPUs that
don't have attached outputs. However, we still want to load those GPUs
because they could still be used by the compositor for rendering.