### PR TITLE
Reuse `wlr_buffer` objects where possible

### DIFF
--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -329,7 +329,7 @@ static void surface_apply_damage(struct wlr_surface *surface) {
 	wlr_buffer_unref(surface->buffer);
 	surface->buffer = NULL;
 
-	struct wlr_buffer *buffer = wlr_buffer_create(surface->renderer, resource);
+	struct wlr_buffer *buffer = wlr_buffer_get(surface->renderer, resource);
 	if (buffer == NULL) {
 		wlr_log(WLR_ERROR, "Failed to upload buffer");
 		return;


### PR DESCRIPTION
Hardware accelerated (ie. only imported) wlr_buffers were previously
destroyed and recreated (ie. reimported) on every usage.
Keep them around even when no one uses them anymore and reuse them (ie.
the ref count goes to 0).

---

As mentioned on IRC, the motivation is rather simple: keeping wl_drm/dmabuf texture objects around shouldn't cost much (the buffers are allocated on gpu anyways) but importing them might have some performance cost. On the egl code path it actually looks small enough (egl image import, texture creation) but even that might result in some work for the driver. On vulkan (more explicit than egl/gl) there is quite something to do (see a first vulkan [texture_from_dmabuf](https://github.com/nyorain/wlroots/blob/vk_ext/render/vulkan/texture.c#L347) implementation that is still missing something (and depending on a currently disabled extension)). Anyways, probably not something we want to do _every frame_ (for hardware accelerated clients) if we don't have to.

Via the `wlr_buffer.keep` flag we currently disable this keeping-alive mechanism for shm bufs: keeping them around even if not read anymore will allocate additional gpu memory and we usually don't have to create a new texture every frame anyways due to the previous buffer/texture re-using mechanism for shm buffers. 