### PR TITLE
Disable hardware cursors when capturing output

### DIFF
--- a/examples/dmabuf-capture.c
+++ b/examples/dmabuf-capture.c
@@ -45,6 +45,7 @@ struct capture_context {
 
 	/* Target */
 	struct wl_output *target_output;
+	bool with_cursor;
 
 	/* Main frame callback */
 	struct zwlr_export_dmabuf_frame_v1 *frame_callback;
@@ -454,7 +455,7 @@ static const struct zwlr_export_dmabuf_frame_v1_listener frame_listener = {
 
 static void register_cb(struct capture_context *ctx) {
 	ctx->frame_callback = zwlr_export_dmabuf_manager_v1_capture_output(
-			ctx->export_manager, 0, ctx->target_output);
+			ctx->export_manager, ctx->with_cursor, ctx->target_output);
 
 	zwlr_export_dmabuf_frame_v1_add_listener(ctx->frame_callback,
 			&frame_listener, ctx);
@@ -802,6 +803,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	ctx.target_output = o->output;
+	ctx.with_cursor = true;
 	ctx.hw_device_type = av_hwdevice_find_type_by_name(argv[2]);
 	ctx.hardware_device = argv[3];
 

--- a/include/wlr/types/wlr_export_dmabuf_v1.h
+++ b/include/wlr/types/wlr_export_dmabuf_v1.h
@@ -9,6 +9,7 @@
 #ifndef WLR_TYPES_WLR_EXPORT_DMABUF_V1_H
 #define WLR_TYPES_WLR_EXPORT_DMABUF_V1_H
 
+#include <stdbool.h>
 #include <wayland-server.h>
 #include <wlr/render/dmabuf.h>
 
@@ -21,6 +22,8 @@ struct wlr_export_dmabuf_frame_v1 {
 
 	struct wlr_dmabuf_attributes attribs;
 	struct wlr_output *output;
+
+	bool cursor_locked;
 
 	struct wl_listener output_swap_buffers;
 };

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -107,6 +107,7 @@ struct wlr_output {
 
 	struct wl_list cursors; // wlr_output_cursor::link
 	struct wlr_output_cursor *hardware_cursor;
+	int software_cursor_locks; // number of locks forcing software cursors
 
 	// the output position in layout space reported to clients
 	int32_t lx, ly;
@@ -196,6 +197,14 @@ bool wlr_output_export_dmabuf(struct wlr_output *output,
 void wlr_output_set_fullscreen_surface(struct wlr_output *output,
 	struct wlr_surface *surface);
 struct wlr_output *wlr_output_from_resource(struct wl_resource *resource);
+/**
+ * Locks the output to only use software cursors instead of hardware cursors.
+ * This is useful if hardware cursors need to be temporarily disabled (e.g.
+ * during screen capture). There must be as many unlocks as there have been
+ * locks to restore the original state. There should never be an unlock before
+ * a lock.
+ */
+void wlr_output_lock_software_cursors(struct wlr_output *output, bool lock);
 
 
 struct wlr_output_cursor *wlr_output_cursor_create(struct wlr_output *output);

--- a/include/wlr/types/wlr_screencopy_v1.h
+++ b/include/wlr/types/wlr_screencopy_v1.h
@@ -9,6 +9,7 @@
 #ifndef WLR_TYPES_WLR_SCREENCOPY_V1_H
 #define WLR_TYPES_WLR_SCREENCOPY_V1_H
 
+#include <stdbool.h>
 #include <wayland-server.h>
 #include <wlr/types/wlr_box.h>
 
@@ -34,6 +35,8 @@ struct wlr_screencopy_frame_v1 {
 	enum wl_shm_format format;
 	struct wlr_box box;
 	int stride;
+
+	bool overlay_cursor, cursor_locked;
 
 	struct wl_shm_buffer *buffer;
 	struct wl_listener buffer_destroy;


### PR DESCRIPTION
We need to track the number of times hardware cursors have been disabled to properly support e.g. screenshooting and screen recording at the same time.