### PR TITLE
backend/drm: set drmEventContext version to 2

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1261,7 +1261,7 @@ static void page_flip_handler(int fd, unsigned seq,
 
 int handle_drm_event(int fd, uint32_t mask, void *data) {
 	drmEventContext event = {
-		.version = DRM_EVENT_CONTEXT_VERSION,
+		.version = 2,
 		.page_flip_handler = page_flip_handler,
 	};
 


### PR DESCRIPTION
As per [1] set drmEventContext version to 2, since wlroots does not use the
page_flip_handler2.

[1]: https://s-opensource.org/2017/04/12/libdrm-event-handling-youre-probably-wrong/