### PR TITLE
data-device: remove wlr_data_source.seat_client

### DIFF
--- a/include/types/wlr_data_device.h
+++ b/include/types/wlr_data_device.h
@@ -11,6 +11,7 @@ struct wlr_client_data_source {
 	struct wlr_data_source source;
 	struct wlr_data_source_impl impl;
 	struct wl_resource *resource;
+	bool finalized;
 };
 
 extern const struct wlr_surface_role drag_icon_surface_role;

--- a/include/wlr/types/wlr_data_device.h
+++ b/include/wlr/types/wlr_data_device.h
@@ -73,7 +73,6 @@ struct wlr_data_source {
 	// source status
 	bool accepted;
 	struct wlr_data_offer *offer;
-	struct wlr_seat_client *seat_client;
 
 	// drag'n'drop status
 	enum wl_data_device_manager_dnd_action current_dnd_action;

--- a/types/data_device/wlr_data_offer.c
+++ b/types/data_device/wlr_data_offer.c
@@ -41,8 +41,7 @@ static uint32_t data_offer_choose_action(struct wlr_data_offer *offer) {
 		return WL_DATA_DEVICE_MANAGER_DND_ACTION_NONE;
 	}
 
-	if (offer->source->seat_client &&
-			offer->source->compositor_action & available_actions) {
+	if (offer->source->compositor_action & available_actions) {
 		return offer->source->compositor_action;
 	}
 

--- a/types/data_device/wlr_data_source.c
+++ b/types/data_device/wlr_data_source.c
@@ -207,11 +207,10 @@ static void data_source_set_actions(struct wl_client *client,
 		return;
 	}
 
-	if (source->source.seat_client) {
+	if (source->finalized) {
 		wl_resource_post_error(source->resource,
 			WL_DATA_SOURCE_ERROR_INVALID_ACTION_MASK,
-			"invalid action change after "
-			"wl_data_device.start_drag");
+			"invalid action change after wl_data_device.start_drag");
 		return;
 	}
 


### PR DESCRIPTION
Since the source doesn't always come from a client, this field
doesn't make sense. It is replaced by a new "finalized" field in
wlr_client_data_source. This is used to make sure set_actions is
not sent after start_drag has been sent.

A check in data_offer_choose_action has been removed: if an offer
has been sent then start_drag has been called, no need to check.

I also wanted to add a check for wl_data_source.offer, but it
turns out (1) this isn't in the spec (2) it breaks GTK+.

This is some preliminary work for Firefox on Wayland compatibility.