### PR TITLE
Steal CRTCs from disabled outputs

### DIFF
--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -129,6 +129,9 @@ static bool atomic_crtc_pageflip(struct wlr_drm_backend *drm,
 static bool atomic_conn_enable(struct wlr_drm_backend *drm,
 		struct wlr_drm_connector *conn, bool enable) {
 	struct wlr_drm_crtc *crtc = conn->crtc;
+	if (crtc == NULL) {
+		return !enable;
+	}
 
 	struct atomic atom;
 	atomic_begin(crtc, &atom);

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -120,6 +120,7 @@ struct wlr_drm_connector {
 
 	enum wlr_drm_connector_state state;
 	struct wlr_output_mode *desired_mode;
+	bool desired_enabled;
 	uint32_t id;
 
 	struct wlr_drm_crtc *crtc;


### PR DESCRIPTION
~~Depends on #1235, new material here is the second commit (https://github.com/swaywm/wlroots/commit/f68740bb9d6dd9364fd1fe958b3b4acfadca7f8b)~~

This commit allows outputs that need a CRTC to steal it from
user-disabled outputs. Note that in the case there are enough
CRTCs, disabled outputs don't loose it (so there's no modeset
and plane initialization needed after DPMS). CRTC allocation
still prefers to keep the old configuration, even if that means
allocating an extra CRTC to a disabled output.

CRTC reallocation now happen when enabling/disabling an output as
well as when trying to modeset. When enabling an output without a
CRTC, we realloc to try to steal a CRTC from a disabled output
(that doesn't really need the CRTC). When disabling an output, we
try to give our CRTC to an output that needs one. Modesetting is
similar to enabling.

A new DRM connector field has been added: `desired_enabled`.
Outputs without CRTCs get automatically disabled. This field keeps
track of the state desired by the user, allowing to automatically
re-enable outputs when a CRTC becomes free.

This required some changes to the allocation algorithm. Previously,
the algorithm tried to keep the previous configuration even if a
new configuration with a better score was possible (it only changed
configuration when the old one didn't work anymore). This is now
changed and the old configuration (still preferred) is only
retained without considering new possibilities when it's perfect
(all outputs have CRTCs).

User-disabled outputs now have `possible_crtcs` set to 0, meaning
they can only retain a previous CRTC (not acquire a new one). The
allocation algorithm has been updated to do not bump the score
when assigning a CRTC to a disabled output.

Test plan: plug in many outputs, disable some of them to allow outputs without CRTCs to gain one, disable old outputs, unplug some of them, etc.

Fixes #409