### PR TITLE
Force ftruncate for shared memory objects on FreeBSD

### DIFF
--- a/include/wlr/config.h.in
+++ b/include/wlr/config.h.in
@@ -14,6 +14,4 @@
 #mesondefine WLR_HAS_XCB_ICCCM
 #mesondefine WLR_HAS_XCB_XKB
 
-#mesondefine WLR_HAS_POSIX_FALLOCATE
-
 #endif

--- a/meson.build
+++ b/meson.build
@@ -72,10 +72,6 @@ if logind.found()
 	wlr_deps += logind
 endif
 
-if cc.has_header_symbol('fcntl.h', 'posix_fallocate', prefix: '#define _POSIX_C_SOURCE 200112L')
-	conf_data.set('WLR_HAS_POSIX_FALLOCATE', true)
-endif
-
 subdir('protocol')
 subdir('render')
 

--- a/util/shm.c
+++ b/util/shm.c
@@ -42,7 +42,7 @@ int allocate_shm_file(size_t size) {
 		return -1;
 	}
 
-#ifdef WLR_HAS_POSIX_FALLOCATE
+#if defined(WLR_HAS_POSIX_FALLOCATE) && !defined(__FreeBSD__)
 	int ret;
 	do {
 		ret = posix_fallocate(fd, 0, size);

--- a/util/shm.c
+++ b/util/shm.c
@@ -42,17 +42,6 @@ int allocate_shm_file(size_t size) {
 		return -1;
 	}
 
-#if defined(WLR_HAS_POSIX_FALLOCATE) && !defined(__FreeBSD__)
-	int ret;
-	do {
-		ret = posix_fallocate(fd, 0, size);
-	} while (ret == EINTR);
-	if (ret != 0) {
-		close(fd);
-		errno = ret;
-		return -1;
-	}
-#else
 	int ret;
 	do {
 		ret = ftruncate(fd, size);
@@ -61,7 +50,6 @@ int allocate_shm_file(size_t size) {
 		close(fd);
 		return -1;
 	}
-#endif
 
 	return fd;
 }


### PR DESCRIPTION
FreeBSD does not allow to use `posix_fallocate` on shared memory objects.

I also think that this function should not be used here anyways, since shared memory objects are not regular files, and `posix_fallocate` should give an ENODEV error if the fd refers to a non-regular file. At least that is my understanding of the POSIX specification. 