### PR TITLE
[RFC] Layer-shell: Add a request for modifiers.

### DIFF
--- a/include/wlr/types/wlr_layer_shell_v1.h
+++ b/include/wlr/types/wlr_layer_shell_v1.h
@@ -52,6 +52,7 @@ struct wlr_layer_surface_v1_state {
 		uint32_t top, right, bottom, left;
 	} margin;
 	bool keyboard_interactive;
+  bool modifier_events;
 	uint32_t desired_width, desired_height;
 	uint32_t actual_width, actual_height;
 };
@@ -94,6 +95,8 @@ struct wlr_layer_surface_v1 {
 		struct wl_signal new_popup;
 	} events;
 
+  struct wl_resource *seat_resource; //For requesting modifier events
+  bool resource_added_to_seat;
 	void *data;
 };
 

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -36,6 +36,7 @@ struct wlr_seat_client {
 		struct wl_signal destroy;
 	} events;
 
+  struct wl_list modifier_event_client;
 	struct wl_list link;
 };
 
@@ -168,6 +169,7 @@ struct wlr_seat_keyboard_state {
 
 	struct wlr_seat_keyboard_grab *grab;
 	struct wlr_seat_keyboard_grab *default_grab;
+  struct wl_list modifier_event_clients;
 };
 
 struct wlr_seat_touch_state {

--- a/protocol/wlr-layer-shell-unstable-v1.xml
+++ b/protocol/wlr-layer-shell-unstable-v1.xml
@@ -25,7 +25,7 @@
     THIS SOFTWARE.
   </copyright>
 
-  <interface name="zwlr_layer_shell_v1" version="1">
+  <interface name="zwlr_layer_shell_v1" version="2">
     <description summary="create surfaces that are layers of the desktop">
       Clients can use this interface to assign the surface_layer role to
       wl_surfaces. Such surfaces are assigned to a "layer" of the output and
@@ -84,7 +84,7 @@
     </enum>
   </interface>
 
-  <interface name="zwlr_layer_surface_v1" version="1">
+  <interface name="zwlr_layer_surface_v1" version="2">
     <description summary="layer metadata interface">
       An interface that may be implemented by a wl_surface, for surfaces that
       are designed to be rendered as a layer of a stacked desktop-like
@@ -281,5 +281,20 @@
       <entry name="left" value="4" summary="the left edge of the anchor rectangle"/>
       <entry name="right" value="8" summary="the right edge of the anchor rectangle"/>
     </enum>
+
+    <!-- version 2 additions -->
+
+    <request name="get_keyboard_modifiers" since="2">
+      <description summary="requests keyboard modifier events">
+        Keyboard modifier events would be sent to the client when need_events
+        is set to 1. Useful when the client wants to know about the current
+        layout.
+
+        Events is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="need_events" type="uint"/>
+      <arg name="seat" type="object" interface="wl_seat" allow-null="true"/>
+    </request>
+
   </interface>
 </protocol>

--- a/types/seat/wlr_seat.c
+++ b/types/seat/wlr_seat.c
@@ -242,6 +242,7 @@ struct wlr_seat *wlr_seat_create(struct wl_display *display, const char *name) {
 
 	seat->keyboard_state.seat = seat;
 	wl_list_init(&seat->keyboard_state.surface_destroy.link);
+  wl_list_init(&seat->keyboard_state.modifier_event_clients);
 
 	// touch state
 	struct wlr_seat_touch_grab *touch_grab =

--- a/types/seat/wlr_seat_keyboard.c
+++ b/types/seat/wlr_seat_keyboard.c
@@ -215,6 +215,26 @@ void wlr_seat_keyboard_send_modifiers(struct wlr_seat *seat,
 				modifiers->locked, modifiers->group);
 		}
 	}
+
+  struct wlr_seat_client* sclient;
+  wl_list_for_each(sclient,
+                   &seat->keyboard_state.modifier_event_clients,
+                   modifier_event_client) {
+    serial = wl_display_next_serial(seat->display);
+    wl_resource_for_each(resource, &sclient->keyboards) {
+      if (seat_client_from_keyboard_resource(resource) == NULL) {
+        continue;
+      }
+
+      if (modifiers == NULL) {
+        wl_keyboard_send_modifiers(resource, serial, 0, 0, 0, 0);
+      } else {
+        wl_keyboard_send_modifiers(resource, serial,
+                                   modifiers->depressed, modifiers->latched,
+                                   modifiers->locked, modifiers->group);
+      }
+    }
+  }
 }
 
 void wlr_seat_keyboard_enter(struct wlr_seat *seat,


### PR DESCRIPTION
Add a new request to the zwlr_layer_surface_v1 interface for requesting
to get keybord modifiers. This enables applications like the status bar
to get the current layout and present it.

Signed-off-by: Harish Krupo <harishkrupo@gmail.com>