### PR TITLE
Include wlr/config.h in x11.h

### DIFF
--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 #include <wayland-server.h>
+#include <wlr/config.h>
 #include <wlr/backend/x11.h>
 #include <wlr/interfaces/wlr_input_device.h>
 #include <wlr/interfaces/wlr_output.h>


### PR DESCRIPTION
This fixes a warning from the linker when using LTO, due to mismatched
types.