### PR TITLE
Add wlr_log_get_verbosity method

### DIFF
--- a/include/wlr/util/log.h
+++ b/include/wlr/util/log.h
@@ -37,6 +37,9 @@ typedef void (*wlr_log_func_t)(enum wlr_log_importance importance,
 // If `callback` is NULL, wlr will use its default logger.
 void wlr_log_init(enum wlr_log_importance verbosity, wlr_log_func_t callback);
 
+// Returns the log verbosity provided to wlr_log_init
+enum wlr_log_importance wlr_log_get_verbosity(void);
+
 #ifdef __GNUC__
 #define _WLR_ATTRIB_PRINTF(start, end) __attribute__((format(printf, start, end)))
 #else

--- a/include/wlr/util/log.h
+++ b/include/wlr/util/log.h
@@ -35,6 +35,8 @@ typedef void (*wlr_log_func_t)(enum wlr_log_importance importance,
 
 // Will log all messages less than or equal to `verbosity`
 // If `callback` is NULL, wlr will use its default logger.
+// The function can be called multiple times to update the verbosity or
+// callback function.
 void wlr_log_init(enum wlr_log_importance verbosity, wlr_log_func_t callback);
 
 // Returns the log verbosity provided to wlr_log_init

--- a/util/log.c
+++ b/util/log.c
@@ -85,3 +85,7 @@ const char *_wlr_strip_path(const char *filepath) {
 	}
 	return filepath;
 }
+
+enum wlr_log_importance wlr_log_get_verbosity(void) {
+	return log_importance;
+}


### PR DESCRIPTION
Returns the verbosity passed to wlr_log_init().

Used to close stdout/stderr for Xwayland.