### PR TITLE
[WIP] wlr_backend_drm: Add wlr_drm_backend_device_name

### DIFF
--- a/include/wlr/backend/drm.h
+++ b/include/wlr/backend/drm.h
@@ -25,6 +25,8 @@ struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
 	struct wlr_session *session, int gpu_fd, struct wlr_backend *parent,
 	wlr_renderer_create_func_t create_renderer_func);
 
+char* wlr_drm_backend_device_name(struct wlr_backend *backend);
+
 bool wlr_backend_is_drm(struct wlr_backend *backend);
 bool wlr_output_is_drm(struct wlr_output *output);
 


### PR DESCRIPTION
Gets the name of the device used by the DRM backend. Also refactored to use this internally. This is in support of an upcoming patch related to swaywm/sway#2896