### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE 500
+#define _POSIX_C_SOURCE 200809L
 #include <assert.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/examples/idle-inhibit.c
+++ b/examples/idle-inhibit.c
@@ -8,7 +8,11 @@
 #include "idle-inhibit-unstable-v1-client-protocol.h"
 #include "xdg-shell-client-protocol.h"
 
+#ifdef __linux__
 #include <linux/input-event-codes.h>
+#elif __FreeBSD__
+#include <dev/evdev/input-event-codes.h>
+#endif
 
 /**
  * Usage: idle-inhibit

--- a/examples/layer-shell.c
+++ b/examples/layer-shell.c
@@ -1,4 +1,4 @@
-#define _POSIX_C_SOURCE 199309L
+#define _POSIX_C_SOURCE 200112L
 #ifdef __linux__
 #include <linux/input-event-codes.h>
 #elif __FreeBSD__

--- a/examples/multi-pointer.c
+++ b/examples/multi-pointer.c
@@ -1,5 +1,4 @@
 #define _POSIX_C_SOURCE 200112L
-#define _XOPEN_SOURCE 500
 #include <assert.h>
 #include <GLES2/gl2.h>
 #include <math.h>

--- a/examples/pointer.c
+++ b/examples/pointer.c
@@ -1,5 +1,4 @@
 #define _POSIX_C_SOURCE 200112L
-#define _XOPEN_SOURCE 500
 #include <assert.h>
 #include <math.h>
 #include <stdio.h>

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -1,5 +1,4 @@
 #define _POSIX_C_SOURCE 200112L
-#define _XOPEN_SOURCE 500
 #include <GLES2/gl2.h>
 #include <getopt.h>
 #include <math.h>

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -1,5 +1,4 @@
-#define _POSIX_C_SOURCE 200112L
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 600
 #include <GLES2/gl2.h>
 #include <math.h>
 #include <stdio.h>

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -1,5 +1,4 @@
 #define _POSIX_C_SOURCE 200112L
-#define _XOPEN_SOURCE 500
 #include <GLES2/gl2.h>
 #include <math.h>
 #include <stdint.h>

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -1,4 +1,4 @@
-#define _POSIX_C_SOURCE 199309L
+#define _POSIX_C_SOURCE 200112L
 #include <assert.h>
 #include <libinput.h>
 #include <stdlib.h>

--- a/types/wlr_virtual_keyboard_v1.c
+++ b/types/wlr_virtual_keyboard_v1.c
@@ -1,4 +1,4 @@
-#define _POSIX_C_SOURCE 1
+#define _POSIX_C_SOURCE 199309L
 #include <assert.h>
 #include <stdlib.h>
 #include <sys/mman.h>


### PR DESCRIPTION
Note: it's in general not a good idea to define both `_POSIX_C_SOURCE` and `_XOPEN_SOURCE`.