### PR TITLE
text-input: Don't reject enable requests when unfocused

### DIFF
--- a/types/wlr_text_input_v3.c
+++ b/types/wlr_text_input_v3.c
@@ -175,11 +175,10 @@ static void text_input_commit(struct wl_client *client,
 	text_input->current_enabled = text_input->pending_enabled;
 	text_input->current_serial++;
 
-	if (text_input->current_enabled && text_input->focused_surface == NULL) {
-		wl_resource_post_error(text_input->resource, 0, "Text input was not"
-			"entered, and cannot be enabled\n");
-		return;
+	if (text_input->focused_surface == NULL) {
+		wlr_log(WLR_DEBUG, "Text input commit received without focus\n");
 	}
+
 	if (!old_enabled && text_input->current_enabled) {
 		wlr_signal_emit_safe(&text_input->events.enable, text_input);
 	} else if (old_enabled && !text_input->current_enabled) {


### PR DESCRIPTION
The prevoius implementation would always raise an error in the following sequence:

1. → enter
2. → leave
3. ← enable

The text-input type is not equipped to manage the validity of clents' requests, which should be handled in the compositor, as rootston does.

There *is* one scenario where this error should stay; namely immediately after creating the text input, but handling it introduces additional state and complexity, so I decided against it.

This should also make terminals work again, fixing https://gitlab.gnome.org/GNOME/gtk/merge_requests/369 from the other side.