### PR TITLE
Fix partial dependency in protocol/meson.build

### DIFF
--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -77,7 +77,7 @@ endforeach
 lib_wl_protos = static_library(
 	'wl_protos',
 	wl_protos_src + wl_protos_headers,
-	dependencies: wayland_client.partial_dependency(includes: true),
+	dependencies: wayland_client.partial_dependency(compile_args: true),
 )
 
 wlr_protos = declare_dependency(


### PR DESCRIPTION
External dependencies in Meson do not have `include_directories`, therefore `includes: true` means nothing for the `wayland-client` partial dependency in protocol/meson.build. Because of this, the `-I` CFLAGs for wayland-client are not used by the build command. This commit fixes this by using `compile_args`.