### PR TITLE
Remove indent_size from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,10 +5,8 @@ end_of_line = lf
 insert_final_newline = true
 charset = utf-8
 indent_style = tab
-indent_size = 4
 trim_trailing_whitespace = true
 
 [*.xml]
 indent_style = space
 indent_size = 2
-tab_width = 8


### PR DESCRIPTION
I've recently bothered to configure my editor to actually use this.
Some of us like to use different indent sizes.