### PR TITLE
Set b_lundef to false on FreeBSD in meson.build

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ Run these commands:
     meson build
     ninja -C build
 
-On FreeBSD, you need to pass an extra flag to prevent a linking error:
-`meson build -D b_lundef=false`.
+If you use Meson older than 0.48.0 on FreeBSD, you need to pass an extra flag
+to prevent a linking error: `meson build -D b_lundef=false`.
 
 Install like so:
 

--- a/README.md
+++ b/README.md
@@ -74,9 +74,6 @@ Run these commands:
     meson build
     ninja -C build
 
-If you use Meson older than 0.48.0 on FreeBSD, you need to pass an extra flag
-to prevent a linking error: `meson build -D b_lundef=false`.
-
 Install like so:
 
 	sudo ninja -C build install

--- a/meson.build
+++ b/meson.build
@@ -111,7 +111,7 @@ wlr_deps += [
 	math,
 ]
 
-if host_machine.system().startswith('freebsd')
+if host_machine.system() == 'freebsd'
 	override_options = ['b_lundef=false']
 else
 	override_options = []

--- a/meson.build
+++ b/meson.build
@@ -111,6 +111,12 @@ wlr_deps += [
 	math,
 ]
 
+if host_machine.system().startswith('freebsd')
+	override_options = ['b_lundef=false']
+else
+	override_options = []
+endif
+
 symbols_file = 'wlroots.syms'
 symbols_flag = '-Wl,--version-script,@0@/@1@'.format(meson.current_source_dir(), symbols_file)
 lib_wlr = library(
@@ -122,6 +128,7 @@ lib_wlr = library(
 	install: true,
 	link_args : symbols_flag,
 	link_depends: symbols_file,
+	override_options: override_options,
 )
 
 wlroots = declare_dependency(

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
 	'c',
 	version: '0.0.1',
 	license: 'MIT',
-	meson_version: '>=0.47.1',
+	meson_version: '>=0.48.0',
 	default_options: [
 		'c_std=c11',
 		'warning_level=2',


### PR DESCRIPTION
The Meson option `b_lundef` need to be set to `false` on FreeBSD, because the symbol `environ` is in crt1.o, which is not linked with shared libraries. Until now, it was done by passing the `-Db_lundef=false` flag manually, but with Meson >=0.48.0 it is possible to set this option conditionally inside meson.build.