### PR TITLE
introduce wlr_output_layout_farthest_output

### DIFF
--- a/include/wlr/types/wlr_output_layout.h
+++ b/include/wlr/types/wlr_output_layout.h
@@ -126,5 +126,8 @@ enum wlr_direction {
 struct wlr_output *wlr_output_layout_adjacent_output(
 		struct wlr_output_layout *layout, enum wlr_direction direction,
 		struct wlr_output *reference, double ref_lx, double ref_ly);
+struct wlr_output *wlr_output_layout_farthest_output(
+		struct wlr_output_layout *layout, enum wlr_direction direction,
+		struct wlr_output *reference, double ref_lx, double ref_ly);
 
 #endif


### PR DESCRIPTION
Similar to wlr_output_layout_adjacent_output but will return the one that is the farthest away from the reference in given direction.

I refactored the adjacent one to share some code. 