### PR TITLE
Fix include path for (libdrm/)drm_fourcc.h

### DIFF
--- a/render/egl.c
+++ b/render/egl.c
@@ -3,7 +3,7 @@
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #include <stdlib.h>
-#include <drm_fourcc.h>
+#include <libdrm/drm_fourcc.h>
 #include <wlr/render/egl.h>
 #include <wlr/util/log.h>
 #include "glapi.h"


### PR DESCRIPTION
This PR broke a private nixpkgs definition I have for wlroots: https://github.com/swaywm/wlroots/pull/1304

It is fixed by changing `#include <drm_fourcc.h>` to `#include <libdrm/drm_fourcc.h>`, which follows what is already done in the dmabuf example.