### PR TITLE
virtual_keyboard: fix virtual keyboard destruction

### DIFF
--- a/types/seat/wlr_seat_keyboard.c
+++ b/types/seat/wlr_seat_keyboard.c
@@ -110,7 +110,7 @@ static void handle_keyboard_repeat_info(struct wl_listener *listener,
 static void handle_keyboard_destroy(struct wl_listener *listener, void *data) {
 	struct wlr_seat_keyboard_state *state =
 		wl_container_of(listener, state, keyboard_destroy);
-	state->keyboard = NULL;
+	wlr_seat_set_keyboard(state->seat, NULL);
 }
 
 void wlr_seat_set_keyboard(struct wlr_seat *seat,

--- a/types/wlr_virtual_keyboard_v1.c
+++ b/types/wlr_virtual_keyboard_v1.c
@@ -99,7 +99,7 @@ static void virtual_keyboard_destroy_resource(struct wl_resource *resource) {
 		virtual_keyboard_from_resource(resource);
 	wlr_signal_emit_safe(&keyboard->events.destroy, keyboard);
 	wl_list_remove(&keyboard->link);
-	wlr_keyboard_destroy(keyboard->input_device.keyboard);
+	wlr_input_device_destroy(&keyboard->input_device);
 	free(keyboard);
 }
 


### PR DESCRIPTION
After destroying the virtual keyboard, listeners could still be pointing to its wlr_input_device signals. This patch sets NULL as the active keyboard if the virtual keyboard is destroyed while in use.