### PR TITLE
output-layout, cursor: fix duplicate cursors

### DIFF
--- a/types/wlr_cursor.c
+++ b/types/wlr_cursor.c
@@ -620,8 +620,14 @@ static void handle_layout_output_destroy(struct wl_listener *listener,
 
 static void layout_add(struct wlr_cursor_state *state,
 		struct wlr_output_layout_output *l_output) {
-	struct wlr_cursor_output_cursor *output_cursor =
-		calloc(1, sizeof(struct wlr_cursor_output_cursor));
+	struct wlr_cursor_output_cursor *output_cursor;
+	wl_list_for_each(output_cursor, &state->output_cursors, link) {
+		if (output_cursor->output_cursor->output == l_output->output) {
+			return; // already added
+		}
+	}
+
+	output_cursor = calloc(1, sizeof(struct wlr_cursor_output_cursor));
 	if (output_cursor == NULL) {
 		wlr_log(WLR_ERROR, "Failed to allocate wlr_cursor_output_cursor");
 		return;

--- a/types/wlr_output_layout.c
+++ b/types/wlr_output_layout.c
@@ -204,6 +204,7 @@ void wlr_output_layout_add(struct wlr_output_layout *layout,
 		struct wlr_output *output, int lx, int ly) {
 	struct wlr_output_layout_output *l_output =
 		wlr_output_layout_get(layout, output);
+	bool is_new = l_output == NULL;
 	if (!l_output) {
 		l_output = output_layout_output_create(layout, output);
 		if (!l_output) {
@@ -211,12 +212,16 @@ void wlr_output_layout_add(struct wlr_output_layout *layout,
 			return;
 		}
 	}
+
 	l_output->x = lx;
 	l_output->y = ly;
 	l_output->state->auto_configured = false;
 	output_layout_reconfigure(layout);
 	output_update_global(output);
-	wlr_signal_emit_safe(&layout->events.add, l_output);
+
+	if (is_new) {
+		wlr_signal_emit_safe(&layout->events.add, l_output);
+	}
 }
 
 struct wlr_output_layout_output *wlr_output_layout_get(
@@ -409,6 +414,7 @@ void wlr_output_layout_add_auto(struct wlr_output_layout *layout,
 		struct wlr_output *output) {
 	struct wlr_output_layout_output *l_output =
 		wlr_output_layout_get(layout, output);
+	bool is_new = l_output == NULL;
 	if (!l_output) {
 		l_output = output_layout_output_create(layout, output);
 		if (!l_output) {
@@ -420,7 +426,10 @@ void wlr_output_layout_add_auto(struct wlr_output_layout *layout,
 	l_output->state->auto_configured = true;
 	output_layout_reconfigure(layout);
 	output_update_global(output);
-	wlr_signal_emit_safe(&layout->events.add, l_output);
+
+	if (is_new) {
+		wlr_signal_emit_safe(&layout->events.add, l_output);
+	}
 }
 
 struct wlr_output *wlr_output_layout_get_center_output(


### PR DESCRIPTION
wlr_cursor: make sure the output doesn't have a cursor before
creating a new one

wlr_output_layout: don't emit the "add" event when the output is
already in the layout

Fixes https://github.com/swaywm/sway/issues/2486
Fixes https://github.com/emersion/grim/issues/20