### PR TITLE
fix cursor loss w/ legacy drm and software cursor (tested on etnaviv)

### DIFF
--- a/backend/drm/legacy.c
+++ b/backend/drm/legacy.c
@@ -39,7 +39,10 @@ bool legacy_crtc_set_cursor(struct wlr_drm_backend *drm,
 	}
 
 	if (!bo) {
-		drmModeSetCursor(drm->fd, crtc->id, 0, 0, 0);
+		if (drmModeSetCursor(drm->fd, crtc->id, 0, 0, 0)) {
+			wlr_log_errno(WLR_DEBUG, "Failed to clear hardware cursor");
+			return false;
+		}
 		return true;
 	}
 


### PR DESCRIPTION
I tested sway today on an etnaviv platform (imx6qp/reform) and it worked fine except that the cursor disappeared as soon as I moved it into the swaybar and would not reappear. This was because swaybar clears and then immediately sets a cursor. Both fail in DRM, but the failure of clearing is not seen, leading to a wrong state. This PR adds a missing error handling for the drmModeSetCursor() case where an empty cursor is set.