### PR TITLE
Update sizes for new EDID database.

### DIFF
--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -65,7 +65,7 @@ struct wlr_output {
 	struct wl_list resources;
 
 	char name[24];
-	char make[48];
+	char make[56];
 	char model[16];
 	char serial[16];
 	int32_t phys_width, phys_height; // mm

--- a/rootston/config.c
+++ b/rootston/config.c
@@ -577,7 +577,7 @@ void roots_config_destroy(struct roots_config *config) {
 
 struct roots_output_config *roots_config_get_output(struct roots_config *config,
 		struct wlr_output *output) {
-	char name[83];
+	char name[88];
 	snprintf(name, sizeof(name), "%s %s %s", output->make, output->model,
 		output->serial);
 


### PR DESCRIPTION
This fixes an error where in certain compiler configurations (Arch Linux?) compilation will fail because the sizes were not large enough.