### PR TITLE
xwm: Remove child->parent pointer when parent destroys

### DIFF
--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -313,6 +313,7 @@ static void xwayland_surface_destroy(
 	wl_list_for_each_safe(child, next, &xsurface->children, parent_link) {
 		wl_list_remove(&child->parent_link);
 		wl_list_init(&child->parent_link);
+		child->parent = NULL;
 	}
 
 	if (xsurface->surface_id) {


### PR DESCRIPTION
Probably fixes https://github.com/swaywm/sway/issues/2840, though I can't reproduce it and there's no confirmation yet.

My suspicion is that some clients (phpstorm) will unmap and destroy a parent surface while there are still children, so we must remove the pointer. Or perhaps we should link the child to the parent's parent instead?