### PR TITLE
Add destroy signals to types that are destroyed by wl_display_destroy

### DIFF
--- a/backend/session/session.c
+++ b/backend/session/session.c
@@ -125,6 +125,7 @@ void wlr_session_destroy(struct wlr_session *session) {
 		return;
 	}
 
+	wlr_signal_emit_safe(&session->events.destroy, session);
 	wl_list_remove(&session->display_destroy.link);
 
 	wl_event_source_remove(session->udev_event);

--- a/include/wlr/backend/session.h
+++ b/include/wlr/backend/session.h
@@ -39,6 +39,10 @@ struct wlr_session {
 	struct wl_list devices;
 
 	struct wl_listener display_destroy;
+
+	struct {
+		struct wl_signal destroy;
+	} events;
 };
 
 /*

--- a/include/wlr/types/wlr_gamma_control.h
+++ b/include/wlr/types/wlr_gamma_control.h
@@ -17,6 +17,10 @@ struct wlr_gamma_control_manager {
 
 	struct wl_listener display_destroy;
 
+	struct {
+		struct wl_signal destroy;
+	} events;
+
 	void *data;
 };
 

--- a/include/wlr/types/wlr_gamma_control_v1.h
+++ b/include/wlr/types/wlr_gamma_control_v1.h
@@ -10,6 +10,10 @@ struct wlr_gamma_control_manager_v1 {
 
 	struct wl_listener display_destroy;
 
+	struct {
+		struct wl_signal destroy;
+	} events;
+
 	void *data;
 };
 

--- a/include/wlr/types/wlr_idle.h
+++ b/include/wlr/types/wlr_idle.h
@@ -30,6 +30,7 @@ struct wlr_idle {
 	struct wl_listener display_destroy;
 	struct {
 		struct wl_signal activity_notify;
+		struct wl_signal destroy;
 	} events;
 
 	void *data;

--- a/include/wlr/types/wlr_idle_inhibit_v1.h
+++ b/include/wlr/types/wlr_idle_inhibit_v1.h
@@ -32,6 +32,7 @@ struct wlr_idle_inhibit_manager_v1 {
 
 	struct {
 		struct wl_signal new_inhibitor;
+		struct wl_signal destroy;
 	} events;
 
 	void *data;

--- a/include/wlr/types/wlr_input_inhibitor.h
+++ b/include/wlr/types/wlr_input_inhibitor.h
@@ -20,6 +20,7 @@ struct wlr_input_inhibit_manager {
 	struct {
 		struct wl_signal activate;   // struct wlr_input_inhibit_manager *
 		struct wl_signal deactivate; // struct wlr_input_inhibit_manager *
+		struct wl_signal destroy;
 	} events;
 
 	void *data;

--- a/include/wlr/types/wlr_layer_shell.h
+++ b/include/wlr/types/wlr_layer_shell.h
@@ -39,6 +39,7 @@ struct wlr_layer_shell {
 		 // Note: the output may be NULL. In this case, it is your
 		 // responsibility to assign an output before returning.
 		struct wl_signal new_surface;
+		struct wl_signal destroy;
 	} events;
 
 	void *data;

--- a/include/wlr/types/wlr_primary_selection.h
+++ b/include/wlr/types/wlr_primary_selection.h
@@ -17,6 +17,10 @@ struct wlr_primary_selection_device_manager {
 
 	struct wl_listener display_destroy;
 
+	struct {
+		struct wl_signal destroy;
+	} events;
+
 	void *data;
 };
 

--- a/include/wlr/types/wlr_screencopy_v1.h
+++ b/include/wlr/types/wlr_screencopy_v1.h
@@ -18,6 +18,10 @@ struct wlr_screencopy_manager_v1 {
 
 	struct wl_listener display_destroy;
 
+	struct {
+		struct wl_signal destroy;
+	} events;
+
 	void *data;
 };
 

--- a/include/wlr/types/wlr_screenshooter.h
+++ b/include/wlr/types/wlr_screenshooter.h
@@ -17,6 +17,10 @@ struct wlr_screenshooter {
 
 	struct wl_listener display_destroy;
 
+	struct {
+		struct wl_signal destroy;
+	} events;
+
 	void *data;
 };
 

--- a/include/wlr/types/wlr_server_decoration.h
+++ b/include/wlr/types/wlr_server_decoration.h
@@ -45,6 +45,7 @@ struct wlr_server_decoration_manager {
 
 	struct {
 		struct wl_signal new_decoration;
+		struct wl_signal destroy;
 	} events;
 
 	void *data;

--- a/include/wlr/types/wlr_tablet_v2.h
+++ b/include/wlr/types/wlr_tablet_v2.h
@@ -29,6 +29,10 @@ struct wlr_tablet_manager_v2 {
 
 	struct wl_listener display_destroy;
 
+	struct {
+		struct wl_signal destroy;
+	} events;
+
 	void *data;
 };
 

--- a/include/wlr/types/wlr_virtual_keyboard_v1.h
+++ b/include/wlr/types/wlr_virtual_keyboard_v1.h
@@ -22,6 +22,7 @@ struct wlr_virtual_keyboard_manager_v1 {
 
 	struct {
 		struct wl_signal new_virtual_keyboard; // struct wlr_virtual_keyboard_v1*
+		struct wl_signal destroy;
 	} events;
 };
 

--- a/include/wlr/types/wlr_wl_shell.h
+++ b/include/wlr/types/wlr_wl_shell.h
@@ -24,6 +24,7 @@ struct wlr_wl_shell {
 
 	struct {
 		struct wl_signal new_surface;
+		struct wl_signal destroy;
 	} events;
 
 	void *data;

--- a/include/wlr/types/wlr_xdg_decoration_v1.h
+++ b/include/wlr/types/wlr_xdg_decoration_v1.h
@@ -19,6 +19,7 @@ struct wlr_xdg_decoration_manager_v1 {
 
 	struct {
 		struct wl_signal new_toplevel_decoration; // struct wlr_xdg_toplevel_decoration *
+		struct wl_signal destroy;
 	} events;
 
 	void *data;

--- a/include/wlr/types/wlr_xdg_output.h
+++ b/include/wlr/types/wlr_xdg_output.h
@@ -34,6 +34,10 @@ struct wlr_xdg_output_manager {
 	struct wl_listener layout_add;
 	struct wl_listener layout_change;
 	struct wl_listener layout_destroy;
+
+	struct {
+		struct wl_signal destroy;
+	} events;
 };
 
 struct wlr_xdg_output_manager *wlr_xdg_output_manager_create(

--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -29,6 +29,7 @@ struct wlr_xdg_shell {
 		 * surface will be ready to be managed on the `map` event.
 		 */
 		struct wl_signal new_surface;
