### PR TITLE
Add support for WLR_SESSION env variable

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -16,6 +16,8 @@ wlroots specific
   of outputs
 * *WLR_NO_HARDWARE_CURSORS*: set to 1 to use software cursors instead of
   hardware cursors
+* *WLR_SESSION*: specifies the wlr\_session to be used (available sessions:
+  logind/systemd, direct)
 
 rootston specific
 ------------------


### PR DESCRIPTION
Fixes #1064 

Valid values are "logind"/"systemd" and "direct". If WLR_SESSION is set,
only its value is potentially tried; it will not try any other option.