### PR TITLE
backend/drm: don't reset conn->pageflip_pending in drm_connector_cleanup

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1354,7 +1354,6 @@ static void drm_connector_cleanup(struct wlr_drm_connector *conn) {
 		conn->output.needs_swap = false;
 		conn->output.frame_pending = false;
 
-		conn->pageflip_pending = false;
 		/* Fallthrough */
 	case WLR_DRM_CONN_NEEDS_MODESET:
 		wlr_log(WLR_INFO, "Emitting destruction signal for '%s'",


### PR DESCRIPTION
If a pageflip is pending before cleanup, it's still pending after. This
is used line 1177: drm_connector_cleanup is called and
conn->pageflip_pending is checked afterwards.

Fixes #1297

@Emantor Can you try this?