### PR TITLE
Send unique keymap file descriptors

### DIFF
--- a/include/wlr/types/wlr_keyboard.h
+++ b/include/wlr/types/wlr_keyboard.h
@@ -50,7 +50,7 @@ struct wlr_keyboard_modifiers {
 struct wlr_keyboard {
 	const struct wlr_keyboard_impl *impl;
 
-	int keymap_fd;
+	char *keymap_string;
 	size_t keymap_size;
 	struct xkb_keymap *keymap;
 	struct xkb_state *xkb_state;


### PR DESCRIPTION
Fixes #1192 

To prevent wl_keyboard keymap being written to by clients, use a unique
file descriptor for each wl_keyboard resource.

Reference: [weston, commit 76829fc4eaea329d2a525c3978271e13bd76c078](https://gitlab.freedesktop.org/wayland/weston/commit/76829fc4eaea329d2a525c3978271e13bd76c078)