### PR TITLE
Fix damage tracking for surfaces with transforms

### DIFF
--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -229,4 +229,12 @@ struct wlr_surface *wlr_surface_from_resource(struct wl_resource *resource);
 void wlr_surface_for_each_surface(struct wlr_surface *surface,
 	wlr_surface_iterator_func_t iterator, void *user_data);
 
+/**
+ * Get the effective damage to the surface in terms of surface local
+ * coordinates. This includes damage induced by resizing and moving the
+ * surface. The damage is not expected to be bounded by the surface itself.
+ */
+void wlr_surface_get_effective_damage(struct wlr_surface *surface,
+	pixman_region32_t *damage);
+
 #endif

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -17,14 +17,14 @@
 #include <wlr/types/wlr_output.h>
 
 enum wlr_surface_state_field {
-	WLR_SURFACE_STATE_BUFFER = 1,
-	WLR_SURFACE_STATE_SURFACE_DAMAGE = 2,
-	WLR_SURFACE_STATE_BUFFER_DAMAGE = 4,
-	WLR_SURFACE_STATE_OPAQUE_REGION = 8,
-	WLR_SURFACE_STATE_INPUT_REGION = 16,
-	WLR_SURFACE_STATE_TRANSFORM = 32,
-	WLR_SURFACE_STATE_SCALE = 64,
-	WLR_SURFACE_STATE_FRAME_CALLBACK_LIST = 128,
+	WLR_SURFACE_STATE_BUFFER = 1 << 0,
+	WLR_SURFACE_STATE_SURFACE_DAMAGE = 1 << 1,
+	WLR_SURFACE_STATE_BUFFER_DAMAGE = 1 << 2,
+	WLR_SURFACE_STATE_OPAQUE_REGION = 1 << 3,
+	WLR_SURFACE_STATE_INPUT_REGION = 1 << 4,
+	WLR_SURFACE_STATE_TRANSFORM = 1 << 5,
+	WLR_SURFACE_STATE_SCALE = 1 << 6,
+	WLR_SURFACE_STATE_FRAME_CALLBACK_LIST = 1 << 7,
 };
 
 struct wlr_surface_state {
@@ -32,7 +32,7 @@ struct wlr_surface_state {
 
 	struct wl_resource *buffer_resource;
 	int32_t dx, dy; // relative to previous position
-	pixman_region32_t surface_damage, buffer_damage;
+	pixman_region32_t surface_damage, buffer_damage; // clipped to bounds
 	pixman_region32_t opaque, input;
 	enum wl_output_transform transform;
 	int32_t scale;
@@ -68,11 +68,12 @@ struct wlr_surface {
 	 * The last commit's buffer damage, in buffer-local coordinates. This
 	 * contains both the damage accumulated by the client via
 	 * `wlr_surface_state.surface_damage` and `wlr_surface_state.buffer_damage`.
-	 * If the buffer has changed its size or moved, the whole buffer is
-	 * damaged.
+	 * If the buffer has been resized, the whole buffer is damaged.
 	 *
 	 * This region needs to be scaled and transformed into output coordinates,
-	 * just like the buffer's texture.
+	 * just like the buffer's texture. In addition, if the buffer has shrunk the
+	 * old size needs to be damaged and if the buffer has moved the old and new
+	 * positions need to be damaged.
 	 */
 	pixman_region32_t buffer_damage;
 	/**

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -696,13 +696,10 @@ static void damage_from_surface(struct wlr_surface *surface, int sx, int sy,
 	int center_x = box.x + box.width/2;
 	int center_y = box.y + box.height/2;
 
-	enum wl_output_transform transform = surface->current.transform;
-
 	pixman_region32_t damage;
 	pixman_region32_init(&damage);
-	pixman_region32_copy(&damage, &surface->buffer_damage);
-	wlr_region_transform(&damage, &damage, transform,
-		surface->current.buffer_width, surface->current.buffer_height);
+	wlr_surface_get_effective_damage(surface, &damage);
+
 	wlr_region_scale(&damage, &damage,
 		wlr_output->scale / (float)surface->current.scale);
 	if (ceil(wlr_output->scale) > surface->current.scale) {

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -700,8 +700,7 @@ static void damage_from_surface(struct wlr_surface *surface, int sx, int sy,
 	pixman_region32_init(&damage);
 	wlr_surface_get_effective_damage(surface, &damage);
 
-	wlr_region_scale(&damage, &damage,
-		wlr_output->scale / (float)surface->current.scale);
+	wlr_region_scale(&damage, &damage, wlr_output->scale);
 	if (ceil(wlr_output->scale) > surface->current.scale) {
 		// When scaling up a surface, it'll become blurry so we need to
 		// expand the damage region

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -696,8 +696,7 @@ static void damage_from_surface(struct wlr_surface *surface, int sx, int sy,
 	int center_x = box.x + box.width/2;
 	int center_y = box.y + box.height/2;
 
-	enum wl_output_transform transform =
-		wlr_output_transform_invert(surface->current.transform);
+	enum wl_output_transform transform = surface->current.transform;
 
 	pixman_region32_t damage;
 	pixman_region32_init(&damage);

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -7,6 +7,7 @@
 #include <wlr/types/wlr_matrix.h>
 #include <wlr/types/wlr_region.h>
 #include <wlr/types/wlr_surface.h>
+#include <wlr/types/wlr_output.h>
 #include <wlr/util/log.h>
 #include <wlr/util/region.h>
 #include "util/signal.h"
@@ -198,7 +199,8 @@ static void surface_update_damage(pixman_region32_t *buffer_damage,
 		pixman_region32_init(&surface_damage);
 		pixman_region32_copy(&surface_damage, &current->surface_damage);
 		wlr_region_transform(&surface_damage, &surface_damage,
-			current->transform, current->buffer_width, current->buffer_height);
+			wlr_output_transform_invert(current->transform),
+			current->width, current->height);
 		wlr_region_scale(&surface_damage, &surface_damage, current->scale);
 		pixman_region32_union(buffer_damage, buffer_damage, &surface_damage);
 		pixman_region32_fini(&surface_damage);
@@ -307,8 +309,8 @@ static void surface_apply_damage(struct wlr_surface *surface) {
 		pixman_region32_init(&surface_damage);
 		pixman_region32_copy(&surface_damage, &surface->current.surface_damage);
 		wlr_region_transform(&surface_damage, &surface_damage,
-			surface->current.transform,
-			surface->current.buffer_width, surface->current.buffer_height);
+			wlr_output_transform_invert(surface->current.transform),
+			surface->current.width, surface->current.height);
 		wlr_region_scale(&surface_damage, &surface_damage,
 			surface->current.scale);
 		pixman_region32_union(&damage, &damage, &surface_damage);

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -301,29 +301,8 @@ static void surface_apply_damage(struct wlr_surface *surface) {
 	}
 
 	if (surface->buffer != NULL && surface->buffer->released) {
-		pixman_region32_t damage;
-		pixman_region32_init(&damage);
-		pixman_region32_copy(&damage, &surface->current.buffer_damage);
-
-		pixman_region32_t surface_damage;
-		pixman_region32_init(&surface_damage);
-		pixman_region32_copy(&surface_damage, &surface->current.surface_damage);
-		wlr_region_transform(&surface_damage, &surface_damage,
-			wlr_output_transform_invert(surface->current.transform),
-			surface->current.width, surface->current.height);
-		wlr_region_scale(&surface_damage, &surface_damage,
-			surface->current.scale);
-		pixman_region32_union(&damage, &damage, &surface_damage);
-		pixman_region32_fini(&surface_damage);
-
-		pixman_region32_intersect_rect(&damage, &damage, 0, 0,
-			surface->current.buffer_width, surface->current.buffer_height);
-
 		struct wlr_buffer *updated_buffer =
-			wlr_buffer_apply_damage(surface->buffer, resource, &damage);
-
-		pixman_region32_fini(&damage);
-
+			wlr_buffer_apply_damage(surface->buffer, resource, &surface->buffer_damage);
 		if (updated_buffer != NULL) {
 			surface->buffer = updated_buffer;
 			return;

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -170,39 +170,39 @@ static void surface_state_finalize(struct wlr_surface *surface,
 }
 
 static void surface_update_damage(pixman_region32_t *buffer_damage,
-		struct wlr_surface_state *previous, struct wlr_surface_state *current) {
+		struct wlr_surface_state *current, struct wlr_surface_state *pending) {
 	pixman_region32_clear(buffer_damage);
 
 	pixman_region32_t surface_damage;
 	pixman_region32_init(&surface_damage);
 
-	if (current->width != previous->width ||
-			current->height != previous->height ||
-			current->dx != 0 || current->dy != 0) {
+	if (pending->width != current->width ||
+			pending->height != current->height ||
+			pending->dx != 0 || pending->dy != 0) {
 		// Damage the whole surface on resize or move
-		int prev_x = -current->dx;
-		int prev_y = -current->dy;
-		if ((previous->transform & WL_OUTPUT_TRANSFORM_90) != 0) {
+		int prev_x = -pending->dx;
+		int prev_y = -pending->dy;
+		if ((current->transform & WL_OUTPUT_TRANSFORM_90) != 0) {
 			int tmp = prev_x;
 			prev_x = prev_y;
 			prev_y = tmp;
 		}
 
 		pixman_region32_union_rect(&surface_damage, &surface_damage, prev_x,
-			prev_y, previous->width, previous->height);
+			prev_y, current->width, current->height);
 		pixman_region32_union_rect(&surface_damage, &surface_damage, 0, 0,
-			current->width, current->height);
+			pending->width, pending->height);
 	} else {
 		// Copy over surface damage + buffer damage
 		pixman_region32_union(buffer_damage, buffer_damage,
-			&current->buffer_damage);
-		pixman_region32_copy(&surface_damage, &current->surface_damage);
+			&pending->buffer_damage);
+		pixman_region32_copy(&surface_damage, &pending->surface_damage);
 	}
 
 	wlr_region_transform(&surface_damage, &surface_damage,
-		wlr_output_transform_invert(current->transform),
-		current->width, current->height);
-	wlr_region_scale(&surface_damage, &surface_damage, current->scale);
+		wlr_output_transform_invert(pending->transform),
+		pending->width, pending->height);
+	wlr_region_scale(&surface_damage, &surface_damage, pending->scale);
 	pixman_region32_union(buffer_damage, buffer_damage, &surface_damage);
 	pixman_region32_fini(&surface_damage);
 }


### PR DESCRIPTION
Fixes bugs with running `weston-simple-damage --transform=90` (for example) and `weston-fullscreen` (use 't' to get a non-zero transform, then resize/scale/move mouse around). Both clients are now working (mostly) perfectly.

*Caveat:* `weston-simple-damage --rotating-transform` leads to a very dirty buffer. Damage tracking is correct though (check in rootston). Weston also behaves the same way. ~~No idea how to fix this.~~ It's a bug with `weston-simple-damage`: it damages the previous location incorrectly when the transformation changes.
