### PR TITLE
Miscellaneous memory leak fixes

### DIFF
--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -163,6 +163,8 @@ static bool backend_start(struct wlr_backend *backend) {
 					0,
 					0,
 					0);
+
+				free(reply);
 			}
 		}
 #endif

--- a/examples/idle.c
+++ b/examples/idle.c
@@ -129,6 +129,7 @@ int main(int argc, char *argv[]) {
 	wl_registry_add_listener(registry, &registry_listener, NULL);
 	wl_display_dispatch(display);
 	wl_display_roundtrip(display);
+	free(registry);
 
 	if (idle_manager == NULL) {
 		fprintf(stderr, "display doesn't support idle protocol\n");

--- a/examples/multi-pointer.c
+++ b/examples/multi-pointer.c
@@ -330,6 +330,11 @@ int main(int argc, char *argv[]) {
 		cursor_destroy(cursor);
 	}
 
+	struct sample_pointer *pointer, *tmp_pointer;
+	wl_list_for_each_safe(pointer, tmp_pointer, &state.pointers, link) {
+		free(pointer);
+	}
+
 	wlr_xcursor_theme_destroy(theme);
 	wlr_output_layout_destroy(state.layout);
 }

--- a/examples/multi-pointer.c
+++ b/examples/multi-pointer.c
@@ -239,15 +239,21 @@ void new_input_notify(struct wl_listener *listener, void *data) {
 			wlr_log(WLR_ERROR, "Failed to create XKB context");
 			exit(1);
 		}
-		wlr_keyboard_set_keymap(device->keyboard, xkb_map_new_from_names(context,
-					&rules, XKB_KEYMAP_COMPILE_NO_FLAGS));
+		struct xkb_keymap *keymap = xkb_map_new_from_names(context, &rules,
+			XKB_KEYMAP_COMPILE_NO_FLAGS);
+		if (!keymap) {
+			wlr_log(WLR_ERROR, "Failed to create XKB keymap");
+			exit(1);
+		}
+		wlr_keyboard_set_keymap(device->keyboard, keymap);
+		xkb_keymap_unref(keymap);
 		xkb_context_unref(context);
 		break;
 	case WLR_INPUT_DEVICE_POINTER:;
-	   	struct sample_cursor *cursor = calloc(1, sizeof(struct sample_cursor));
+		struct sample_cursor *cursor = calloc(1, sizeof(struct sample_cursor));
 		struct sample_pointer *pointer = calloc(1, sizeof(struct sample_pointer));
 		pointer->device = device;
-	   	cursor->sample = sample;
+		cursor->sample = sample;
 		cursor->device = device;
 
 		cursor->cursor = wlr_cursor_create();

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -239,8 +239,14 @@ void new_input_notify(struct wl_listener *listener, void *data) {
 			wlr_log(WLR_ERROR, "Failed to create XKB context");
 			exit(1);
 		}
-		wlr_keyboard_set_keymap(device->keyboard, xkb_map_new_from_names(context,
-					&rules, XKB_KEYMAP_COMPILE_NO_FLAGS));
+		struct xkb_keymap *keymap = xkb_map_new_from_names(context, &rules,
+			XKB_KEYMAP_COMPILE_NO_FLAGS);
+		if (!keymap) {
+			wlr_log(WLR_ERROR, "Failed to create XKB keymap");
+			exit(1);
+		}
+		wlr_keyboard_set_keymap(device->keyboard, keymap);
+		xkb_keymap_unref(keymap);
 		xkb_context_unref(context);
 		break;
 	default:

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -291,6 +291,6 @@ int main(int argc, char *argv[]) {
 
 	wlr_texture_destroy(state.cat_texture);
 
-	wlr_output_layout_destroy(state.layout);
 	wl_display_destroy(state.display);
+	wlr_output_layout_destroy(state.layout);
 }

--- a/examples/pointer.c
+++ b/examples/pointer.c
@@ -304,8 +304,14 @@ void new_input_notify(struct wl_listener *listener, void *data) {
 			wlr_log(WLR_ERROR, "Failed to create XKB context");
 			exit(1);
 		}
-		wlr_keyboard_set_keymap(device->keyboard, xkb_map_new_from_names(context,
-					&rules, XKB_KEYMAP_COMPILE_NO_FLAGS));
+		struct xkb_keymap *keymap = xkb_map_new_from_names(context, &rules,
+			XKB_KEYMAP_COMPILE_NO_FLAGS);
+		if (!keymap) {
+			wlr_log(WLR_ERROR, "Failed to create XKB keymap");
+			exit(1);
+		}
+		wlr_keyboard_set_keymap(device->keyboard, keymap);
+		xkb_keymap_unref(keymap);
 		xkb_context_unref(context);
 		break;
 	default:

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -188,8 +188,14 @@ void new_input_notify(struct wl_listener *listener, void *data) {
 			wlr_log(WLR_ERROR, "Failed to create XKB context");
 			exit(1);
 		}
-		wlr_keyboard_set_keymap(device->keyboard, xkb_map_new_from_names(context,
-					&rules, XKB_KEYMAP_COMPILE_NO_FLAGS));
+		struct xkb_keymap *keymap = xkb_map_new_from_names(context, &rules,
+			XKB_KEYMAP_COMPILE_NO_FLAGS);
+		if (!keymap) {
+			wlr_log(WLR_ERROR, "Failed to create XKB keymap");
+			exit(1);
+		}
+		wlr_keyboard_set_keymap(device->keyboard, keymap);
+		xkb_keymap_unref(keymap);
 		xkb_context_unref(context);
 		break;
 	default:

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -141,8 +141,14 @@ void new_input_notify(struct wl_listener *listener, void *data) {
 			wlr_log(WLR_ERROR, "Failed to create XKB context");
 			exit(1);
 		}
-		wlr_keyboard_set_keymap(device->keyboard, xkb_map_new_from_names(context,
-					&rules, XKB_KEYMAP_COMPILE_NO_FLAGS));
+		struct xkb_keymap *keymap = xkb_map_new_from_names(context, &rules,
+			XKB_KEYMAP_COMPILE_NO_FLAGS);
+		if (!keymap) {
+			wlr_log(WLR_ERROR, "Failed to create XKB keymap");
+			exit(1);
+		}
+		wlr_keyboard_set_keymap(device->keyboard, keymap);
+		xkb_keymap_unref(keymap);
 		xkb_context_unref(context);
 		break;
 	default:

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -297,8 +297,14 @@ void new_input_notify(struct wl_listener *listener, void *data) {
 			wlr_log(WLR_ERROR, "Failed to create XKB context");
 			exit(1);
 		}
-		wlr_keyboard_set_keymap(device->keyboard, xkb_map_new_from_names(context,
-					&rules, XKB_KEYMAP_COMPILE_NO_FLAGS));
+		struct xkb_keymap *keymap = xkb_map_new_from_names(context, &rules,
+			XKB_KEYMAP_COMPILE_NO_FLAGS);
+		if (!keymap) {
+			wlr_log(WLR_ERROR, "Failed to create XKB keymap");
+			exit(1);
+		}
+		wlr_keyboard_set_keymap(device->keyboard, keymap);
+		xkb_keymap_unref(keymap);
 		xkb_context_unref(context);
 		break;
 	case WLR_INPUT_DEVICE_TABLET_PAD:;

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -210,8 +210,14 @@ void new_input_notify(struct wl_listener *listener, void *data) {
 			wlr_log(WLR_ERROR, "Failed to create XKB context");
 			exit(1);
 		}
-		wlr_keyboard_set_keymap(device->keyboard, xkb_map_new_from_names(context,
-					&rules, XKB_KEYMAP_COMPILE_NO_FLAGS));
+		struct xkb_keymap *keymap = xkb_map_new_from_names(context, &rules,
+			XKB_KEYMAP_COMPILE_NO_FLAGS);
+		if (!keymap) {
+			wlr_log(WLR_ERROR, "Failed to create XKB keymap");
+			exit(1);
+		}
+		wlr_keyboard_set_keymap(device->keyboard, keymap);
+		xkb_keymap_unref(keymap);
 		xkb_context_unref(context);
 		break;
 	case WLR_INPUT_DEVICE_TOUCH:;

--- a/types/tablet_v2/wlr_tablet_v2.c
+++ b/types/tablet_v2/wlr_tablet_v2.c
@@ -294,13 +294,6 @@ struct wlr_tablet_manager_v2 *wlr_tablet_v2_create(struct wl_display *display) {
 		return NULL;
 	}
 
-	wl_signal_init(&tablet->events.destroy);
-	wl_list_init(&tablet->clients);
-	wl_list_init(&tablet->seats);
-
-	tablet->display_destroy.notify = handle_display_destroy;
-	wl_display_add_destroy_listener(display, &tablet->display_destroy);
-
 	tablet->wl_global = wl_global_create(display,
 		&zwp_tablet_manager_v2_interface, TABLET_MANAGER_VERSION,
 		tablet, tablet_v2_bind);
@@ -308,6 +301,13 @@ struct wlr_tablet_manager_v2 *wlr_tablet_v2_create(struct wl_display *display) {
 		free(tablet);
 		return NULL;
 	}
+
+	wl_signal_init(&tablet->events.destroy);
+	wl_list_init(&tablet->clients);
+	wl_list_init(&tablet->seats);
+
+	tablet->display_destroy.notify = handle_display_destroy;
+	wl_display_add_destroy_listener(display, &tablet->display_destroy);
 
 	return tablet;
 }

--- a/types/tablet_v2/wlr_tablet_v2.c
+++ b/types/tablet_v2/wlr_tablet_v2.c
@@ -283,6 +283,7 @@ void wlr_tablet_v2_destroy(struct wlr_tablet_manager_v2 *manager) {
 	}
 
 	wlr_signal_emit_safe(&manager->events.destroy, manager);
+	wl_list_remove(&manager->display_destroy.link);
 	wl_global_destroy(manager->wl_global);
 	free(manager);
 }


### PR DESCRIPTION
The changes in wlroot include a very minor leak in x11/backend.c (7bc2657) and a bug in tablet_manager_v2 (9f511ae).

The other commits to the examples include setting keymaps more securely (7105864), and removing pointers in multi-pointer (6af77e3).

Please let me know if some commits are better merged squashed (say, all the edits to examples).