### PR TITLE
backend/drm: allow disabling outputs in NEEDS_MODESET state

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -344,7 +344,8 @@ static void drm_connector_start_renderer(struct wlr_drm_connector *conn) {
 
 void enable_drm_connector(struct wlr_output *output, bool enable) {
 	struct wlr_drm_connector *conn = (struct wlr_drm_connector *)output;
-	if (conn->state != WLR_DRM_CONN_CONNECTED) {
+	if (conn->state != WLR_DRM_CONN_CONNECTED
+			&& conn->state != WLR_DRM_CONN_NEEDS_MODESET) {
 		return;
 	}
 


### PR DESCRIPTION
This correctly frees CRTCs when disabling outputs without setting
a mode.

Fixes the situation in which some CRTCs were in use by disabled outputs and we want to re-allocate them to other outputs. The first modeset attempt still fails, so this isn't a full fix.

Fixes part of #409