### PR TITLE
Fix #1129

### DIFF
--- a/include/wlr/types/wlr_data_device.h
+++ b/include/wlr/types/wlr_data_device.h
@@ -93,8 +93,6 @@ struct wlr_drag_icon {
 	bool is_pointer;
 	int32_t touch_id;
 
-	int32_t sx, sy;
-
 	struct {
 		struct wl_signal map;
 		struct wl_signal unmap;

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -502,16 +502,16 @@ void roots_drag_icon_update_position(struct roots_drag_icon *icon) {
 	struct roots_seat *seat = icon->seat;
 	struct wlr_cursor *cursor = seat->cursor->cursor;
 	if (wlr_icon->is_pointer) {
-		icon->x = cursor->x + wlr_icon->sx;
-		icon->y = cursor->y + wlr_icon->sy;
+		icon->x = cursor->x;
+		icon->y = cursor->y;
 	} else {
 		struct wlr_touch_point *point =
 			wlr_seat_touch_get_point(seat->seat, wlr_icon->touch_id);
 		if (point == NULL) {
 			return;
 		}
-		icon->x = seat->touch_x + wlr_icon->sx;
-		icon->y = seat->touch_y + wlr_icon->sy;
+		icon->x = seat->touch_x;
+		icon->y = seat->touch_y;
 	}
 
 	roots_drag_icon_damage_whole(icon);

--- a/types/data_device/wlr_drag.c
+++ b/types/data_device/wlr_drag.c
@@ -345,9 +345,6 @@ static void drag_icon_surface_role_commit(struct wlr_surface *surface) {
 		return;
 	}
 
-	icon->sx += icon->surface->current.dx;
-	icon->sy += icon->surface->current.dy;
-
 	drag_icon_set_mapped(icon, wlr_surface_has_buffer(surface));
 }
 


### PR DESCRIPTION
wlr_drag_icon.{sx, sy} used to store the buffer offset of the drag surface which was
then be added (by rootston) to the drag icon position.
Buffer offsets are handled already in surface_intersect_output
(output.c) so they were added twice for dnd surfaces.

If sx, sy were also intended for other usages or it could somehow be useful
to store the buffer offset there as well (kind of redundant though),
i can revert the removing from wlr and simply leave them ignored by rootston.

Tested with weston-dnd and qutebrowser (as a bit more complex dnd client).