### PR TITLE
Fix wlroots.pc file path on FreeBSD

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -31,6 +31,7 @@ conf_data = configuration_data()
 wlr_inc = include_directories('.', 'include')
 
 cc = meson.get_compiler('c')
+prefix = get_option('prefix')
 
 # Clang complains about some zeroed initializer lists (= {0}), even though they
 # are valid
@@ -157,6 +158,12 @@ message('\n'.join(summary))
 subdir('examples')
 subdir('rootston')
 
+if host_machine.system() == 'freebsd'
+	pkgconfig_install_dir = join_paths(prefix, 'libdata/pkgconfig')
+else
+	pkgconfig_install_dir = join_paths(prefix, libdir, 'pkgconfig')
+endif
+
 pkgconfig = import('pkgconfig')
 pkgconfig.generate(
 	libraries: lib_wlr,
@@ -164,6 +171,7 @@ pkgconfig.generate(
 	filebase: meson.project_name(),
 	name: meson.project_name(),
 	description: 'Wayland compositor library',
+	install_dir: pkgconfig_install_dir,
 )
 
 git = find_program('git', required: false)


### PR DESCRIPTION
I did not catch this earlier because I'm using the ports system to install wlroots, which automatically deals with such issues, but the default directory for pkg-config files is not the right one for FreeBSD.

This commit changes the installation directory of wlroots.pc on FreeBSD to <prefix>/libdata/pkgconfig, and leaves it as the default on other systems.