### PR TITLE
output: don't trigger a frame immediately in schedule_frame

### DIFF
--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -192,9 +192,22 @@ void update_wl_output_cursor(struct wlr_wl_output *output) {
 	}
 }
 
-bool output_move_cursor(struct wlr_output *_output, int x, int y) {
+static bool output_move_cursor(struct wlr_output *_output, int x, int y) {
 	// TODO: only return true if x == current x and y == current y
 	return true;
+}
+
+static void output_schedule_frame(struct wlr_output *wlr_output) {
+	struct wlr_wl_output *output = get_wl_output_from_output(wlr_output);
+
+	if (output->frame_callback != NULL) {
+		wlr_log(WLR_ERROR, "Skipping frame scheduling");
+		return;
+	}
+
+	output->frame_callback = wl_surface_frame(output->surface);
+	wl_callback_add_listener(output->frame_callback, &frame_listener, output);
+	wl_surface_commit(output->surface);
 }
 
 static const struct wlr_output_impl output_impl = {
@@ -205,6 +218,7 @@ static const struct wlr_output_impl output_impl = {
 	.swap_buffers = output_swap_buffers,
 	.set_cursor = output_set_cursor,
 	.move_cursor = output_move_cursor,
+	.schedule_frame = output_schedule_frame,
 };
 
 bool wlr_output_is_wl(struct wlr_output *wlr_output) {

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -33,6 +33,7 @@ struct wlr_output_impl {
 	size_t (*get_gamma_size)(struct wlr_output *output);
 	bool (*export_dmabuf)(struct wlr_output *output,
 		struct wlr_dmabuf_attributes *attribs);
+	void (*schedule_frame)(struct wlr_output *output);
 };
 
 void wlr_output_init(struct wlr_output *output, struct wlr_backend *backend,

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -545,14 +545,10 @@ void wlr_output_send_frame(struct wlr_output *output) {
 static void schedule_frame_handle_idle_timer(void *data) {
 	struct wlr_output *output = data;
 	output->idle_frame = NULL;
-	if (!output->frame_pending) {
-		if (output->impl->schedule_frame) {
-			// Ask the backend to send a frame event when appropriate
-			output->frame_pending = true;
-			output->impl->schedule_frame(output);
-		} else {
-			wlr_output_send_frame(output);
-		}
+	if (!output->frame_pending && output->impl->schedule_frame) {
+		// Ask the backend to send a frame event when appropriate
+		output->frame_pending = true;
+		output->impl->schedule_frame(output);
 	}
 }
 

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -546,7 +546,13 @@ static void schedule_frame_handle_idle_timer(void *data) {
 	struct wlr_output *output = data;
 	output->idle_frame = NULL;
 	if (!output->frame_pending) {
-		wlr_output_send_frame(output);
+		if (output->impl->schedule_frame) {
+			// Ask the backend to send a frame event when appropriate
+			output->frame_pending = true;
+			output->impl->schedule_frame(output);
+		} else {
+			wlr_output_send_frame(output);
+		}
 	}
 }
 
@@ -555,7 +561,8 @@ void wlr_output_schedule_frame(struct wlr_output *output) {
 		return;
 	}
 
-	// TODO: ask the backend to send a frame event when appropriate instead
+	// We're using an idle timer here in case a buffer swap happens right after
+	// this function is called
 	struct wl_event_loop *ev = wl_display_get_event_loop(output->display);
 	output->idle_frame =
 		wl_event_loop_add_idle(ev, schedule_frame_handle_idle_timer, output);


### PR DESCRIPTION
This desynchronizes our rendering loop with the vblank cycle.

In case a compositor doesn't swap buffers but schedules a frame,
emitting a frame event immediately enters a busy-loop.

Instead, ask the backend to send a frame when appropriate. On
Wayland we can just register a frame callback on our surface. On
DRM we can do a no-op pageflip.

Fixes #617
Fixes swaywm/sway#2748