### PR TITLE
Improve session handling

### DIFF
--- a/backend/backend.c
+++ b/backend/backend.c
@@ -15,6 +15,7 @@
 #include <wlr/backend/wayland.h>
 #include <wlr/config.h>
 #include <wlr/util/log.h>
+#include "backend/multi.h"
 
 /* WLR_HAS_X11_BACKEND needs to be after wlr/config.h */
 #ifdef WLR_HAS_X11_BACKEND
@@ -52,6 +53,13 @@ void wlr_backend_destroy(struct wlr_backend *backend) {
 struct wlr_renderer *wlr_backend_get_renderer(struct wlr_backend *backend) {
 	if (backend->impl->get_renderer) {
 		return backend->impl->get_renderer(backend);
+	}
+	return NULL;
+}
+
+struct wlr_session *wlr_backend_get_session(struct wlr_backend *backend) {
+	if (backend->impl->get_session) {
+		return backend->impl->get_session(backend);
 	}
 	return NULL;
 }
@@ -158,10 +166,12 @@ static struct wlr_backend *attempt_backend_by_name(struct wl_display *display,
 		return attempt_headless_backend(display, create_renderer_func);
 	} else if (strcmp(name, "drm") == 0 || strcmp(name, "libinput") == 0) {
 		// DRM and libinput need a session
-		*session = wlr_session_create(display);
 		if (!*session) {
-			wlr_log(WLR_ERROR, "failed to start a session");
-			return NULL;
+			*session = wlr_session_create(display);
+			if (!*session) {
+				wlr_log(WLR_ERROR, "failed to start a session");
+				return NULL;
+			}
 		}
 
 		if (strcmp(name, "libinput") == 0) {
@@ -178,12 +188,11 @@ static struct wlr_backend *attempt_backend_by_name(struct wl_display *display,
 struct wlr_backend *wlr_backend_autocreate(struct wl_display *display,
 		wlr_renderer_create_func_t create_renderer_func) {
 	struct wlr_backend *backend = wlr_multi_backend_create(display);
+	struct wlr_multi_backend *multi = (struct wlr_multi_backend *)backend;
 	if (!backend) {
 		wlr_log(WLR_ERROR, "could not allocate multibackend");
 		return NULL;
 	}
-
-	struct wlr_session *session = NULL;
 
 	char *names = getenv("WLR_BACKENDS");
 	if (names) {
@@ -197,12 +206,12 @@ struct wlr_backend *wlr_backend_autocreate(struct wl_display *display,
 		char *saveptr;
 		char *name = strtok_r(names, ",", &saveptr);
 		while (name != NULL) {
-			struct wlr_backend *subbackend =
-				attempt_backend_by_name(display, backend, &session, name, create_renderer_func);
+			struct wlr_backend *subbackend = attempt_backend_by_name(display,
+				backend, &multi->session, name, create_renderer_func);
 			if (subbackend == NULL) {
 				wlr_log(WLR_ERROR, "failed to start backend '%s'", name);
 				wlr_backend_destroy(backend);
-				wlr_session_destroy(session);
+				wlr_session_destroy(multi->session);
 				free(names);
 				return NULL;
 			}
@@ -210,7 +219,7 @@ struct wlr_backend *wlr_backend_autocreate(struct wl_display *display,
 			if (!wlr_multi_backend_add(backend, subbackend)) {
 				wlr_log(WLR_ERROR, "failed to add backend '%s'", name);
 				wlr_backend_destroy(backend);
-				wlr_session_destroy(session);
+				wlr_session_destroy(multi->session);
 				free(names);
 				return NULL;
 			}
@@ -245,29 +254,30 @@ struct wlr_backend *wlr_backend_autocreate(struct wl_display *display,
 #endif
 
 	// Attempt DRM+libinput
-	session = wlr_session_create(display);
-	if (!session) {
+	multi->session = wlr_session_create(display);
+	if (!multi->session) {
 		wlr_log(WLR_ERROR, "Failed to start a DRM session");
 		wlr_backend_destroy(backend);
 		return NULL;
 	}
 
-	struct wlr_backend *libinput = wlr_libinput_backend_create(display, session);
+	struct wlr_backend *libinput = wlr_libinput_backend_create(display,
+		multi->session);
 	if (!libinput) {
 		wlr_log(WLR_ERROR, "Failed to start libinput backend");
 		wlr_backend_destroy(backend);
-		wlr_session_destroy(session);
+		wlr_session_destroy(multi->session);
 		return NULL;
 	}
 	wlr_multi_backend_add(backend, libinput);
 
-	struct wlr_backend *primary_drm =
-		attempt_drm_backend(display, backend, session, create_renderer_func);
+	struct wlr_backend *primary_drm = attempt_drm_backend(display, backend,
+		multi->session, create_renderer_func);
 	if (!primary_drm) {
 		wlr_log(WLR_ERROR, "Failed to open any DRM device");
 		wlr_backend_destroy(libinput);
 		wlr_backend_destroy(backend);
-		wlr_session_destroy(session);
+		wlr_session_destroy(multi->session);
 		return NULL;
 	}
 

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -193,8 +193,3 @@ error_fd:
 	free(drm);
 	return NULL;
 }
-
-struct wlr_session *wlr_drm_backend_get_session(struct wlr_backend *backend) {
-	struct wlr_drm_backend *drm = get_drm_backend_from_backend(backend);
-	return drm->session;
-}

--- a/include/backend/multi.h
+++ b/include/backend/multi.h
@@ -8,6 +8,7 @@
 
 struct wlr_multi_backend {
 	struct wlr_backend backend;
+	struct wlr_session *session;
 
 	struct wl_list backends;
 

--- a/include/wlr/backend.h
+++ b/include/wlr/backend.h
@@ -57,5 +57,10 @@ void wlr_backend_destroy(struct wlr_backend *backend);
  * Obtains the wlr_renderer reference this backend is using.
  */
 struct wlr_renderer *wlr_backend_get_renderer(struct wlr_backend *backend);
+/**
+ * Obtains the wlr_session reference from this backend if there is any.
+ * Might return NULL for backends that don't use a session.
+ */
+struct wlr_session *wlr_backend_get_session(struct wlr_backend *backend);
 
 #endif

--- a/include/wlr/backend/drm.h
+++ b/include/wlr/backend/drm.h
@@ -34,6 +34,4 @@ bool wlr_output_is_drm(struct wlr_output *output);
 typedef struct _drmModeModeInfo drmModeModeInfo;
 bool wlr_drm_connector_add_mode(struct wlr_output *output, const drmModeModeInfo *mode);
 
-struct wlr_session *wlr_drm_backend_get_session(struct wlr_backend *backend);
-
 #endif

--- a/include/wlr/backend/interface.h
+++ b/include/wlr/backend/interface.h
@@ -17,6 +17,7 @@ struct wlr_backend_impl {
 	bool (*start)(struct wlr_backend *backend);
 	void (*destroy)(struct wlr_backend *backend);
 	struct wlr_renderer *(*get_renderer)(struct wlr_backend *backend);
+	struct wlr_session *(*get_session)(struct wlr_backend *backend);
 };
 
 /**

--- a/include/wlr/backend/multi.h
+++ b/include/wlr/backend/multi.h
@@ -28,7 +28,6 @@ void wlr_multi_backend_remove(struct wlr_backend *multi,
 	struct wlr_backend *backend);
 
 bool wlr_backend_is_multi(struct wlr_backend *backend);
-struct wlr_session *wlr_multi_get_session(struct wlr_backend *base);
 bool wlr_multi_is_empty(struct wlr_backend *backend);
 
 void wlr_multi_for_each_backend(struct wlr_backend *backend,

--- a/rootston/keyboard.c
+++ b/rootston/keyboard.c
@@ -5,7 +5,6 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include <wayland-server.h>
-#include <wlr/backend/multi.h>
 #include <wlr/backend/session.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_pointer.h>
@@ -193,14 +192,13 @@ static bool keyboard_execute_compositor_binding(struct roots_keyboard *keyboard,
 	if (keysym >= XKB_KEY_XF86Switch_VT_1 &&
 			keysym <= XKB_KEY_XF86Switch_VT_12) {
 		struct roots_server *server = keyboard->input->server;
-		if (wlr_backend_is_multi(server->backend)) {
-			struct wlr_session *session =
-				wlr_multi_get_session(server->backend);
-			if (session) {
-				unsigned vt = keysym - XKB_KEY_XF86Switch_VT_1 + 1;
-				wlr_session_change_vt(session, vt);
-			}
+
+		struct wlr_session *session = wlr_backend_get_session(server->backend);
+		if (session) {
+			unsigned vt = keysym - XKB_KEY_XF86Switch_VT_1 + 1;
+			wlr_session_change_vt(session, vt);
 		}
+
 		return true;
 	}
 


### PR DESCRIPTION
Sessions can now be retrieved from a backend in a more general manner.
Multi-backend gets back its `session` field that contains the session
if one was created, removing the interfacing from multi backend with the
drm backend directly. This adds the possibility to use sessions even
without the drm backend.

It additionally fixes the bug that 2 session objects got created when
WLR_BACKENDS were set to "libinput,drm".

To allow vt switching without drm backend (and drm fd) on logind, start
listening to PropertiesChanged signals from dbus and parse the session
"Active" property when no master fd was created (this does not change
current drm backend behaviour in any way).

---

The main reason for this pr is to allow future session-based backends other than the drm one (like a VkDisplayKHR backend, i did a rather basic implementation [here](https://github.com/nyorain/wlroots/tree/vk_display) but it depends on the vulkan pr so it may take a while until it hits master (if it will at all...) and i figured it's a good idea submitting these rather independent changes/fixes already). The interface changes make session interaction in general simpler though, see the rootston/keyboard.c change for vt switching. Rootston no longer has to directly interface with the multi backend.

This is my first time really touching dbus/the sdbus library so a review of that part by someone with more experience is appreciated. Note that weston does handle it the same way; although it leaves the decision how/when to (de)activate sessions explicitly to the backend (it seems) and does not decide it implicitly by whether or not a drm device is taken.