### PR TITLE
FreeBSD fixes

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1,4 +1,4 @@
-#define _POSIX_C_SOURCE 199309L
+#define _POSIX_C_SOURCE 200112L
 #include <assert.h>
 #include <drm_mode.h>
 #include <EGL/egl.h>

--- a/backend/multi/backend.c
+++ b/backend/multi/backend.c
@@ -1,4 +1,4 @@
-#define _POSIX_C_SOURCE 199309L
+#define _POSIX_C_SOURCE 200112L
 #include <assert.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -6,6 +6,13 @@ libavutil = dependency('libavutil', version: '>=56.14.100', required: false)
 libavcodec = dependency('libavcodec', version: '>=58.18.100', required: false)
 libavformat = dependency('libavformat', version: '>=58.12.100', required: false)
 
+# epoll is a separate library in FreeBSD
+if host_machine.system() == 'freebsd'
+	libepoll = [dependency('epoll-shim')]
+else
+	libepoll = []
+endif
+
 # Small hack until https://github.com/mesonbuild/meson/pull/3386/ is merged
 foreach dep : ['libpng', 'libavutil', 'libavcodec', 'libavformat']
 	if not get_variable(dep).found()
@@ -97,7 +104,7 @@ examples = {
 	},
 	'input-method': {
 	    'src': 'input-method.c',
-	    'dep': [wayland_client, wlr_protos, wlroots],
+	    'dep': [wayland_client, wlr_protos, wlroots] + libepoll,
     },
 	'text-input': {
 	    'src': 'text-input.c',


### PR DESCRIPTION
This PR fixes two issues on FreeBSD:

1. `CLOCK_MONOTONIC` appeared in IEEE Std. 1003.1-200x, it was not part of
POSIX.1b (the 1993 version). FreeBSD treats it accordingly, thus `_POSIX_C_SOURCE` needs to be set to `200112L`.
2. `epoll` is not part of FreeBSD, it is provided as a 3rd party library, so it needs to be set as a dependency.

