### PR TITLE
X11 backend improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ If you choose to enable X11 support:
 * x11-xcb
 * xcb-errors (optional, for improved error reporting)
 * x11-icccm (optional, for improved Xwayland introspection)
-* xcb-xkb (optional, for improved keyboard handling on the X11 backend)
 
 Run these commands:
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ If you choose to enable X11 support:
 * xcb
 * xcb-composite
 * xcb-xfixes
+* xcb-xinput
 * xcb-image
 * xcb-render
 * x11-xcb

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -1,25 +1,30 @@
 #define _POSIX_C_SOURCE 200112L
+
 #include <assert.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-#include <wayland-server.h>
-#include <wlr/backend/interface.h>
-#include <wlr/backend/x11.h>
+
 #include <wlr/config.h>
-#include <wlr/interfaces/wlr_input_device.h>
-#include <wlr/interfaces/wlr_keyboard.h>
-#include <wlr/interfaces/wlr_pointer.h>
-#include <wlr/render/egl.h>
-#include <wlr/render/gles2.h>
-#include <wlr/util/log.h>
+
 #include <X11/Xlib-xcb.h>
+#include <wayland-server.h>
 #include <xcb/xcb.h>
 #if WLR_HAS_XCB_XKB
 #include <xcb/xkb.h>
 #endif
+
+#include <wlr/backend/interface.h>
+#include <wlr/backend/x11.h>
+#include <wlr/interfaces/wlr_input_device.h>
+#include <wlr/interfaces/wlr_keyboard.h>
+#include <wlr/interfaces/wlr_pointer.h>
+#include <wlr/render/egl.h>
+#include <wlr/render/wlr_renderer.h>
+#include <wlr/util/log.h>
+
 #include "backend/x11.h"
 #include "util/signal.h"
 

--- a/backend/x11/input_device.c
+++ b/backend/x11/input_device.c
@@ -10,9 +10,6 @@
 
 #include <xcb/xcb.h>
 #include <xcb/xinput.h>
-#if WLR_HAS_XCB_XKB
-#include <xcb/xkb.h>
-#endif
 
 #include <wlr/interfaces/wlr_input_device.h>
 #include <wlr/interfaces/wlr_keyboard.h>
@@ -21,126 +18,6 @@
 
 #include "backend/x11.h"
 #include "util/signal.h"
