### PR TITLE
render: fix meson including libdrm

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -80,7 +80,7 @@ examples = {
 			libavcodec,
 			libavformat,
 			libavutil,
-			drm.partial_dependency(includes: true), # <drm_fourcc.h>
+			drm.partial_dependency(compile_args: true), # <drm_fourcc.h>
 			threads,
 			wayland_client,
 			wlr_protos,

--- a/render/meson.build
+++ b/render/meson.build
@@ -24,7 +24,7 @@ lib_wlr_render = static_library(
 	include_directories: wlr_inc,
 	dependencies: [
 		egl,
-		drm.partial_dependency(includes: true), # <drm_fourcc.h>
+		drm.partial_dependency(compile_args: true), # <drm_fourcc.h>
 		glesv2,
 		pixman,
 		wayland_server


### PR DESCRIPTION
See https://github.com/swaywm/wlroots/pull/1257 for context for why this seems to be necessary.

This fixes the build issues on my system, I believe the right way.