### PR TITLE
Fix bugs listed by clang's static analyzer

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -25,4 +25,4 @@ tasks:
       ninja
   - clang: |
       cd wlroots/build-clang
-      ninja
+      ninja scan-build

--- a/backend/libinput/tablet_pad.c
+++ b/backend/libinput/tablet_pad.c
@@ -28,7 +28,7 @@ static void add_pad_group_from_libinput(struct wlr_tablet_pad *pad,
 			++group->ring_count;
 		}
 	}
-	group->rings = calloc(sizeof(int), group->ring_count);
+	group->rings = calloc(sizeof(unsigned int), group->ring_count);
 	size_t ring = 0;
 	for (size_t i = 0; i < pad->ring_count; ++i) {
 		if (libinput_tablet_pad_mode_group_has_ring(li_group, i)) {
@@ -41,7 +41,7 @@ static void add_pad_group_from_libinput(struct wlr_tablet_pad *pad,
 			++group->strip_count;
 		}
 	}
-	group->strips = calloc(sizeof(int), group->strip_count);
+	group->strips = calloc(sizeof(unsigned int), group->strip_count);
 	size_t strip = 0;
 	for (size_t i = 0; i < pad->strip_count; ++i) {
 		if (libinput_tablet_pad_mode_group_has_strip(li_group, i)) {
@@ -54,7 +54,7 @@ static void add_pad_group_from_libinput(struct wlr_tablet_pad *pad,
 			++group->button_count;
 		}
 	}
-	group->buttons = calloc(sizeof(int), group->button_count);
+	group->buttons = calloc(sizeof(unsigned int), group->button_count);
 	size_t button = 0;
 	for (size_t i = 0; i < pad->button_count; ++i) {
 		if (libinput_tablet_pad_mode_group_has_button(li_group, i)) {

--- a/rootston/xdg_shell.c
+++ b/rootston/xdg_shell.c
@@ -507,8 +507,6 @@ static void decoration_handle_surface_commit(struct wl_listener *listener,
 }
 
 void handle_xdg_toplevel_decoration(struct wl_listener *listener, void *data) {
-	struct roots_desktop *desktop =
-		wl_container_of(listener, desktop, xdg_toplevel_decoration);
 	struct wlr_xdg_toplevel_decoration_v1 *wlr_decoration = data;
 
 	wlr_log(WLR_DEBUG, "new xdg toplevel decoration");

--- a/types/tablet_v2/wlr_tablet_v2_pad.c
+++ b/types/tablet_v2/wlr_tablet_v2_pad.c
@@ -368,7 +368,7 @@ struct wlr_tablet_v2_tablet_pad *wlr_tablet_pad_create(
 	}
 
 	pad->group_count = wl_list_length(&wlr_pad->groups);
-	pad->groups = calloc(pad->group_count, sizeof(int));
+	pad->groups = calloc(pad->group_count, sizeof(uint32_t));
 	if (!pad->groups) {
 		free(pad);
 		return NULL;
@@ -471,9 +471,9 @@ void wlr_send_tablet_v2_tablet_pad_button(
 
 void wlr_send_tablet_v2_tablet_pad_strip(struct wlr_tablet_v2_tablet_pad *pad,
 		uint32_t strip, double position, bool finger, uint32_t time) {
-	if (!pad->current_client &&
-			pad->current_client->strips &&
-			pad->current_client->strips[strip]) {
+	if (!pad->current_client ||
+			!pad->current_client->strips ||
+			!pad->current_client->strips[strip]) {
 		return;
 	}
 	struct wl_resource *resource = pad->current_client->strips[strip];

--- a/types/wlr_cursor.c
+++ b/types/wlr_cursor.c
@@ -332,7 +332,7 @@ static void handle_pointer_motion(struct wl_listener *listener, void *data) {
 
 static void apply_output_transform(double *x, double *y,
 		enum wl_output_transform transform) {
-	double dx = *x, dy = *y;
+	double dx, dy;
 	double width = 1.0, height = 1.0;
 
 	switch (transform) {


### PR DESCRIPTION
A few pedantic changes and unused variables (1-4), and genuine bugs (5,
6).

The reports with the corresponding files and lines numbers are as
follows.

1. backend/libinput/tablet_pad.c@31,44,57
"Allocator sizeof operand mismatch"
"Result of 'calloc' is converted to a pointer of type 'unsigned int',
which is incompatible with sizeof operand type 'int'"

2. types/tablet_v2/wlr_tablet_v2_pad.c@371
"Allocator sizeof operand mismatch"
"Result of 'calloc' is converted to a pointer of type 'uint32_t', which
is incompatible with sizeof operand type 'int'"

3. types/wlr_cursor.c@335
"Dead initialization"
"Value stored to 'dx'/'dy' during its initialization is never read"

4. rootston/xdg_shell.c@510
"Dead initialization"
"Value stored to 'desktop' during its initialization is never read"

5. types/tablet_v2/wlr_tablet_v2_pad.c@475
"Dereference of null pointer"
"Access to field 'strips' results in a dereference of a null pointer
(loaded from field 'current_client')"

The boolean logic was incorrect (c.f. the check in the following
function).

6. examples/idle.c@163,174,182
"Uninitialized argument value"
"1st function call argument is an uninitialized value"

If close_timeout != 0, but simulate_activity_timeout >= close_timeout,
the program would segfault at pthread_cancel(t1).