### PR TITLE
Fix compilation error on musl

### DIFF
--- a/types/data_device/wlr_data_offer.c
+++ b/types/data_device/wlr_data_offer.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700
 #include <assert.h>
 #include <stdlib.h>
 #include <strings.h>


### PR DESCRIPTION
I have the following error when compiling latest sway+wlroots on Void Linux with musl 
```
[130/204] Compiling C object 'types/types@@wlr_types@sta/data_device_wlr_data_offer.c.o'.
FAILED: types/types@@wlr_types@sta/data_device_wlr_data_offer.c.o
cc -Itypes/types@@wlr_types@sta -Itypes -I../types -I. -I../ -Iinclude -I../include -Iprotocol -I/usr/include/pixman-1 -flto -fdiagnostics-color=always -DNDEBUG -pipe -D_FILE_OFFSET_BITS=64 -Werror -std=c11 -Wno-unused-parameter '-DWLR_SRC_DIR="/builddir/wlroots-master"' -DWLR_USE_UNSTABLE -DWL_HIDE_DEPRECATED -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -fPIC  -MD -MQ 'types/types@@wlr_types@sta/data_device_wlr_data_offer.c.o' -MF 'types/types@@wlr_types@sta/data_device_wlr_data_offer.c.o.d' -o 'types/types@@wlr_types@sta/data_device_wlr_data_offer.c.o' -c ../types/data_device/wlr_data_offer.c
../types/data_device/wlr_data_offer.c: In function 'data_offer_choose_action':
../types/data_device/wlr_data_offer.c:53:15: error: implicit declaration of function 'ffs' [-Werror=implicit-function-declaration]
  return 1 << (ffs(available_actions) - 1);
               ^~~
cc1: all warnings being treated as errors
ninja: build stopped: subcommand failed.
```
Investigating the error, I found that it was introduced when commit 2d0c5ec was merged.
That commit removed the `_XOPEN_SOURCE` definition. If you read the `strings.h` musl implementation [here](https://git.musl-libc.org/cgit/musl/tree/include/strings.h#n23) we can see that the definition is needed if the `ffs` function is to be included.

```
#if defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE)  || defined(_BSD_SOURCE)
int ffs (int);
int ffsl (long);
int ffsll (long long);
#endif
```