### PR TITLE
Render software cursors in compositor

### DIFF
--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -106,11 +106,6 @@ struct wlr_output {
 
 	struct wl_event_source *idle_frame;
 
-	struct wlr_surface *fullscreen_surface;
-	struct wl_listener fullscreen_surface_commit;
-	struct wl_listener fullscreen_surface_destroy;
-	int fullscreen_width, fullscreen_height;
-
 	struct wl_list cursors; // wlr_output_cursor::link
 	struct wlr_output_cursor *hardware_cursor;
 	int software_cursor_locks; // number of locks forcing software cursors
@@ -226,8 +221,6 @@ bool wlr_output_set_gamma(struct wlr_output *output, size_t size,
 	const uint16_t *r, const uint16_t *g, const uint16_t *b);
 bool wlr_output_export_dmabuf(struct wlr_output *output,
 	struct wlr_dmabuf_attributes *attribs);
-void wlr_output_set_fullscreen_surface(struct wlr_output *output,
-	struct wlr_surface *surface);
 struct wlr_output *wlr_output_from_resource(struct wl_resource *resource);
 /**
  * Locks the output to only use software cursors instead of hardware cursors.

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -230,6 +230,12 @@ struct wlr_output *wlr_output_from_resource(struct wl_resource *resource);
  * a lock.
  */
 void wlr_output_lock_software_cursors(struct wlr_output *output, bool lock);
+/**
+ * Renders software cursors. This is a utility function that can be called when
+ * compositors render.
+ */
+void wlr_output_render_software_cursors(struct wlr_output *output,
+	pixman_region32_t *damage);
 
 
 struct wlr_output_cursor *wlr_output_cursor_create(struct wlr_output *output);

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -518,6 +518,7 @@ static void render_output(struct roots_output *output) {
 			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]);
 
 renderer_end:
+	wlr_output_render_software_cursors(wlr_output, &damage);
 	wlr_renderer_scissor(renderer, NULL);
 	wlr_renderer_end(renderer);
 


### PR DESCRIPTION
This PR removes `wlr_output_set_fullscreen_surface`, adds a new `wlr_output_render_software_cursors` helper, and removes the 180 damage flip in `wlr_output_swap_buffers` (which is GL-specific).

This also fixes frame events for hardware cursors, which were sent too soon.

While this improves the situation, this doesn't completely fix <span></span>#1363, because redesigning how cursor surfaces are handled and how output damage is managed requires more thought.

See #1363