### PR TITLE
Use _POSIX_C_SOURCE, use shm_open

### DIFF
--- a/examples/dmabuf-capture.c
+++ b/examples/dmabuf-capture.c
@@ -1,4 +1,3 @@
-#define _XOPEN_SOURCE 700
 #define _POSIX_C_SOURCE 199309L
 #include <libavformat/avformat.h>
 #include <libavutil/display.h>

--- a/examples/idle.c
+++ b/examples/idle.c
@@ -1,12 +1,12 @@
 #include <getopt.h>
 #include <pthread.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <wayland-client-protocol.h>
 #include <wayland-client.h>
-#include <wlr/util/log.h>
 #include "idle-client-protocol.h"
 
 static struct org_kde_kwin_idle *idle_manager = NULL;
@@ -109,8 +109,6 @@ void *main_loop(void *data) {
 }
 
 int main(int argc, char *argv[]) {
-	wlr_log_init(WLR_DEBUG, NULL);
-
 	if (parse_args(argc, argv) != 0) {
 		return -1;
 	}

--- a/examples/input-method.c
+++ b/examples/input-method.c
@@ -1,6 +1,7 @@
 #define _POSIX_C_SOURCE 200809L
 #include <assert.h>
 #include <errno.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -9,7 +10,6 @@
 #include <unistd.h>
 #include <wayland-client.h>
 #include <wayland-egl.h>
-#include <wlr/render/egl.h>
 #include "input-method-unstable-v2-client-protocol.h"
 #include "text-input-unstable-v3-client-protocol.h"
 #include "xdg-shell-client-protocol.h"

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -55,7 +55,7 @@ examples = {
 	},
 	'screenshot': {
 		'src': 'screenshot.c',
-		'dep': [wayland_client, wlr_protos, wlroots],
+		'dep': [wayland_client, wlr_protos, rt],
 	},
 	'idle': {
 		'src': 'idle.c',
@@ -96,7 +96,7 @@ examples = {
 	},
 	'screencopy': {
 		'src': 'screencopy.c',
-		'dep': [libpng, wayland_client, wlr_protos, wlroots],
+		'dep': [libpng, wayland_client, wlr_protos, rt],
 	},
 	'toplevel-decoration': {
 		'src': 'toplevel-decoration.c',

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -59,7 +59,7 @@ examples = {
 	},
 	'idle': {
 		'src': 'idle.c',
-		'dep': [wayland_client, wlr_protos, wlroots, threads],
+		'dep': [wayland_client, wlr_protos, threads],
 	},
 	'idle-inhibit': {
 		'src': 'idle-inhibit.c',
@@ -75,7 +75,7 @@ examples = {
 	},
 	'gamma-control': {
 		'src': 'gamma-control.c',
-		'dep': [wayland_client, wayland_cursor, wlr_protos, wlroots],
+		'dep': [wayland_client, wayland_cursor, wlr_protos, math],
 	},
 	'pointer-constraints': {
 		'src': 'pointer-constraints.c',
@@ -91,7 +91,6 @@ examples = {
 			threads,
 			wayland_client,
 			wlr_protos,
-			wlroots,
 		],
 	},
 	'screencopy': {
@@ -103,13 +102,13 @@ examples = {
 		'dep': [wayland_client, wlr_protos, wlroots],
 	},
 	'input-method': {
-	    'src': 'input-method.c',
-	    'dep': [wayland_client, wlr_protos, wlroots] + libepoll,
-    },
+		'src': 'input-method.c',
+		'dep': [wayland_client, wlr_protos] + libepoll,
+	},
 	'text-input': {
-	    'src': 'text-input.c',
-	    'dep': [wayland_cursor, wayland_client, wlr_protos, wlroots],
-    },
+		'src': 'text-input.c',
+		'dep': [wayland_cursor, wayland_client, wlr_protos, wlroots],
+	},
 }
 
 foreach name, info : examples

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -1,5 +1,4 @@
 #define _POSIX_C_SOURCE 200112L
-#define _XOPEN_SOURCE 700
 #include <GLES2/gl2.h>
 #include <limits.h>
 #include <math.h>

--- a/types/data_device/wlr_data_device.c
+++ b/types/data_device/wlr_data_device.c
@@ -1,4 +1,3 @@
-#define _XOPEN_SOURCE 700
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>

--- a/types/data_device/wlr_data_offer.c
+++ b/types/data_device/wlr_data_offer.c
@@ -1,4 +1,3 @@
-#define _XOPEN_SOURCE 700
 #include <assert.h>
 #include <stdlib.h>
 #include <strings.h>

--- a/types/data_device/wlr_data_source.c
+++ b/types/data_device/wlr_data_source.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE 700
+#define _POSIX_C_SOURCE 200809L
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>

--- a/types/data_device/wlr_drag.c
+++ b/types/data_device/wlr_drag.c
@@ -1,4 +1,3 @@
-#define _XOPEN_SOURCE 700
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>

--- a/types/wlr_input_device.c
+++ b/types/wlr_input_device.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE 500
+#define _POSIX_C_SOURCE 200809L
 #include <stdlib.h>
 #include <string.h>
 #include <wayland-server.h>

--- a/types/wlr_primary_selection.c
+++ b/types/wlr_primary_selection.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE 700
+#define _POSIX_C_SOURCE 200809L
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>

--- a/xcursor/wlr_xcursor.c
+++ b/xcursor/wlr_xcursor.c
@@ -23,7 +23,7 @@
  * SOFTWARE.
  */
 
-#define _XOPEN_SOURCE 500
+#define _POSIX_C_SOURCE 200809L
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/xwayland/selection/dnd.c
+++ b/xwayland/selection/dnd.c
@@ -1,4 +1,3 @@
-#define _XOPEN_SOURCE 700
 #include <assert.h>
 #include <fcntl.h>
 #include <stdlib.h>

--- a/xwayland/selection/incoming.c
+++ b/xwayland/selection/incoming.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE 700
+#define _POSIX_C_SOURCE 200809L
 #include <assert.h>
 #include <fcntl.h>
 #include <stdlib.h>

--- a/xwayland/selection/outgoing.c
+++ b/xwayland/selection/outgoing.c
@@ -1,4 +1,3 @@
-#define _XOPEN_SOURCE 700
 #include <assert.h>
 #include <fcntl.h>
 #include <stdlib.h>

--- a/xwayland/selection/selection.c
+++ b/xwayland/selection/selection.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE 700
+#define _POSIX_C_SOURCE 200809L
 #include <assert.h>
 #include <fcntl.h>
 #include <stdlib.h>

--- a/xwayland/sockets.c
+++ b/xwayland/sockets.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE 700
+#define _POSIX_C_SOURCE 200809L
 #ifdef __FreeBSD__
 // for SOCK_CLOEXEC
 #define __BSD_VISIBLE 1

--- a/xwayland/xwayland.c
+++ b/xwayland/xwayland.c
@@ -1,4 +1,3 @@
-#define _XOPEN_SOURCE 700
 #define _DEFAULT_SOURCE
 #ifdef __FreeBSD__
 // for SOCK_CLOEXEC


### PR DESCRIPTION
* Prefer `_POSIX_C_SOURCE` over `_XOPEN_SOURCE` where possible (we only need `_XOPEN_SOURCE >= 500` for `M_PI`)
* Simplify examples by using `shm_open` instead of `XDG_RUNTIME_DIR`
* Don't link client examples to wlroots if possible