### PR TITLE
Fix wlr_xwayland_destroy

### DIFF
--- a/xwayland/xwayland.c
+++ b/xwayland/xwayland.c
@@ -406,6 +406,10 @@ static bool xwayland_start_server_lazy(struct wlr_xwayland *wlr_xwayland) {
 }
 
 void wlr_xwayland_destroy(struct wlr_xwayland *wlr_xwayland) {
+	if (!wlr_xwayland) {
+		return;
+	}
+
 	wlr_xwayland_set_seat(wlr_xwayland, NULL);
 	xwayland_finish_server(wlr_xwayland);
 	xwayland_finish_display(wlr_xwayland);


### PR DESCRIPTION
In rootston, wlr_xwayland_destroy is always called (when compiled with xwayland) which causes a segmentation fault on exit when disabling xwayland per config (e.g. example config).
We could also just fix this by checking in rootston, but this follows the wlr convention of most destroy functions that passing NULL is ok.