### PR TITLE
buffer: disconnect clients that commit an unknown buffer type

### DIFF
--- a/types/wlr_buffer.c
+++ b/types/wlr_buffer.c
@@ -87,6 +87,10 @@ struct wlr_buffer *wlr_buffer_create(struct wlr_renderer *renderer,
 		// the buffer yet.
 	} else {
 		wlr_log(WLR_ERROR, "Cannot upload texture: unknown buffer type");
+
+		// Instead of just logging the error, also disconnect the client with a
+		// fatal protocol error so that it's clear something went wrong.
+		wl_resource_post_error(resource, 0, "unknown buffer type");
 		return NULL;
 	}
 


### PR DESCRIPTION
If this happens, something went really wrong and we should do more
than just logging an error. See [1].

[1]: https://gitlab.freedesktop.org/wayland/weston/issues/148