### PR TITLE
Fix cursor visibility on surface commit

### DIFF
--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -874,6 +874,7 @@ static void output_cursor_handle_commit(struct wl_listener *listener,
 	struct wlr_output_cursor *cursor =
 		wl_container_of(listener, cursor, surface_commit);
 	output_cursor_commit(cursor, true);
+	output_cursor_update_visible(cursor);
 }
 
 static void output_cursor_handle_destroy(struct wl_listener *listener,

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -853,6 +853,7 @@ static void output_cursor_commit(struct wlr_output_cursor *cursor,
 	cursor->enabled = wlr_surface_has_buffer(surface);
 	cursor->width = surface->current.width * cursor->output->scale;
 	cursor->height = surface->current.height * cursor->output->scale;
+	output_cursor_update_visible(cursor);
 	if (update_hotspot) {
 		cursor->hotspot_x -= surface->current.dx * cursor->output->scale;
 		cursor->hotspot_y -= surface->current.dy * cursor->output->scale;
@@ -874,7 +875,6 @@ static void output_cursor_handle_commit(struct wl_listener *listener,
 	struct wlr_output_cursor *cursor =
 		wl_container_of(listener, cursor, surface_commit);
 	output_cursor_commit(cursor, true);
-	output_cursor_update_visible(cursor);
 }
 
 static void output_cursor_handle_destroy(struct wl_listener *listener,
@@ -916,10 +916,9 @@ void wlr_output_cursor_set_surface(struct wlr_output_cursor *cursor,
 	if (surface != NULL) {
 		wl_signal_add(&surface->events.commit, &cursor->surface_commit);
 		wl_signal_add(&surface->events.destroy, &cursor->surface_destroy);
-		output_cursor_commit(cursor, false);
 
 		cursor->visible = false;
-		output_cursor_update_visible(cursor);
+		output_cursor_commit(cursor, false);
 	} else {
 		cursor->enabled = false;
 		cursor->width = 0;


### PR DESCRIPTION
When spawning a new window in Rootston the cursor will disappear if it is over the surface. It is supposed to be set to a surface specific cursor. I think this is caused by the client sending an empty cursor surface when requested causing cursor->visible to be set to false. The surface is then committed but the visibility is not updated so it stays hidden until it registers movement. 

I'm unsure if I put it in the correct place though. Maybe it should be called inside output_cursor_commit since it updates the dimenstions, I don't know what consequences that will have though. 