### PR TITLE
xwayland/xwm: make hints->input default to true

### DIFF
--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -522,6 +522,12 @@ static void read_surface_hints(struct wlr_xwm *xwm,
 	memcpy(xsurface->hints, &hints, sizeof(struct wlr_xwayland_surface_hints));
 	xsurface->hints_urgency = xcb_icccm_wm_hints_get_urgency(&hints);
 
+	if (!(xsurface->hints->flags & XCB_ICCCM_WM_HINT_INPUT)) {
+		// The client didn't specify whether it wants input.
+		// Assume it does.
+		xsurface->hints->input = true;
+	}
+
 	wlr_log(WLR_DEBUG, "WM_HINTS (%d)", reply->value_len);
 	wlr_signal_emit_safe(&xsurface->events.set_hints, xsurface);
 }


### PR DESCRIPTION
An X11 client can leave the hints->input WM hint unspecified,
by not setting the XCB_ICCCM_WM_HINT_INPUT flag in hints->flags.
In that case, we should assume a sane default.

Make the hint default to true, so that clients which do not specify
the hint, like mupdf, still get keyboard focus.

This should fix swaywm/sway#2231

How to test:
1. start rootston like:
    `rootston -E xterm`
2. from xterm in rootston start mupdf:
    `mupdf some-file.pdf`
3. press left and right arrows to switch pages in PDF, +/- to zoom/unzoom,
    switch focus to the xterm and back to mupdf, press some more buttons, press q to quit

Before this patch, mupdf doesn't react to any key presses (if you use a non-Xwayland terminal, then the fisrt mupdf you start will react, until you switch focus, then it will stop reacting).

After this patch, mupdf reacts to all key presses like it should.