### PR TITLE
output: remove idle_frame event source when destroying output

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1347,6 +1347,13 @@ static void drm_connector_cleanup(struct wlr_drm_connector *conn) {
 		memset(&conn->output.model, 0, sizeof(conn->output.model));
 		memset(&conn->output.serial, 0, sizeof(conn->output.serial));
 
+		if (conn->output.idle_frame != NULL) {
+			wl_event_source_remove(conn->output.idle_frame);
+			conn->output.idle_frame = NULL;
+		}
+		conn->output.needs_swap = false;
+		conn->output.frame_pending = false;
+
 		conn->pageflip_pending = false;
 		/* Fallthrough */
 	case WLR_DRM_CONN_NEEDS_MODESET:

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -298,15 +298,15 @@ void wlr_output_destroy(struct wlr_output *output) {
 
 	wlr_signal_emit_safe(&output->events.destroy, output);
 
-	struct wlr_output_mode *mode, *tmp_mode;
-	wl_list_for_each_safe(mode, tmp_mode, &output->modes, link) {
-		wl_list_remove(&mode->link);
-		free(mode);
-	}
+	// The backend is responsible for free-ing the list of modes
 
 	struct wlr_output_cursor *cursor, *tmp_cursor;
 	wl_list_for_each_safe(cursor, tmp_cursor, &output->cursors, link) {
 		wlr_output_cursor_destroy(cursor);
+	}
+
+	if (output->idle_frame != NULL) {
+		wl_event_source_remove(output->idle_frame);
 	}
 
 	pixman_region32_fini(&output->damage);


### PR DESCRIPTION
This prevents the idle event to be activated on a destroyed
output.

This also makes the backend responsible for free-ing modes, as it
is the one allocating them and adding them to the list. Note that
the DRM backend (the only one using modes) already frees them.

Fixes https://github.com/swaywm/wlroots/issues/1296