### PR TITLE
xwayland/xwm: Stop including xcb_image.h

### DIFF
--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -12,7 +12,6 @@
 #include <wlr/xwayland.h>
 #include <xcb/composite.h>
 #include <xcb/render.h>
-#include <xcb/xcb_image.h>
 #include <xcb/xfixes.h>
 #include "util/signal.h"
 #include "xwayland/xwm.h"


### PR DESCRIPTION
It's not used (XCB_IMAGE_FORMAT_Z_PIXMAP comes from xproto.h) and we
don't even have a pkg-config dependency on xcb-image, making the build
to fail on that inclusion on systems without the package.