### PR TITLE
rootston: Keep older anchored layers near anchor points

### DIFF
--- a/rootston/layer_shell.c
+++ b/rootston/layer_shell.c
@@ -110,7 +110,7 @@ static void arrange_layer(struct wlr_output *output,
 	struct wlr_box full_area = { 0 };
 	wlr_output_effective_resolution(output,
 			&full_area.width, &full_area.height);
-	wl_list_for_each(roots_surface, list, link) {
+	wl_list_for_each_reverse(roots_surface, list, link) {
 		struct wlr_layer_surface *layer = roots_surface->layer_surface;
 		struct wlr_layer_surface_state *state = &layer->current;
 		if (exclusive != (state->exclusive_zone > 0)) {


### PR DESCRIPTION
Layer surfaces are attached to edges of the screen starting with the youngest, causing new ones to always displace existing ones. This changes the order to oldest first, keeping the positions more often.

With this change, layers attached to edges have a more intuitive feeling of "building upon" the edge.