### PR TITLE
Remove fmt parameter from wlr_texture_write_pixels

### DIFF
--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -19,7 +19,7 @@
 extern PFNGLEGLIMAGETARGETTEXTURE2DOESPROC glEGLImageTargetTexture2DOES;
 
 struct wlr_gles2_pixel_format {
-	uint32_t wl_format;
+	enum wl_shm_format wl_format;
 	GLint gl_format, gl_type;
 	int depth, bpp;
 	bool has_alpha;
@@ -72,7 +72,7 @@ struct wlr_gles2_texture {
 	enum wlr_gles2_texture_type type;
 	int width, height;
 	bool has_alpha;
-	uint32_t wl_format; // used to interpret upload data
+	enum wl_shm_format wl_format; // used to interpret upload data
 	bool inverted_y;
 
 	// Not set if WLR_GLES2_TEXTURE_GLTEX

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -72,6 +72,7 @@ struct wlr_gles2_texture {
 	enum wlr_gles2_texture_type type;
 	int width, height;
 	bool has_alpha;
+	uint32_t wl_format; // used to interpret upload data
 	bool inverted_y;
 
 	// Not set if WLR_GLES2_TEXTURE_GLTEX

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -66,9 +66,9 @@ struct wlr_texture_impl {
 	void (*get_size)(struct wlr_texture *texture, int *width, int *height);
 	bool (*is_opaque)(struct wlr_texture *texture);
 	bool (*write_pixels)(struct wlr_texture *texture,
-		enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width,
-		uint32_t height, uint32_t src_x, uint32_t src_y, uint32_t dst_x,
-		uint32_t dst_y, const void *data);
+		uint32_t stride, uint32_t width, uint32_t height,
+		uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y,
+		const void *data);
 	bool (*to_dmabuf)(struct wlr_texture *texture,
 		struct wlr_dmabuf_attributes *attribs);
 	void (*destroy)(struct wlr_texture *texture);

--- a/include/wlr/render/wlr_texture.h
+++ b/include/wlr/render/wlr_texture.h
@@ -55,9 +55,11 @@ bool wlr_texture_is_opaque(struct wlr_texture *texture);
 
 /**
  * Update a texture with raw pixels. The texture must be mutable.
+ * The given data is interpreted as being in the format the
+ * texture was created with.
  */
 bool wlr_texture_write_pixels(struct wlr_texture *texture,
-	enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width, uint32_t height,
+	uint32_t stride, uint32_t width, uint32_t height,
 	uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y,
 	const void *data);
 

--- a/include/wlr/render/wlr_texture.h
+++ b/include/wlr/render/wlr_texture.h
@@ -54,10 +54,9 @@ void wlr_texture_get_size(struct wlr_texture *texture, int *width, int *height);
 bool wlr_texture_is_opaque(struct wlr_texture *texture);
 
 /**
- * Update a texture with raw pixels. The texture must be mutable.
- * The given data is interpreted as being in the format the
- * texture was created with.
- */
+  * Update a texture with raw pixels. The texture must be mutable, and the input
+  * data must have the same pixel format that the texture was created with.
+  */
 bool wlr_texture_write_pixels(struct wlr_texture *texture,
 	uint32_t stride, uint32_t width, uint32_t height,
 	uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y,

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -55,8 +55,8 @@ static bool gles2_texture_write_pixels(struct wlr_texture *wlr_texture,
 		return false;
 	}
 
-	const struct wlr_gles2_pixel_format *fmt = get_gles2_format_from_wl(
-		texture->wl_format);
+	const struct wlr_gles2_pixel_format *fmt =
+		get_gles2_format_from_wl(texture->wl_format);
 	assert(fmt);
 
 	// TODO: what if the unpack subimage extension isn't supported?

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -44,9 +44,9 @@ static bool gles2_texture_is_opaque(struct wlr_texture *wlr_texture) {
 }
 
 static bool gles2_texture_write_pixels(struct wlr_texture *wlr_texture,
-		enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width,
-		uint32_t height, uint32_t src_x, uint32_t src_y, uint32_t dst_x,
-		uint32_t dst_y, const void *data) {
+		uint32_t stride, uint32_t width, uint32_t height,
+		uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y,
+		const void *data) {
 	struct wlr_gles2_texture *texture =
 		get_gles2_texture_in_context(wlr_texture);
 
@@ -55,11 +55,9 @@ static bool gles2_texture_write_pixels(struct wlr_texture *wlr_texture,
 		return false;
 	}
 
-	const struct wlr_gles2_pixel_format *fmt = get_gles2_format_from_wl(wl_fmt);
-	if (fmt == NULL) {
-		wlr_log(WLR_ERROR, "Unsupported pixel format %"PRIu32, wl_fmt);
-		return false;
-	}
+	const struct wlr_gles2_pixel_format *fmt = get_gles2_format_from_wl(
+		texture->wl_format);
+	assert(fmt);
 
 	// TODO: what if the unpack subimage extension isn't supported?
 	PUSH_GLES2_DEBUG;
@@ -167,6 +165,7 @@ struct wlr_texture *wlr_gles2_texture_from_pixels(struct wlr_egl *egl,
 	texture->height = height;
 	texture->type = WLR_GLES2_TEXTURE_GLTEX;
 	texture->has_alpha = fmt->has_alpha;
+	texture->wl_format = fmt->wl_format;
 
 	PUSH_GLES2_DEBUG;
 
@@ -203,6 +202,7 @@ struct wlr_texture *wlr_gles2_texture_from_wl_drm(struct wlr_egl *egl,
 	texture->wl_drm = data;
 
 	EGLint fmt;
+	texture->wl_format = 0xFFFFFFFF; // texture can't be written anyways
 	texture->image = wlr_egl_create_image_from_wl_drm(egl, data, &fmt,
 		&texture->width, &texture->height, &texture->inverted_y);
 	if (texture->image == NULL) {
@@ -283,6 +283,7 @@ struct wlr_texture *wlr_gles2_texture_from_dmabuf(struct wlr_egl *egl,
 	texture->height = attribs->height;
 	texture->type = WLR_GLES2_TEXTURE_DMABUF;
 	texture->has_alpha = true;
+	texture->wl_format = 0xFFFFFFFF; // texture can't be written anyways
 	texture->inverted_y =
 		(attribs->flags & WLR_DMABUF_ATTRIBUTES_FLAGS_Y_INVERT) != 0;
 

--- a/render/wlr_texture.c
+++ b/render/wlr_texture.c
@@ -55,10 +55,10 @@ bool wlr_texture_is_opaque(struct wlr_texture *texture) {
 }
 
 bool wlr_texture_write_pixels(struct wlr_texture *texture,
-		enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width,
-		uint32_t height, uint32_t src_x, uint32_t src_y, uint32_t dst_x,
-		uint32_t dst_y, const void *data) {
-	return texture->impl->write_pixels(texture, wl_fmt, stride, width, height,
+		uint32_t stride, uint32_t width, uint32_t height,
+		uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y,
+		const void *data) {
+	return texture->impl->write_pixels(texture, stride, width, height,
 		src_x, src_y, dst_x, dst_y, data);
 }
 


### PR DESCRIPTION
This uses dummy format values (0xFFFFFFFF) for immutable wlr_gles2_texture objects since we don't always know their formats (and don't write the textures anyways so why bother with additional conversions in that case).
The buffer damage handling had to be changed a bit; the previous implementation seemed to rely on being able to change the textures format (which was broken for the gles2 renderer since has_alpha was not updated on format change).
Breaking change, i guess this is relevant for sway and @ongy @Timidger @ammen99 (add anyone i missed) if it gets merged.