### PR TITLE
text-input: Accept disable requests

### DIFF
--- a/rootston/text_input.c
+++ b/rootston/text_input.c
@@ -163,10 +163,6 @@ static void handle_text_input_disable(struct wl_listener *listener,
 		text_input_disable);
 	struct roots_text_input *text_input = text_input_to_roots(relay,
 		(struct wlr_text_input_v3*)data);
-	if (!text_input->input->current_enabled) {
-		wlr_log(WLR_DEBUG, "Inactive text input tried to disable itself");
-		return;
-	}
 	relay_disable_text_input(relay, text_input);
 }
 


### PR DESCRIPTION
The disable signal on text-input objects must not be ignored. It is only sent when the previous state was enabled.

This led to input method not being disabled when the application requested it.