### PR TITLE
Fix tablet_tool tilt and send proximity_out

### DIFF
--- a/include/rootston/seat.h
+++ b/include/rootston/seat.h
@@ -114,6 +114,7 @@ struct roots_tablet_tool {
 	struct wlr_tablet_v2_tablet_tool *tablet_v2_tool;
 
 	struct roots_seat *seat;
+	double tilt_x, tilt_y;
 
 	struct wl_listener set_cursor;
 	struct wl_listener tool_destroy;

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -178,9 +178,18 @@ static void handle_tool_axis(struct wl_listener *listener, void *data) {
 			roots_tool->tablet_v2_tool, event->distance);
 	}
 
+	if (event->updated_axes & WLR_TABLET_TOOL_AXIS_TILT_X) {
+		roots_tool->tilt_x = event->tilt_x;
+	}
+
+	if (event->updated_axes & WLR_TABLET_TOOL_AXIS_TILT_Y) {
+		roots_tool->tilt_y = event->tilt_y;
+	}
+
 	if (event->updated_axes & (WLR_TABLET_TOOL_AXIS_TILT_X | WLR_TABLET_TOOL_AXIS_TILT_Y)) {
 		wlr_tablet_v2_tablet_tool_notify_tilt(
-			roots_tool->tablet_v2_tool, event->tilt_x, event->tilt_y);
+			roots_tool->tablet_v2_tool,
+			roots_tool->tilt_x, roots_tool->tilt_y);
 	}
 
 	if (event->updated_axes & WLR_TABLET_TOOL_AXIS_ROTATION) {
@@ -283,6 +292,12 @@ static void handle_tool_proximity(struct wl_listener *listener, void *data) {
 
 		wl_list_init(&roots_tool->link);
 		wl_list_init(&roots_tool->tool_link);
+	}
+
+	if (event->state == WLR_TABLET_TOOL_PROXIMITY_OUT) {
+		struct roots_tablet_tool *roots_tool = tool->data;
+		wlr_tablet_v2_tablet_tool_notify_proximity_out(roots_tool->tablet_v2_tool);
+		return;
 	}
 
 	handle_tablet_tool_position(cursor, event->device->data, event->tool,


### PR DESCRIPTION
Originally I asumed tilt_x and tilt_y are very unlikely to change
independent, I was proven wrong.
And while investigating Krita not using the Erasor tool, I found a bug,
which is unrelated though.