### PR TITLE
add missing wlr_box.h include in wlr_screencopy_v1.h

### DIFF
--- a/include/wlr/types/wlr_screencopy_v1.h
+++ b/include/wlr/types/wlr_screencopy_v1.h
@@ -10,6 +10,7 @@
 #define WLR_TYPES_WLR_SCREENCOPY_V1_H
 
 #include <wayland-server.h>
+#include <wlr/types/wlr_box.h>
 
 struct wlr_screencopy_manager_v1 {
 	struct wl_global *global;


### PR DESCRIPTION
`wlr_screencopy_v1.h` depends on `wlr_box`, but doesn't have the include.