### PR TITLE
Fix libdrm includes

### DIFF
--- a/examples/dmabuf-capture.c
+++ b/examples/dmabuf-capture.c
@@ -12,7 +12,7 @@
 #include <unistd.h>
 #include <pthread.h>
 #include <stdbool.h>
-#include <libdrm/drm_fourcc.h>
+#include <drm_fourcc.h>
 #include "wlr-export-dmabuf-unstable-v1-client-protocol.h"
 
 struct wayland_output {

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -80,6 +80,7 @@ examples = {
 			libavcodec,
 			libavformat,
 			libavutil,
+			drm.partial_dependency(includes: true), # <drm_fourcc.h>
 			threads,
 			wayland_client,
 			wlr_protos,

--- a/render/egl.c
+++ b/render/egl.c
@@ -3,7 +3,7 @@
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #include <stdlib.h>
-#include <libdrm/drm_fourcc.h>
+#include <drm_fourcc.h>
 #include <wlr/render/egl.h>
 #include <wlr/util/log.h>
 #include "glapi.h"

--- a/render/meson.build
+++ b/render/meson.build
@@ -22,7 +22,13 @@ lib_wlr_render = static_library(
 	),
 	glapi,
 	include_directories: wlr_inc,
-	dependencies: [egl, glesv2, pixman, wayland_server],
+	dependencies: [
+		egl,
+		drm.partial_dependency(includes: true), # <drm_fourcc.h>
+		glesv2,
+		pixman,
+		wayland_server
+	],
 )
 
 wlr_render = declare_dependency(


### PR DESCRIPTION
This removes any assumptions about how the libdrm headers are installed, and uses the pkg-config include directories as we're "supposed to".
This only adds a partial dependency, since we don't actually need to link against libdrm.