### PR TITLE
[WIP] xcursor-configuration: initial protocol implementation

### DIFF
--- a/include/rootston/desktop.h
+++ b/include/rootston/desktop.h
@@ -21,6 +21,7 @@
 #include <wlr/types/wlr_text_input_v3.h>
 #include <wlr/types/wlr_virtual_keyboard_v1.h>
 #include <wlr/types/wlr_wl_shell.h>
+#include <wlr/types/wlr_xcursor_configuration_v1.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/types/wlr_xdg_decoration_v1.h>
 #include <wlr/types/wlr_xdg_shell_v6.h>
@@ -63,6 +64,7 @@ struct roots_desktop {
 	struct wlr_tablet_manager_v2 *tablet_v2;
 	struct wlr_pointer_constraints_v1 *pointer_constraints;
 	struct wlr_presentation *presentation;
+	struct wlr_xcursor_configuration_manager_v1 *xcursor_configuration_manager;
 
 	struct wl_listener new_output;
 	struct wl_listener layout_change;

--- a/include/wlr/types/meson.build
+++ b/include/wlr/types/meson.build
@@ -36,6 +36,7 @@ install_headers(
 	'wlr_touch.h',
 	'wlr_virtual_keyboard_v1.h',
 	'wlr_wl_shell.h',
+	'wlr_xcursor_configuration_v1.h',
 	'wlr_xcursor_manager.h',
 	'wlr_xdg_decoration_v1.h',
 	'wlr_xdg_output_v1.h',

--- a/include/wlr/types/wlr_xcursor_configuration_v1.h
+++ b/include/wlr/types/wlr_xcursor_configuration_v1.h
@@ -1,0 +1,60 @@
+/*
+ * This an unstable interface of wlroots. No guarantees are made regarding the
+ * future consistency of this API.
+ */
+#ifndef WLR_USE_UNSTABLE
+#error "Add -DWLR_USE_UNSTABLE to enable unstable wlroots features"
+#endif
+
+#ifndef WLR_TYPES_WLR_XCURSOR_CONFIGURATION_V1_H
+#define WLR_TYPES_WLR_XCURSOR_CONFIGURATION_V1_H
+
+#include <wayland-server.h>
+#include <xcursor-configuration-unstable-v1-protocol.h>
+
+struct wlr_xcursor_configuration_v1_attrs {
+	struct {
+		char *name;
+		uint32_t size;
+	} theme;
+
+	char *default_cursor;
+};
+
+struct wlr_xcursor_configuration_v1 {
+	struct wl_list resources; // wl_resource_get_link
+	struct wlr_seat *seat;
+	enum zwp_xcursor_configuration_manager_v1_device_type device_type;
+	struct wl_list link;
+
+	struct wlr_xcursor_configuration_v1_attrs attrs;
+
+	struct wl_listener seat_destroy;
+
+	void *data;
+};
+
+struct wlr_xcursor_configuration_manager_v1 {
+	struct wl_global *global;
+	struct wl_list resources; // wl_resource_get_link
+	struct wl_list configurations; // wlr_xcursor_configuration_v1::link
+
+	struct {
+		struct wl_signal destroy;
+	} events;
+
+	struct wl_listener display_destroy;
+
+	void *data;
+};
+
+struct wlr_xcursor_configuration_manager_v1 *
+	wlr_xcursor_configuration_manager_v1_create(struct wl_display *display);
+void wlr_xcursor_configuration_manager_v1_destroy(
+	struct wlr_xcursor_configuration_manager_v1 *manager);
+void wlr_xcursor_configuration_manager_v1_configure(
+	struct wlr_xcursor_configuration_manager_v1 *manager, struct wlr_seat *seat,
+	enum zwp_xcursor_configuration_manager_v1_device_type device_type,
+	const struct wlr_xcursor_configuration_v1_attrs *attrs);
+
+#endif

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -33,6 +33,7 @@ protocols = [
 	'wlr-input-inhibitor-unstable-v1.xml',
 	'wlr-layer-shell-unstable-v1.xml',
 	'wlr-screencopy-unstable-v1.xml',
+	'xcursor-configuration-unstable-v1.xml',
 ]
 
 client_protocols = [

--- a/protocol/xcursor-configuration-unstable-v1.xml
+++ b/protocol/xcursor-configuration-unstable-v1.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wp_xcursor_configuration_unstable_v1">
+  <copyright>
+    Copyright © 2018 Simon Ser
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="protocol to configure XCursor themes">
+    This protocol allows compositors to advertize XCursor configuration to
+    clients.
+
+    Once compositor configuration is received, clients are responsible for
+    loading the XCursor theme, creating wl_buffers with cursor images and
+    setting the cursor. Clients are free to ignore configuration set by this
+    protocol and use different settings: this protocol merely exposes hints.
+
+    Warning! The protocol described in this file is experimental and
+    backward incompatible changes may be made. Backward compatible changes
+    may be added together with the corresponding interface version bump.
+    Backward incompatible changes are done by bumping the version number in
+    the protocol and interface names and resetting the interface version.
+    Once the protocol is to be declared stable, the 'z' prefix and the
+    version number in the protocol and interface names are removed and the
+    interface version number is reset.
+  </description>
+
+  <interface name="zwp_xcursor_configuration_manager_v1" version="1">
+    <description summary="XCursor configuration manager">
+      A global factory interface for wp_xcursor_configuration objects.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the XCursor configuration manager object">
+        Destroy the XCursor configuration manager. This doesn't destroy objects
+        created with the manager.
+      </description>
+    </request>
+
+    <enum name="device_type">
+      <description summary="an input device type">
+        Describes input devices that have a cursor and are attached to a seat.
+      </description>
+      <entry name="pointer" value="1" summary="Pointer"/>
+      <entry name="tablet_tool" value="2" summary="Tablet tool"/>
+    </enum>
+
+    <request name="get_device_xcursor_configuration">
+      <description summary="create a wp_xcursor_configuration object for a device">
+        This creates a new wp_xcursor_configuration object for the input device
+        attached to the given seat.
+      </description>
+      <arg name="id" type="new_id" interface="zwp_xcursor_configuration_v1"/>
+      <arg name="seat" type="object" interface="wl_seat"/>
+      <arg name="device" type="uint" enum="device_type"/>
+    </request>
+  </interface>
+
+  <interface name="zwp_xcursor_configuration_v1" version="1">
+    <description summary="XCursor configuration for a device">
+      A Xcursor configuration object describes XCursor settings for a specific
+      device.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy this object">
+        Using this request a client can tell the server that it is not going to
+        use this object anymore.
+      </description>
+    </request>
+
+    <event name="done">
+      <description summary="all information about the configuration has been sent">
+        This event is sent after all other properties of a
+        wp_xcursor_configuration have been sent.
+
+        This allows changes to the wp_xcursor_configuration properties to be
+        seen as atomic, even if they happen via multiple events.
+      </description>
+    </event>
+
+    <event name="theme">
+      <description summary="theme configuration">
+        The theme event describes XCursor theme configuration for this device.
+      </description>
+      <arg name="name" type="string" summary="theme name"/>
+      <arg name="size" type="uint" summary="theme size"/>
+    </event>
+
+    <event name="default_cursor">
+      <description summary="default cursor name">
+        The default_cursor event describes the default XCursor cursor name to be
+        used for this device.
+      </description>
+      <arg name="name" type="string" summary="default cursor name"/>
+    </event>
+  </interface>
+</protocol>

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -8,8 +8,8 @@
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_export_dmabuf_v1.h>
-#include <wlr/types/wlr_gamma_control.h>
 #include <wlr/types/wlr_gamma_control_v1.h>
+#include <wlr/types/wlr_gamma_control.h>
 #include <wlr/types/wlr_idle_inhibit_v1.h>
 #include <wlr/types/wlr_idle.h>
 #include <wlr/types/wlr_input_inhibitor.h>
@@ -18,13 +18,14 @@
 #include <wlr/types/wlr_pointer_constraints_v1.h>
 #include <wlr/types/wlr_primary_selection.h>
 #include <wlr/types/wlr_server_decoration.h>
+#include <wlr/types/wlr_tablet_v2.h>
 #include <wlr/types/wlr_wl_shell.h>
+#include <wlr/types/wlr_xcursor_configuration_v1.h>
 #include <wlr/types/wlr_xcursor_manager.h>
+#include <wlr/types/wlr_xdg_output_v1.h>
 #include <wlr/types/wlr_xdg_output_v1.h>
 #include <wlr/types/wlr_xdg_shell_v6.h>
 #include <wlr/types/wlr_xdg_shell.h>
-#include <wlr/types/wlr_xdg_output_v1.h>
-#include <wlr/types/wlr_tablet_v2.h>
 #include <wlr/util/log.h>
 #include "rootston/layers.h"
 #include "rootston/seat.h"
@@ -984,6 +985,8 @@ struct roots_desktop *desktop_create(struct roots_server *server,
 
 	desktop->presentation =
 		wlr_presentation_create(server->wl_display, server->backend);
+	desktop->xcursor_configuration_manager =
+		wlr_xcursor_configuration_manager_v1_create(server->wl_display);
 
 	return desktop;
 }

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -968,6 +968,8 @@ void roots_seat_add_device(struct roots_seat *seat,
 }
 
 void roots_seat_configure_xcursor(struct roots_seat *seat) {
+	struct roots_desktop *desktop = seat->input->server->desktop;
+
 	const char *cursor_theme = NULL;
 	struct roots_cursor_config *cc =
 		roots_config_get_cursor(seat->input->config, seat->seat->name);
@@ -1001,6 +1003,23 @@ void roots_seat_configure_xcursor(struct roots_seat *seat) {
 		seat->cursor->default_xcursor, seat->cursor->cursor);
 	wlr_cursor_warp(seat->cursor->cursor, NULL, seat->cursor->cursor->x,
 		seat->cursor->cursor->y);
+
+	const struct wlr_xcursor_configuration_v1_attrs xcursor_attrs = {
+		.theme = {
+			.name = (char *)(cursor_theme != NULL ? cursor_theme : "default"),
+			.size = ROOTS_XCURSOR_SIZE,
+		},
+		.default_cursor = (char *)(seat->cursor->default_xcursor != NULL ?
+			seat->cursor->default_xcursor : "left_ptr"),
+	};
+	wlr_xcursor_configuration_manager_v1_configure(
+		desktop->xcursor_configuration_manager, seat->seat,
+		ZWP_XCURSOR_CONFIGURATION_MANAGER_V1_DEVICE_TYPE_POINTER,
+		&xcursor_attrs);
+	wlr_xcursor_configuration_manager_v1_configure(
+		desktop->xcursor_configuration_manager, seat->seat,
+		ZWP_XCURSOR_CONFIGURATION_MANAGER_V1_DEVICE_TYPE_TABLET_TOOL,
+		&xcursor_attrs);
 }
 
 bool roots_seat_has_meta_pressed(struct roots_seat *seat) {

--- a/types/meson.build
+++ b/types/meson.build
@@ -58,6 +58,7 @@ lib_wlr_types = static_library(
 		'wlr_touch.c',
 		'wlr_virtual_keyboard_v1.c',
 		'wlr_wl_shell.c',
+		'wlr_xcursor_configuration_v1.c',
 		'wlr_xcursor_manager.c',
 		'wlr_xdg_decoration_v1.c',
 		'wlr_xdg_output_v1.c',

--- a/types/wlr_screencopy_v1.c
+++ b/types/wlr_screencopy_v1.c
@@ -261,7 +261,7 @@ static const struct zwlr_screencopy_manager_v1_interface manager_impl = {
 	.destroy = manager_handle_destroy,
 };
 
-void manager_handle_resource_destroy(struct wl_resource *resource) {
+static void manager_handle_resource_destroy(struct wl_resource *resource) {
 	wl_list_remove(wl_resource_get_link(resource));
 }
 

--- a/types/wlr_xcursor_configuration_v1.c
+++ b/types/wlr_xcursor_configuration_v1.c
@@ -1,0 +1,229 @@
+#define _POSIX_C_SOURCE 200809L
+#include <assert.h>
+#include <stdlib.h>
+#include <wlr/types/wlr_seat.h>
+#include <wlr/types/wlr_xcursor_configuration_v1.h>
+#include <wlr/util/log.h>
+#include "util/signal.h"
+
+#define XCURSOR_CONFIGURATION_MANAGER_VERSION 1
+
+static struct wlr_xcursor_configuration_v1 *manager_get_configuration(
+		struct wlr_xcursor_configuration_manager_v1 *manager,
+		struct wlr_seat *seat,
+		enum zwp_xcursor_configuration_manager_v1_device_type device_type) {
+	struct wlr_xcursor_configuration_v1 *config;
+	wl_list_for_each(config, &manager->configurations, link) {
+		if (config->seat == seat && config->device_type == device_type) {
+			return config;
+		}
+	}
+	return NULL;
+}
+
+static void configuration_handle_destroy(struct wl_client *client,
+		struct wl_resource *config_resource) {
+	wl_resource_destroy(config_resource);
+}
+
+static const struct zwp_xcursor_configuration_v1_interface
+		configuration_impl = {
+	.destroy = configuration_handle_destroy,
+};
+
+static void configuration_send(struct wlr_xcursor_configuration_v1 *config,
+		struct wl_resource *resource) {
+	zwp_xcursor_configuration_v1_send_theme(resource,
+		config->attrs.theme.name, config->attrs.theme.size);
+	zwp_xcursor_configuration_v1_send_default_cursor(resource,
+		config->attrs.default_cursor);
+	zwp_xcursor_configuration_v1_send_done(resource);
+}
+
+static void configuration_handle_resource_destroy(
+		struct wl_resource *resource) {
+	wl_list_remove(wl_resource_get_link(resource));
+}
+
+static const struct zwp_xcursor_configuration_manager_v1_interface manager_impl;
+
+struct wlr_xcursor_configuration_manager_v1 *manager_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource,
+		&zwp_xcursor_configuration_manager_v1_interface, &manager_impl));
+	return wl_resource_get_user_data(resource);
+}
+
+static void manager_handle_get_device_xcursor_configuration(
+		struct wl_client *client, struct wl_resource *manager_resource,
+		uint32_t id, struct wl_resource *seat_resource,
+		enum zwp_xcursor_configuration_manager_v1_device_type device_type) {
+	struct wlr_xcursor_configuration_manager_v1 *manager =
+		manager_from_resource(manager_resource);
+	struct wlr_seat_client *seat_client =
+		wlr_seat_client_from_resource(seat_resource);
+
+	struct wlr_xcursor_configuration_v1 *config =
+		manager_get_configuration(manager, seat_client->seat, device_type);
+	assert(config != NULL);
+
+	uint32_t version = wl_resource_get_version(manager_resource);
+	struct wl_resource *resource = wl_resource_create(client,
+		&zwp_xcursor_configuration_v1_interface, version, id);
+	if (resource == NULL) {
+		wl_client_post_no_memory(client);
+		return;
+	}
+	wl_resource_set_implementation(resource, &configuration_impl, config,
+		configuration_handle_resource_destroy);
+
+	wl_list_insert(&config->resources, wl_resource_get_link(resource));
+
+	configuration_send(config, resource);
+}
+
+static void manager_handle_destroy(struct wl_client *client,
+		struct wl_resource *manager_resource) {
+	wl_resource_destroy(manager_resource);
+}
+
+static const struct zwp_xcursor_configuration_manager_v1_interface
+		manager_impl = {
+	.get_device_xcursor_configuration =
+		manager_handle_get_device_xcursor_configuration,
+	.destroy = manager_handle_destroy,
+};
+
+static void manager_handle_resource_destroy(struct wl_resource *resource) {
+	wl_list_remove(wl_resource_get_link(resource));
+}
+
+static void manager_bind(struct wl_client *client, void *data, uint32_t version,
+		uint32_t id) {
+	struct wlr_xcursor_configuration_manager_v1 *manager = data;
+
+	struct wl_resource *resource = wl_resource_create(client,
+		&zwp_xcursor_configuration_manager_v1_interface, version, id);
+	if (resource == NULL) {
+		wl_client_post_no_memory(client);
+		return;
+	}
+	wl_resource_set_implementation(resource, &manager_impl, manager,
+		manager_handle_resource_destroy);
+
+	wl_list_insert(&manager->resources, wl_resource_get_link(resource));
+}
+
+static void handle_display_destroy(struct wl_listener *listener, void *data) {
+	struct wlr_xcursor_configuration_manager_v1 *manager =
+		wl_container_of(listener, manager, display_destroy);
+	wlr_xcursor_configuration_manager_v1_destroy(manager);
+}
+
+struct wlr_xcursor_configuration_manager_v1 *
+		wlr_xcursor_configuration_manager_v1_create(struct wl_display *display) {
+	struct wlr_xcursor_configuration_manager_v1 *manager =
+		calloc(1, sizeof(struct wlr_xcursor_configuration_manager_v1));
+	if (manager == NULL) {
+		return NULL;
+	}
+
+	manager->global = wl_global_create(display,
+		&zwp_xcursor_configuration_manager_v1_interface,
+		XCURSOR_CONFIGURATION_MANAGER_VERSION, manager, manager_bind);
+	if (manager->global == NULL) {
+		free(manager);
+		return NULL;
+	}
+
+	wl_list_init(&manager->resources);
+	wl_list_init(&manager->configurations);
+	wl_signal_init(&manager->events.destroy);
+
+	manager->display_destroy.notify = handle_display_destroy;
+	wl_display_add_destroy_listener(display, &manager->display_destroy);
+
+	return manager;
+}
+
+static void configuration_destroy(struct wlr_xcursor_configuration_v1 *config) {
+	struct wl_resource *resource, *tmp_resource;
+	wl_resource_for_each_safe(resource, tmp_resource, &config->resources) {
+		// Make resource inert
+		wl_resource_set_user_data(resource, NULL);
+		wl_list_remove(wl_resource_get_link(resource));
+		wl_list_init(wl_resource_get_link(resource));
+	}
+	wl_list_remove(&config->seat_destroy.link);
+	free(config->attrs.theme.name);
+	free(config->attrs.default_cursor);
+	free(config);
+}
+
+void wlr_xcursor_configuration_manager_v1_destroy(
+		struct wlr_xcursor_configuration_manager_v1 *manager) {
+	if (manager == NULL) {
+		return;
+	}
+	wlr_signal_emit_safe(&manager->events.destroy, manager);
+	wl_list_remove(&manager->display_destroy.link);
+	struct wlr_xcursor_configuration_v1 *config, *tmp_config;
+	wl_list_for_each_safe(config, tmp_config, &manager->configurations, link) {
+		struct wl_resource *resource, *tmp_resource;
+		wl_resource_for_each_safe(resource, tmp_resource, &config->resources) {
+			wl_resource_destroy(resource);
+		}
+		configuration_destroy(config);
+	}
+	struct wl_resource *resource, *tmp_resource;
+	wl_resource_for_each_safe(resource, tmp_resource, &manager->resources) {
+		wl_resource_destroy(resource);
+	}
+	wl_global_destroy(manager->global);
+	free(manager);
+}
+
+static void configuration_handle_seat_destroy(struct wl_listener *listener,
+		void *data) {
+	struct wlr_xcursor_configuration_v1 *config =
+		wl_container_of(listener, config, seat_destroy);
+	configuration_destroy(config);
+}
+
+void wlr_xcursor_configuration_manager_v1_configure(
+		struct wlr_xcursor_configuration_manager_v1 *manager,
+		struct wlr_seat *seat,
+		enum zwp_xcursor_configuration_manager_v1_device_type device_type,
+		const struct wlr_xcursor_configuration_v1_attrs *attrs) {
+	struct wlr_xcursor_configuration_v1 *config =
+		manager_get_configuration(manager, seat, device_type);
+	if (config == NULL) {
+		config = calloc(1, sizeof(struct wlr_xcursor_configuration_v1));
+		if (config == NULL) {
+			wlr_log_errno(WLR_ERROR, "Allocation failed");
+			return;
+		}
+		config->seat = seat;
+		config->device_type = device_type;
+		wl_list_init(&config->resources);
+		wl_list_insert(&manager->configurations, &config->link);
+
+		config->seat_destroy.notify = configuration_handle_seat_destroy;
+		wl_signal_add(&seat->events.destroy, &config->seat_destroy);
+	}
+
+	assert(attrs->theme.name != NULL);
+	assert(attrs->theme.size != 0);
+	assert(attrs->default_cursor != NULL);
+
+	free(config->attrs.theme.name);
+	config->attrs.theme.name = strdup(attrs->theme.name);
+	config->attrs.theme.size = attrs->theme.size;
+	free(config->attrs.default_cursor);
+	config->attrs.default_cursor = strdup(attrs->default_cursor);
+
+	struct wl_resource *resource;
+	wl_resource_for_each(resource, &config->resources) {
+		configuration_send(config, resource);
+	}
+}


### PR DESCRIPTION
* wayland-protocols patch: https://patchwork.freedesktop.org/series/50948/
* libwayland-cursor patch: https://patchwork.freedesktop.org/series/51322/

- [ ] Consider adding fallback seat and device type configurations (but how to handle adding configuration after a resource has been added to the fallback?)