### PR TITLE
Support older wlr_linux_dmabuf_v1 clients

### DIFF
--- a/include/wlr/render/dmabuf.h
+++ b/include/wlr/render/dmabuf.h
@@ -16,6 +16,10 @@
 #define DRM_FORMAT_MOD_INVALID ((1ULL<<56) - 1)
 #endif
 
+#ifndef DRM_FORMAT_MOD_LINEAR
+#define DRM_FORMAT_MOD_LINEAR 0
+#endif
+
 #define WLR_DMABUF_MAX_PLANES 4
 
 enum wlr_dmabuf_attributes_flags {


### PR DESCRIPTION
If a client uses an older version of the dmabuf protocol, use the
`formats` event instead of `modifiers` (since that didn't exist in older
versions).
With a bit of necessary guessing, support dmabuf importing even when
EGL_EXT_image_dma_buf_import_modifiers isn't present instead of
failing up front.

---

Makes weston-simple-dmabuf-v4l work (at least with XR24 formats since the gl renderer does not support yuv). See the help manual of that program for information (loading the dummy vivid kernel module). Mainly useful to test dmabuf support (e.g. in renderers, think you can guess what i needed this for).

Note that the way we support older versions of the protocol is implemented different from weston: in weston, the modifier the client passes the compositor are simply ignored (see [here](https://gitlab.freedesktop.org/wayland/weston/blob/master/libweston/linux-dmabuf.c#L115)) which may (theoretically?) cause problems later on i guess (reading garbage). We never ignore the modifier, but assume that without the modifiers egl extension it expects linear data (DRM_FORMAT_MOD_LINEAR).
Otherwise we implement roughly the same guessing that weston does when the egl modifiers extension is not present (note that this is still the case for amd drivers. Not sure if it will soon change since amd doesn't really seem to use public modifiers so we should really support this case as good as we can).

I guess @agx should have a look at this since it seems like he implemented the protocol in the first place.