### PR TITLE
backend/drm: fix frame scheduling on secondary GPUs

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -735,11 +735,11 @@ static bool drm_connector_move_cursor(struct wlr_output *output,
 	return ok;
 }
 
-static void drm_connector_schedule_frame(struct wlr_output *output) {
+static bool drm_connector_schedule_frame(struct wlr_output *output) {
 	struct wlr_drm_connector *conn = get_drm_connector_from_output(output);
 	struct wlr_drm_backend *drm = get_drm_backend_from_backend(output->backend);
 	if (!drm->session->active) {
-		return;
+		return false;
 	}
 
 	// We need to figure out where we are in the vblank cycle
@@ -747,29 +747,33 @@ static void drm_connector_schedule_frame(struct wlr_output *output) {
 
 	struct wlr_drm_crtc *crtc = conn->crtc;
 	if (!crtc) {
-		return;
+		return false;
 	}
 	struct wlr_drm_plane *plane = crtc->primary;
 	struct gbm_bo *bo = plane->surf.back;
 	if (!bo) {
 		// We haven't swapped buffers yet -- can't do a pageflip
 		wlr_output_send_frame(output);
-		return;
+		return true;
+	}
+	if (drm->parent) {
+		bo = copy_drm_surface_mgpu(&plane->mgpu_surf, bo);
 	}
 	uint32_t fb_id = get_fb_for_bo(bo);
 
 	if (conn->pageflip_pending) {
 		wlr_log(WLR_ERROR, "Skipping pageflip on output '%s'",
 			conn->output.name);
-		return;
+		return true;
 	}
 
 	if (!drm->iface->crtc_pageflip(drm, conn, crtc, fb_id, NULL)) {
-		return;
+		return false;
 	}
 
 	conn->pageflip_pending = true;
 	wlr_output_update_enabled(output, true);
+	return true;
 }
 
 static void drm_connector_destroy(struct wlr_output *output) {

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -197,17 +197,18 @@ static bool output_move_cursor(struct wlr_output *_output, int x, int y) {
 	return true;
 }
 
-static void output_schedule_frame(struct wlr_output *wlr_output) {
+static bool output_schedule_frame(struct wlr_output *wlr_output) {
 	struct wlr_wl_output *output = get_wl_output_from_output(wlr_output);
 
 	if (output->frame_callback != NULL) {
 		wlr_log(WLR_ERROR, "Skipping frame scheduling");
-		return;
+		return true;
 	}
 
 	output->frame_callback = wl_surface_frame(output->surface);
 	wl_callback_add_listener(output->frame_callback, &frame_listener, output);
 	wl_surface_commit(output->surface);
+	return true;
 }
 
 static const struct wlr_output_impl output_impl = {

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -33,7 +33,7 @@ struct wlr_output_impl {
 	size_t (*get_gamma_size)(struct wlr_output *output);
 	bool (*export_dmabuf)(struct wlr_output *output,
 		struct wlr_dmabuf_attributes *attribs);
-	void (*schedule_frame)(struct wlr_output *output);
+	bool (*schedule_frame)(struct wlr_output *output);
 };
 
 void wlr_output_init(struct wlr_output *output, struct wlr_backend *backend,

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -547,8 +547,9 @@ static void schedule_frame_handle_idle_timer(void *data) {
 	output->idle_frame = NULL;
 	if (!output->frame_pending && output->impl->schedule_frame) {
 		// Ask the backend to send a frame event when appropriate
-		output->frame_pending = true;
-		output->impl->schedule_frame(output);
+		if (output->impl->schedule_frame(output)) {
+			output->frame_pending = true;
+		}
 	}
 }
 


### PR DESCRIPTION
There was a missing copy_drm_surface_mgpu call in drm_connector_schedule_frame
so we asked for a pageflip with an unknown BO, resulting in ENOENT.

Additionally, this commit makes schedule_frame return a bool indicating
failures. This allows schedule_frame_handle_idle_timer to only set
frame_pending to true if a frame has been successfully scheduled. Thus, if a
pageflip fails, rendering won't be blocked forever anymore.

In case a pageflip is already pending, true is returned because a frame has
already been scheduled and will be sent sometime soon.

@JonnyMako @DawidLoubser @JonathanILevi Please test!

Fixes swaywm/sway#2800
Fixes #1328