-
-static uint32_t xcb_button_to_wl(uint32_t button) {
-	switch (button) {
-	case XCB_BUTTON_INDEX_1: return BTN_LEFT;
-	case XCB_BUTTON_INDEX_2: return BTN_MIDDLE;
-	case XCB_BUTTON_INDEX_3: return BTN_RIGHT;
-	case XCB_BUTTON_INDEX_4: return BTN_GEAR_UP;
-	case XCB_BUTTON_INDEX_5: return BTN_GEAR_DOWN;
-	default: return 0;
-	}
-}
-
-static void x11_handle_pointer_position(struct wlr_x11_output *output,
-		int16_t x, int16_t y, xcb_timestamp_t time) {
-	struct wlr_x11_backend *x11 = output->x11;
-	struct wlr_output *wlr_output = &output->wlr_output;
-	struct wlr_event_pointer_motion_absolute event = {
-		.device = &output->pointer_dev,
-		.time_msec = time,
-		.x = (double)x / wlr_output->width,
-		.y = (double)y / wlr_output->height,
-	};
-	wlr_signal_emit_safe(&output->pointer.events.motion_absolute, &event);
-
-	x11->time = time;
-}
-
-void handle_x11_input_event(struct wlr_x11_backend *x11,
-		xcb_generic_event_t *event) {
-	switch (event->response_type & XCB_EVENT_RESPONSE_TYPE_MASK) {
-	case XCB_KEY_PRESS:
-	case XCB_KEY_RELEASE: {
-		xcb_key_press_event_t *ev = (xcb_key_press_event_t *)event;
-		struct wlr_event_keyboard_key key = {
-			.time_msec = ev->time,
-			.keycode = ev->detail - 8,
-			.state = event->response_type == XCB_KEY_PRESS ?
-				WLR_KEY_PRESSED : WLR_KEY_RELEASED,
-			.update_state = true,
-		};
-
-		// TODO use xcb-xkb for more precise modifiers state?
-		wlr_keyboard_notify_key(&x11->keyboard, &key);
-		x11->time = ev->time;
-		return;
-	}
-	case XCB_BUTTON_PRESS: {
-		xcb_button_press_event_t *ev = (xcb_button_press_event_t *)event;
-
-		struct wlr_x11_output *output =
-			get_x11_output_from_window_id(x11, ev->event);
-		if (output == NULL) {
-			break;
-		}
-
-		if (ev->detail == XCB_BUTTON_INDEX_4 ||
-				ev->detail == XCB_BUTTON_INDEX_5) {
-			int32_t delta_discrete = ev->detail == XCB_BUTTON_INDEX_4 ? -1 : 1;
-			struct wlr_event_pointer_axis axis = {
-				.device = &output->pointer_dev,
-				.time_msec = ev->time,
-				.source = WLR_AXIS_SOURCE_WHEEL,
-				.orientation = WLR_AXIS_ORIENTATION_VERTICAL,
-				// 15 is a typical value libinput sends for one scroll
-				.delta = delta_discrete * 15,
-				.delta_discrete = delta_discrete,
-			};
-			wlr_signal_emit_safe(&output->pointer.events.axis, &axis);
-			x11->time = ev->time;
-			break;
-		}
-	}
-	/* fallthrough */
-	case XCB_BUTTON_RELEASE: {
-		xcb_button_press_event_t *ev = (xcb_button_press_event_t *)event;
-
-		struct wlr_x11_output *output =
-			get_x11_output_from_window_id(x11, ev->event);
-		if (output == NULL) {
-			break;
-		}
-
-		if (ev->detail != XCB_BUTTON_INDEX_4 &&
-				ev->detail != XCB_BUTTON_INDEX_5) {
-			struct wlr_event_pointer_button button = {
-				.device = &output->pointer_dev,
-				.time_msec = ev->time,
-				.button = xcb_button_to_wl(ev->detail),
-				.state = event->response_type == XCB_BUTTON_PRESS ?
-					WLR_BUTTON_PRESSED : WLR_BUTTON_RELEASED,
-			};
-
-			wlr_signal_emit_safe(&output->pointer.events.button, &button);
-		}
-		x11->time = ev->time;
-		return;
-	}
-	case XCB_MOTION_NOTIFY: {
-		xcb_motion_notify_event_t *ev = (xcb_motion_notify_event_t *)event;
-
-		struct wlr_x11_output *output =
-			get_x11_output_from_window_id(x11, ev->event);
-		if (output != NULL) {
-			x11_handle_pointer_position(output, ev->event_x, ev->event_y, ev->time);
-		}
-		return;
-	}
-	default:
-#if WLR_HAS_XCB_XKB
-		if (x11->xkb_supported && event->response_type == x11->xkb_base_event) {
-			xcb_xkb_state_notify_event_t *ev =
-				(xcb_xkb_state_notify_event_t *)event;
-			wlr_keyboard_notify_modifiers(&x11->keyboard, ev->baseMods,
-				ev->latchedMods, ev->lockedMods, ev->lockedGroup);
-			return;
-		}
-#endif
-		break;
-	}
-}
 
 static void send_key_event(struct wlr_x11_backend *x11, uint32_t key,
 		enum wlr_key_state st, xcb_timestamp_t time) {
@@ -176,6 +53,17 @@ static void send_axis_event(struct wlr_x11_output *output, int32_t delta,
 		.delta_discrete = delta,
 	};
 	wlr_signal_emit_safe(&output->pointer.events.axis, &ev);
+}
+
+static void send_pointer_position_event(struct wlr_x11_output *output,
+		int16_t x, int16_t y, xcb_timestamp_t time) {
+	struct wlr_event_pointer_motion_absolute ev = {
+		.device = &output->pointer_dev,
+		.time_msec = time,
+		.x = (double)x / output->wlr_output.width,
+		.y = (double)y / output->wlr_output.height,
+	};
+	wlr_signal_emit_safe(&output->pointer.events.motion_absolute, &ev);
 }
 
 void handle_x11_xinput_event(struct wlr_x11_backend *x11,
@@ -271,7 +159,7 @@ void handle_x11_xinput_event(struct wlr_x11_backend *x11,
 			return;
 		}
 
-		x11_handle_pointer_position(output, ev->event_x >> 16,
+		send_pointer_position_event(output, ev->event_x >> 16,
 			ev->event_y >> 16, ev->time);
 		x11->time = ev->time;
 		break;
@@ -315,7 +203,7 @@ void update_x11_pointer_position(struct wlr_x11_output *output,
 		return;
 	}
 
-	x11_handle_pointer_position(output, reply->win_x, reply->win_y, time);
+	send_pointer_position_event(output, reply->win_x, reply->win_y, time);
 
 	free(reply);
 }

--- a/backend/x11/input_device.c
+++ b/backend/x11/input_device.c
@@ -166,9 +166,9 @@ void update_x11_pointer_position(struct wlr_x11_output *output,
 	struct wlr_x11_backend *x11 = output->x11;
 
 	xcb_query_pointer_cookie_t cookie =
-		xcb_query_pointer(x11->xcb_conn, output->win);
+		xcb_query_pointer(x11->xcb, output->win);
 	xcb_query_pointer_reply_t *reply =
-		xcb_query_pointer_reply(x11->xcb_conn, cookie, NULL);
+		xcb_query_pointer_reply(x11->xcb, cookie, NULL);
 	if (!reply) {
 		return;
 	}

--- a/backend/x11/input_device.c
+++ b/backend/x11/input_device.c
@@ -1,18 +1,23 @@
 #include <stdlib.h>
+
 #include <wlr/config.h>
-#include <wlr/interfaces/wlr_input_device.h>
-#include <wlr/interfaces/wlr_keyboard.h>
-#include <wlr/interfaces/wlr_pointer.h>
-#include <wlr/util/log.h>
-#include <xcb/xcb.h>
+
 #ifdef __linux__
 #include <linux/input-event-codes.h>
 #elif __FreeBSD__
 #include <dev/evdev/input-event-codes.h>
 #endif
+
+#include <xcb/xcb.h>
 #if WLR_HAS_XCB_XKB
 #include <xcb/xkb.h>
 #endif
+
+#include <wlr/interfaces/wlr_input_device.h>
+#include <wlr/interfaces/wlr_keyboard.h>
+#include <wlr/interfaces/wlr_pointer.h>
+#include <wlr/util/log.h>
+
 #include "backend/x11.h"
 #include "util/signal.h"
 

--- a/backend/x11/meson.build
+++ b/backend/x11/meson.build
@@ -3,6 +3,7 @@ x11_required = [
 	'x11-xcb',
 	'xcb',
 	'xcb-xinput',
+	'xcb-xfixes',
 ]
 
 foreach lib : x11_required

--- a/backend/x11/meson.build
+++ b/backend/x11/meson.build
@@ -4,9 +4,6 @@ x11_required = [
 	'xcb',
 	'xcb-xinput',
 ]
-x11_optional = [
-	'xcb-xkb',
-]
 
 foreach lib : x11_required
 	dep = dependency(lib, required: get_option('x11-backend'))
@@ -15,14 +12,6 @@ foreach lib : x11_required
 	endif
 
 	x11_libs += dep
-endforeach
-
-foreach lib : x11_optional
-	dep = dependency(lib, required: get_option(lib))
-	if dep.found()
-		x11_libs += dep
-		conf_data.set10('WLR_HAS_' + lib.underscorify().to_upper(), true)
-	endif
 endforeach
 
 lib_wlr_backend_x11 = static_library(

--- a/backend/x11/meson.build
+++ b/backend/x11/meson.build
@@ -1,7 +1,8 @@
 x11_libs = []
 x11_required = [
-	'xcb',
 	'x11-xcb',
+	'xcb',
+	'xcb-xinput',
 ]
 x11_optional = [
 	'xcb-xkb',

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -152,18 +152,13 @@ struct wlr_output *wlr_x11_output_create(struct wlr_backend *backend) {
 
 	uint32_t mask = XCB_CW_EVENT_MASK;
 	uint32_t values[] = {
-		XCB_EVENT_MASK_EXPOSURE |
-		XCB_EVENT_MASK_KEY_PRESS | XCB_EVENT_MASK_KEY_RELEASE |
-		XCB_EVENT_MASK_BUTTON_PRESS | XCB_EVENT_MASK_BUTTON_RELEASE |
-		XCB_EVENT_MASK_POINTER_MOTION |
-		XCB_EVENT_MASK_STRUCTURE_NOTIFY
+		XCB_EVENT_MASK_EXPOSURE | XCB_EVENT_MASK_STRUCTURE_NOTIFY
 	};
 	output->win = xcb_generate_id(x11->xcb);
 	xcb_create_window(x11->xcb, XCB_COPY_FROM_PARENT, output->win,
 		x11->screen->root, 0, 0, wlr_output->width, wlr_output->height, 1,
 		XCB_WINDOW_CLASS_INPUT_OUTPUT, x11->screen->root_visual, mask, values);
 
-#if 0
 	struct {
 		xcb_input_event_mask_t head;
 		xcb_input_xi_event_mask_t mask;
@@ -176,7 +171,6 @@ struct wlr_output *wlr_x11_output_create(struct wlr_backend *backend) {
 			XCB_INPUT_XI_EVENT_MASK_MOTION,
 	};
 	xcb_input_xi_select_events(x11->xcb, output->win, 1, &xinput_mask.head);
-#endif
 
 	output->surf = wlr_egl_create_surface(&x11->egl, &output->win);
 	if (!output->surf) {

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -16,8 +16,8 @@ static int signal_frame(void *data) {
 }
 
 static void parse_xcb_setup(struct wlr_output *output,
-		xcb_connection_t *xcb_conn) {
-	const xcb_setup_t *xcb_setup = xcb_get_setup(xcb_conn);
+		xcb_connection_t *xcb) {
+	const xcb_setup_t *xcb_setup = xcb_get_setup(xcb);
 
 	snprintf(output->make, sizeof(output->make), "%.*s",
 			xcb_setup_vendor_length(xcb_setup),
@@ -55,11 +55,11 @@ static bool output_set_custom_mode(struct wlr_output *wlr_output,
 
 	const uint32_t values[] = { width, height };
 	xcb_void_cookie_t cookie = xcb_configure_window_checked(
-		x11->xcb_conn, output->win,
+		x11->xcb, output->win,
 		XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT, values);
 
 	xcb_generic_error_t *error;
-	if ((error = xcb_request_check(x11->xcb_conn, cookie))) {
+	if ((error = xcb_request_check(x11->xcb, cookie))) {
 		wlr_log(WLR_ERROR, "Could not set window size to %dx%d\n",
 			width, height);
 		free(error);
@@ -84,8 +84,8 @@ static void output_destroy(struct wlr_output *wlr_output) {
 	wl_list_remove(&output->link);
 	wl_event_source_remove(output->frame_timer);
 	wlr_egl_destroy_surface(&x11->egl, output->surf);
-	xcb_destroy_window(x11->xcb_conn, output->win);
-	xcb_flush(x11->xcb_conn);
+	xcb_destroy_window(x11->xcb, output->win);
+	xcb_flush(x11->xcb);
 	free(output);
 }
 
@@ -142,7 +142,7 @@ struct wlr_output *wlr_x11_output_create(struct wlr_backend *backend) {
 
 	snprintf(wlr_output->name, sizeof(wlr_output->name), "X11-%d",
 		wl_list_length(&x11->outputs) + 1);
-	parse_xcb_setup(wlr_output, x11->xcb_conn);
+	parse_xcb_setup(wlr_output, x11->xcb);
 
 	uint32_t mask = XCB_CW_EVENT_MASK;
 	uint32_t values[] = {
@@ -152,8 +152,8 @@ struct wlr_output *wlr_x11_output_create(struct wlr_backend *backend) {
 		XCB_EVENT_MASK_POINTER_MOTION |
 		XCB_EVENT_MASK_STRUCTURE_NOTIFY
 	};
-	output->win = xcb_generate_id(x11->xcb_conn);
-	xcb_create_window(x11->xcb_conn, XCB_COPY_FROM_PARENT, output->win,
+	output->win = xcb_generate_id(x11->xcb);
+	xcb_create_window(x11->xcb, XCB_COPY_FROM_PARENT, output->win,
 		x11->screen->root, 0, 0, wlr_output->width, wlr_output->height, 1,
 		XCB_WINDOW_CLASS_INPUT_OUTPUT, x11->screen->root_visual, mask, values);
 
@@ -164,23 +164,23 @@ struct wlr_output *wlr_x11_output_create(struct wlr_backend *backend) {
 		return NULL;
 	}
 
-	xcb_change_property(x11->xcb_conn, XCB_PROP_MODE_REPLACE, output->win,
+	xcb_change_property(x11->xcb, XCB_PROP_MODE_REPLACE, output->win,
 		x11->atoms.wm_protocols, XCB_ATOM_ATOM, 32, 1,
 		&x11->atoms.wm_delete_window);
 
 	char title[32];
 	if (snprintf(title, sizeof(title), "wlroots - %s", wlr_output->name)) {
-		xcb_change_property(x11->xcb_conn, XCB_PROP_MODE_REPLACE, output->win,
+		xcb_change_property(x11->xcb, XCB_PROP_MODE_REPLACE, output->win,
 			x11->atoms.net_wm_name, x11->atoms.utf8_string, 8,
 			strlen(title), title);
 	}
 
 	uint32_t cursor_values[] = { x11->cursor };
-	xcb_change_window_attributes(x11->xcb_conn, output->win, XCB_CW_CURSOR,
+	xcb_change_window_attributes(x11->xcb, output->win, XCB_CW_CURSOR,
 		cursor_values);
 
-	xcb_map_window(x11->xcb_conn, output->win);
-	xcb_flush(x11->xcb_conn);
+	xcb_map_window(x11->xcb, output->win);
+	xcb_flush(x11->xcb);
 
 	struct wl_event_loop *ev = wl_display_get_event_loop(x11->wl_display);
 	output->frame_timer = wl_event_loop_add_timer(ev, signal_frame, output);

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -1,10 +1,13 @@
 #define _POSIX_C_SOURCE 200809L
+
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include <wlr/interfaces/wlr_output.h>
 #include <wlr/interfaces/wlr_pointer.h>
 #include <wlr/util/log.h>
+
 #include "backend/x11.h"
 #include "util/signal.h"
 

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -4,6 +4,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <xcb/xcb.h>
+#include <xcb/xinput.h>
+
 #include <wlr/interfaces/wlr_output.h>
 #include <wlr/interfaces/wlr_pointer.h>
 #include <wlr/util/log.h>
@@ -159,6 +162,21 @@ struct wlr_output *wlr_x11_output_create(struct wlr_backend *backend) {
 	xcb_create_window(x11->xcb, XCB_COPY_FROM_PARENT, output->win,
 		x11->screen->root, 0, 0, wlr_output->width, wlr_output->height, 1,
 		XCB_WINDOW_CLASS_INPUT_OUTPUT, x11->screen->root_visual, mask, values);
+
+#if 0
+	struct {
+		xcb_input_event_mask_t head;
+		xcb_input_xi_event_mask_t mask;
+	} xinput_mask = {
+		.head = { .deviceid = XCB_INPUT_DEVICE_ALL_MASTER, .mask_len = 1 },
+		.mask = XCB_INPUT_XI_EVENT_MASK_KEY_PRESS |
+			XCB_INPUT_XI_EVENT_MASK_KEY_RELEASE |
+			XCB_INPUT_XI_EVENT_MASK_BUTTON_PRESS |
+			XCB_INPUT_XI_EVENT_MASK_BUTTON_RELEASE |
+			XCB_INPUT_XI_EVENT_MASK_MOTION,
+	};
+	xcb_input_xi_select_events(x11->xcb, output->win, 1, &xinput_mask.head);
+#endif
 
 	output->surf = wlr_egl_create_surface(&x11->egl, &output->win);
 	if (!output->surf) {

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -168,7 +168,9 @@ struct wlr_output *wlr_x11_output_create(struct wlr_backend *backend) {
 			XCB_INPUT_XI_EVENT_MASK_KEY_RELEASE |
 			XCB_INPUT_XI_EVENT_MASK_BUTTON_PRESS |
 			XCB_INPUT_XI_EVENT_MASK_BUTTON_RELEASE |
-			XCB_INPUT_XI_EVENT_MASK_MOTION,
+			XCB_INPUT_XI_EVENT_MASK_MOTION |
+			XCB_INPUT_XI_EVENT_MASK_ENTER |
+			XCB_INPUT_XI_EVENT_MASK_LEAVE,
 	};
 	xcb_input_xi_select_events(x11->xcb, output->win, 1, &xinput_mask.head);
 
@@ -189,10 +191,6 @@ struct wlr_output *wlr_x11_output_create(struct wlr_backend *backend) {
 			x11->atoms.net_wm_name, x11->atoms.utf8_string, 8,
 			strlen(title), title);
 	}
-
-	uint32_t cursor_values[] = { x11->cursor };
-	xcb_change_window_attributes(x11->xcb, output->win, XCB_CW_CURSOR,
-		cursor_values);
 
 	xcb_map_window(x11->xcb, output->win);
 	xcb_flush(x11->xcb);

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -67,6 +67,8 @@ struct wlr_x11_backend {
 	// A blank cursor
 	xcb_cursor_t cursor;
 
+	uint8_t xinput_opcode;
+
 #if WLR_HAS_XCB_XKB
 	bool xkb_supported;
 	uint8_t xkb_base_event;

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -33,6 +33,8 @@ struct wlr_x11_output {
 
 	struct wl_event_source *frame_timer;
 	int frame_delay;
+
+	bool cursor_hidden;
 };
 
 struct wlr_x11_backend {
@@ -63,9 +65,6 @@ struct wlr_x11_backend {
 
 	// The time we last received an event
 	xcb_timestamp_t time;
-
-	// A blank cursor
-	xcb_cursor_t cursor;
 
 	uint8_t xinput_opcode;
 

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -89,6 +89,8 @@ extern const struct wlr_input_device_impl input_device_impl;
 
 void handle_x11_input_event(struct wlr_x11_backend *x11,
 	xcb_generic_event_t *event);
+void handle_x11_xinput_event(struct wlr_x11_backend *x11,
+		xcb_ge_generic_event_t *event);
 void update_x11_pointer_position(struct wlr_x11_output *output,
 	xcb_timestamp_t time);
 

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -69,12 +69,6 @@ struct wlr_x11_backend {
 
 	uint8_t xinput_opcode;
 
-#if WLR_HAS_XCB_XKB
-	bool xkb_supported;
-	uint8_t xkb_base_event;
-	uint8_t xkb_base_error;
-#endif
-
 	struct wl_listener display_destroy;
 };
 
@@ -87,8 +81,6 @@ extern const struct wlr_keyboard_impl keyboard_impl;
 extern const struct wlr_pointer_impl pointer_impl;
 extern const struct wlr_input_device_impl input_device_impl;
 
-void handle_x11_input_event(struct wlr_x11_backend *x11,
-	xcb_generic_event_t *event);
 void handle_x11_xinput_event(struct wlr_x11_backend *x11,
 		xcb_ge_generic_event_t *event);
 void update_x11_pointer_position(struct wlr_x11_output *output,

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -38,7 +38,7 @@ struct wlr_x11_backend {
 	bool started;
 
 	Display *xlib_conn;
-	xcb_connection_t *xcb_conn;
+	xcb_connection_t *xcb;
 	xcb_screen_t *screen;
 
 	size_t requested_outputs;

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -2,14 +2,17 @@
 #define BACKEND_X11_H
 
 #include <stdbool.h>
+
+#include <X11/Xlib-xcb.h>
 #include <wayland-server.h>
-#include <wlr/config.h>
+#include <xcb/xcb.h>
+
 #include <wlr/backend/x11.h>
+#include <wlr/config.h>
 #include <wlr/interfaces/wlr_input_device.h>
 #include <wlr/interfaces/wlr_output.h>
 #include <wlr/render/egl.h>
-#include <X11/Xlib-xcb.h>
-#include <xcb/xcb.h>
+#include <wlr/render/wlr_renderer.h>
 
 #define XCB_EVENT_RESPONSE_TYPE_MASK 0x7f
 

--- a/include/wlr/backend/x11.h
+++ b/include/wlr/backend/x11.h
@@ -2,7 +2,9 @@
 #define WLR_BACKEND_X11_H
 
 #include <stdbool.h>
+
 #include <wayland-server.h>
+
 #include <wlr/backend.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_output.h>

--- a/include/wlr/config.h.in
+++ b/include/wlr/config.h.in
@@ -12,6 +12,5 @@
 
 #mesondefine WLR_HAS_XCB_ERRORS
 #mesondefine WLR_HAS_XCB_ICCCM
-#mesondefine WLR_HAS_XCB_XKB
 
 #endif

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,6 @@ conf_data.set10('WLR_HAS_X11_BACKEND', false)
 conf_data.set10('WLR_HAS_XWAYLAND', false)
 conf_data.set10('WLR_HAS_XCB_ERRORS', false)
 conf_data.set10('WLR_HAS_XCB_ICCCM', false)
-conf_data.set10('WLR_HAS_XCB_XKB', false)
 
 wlr_inc = include_directories('.', 'include')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,7 +3,6 @@ option('logind', type: 'feature', value: 'auto', description: 'Enable support fo
 option('logind-provider', type: 'combo', choices: ['systemd', 'elogind'], value: 'systemd', description: 'Provider of logind support library')
 option('xcb-errors', type: 'feature', value: 'auto', description: 'Use xcb-errors util library')
 option('xcb-icccm', type: 'feature', value: 'auto', description: 'Use xcb-icccm util library')
-option('xcb-xkb', type: 'feature', value: 'auto', description: 'Use xcb-xkb util library')
 option('xwayland', type: 'feature', value: 'auto', description: 'Enable support for X11 applications')
 option('x11-backend', type: 'feature', value: 'auto', description: 'Enable X11 backend')
 option('rootston', type: 'boolean', value: true, description: 'Build the rootston example compositor')


### PR DESCRIPTION
This contains a lot of the X11 backend refactoring and changes I did in my #1355 that really deserved to be part of a different PR, with the history cleaned up.

This removes xcb-xkb, and adds xcb-xinput and xcb-xfixes as dependencies.

~~While working on this PR, I actually encountered another bug which affects this:~~

~~I've changed the X11 backend to use xfixes to hide the cursor, but we need to turn this off once the pointer leaves our window. However, it seems that sway/wlroots is not sending the "leave" event, so the cursor remains hidden.
While the X11 backend is open in sway, your cursor will be invisible over other Xwayland windows.
This does not affect weston or native X11.
I need to debug this more, but is technically not a bug in this PR.~~
Never mind all that. It was because I wasn't flushing the connection.