### PR TITLE
move wlr_drm_connector_add_mode to wlr/backend/drm.h

### DIFF
--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -143,9 +143,5 @@ void restore_drm_outputs(struct wlr_drm_backend *drm);
 void scan_drm_connectors(struct wlr_drm_backend *state);
 int handle_drm_event(int fd, uint32_t mask, void *data);
 void enable_drm_connector(struct wlr_output *output, bool enable);
-/**
- * Add mode to the list of available modes
- */
-bool wlr_drm_connector_add_mode(struct wlr_output *output, const drmModeModeInfo *mode);
 
 #endif

--- a/include/wlr/backend/drm.h
+++ b/include/wlr/backend/drm.h
@@ -28,6 +28,12 @@ struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
 bool wlr_backend_is_drm(struct wlr_backend *backend);
 bool wlr_output_is_drm(struct wlr_output *output);
 
+/**
+ * Add mode to the list of available modes
+ */
+typedef struct _drmModeModeInfo drmModeModeInfo;
+bool wlr_drm_connector_add_mode(struct wlr_output *output, const drmModeModeInfo *mode);
+
 struct wlr_session *wlr_drm_backend_get_session(struct wlr_backend *backend);
 
 #endif

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <time.h>
+#include <wlr/backend/drm.h>
 #include <wlr/config.h>
 #include <wlr/types/wlr_matrix.h>
 #include <wlr/types/wlr_compositor.h>
@@ -16,7 +17,6 @@
 #include "rootston/layers.h"
 #include "rootston/output.h"
 #include "rootston/server.h"
-#include "backend/drm/drm.h"
 
 /**
  * Rotate a child's position relative to a parent. The parent size is (pw, ph),


### PR DESCRIPTION
It is meant to be used by compositors, so it should be in the public headers.