+		struct wl_signal destroy;
 	} events;
 
 	void *data;

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -30,6 +30,7 @@ struct wlr_xdg_shell_v6 {
 		 * surface will be ready to be managed on the `map` event.
 		 */
 		struct wl_signal new_surface;
+		struct wl_signal destroy;
 	} events;
 
 	void *data;

--- a/types/tablet_v2/wlr_tablet_v2.c
+++ b/types/tablet_v2/wlr_tablet_v2.c
@@ -14,6 +14,7 @@
 #include <wlr/types/wlr_tablet_v2.h>
 #include <wlr/util/log.h>
 #include "tablet-unstable-v2-protocol.h"
+#include "util/signal.h"
 
 #define TABLET_MANAGER_VERSION 1
 
@@ -281,6 +282,7 @@ void wlr_tablet_v2_destroy(struct wlr_tablet_manager_v2 *manager) {
 		wlr_tablet_manager_v2_destroy(pos->resource);
 	}
 
+	wlr_signal_emit_safe(&manager->events.destroy, manager);
 	wl_global_destroy(manager->wl_global);
 	free(manager);
 }

--- a/types/wlr_gamma_control.c
+++ b/types/wlr_gamma_control.c
@@ -155,11 +155,12 @@ void wlr_gamma_control_manager_destroy(
 	if (!manager) {
 		return;
 	}
-	wl_list_remove(&manager->display_destroy.link);
 	struct wlr_gamma_control *gamma_control, *tmp;
 	wl_list_for_each_safe(gamma_control, tmp, &manager->controls, link) {
 		gamma_control_destroy(gamma_control);
 	}
+	wlr_signal_emit_safe(&manager->events.destroy, manager);
+	wl_list_remove(&manager->display_destroy.link);
 	wl_global_destroy(manager->global);
 	free(manager);
 }

--- a/types/wlr_gamma_control_v1.c
+++ b/types/wlr_gamma_control_v1.c
@@ -219,11 +219,12 @@ void wlr_gamma_control_manager_v1_destroy(
 	if (!manager) {
 		return;
 	}
-	wl_list_remove(&manager->display_destroy.link);
 	struct wlr_gamma_control_v1 *gamma_control, *tmp;
 	wl_list_for_each_safe(gamma_control, tmp, &manager->controls, link) {
 		wl_resource_destroy(gamma_control->resource);
 	}
+	wlr_signal_emit_safe(&manager->events.destroy, manager);
+	wl_list_remove(&manager->display_destroy.link);
 	struct wl_resource *resource, *resource_tmp;
 	wl_resource_for_each_safe(resource, resource_tmp, &manager->resources) {
 		wl_resource_destroy(resource);

--- a/types/wlr_idle.c
+++ b/types/wlr_idle.c
@@ -187,6 +187,7 @@ void wlr_idle_destroy(struct wlr_idle *idle) {
 	if (!idle) {
 		return;
 	}
+	wlr_signal_emit_safe(&idle->events.destroy, idle);
 	wl_list_remove(&idle->display_destroy.link);
 	struct wlr_idle_timeout *timer, *tmp;
 	wl_list_for_each_safe(timer, tmp, &idle->idle_timers, link) {

--- a/types/wlr_idle_inhibit_v1.c
+++ b/types/wlr_idle_inhibit_v1.c
@@ -144,13 +144,14 @@ void wlr_idle_inhibit_v1_destroy(struct wlr_idle_inhibit_manager_v1 *idle_inhibi
 		return;
 	}
 
-	wl_list_remove(&idle_inhibit->display_destroy.link);
-
 	struct wlr_idle_inhibitor_v1 *inhibitor;
 	struct wlr_idle_inhibitor_v1 *tmp;
 	wl_list_for_each_safe(inhibitor, tmp, &idle_inhibit->inhibitors, link) {
 		idle_inhibitor_v1_destroy(inhibitor);
 	}
+
+	wlr_signal_emit_safe(&idle_inhibit->events.destroy, idle_inhibit);
+	wl_list_remove(&idle_inhibit->display_destroy.link);
 
 	struct wl_resource *resource;
 	struct wl_resource *tmp_resource;

--- a/types/wlr_input_inhibitor.c
+++ b/types/wlr_input_inhibitor.c
@@ -112,6 +112,7 @@ void wlr_input_inhibit_manager_destroy(
 		input_inhibitor_destroy(manager->active_client,
 				manager->active_inhibitor);
 	}
+	wlr_signal_emit_safe(&manager->events.destroy, manager);
 	wl_list_remove(&manager->display_destroy.link);
 	wl_global_destroy(manager->global);
 	free(manager);

--- a/types/wlr_layer_shell.c
+++ b/types/wlr_layer_shell.c
@@ -464,6 +464,7 @@ void wlr_layer_shell_destroy(struct wlr_layer_shell *layer_shell) {
 	wl_resource_for_each_safe(client, tmp, &layer_shell->client_resources) {
 		wl_resource_destroy(client);
 	}
+	wlr_signal_emit_safe(&layer_shell->events.destroy, layer_shell);
 	wl_list_remove(&layer_shell->display_destroy.link);
 	wl_global_destroy(layer_shell->global);
 	free(layer_shell);

--- a/types/wlr_primary_selection.c
+++ b/types/wlr_primary_selection.c
@@ -419,6 +419,7 @@ void wlr_primary_selection_device_manager_destroy(
 	if (manager == NULL) {
 		return;
 	}
+	wlr_signal_emit_safe(&manager->events.destroy, manager);
 	wl_list_remove(&manager->display_destroy.link);
 	// TODO: free resources
 	wl_global_destroy(manager->global);

--- a/types/wlr_screencopy_v1.c
+++ b/types/wlr_screencopy_v1.c
@@ -5,6 +5,7 @@
 #include <wlr/types/wlr_screencopy_v1.h>
 #include <wlr/backend.h>
 #include "wlr-screencopy-unstable-v1-protocol.h"
+#include "util/signal.h"
 
 #define SCREENCOPY_MANAGER_VERSION 1
 
@@ -306,6 +307,7 @@ void wlr_screencopy_manager_v1_destroy(
 	if (manager == NULL) {
 		return;
 	}
+	wlr_signal_emit_safe(&manager->events.destroy, manager);
 	wl_list_remove(&manager->display_destroy.link);
 	struct wlr_screencopy_frame_v1 *frame, *tmp_frame;
 	wl_list_for_each_safe(frame, tmp_frame, &manager->frames, link) {

--- a/types/wlr_screenshooter.c
+++ b/types/wlr_screenshooter.c
@@ -8,6 +8,7 @@
 #include <wlr/types/wlr_screenshooter.h>
 #include <wlr/util/log.h>
 #include "screenshooter-protocol.h"
+#include "util/signal.h"
 
 static struct wlr_screenshot *screenshot_from_resource(
 		struct wl_resource *resource) {
@@ -177,6 +178,7 @@ void wlr_screenshooter_destroy(struct wlr_screenshooter *screenshooter) {
 	wl_list_for_each_safe(screenshot, tmp, &screenshooter->screenshots, link) {
 		screenshot_destroy(screenshot);
 	}
+	wlr_signal_emit_safe(&screenshooter->events.destroy, screenshooter);
 	wl_global_destroy(screenshooter->global);
 	free(screenshooter);
 }

--- a/types/wlr_server_decoration.c
+++ b/types/wlr_server_decoration.c
@@ -167,12 +167,13 @@ void wlr_server_decoration_manager_destroy(
 	if (manager == NULL) {
 		return;
 	}
-	wl_list_remove(&manager->display_destroy.link);
 	struct wlr_server_decoration *decoration, *tmp_decoration;
 	wl_list_for_each_safe(decoration, tmp_decoration, &manager->decorations,
 			link) {
 		server_decoration_destroy(decoration);
 	}
+	wlr_signal_emit_safe(&manager->events.destroy, manager);
+	wl_list_remove(&manager->display_destroy.link);
 	struct wl_resource *resource, *tmp_resource;
 	wl_resource_for_each_safe(resource, tmp_resource, &manager->resources) {
 		server_decoration_manager_destroy_resource(resource);

--- a/types/wlr_virtual_keyboard_v1.c
+++ b/types/wlr_virtual_keyboard_v1.c
@@ -231,6 +231,7 @@ struct wlr_virtual_keyboard_manager_v1*
 
 void wlr_virtual_keyboard_manager_v1_destroy(
 		struct wlr_virtual_keyboard_manager_v1 *manager) {
+	wlr_signal_emit_safe(&manager->events.destroy, manager);
 	wl_list_remove(&manager->display_destroy.link);
 	wl_global_destroy(manager->global);
 	struct wl_resource *resource, *resource_tmp;

--- a/types/wlr_xdg_decoration_v1.c
+++ b/types/wlr_xdg_decoration_v1.c
@@ -287,6 +287,7 @@ void wlr_xdg_decoration_manager_v1_destroy(
 	if (manager == NULL) {
 		return;
 	}
+	wlr_signal_emit_safe(&manager->events.destroy, manager);
 	wl_list_remove(&manager->display_destroy.link);
 	struct wlr_xdg_toplevel_decoration_v1 *decoration, *tmp_decoration;
 	wl_list_for_each_safe(decoration, tmp_decoration, &manager->decorations,

--- a/types/wlr_xdg_output.c
+++ b/types/wlr_xdg_output.c
@@ -6,6 +6,7 @@
 #include <wlr/types/wlr_xdg_output.h>
 #include <wlr/util/log.h>
 #include "xdg-output-unstable-v1-protocol.h"
+#include "util/signal.h"
 
 #define OUTPUT_MANAGER_VERSION 2
 
@@ -245,6 +246,7 @@ void wlr_xdg_output_manager_destroy(struct wlr_xdg_output_manager *manager) {
 	wl_resource_for_each_safe(resource, resource_tmp, &manager->resources) {
 		wl_resource_destroy(resource);
 	}
+	wlr_signal_emit_safe(&manager->events.destroy, manager);
 	wl_list_remove(&manager->layout_add.link);
 	wl_list_remove(&manager->layout_change.link);
 	wl_list_remove(&manager->layout_destroy.link);

--- a/types/xdg_shell/wlr_xdg_shell.c
+++ b/types/xdg_shell/wlr_xdg_shell.c
@@ -166,6 +166,7 @@ void wlr_xdg_shell_destroy(struct wlr_xdg_shell *xdg_shell) {
 	if (!xdg_shell) {
 		return;
 	}
+	wlr_signal_emit_safe(&xdg_shell->events.destroy, xdg_shell);
 	wl_list_remove(&xdg_shell->display_destroy.link);
 	wl_global_destroy(xdg_shell->global);
 	free(xdg_shell);

--- a/types/xdg_shell_v6/wlr_xdg_shell_v6.c
+++ b/types/xdg_shell_v6/wlr_xdg_shell_v6.c
@@ -167,6 +167,7 @@ void wlr_xdg_shell_v6_destroy(struct wlr_xdg_shell_v6 *xdg_shell) {
 	if (!xdg_shell) {
 		return;
 	}
+	wlr_signal_emit_safe(&xdg_shell->events.destroy, xdg_shell);
 	wl_list_remove(&xdg_shell->display_destroy.link);
 	wl_global_destroy(xdg_shell->global);
 	free(xdg_shell);


### PR DESCRIPTION
As discussed on IRC. This should make it a bit easier for compositors to keep track of which resources get destroyed.