### PR TITLE
Use #if instead of #ifdef for wlroots config data

### DIFF
--- a/backend/backend.c
+++ b/backend/backend.c
@@ -17,8 +17,7 @@
 #include <wlr/util/log.h>
 #include "backend/multi.h"
 
-/* WLR_HAS_X11_BACKEND needs to be after wlr/config.h */
-#ifdef WLR_HAS_X11_BACKEND
+#if WLR_HAS_X11_BACKEND
 #include <wlr/backend/x11.h>
 #endif
 
@@ -102,7 +101,7 @@ static struct wlr_backend *attempt_wl_backend(struct wl_display *display,
 	return backend;
 }
 
-#ifdef WLR_HAS_X11_BACKEND
+#if WLR_HAS_X11_BACKEND
 static struct wlr_backend *attempt_x11_backend(struct wl_display *display,
 		const char *x11_display, wlr_renderer_create_func_t create_renderer_func) {
 	struct wlr_backend *backend = wlr_x11_backend_create(display, x11_display, create_renderer_func);
@@ -165,7 +164,7 @@ static struct wlr_backend *attempt_backend_by_name(struct wl_display *display,
 		const char *name, wlr_renderer_create_func_t create_renderer_func) {
 	if (strcmp(name, "wayland") == 0) {
 		return attempt_wl_backend(display, create_renderer_func);
-#ifdef WLR_HAS_X11_BACKEND
+#if WLR_HAS_X11_BACKEND
 	} else if (strcmp(name, "x11") == 0) {
 		return attempt_x11_backend(display, NULL, create_renderer_func);
 #endif
@@ -248,7 +247,7 @@ struct wlr_backend *wlr_backend_autocreate(struct wl_display *display,
 		}
 	}
 
-#ifdef WLR_HAS_X11_BACKEND
+#if WLR_HAS_X11_BACKEND
 	const char *x11_display = getenv("DISPLAY");
 	if (x11_display) {
 		struct wlr_backend *x11_backend =

--- a/backend/session/direct-ipc.c
+++ b/backend/session/direct-ipc.c
@@ -24,7 +24,7 @@
 
 enum { DRM_MAJOR = 226 };
 
-#ifdef WLR_HAS_LIBCAP
+#if WLR_HAS_LIBCAP
 #include <sys/capability.h>
 
 static bool have_permissions(void) {

--- a/backend/session/logind.c
+++ b/backend/session/logind.c
@@ -15,10 +15,10 @@
 #include <wlr/util/log.h>
 #include "util/signal.h"
 
-#ifdef WLR_HAS_SYSTEMD
+#if WLR_HAS_SYSTEMD
 	#include <systemd/sd-bus.h>
 	#include <systemd/sd-login.h>
-#elif defined(WLR_HAS_ELOGIND)
+#elif WLR_HAS_ELOGIND
 	#include <elogind/sd-bus.h>
 	#include <elogind/sd-login.h>
 #endif

--- a/backend/session/session.c
+++ b/backend/session/session.c
@@ -19,7 +19,7 @@ extern const struct session_impl session_logind;
 extern const struct session_impl session_direct;
 
 static const struct session_impl *impls[] = {
-#if defined(WLR_HAS_SYSTEMD) || defined(WLR_HAS_ELOGIND)
+#if WLR_HAS_SYSTEMD || WLR_HAS_ELOGIND
 	&session_logind,
 #endif
 	&session_direct,
@@ -70,7 +70,7 @@ struct wlr_session *wlr_session_create(struct wl_display *disp) {
 	const char *env_wlr_session = getenv("WLR_SESSION");
 	if (env_wlr_session) {
 		if (!strcmp(env_wlr_session, "logind") || !strcmp(env_wlr_session, "systemd")) {
-		#if defined(WLR_HAS_SYSTEMD) || defined(WLR_HAS_ELOGIND)
+		#if WLR_HAS_SYSTEMD || WLR_HAS_ELOGIND
 			session = session_logind.create(disp);
 		#else
 			wlr_log(WLR_ERROR, "wlroots is not compiled with logind support");

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -17,7 +17,7 @@
 #include <wlr/util/log.h>
 #include <X11/Xlib-xcb.h>
 #include <xcb/xcb.h>
-#ifdef WLR_HAS_XCB_XKB
+#if WLR_HAS_XCB_XKB
 #include <xcb/xkb.h>
 #endif
 #include "backend/x11.h"
@@ -148,7 +148,7 @@ static bool backend_start(struct wlr_backend *backend) {
 		0, 0);
 	xcb_free_pixmap(x11->xcb_conn, pix);
 
-#ifdef WLR_HAS_XCB_XKB
+#if WLR_HAS_XCB_XKB
 		const xcb_query_extension_reply_t *reply =
 			xcb_get_extension_data(x11->xcb_conn, &xcb_xkb_id);
 		if (reply != NULL && reply->present) {

--- a/backend/x11/input_device.c
+++ b/backend/x11/input_device.c
@@ -10,7 +10,7 @@
 #elif __FreeBSD__
 #include <dev/evdev/input-event-codes.h>
 #endif
-#ifdef WLR_HAS_XCB_XKB
+#if WLR_HAS_XCB_XKB
 #include <xcb/xkb.h>
 #endif
 #include "backend/x11.h"
@@ -124,7 +124,7 @@ void handle_x11_input_event(struct wlr_x11_backend *x11,
 		return;
 	}
 	default:
-#ifdef WLR_HAS_XCB_XKB
+#if WLR_HAS_XCB_XKB
 		if (x11->xkb_supported && event->response_type == x11->xkb_base_event) {
 			xcb_xkb_state_notify_event_t *ev =
 				(xcb_xkb_state_notify_event_t *)event;

--- a/backend/x11/meson.build
+++ b/backend/x11/meson.build
@@ -20,7 +20,7 @@ foreach lib : x11_optional
 	dep = dependency(lib, required: get_option(lib))
 	if dep.found()
 		x11_libs += dep
-		conf_data.set('WLR_HAS_' + lib.underscorify().to_upper(), true)
+		conf_data.set10('WLR_HAS_' + lib.underscorify().to_upper(), true)
 	endif
 endforeach
 
@@ -41,4 +41,4 @@ lib_wlr_backend_x11 = static_library(
 )
 
 backend_parts += lib_wlr_backend_x11
-conf_data.set('WLR_HAS_X11_BACKEND', true)
+conf_data.set10('WLR_HAS_X11_BACKEND', true)

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -64,7 +64,7 @@ struct wlr_x11_backend {
 	// A blank cursor
 	xcb_cursor_t cursor;
 
-#ifdef WLR_HAS_XCB_XKB
+#if WLR_HAS_XCB_XKB
 	bool xkb_supported;
 	uint8_t xkb_base_event;
 	uint8_t xkb_base_error;

--- a/include/rootston/desktop.h
+++ b/include/rootston/desktop.h
@@ -76,7 +76,7 @@ struct roots_desktop {
 	struct wl_listener virtual_keyboard_new;
 	struct wl_listener pointer_constraint;
 
-#ifdef WLR_HAS_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	struct wlr_xwayland *xwayland;
 	struct wl_listener xwayland_surface;
 #endif

--- a/include/rootston/server.h
+++ b/include/rootston/server.h
@@ -7,7 +7,7 @@
 #include <wlr/config.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_data_device.h>
-#ifdef WLR_HAS_XWAYLAND
+#if WLR_HAS_XWAYLAND
 #include <wlr/xwayland.h>
 #endif
 #include "rootston/config.h"

--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -79,7 +79,7 @@ enum roots_view_type {
 	ROOTS_WL_SHELL_VIEW,
 	ROOTS_XDG_SHELL_V6_VIEW,
 	ROOTS_XDG_SHELL_VIEW,
-#ifdef WLR_HAS_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	ROOTS_XWAYLAND_VIEW,
 #endif
 };
@@ -117,7 +117,7 @@ struct roots_view {
 		struct wlr_wl_shell_surface *wl_shell_surface;
 		struct wlr_xdg_surface_v6 *xdg_surface_v6;
 		struct wlr_xdg_surface *xdg_surface;
-#ifdef WLR_HAS_XWAYLAND
+#if WLR_HAS_XWAYLAND
 		struct wlr_xwayland_surface *xwayland_surface;
 #endif
 	};
@@ -125,7 +125,7 @@ struct roots_view {
 		struct roots_wl_shell_surface *roots_wl_shell_surface;
 		struct roots_xdg_surface_v6 *roots_xdg_surface_v6;
 		struct roots_xdg_surface *roots_xdg_surface;
-#ifdef WLR_HAS_XWAYLAND
+#if WLR_HAS_XWAYLAND
 		struct roots_xwayland_surface *roots_xwayland_surface;
 #endif
 	};

--- a/include/wlr/backend/meson.build
+++ b/include/wlr/backend/meson.build
@@ -9,7 +9,7 @@ install_headers(
 	subdir: 'wlr/backend',
 )
 
-if conf_data.get('WLR_HAS_X11_BACKEND', false)
+if conf_data.get('WLR_HAS_X11_BACKEND', 0) == 1
 	install_headers('x11.h', subdir: 'wlr/backend')
 endif
 

--- a/include/wlr/meson.build
+++ b/include/wlr/meson.build
@@ -15,7 +15,7 @@ install_headers(
 	'xcursor.h',
 	subdir: 'wlr'
 )
-if conf_data.get('WLR_HAS_XWAYLAND', false)
+if conf_data.get('WLR_HAS_XWAYLAND', 0) == 1
 	install_headers('xwayland.h', subdir: 'wlr')
 endif
 

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -11,7 +11,7 @@
 
 #include <wlr/config.h>
 
-#if !(defined(WLR_HAS_X11_BACKEND) || defined(WLR_HAS_WAYLAND))
+#if !WLR_HAS_X11_BACKEND && !WLR_HAS_XWAYLAND
 #define MESA_EGL_NO_X11_HEADERS
 #endif
 

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -11,7 +11,7 @@
 
 #include <wlr/config.h>
 
-#if !(defined(WLR_HAS_X11_BACKEND) || defined(WLR_HAS_WAYLAND))
+#if !WLR_HAS_X11_BACKEND && !WLR_HAS_XWAYLAND
 #define MESA_EGL_NO_X11_HEADERS
 #endif
 

--- a/include/xwayland/xwm.h
+++ b/include/xwayland/xwm.h
@@ -5,10 +5,10 @@
 #include <wlr/config.h>
 #include <wlr/xwayland.h>
 #include <xcb/render.h>
-#ifdef WLR_HAS_XCB_ICCCM
+#if WLR_HAS_XCB_ICCCM
 #include <xcb/xcb_icccm.h>
 #endif
-#ifdef WLR_HAS_XCB_ERRORS
+#if WLR_HAS_XCB_ERRORS
 #include <xcb/xcb_errors.h>
 #endif
 #include "xwayland/selection.h"
@@ -122,7 +122,7 @@ struct wlr_xwm {
 	struct wlr_xwayland_surface *drag_focus;
 
 	const xcb_query_extension_reply_t *xfixes;
-#ifdef WLR_HAS_XCB_ERRORS
+#if WLR_HAS_XCB_ERRORS
 	xcb_errors_context_t *errors_context;
 #endif
 

--- a/meson.build
+++ b/meson.build
@@ -16,17 +16,26 @@ project(
 # for a reference about clean library versioning.
 so_version = ['0', '0', '0']
 
-add_project_arguments('-Wno-unused-parameter', language: 'c')
 add_project_arguments(
-	'-DWLR_SRC_DIR="@0@"'.format(meson.current_source_dir()),
-	language: 'c',
-)
-add_project_arguments(
-	'-DWLR_USE_UNSTABLE',
+	[
+		'-DWLR_SRC_DIR="@0@"'.format(meson.current_source_dir()),
+		'-DWLR_USE_UNSTABLE',
+
+		'-Wno-unused-parameter',
+		'-Wundef',
+	],
 	language: 'c',
 )
 
 conf_data = configuration_data()
+conf_data.set10('WLR_HAS_LIBCAP', false)
+conf_data.set10('WLR_HAS_SYSTEMD', false)
+conf_data.set10('WLR_HAS_ELOGIND', false)
+conf_data.set10('WLR_HAS_X11_BACKEND', false)
+conf_data.set10('WLR_HAS_XWAYLAND', false)
+conf_data.set10('WLR_HAS_XCB_ERRORS', false)
+conf_data.set10('WLR_HAS_XCB_ICCCM', false)
+conf_data.set10('WLR_HAS_XCB_XKB', false)
 
 wlr_inc = include_directories('.', 'include')
 
@@ -63,12 +72,12 @@ wlr_parts = []
 wlr_deps = []
 
 if libcap.found()
-	conf_data.set('WLR_HAS_LIBCAP', true)
+	conf_data.set10('WLR_HAS_LIBCAP', true)
 	wlr_deps += libcap
 endif
 
 if logind.found()
-	conf_data.set('WLR_HAS_' + get_option('logind-provider').to_upper(), true)
+	conf_data.set10('WLR_HAS_' + get_option('logind-provider').to_upper(), true)
 	wlr_deps += logind
 endif
 

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -619,7 +619,7 @@ static bool view_at(struct roots_view *view, double lx, double ly,
 		_surface = wlr_wl_shell_surface_surface_at(view->wl_shell_surface,
 			view_sx, view_sy, &_sx, &_sy);
 		break;
-#ifdef WLR_HAS_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	case ROOTS_XWAYLAND_VIEW:
 		_surface = wlr_surface_surface_at(view->wlr_surface,
 			view_sx, view_sy, &_sx, &_sy);
@@ -890,14 +890,14 @@ struct roots_desktop *desktop_create(struct roots_server *server,
 	desktop->tablet_v2 = wlr_tablet_v2_create(server->wl_display);
 
 	const char *cursor_theme = NULL;
-#ifdef WLR_HAS_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	const char *cursor_default = ROOTS_XCURSOR_DEFAULT;
 #endif
 	struct roots_cursor_config *cc =
 		roots_config_get_cursor(config, ROOTS_CONFIG_DEFAULT_SEAT_NAME);
 	if (cc != NULL) {
 		cursor_theme = cc->theme;
-#ifdef WLR_HAS_XWAYLAND
+#if WLR_HAS_XWAYLAND
 		if (cc->default_image != NULL) {
 			cursor_default = cc->default_image;
 		}
@@ -912,7 +912,7 @@ struct roots_desktop *desktop_create(struct roots_server *server,
 		setenv("XCURSOR_THEME", cursor_theme, 1);
 	}
 
-#ifdef WLR_HAS_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	desktop->xcursor_manager = wlr_xcursor_manager_create(cursor_theme,
 		ROOTS_XCURSOR_SIZE);
 	if (desktop->xcursor_manager == NULL) {

--- a/rootston/input.c
+++ b/rootston/input.c
@@ -8,7 +8,7 @@
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/util/log.h>
 #include <wlr/xcursor.h>
-#ifdef WLR_HAS_XWAYLAND
+#if WLR_HAS_XWAYLAND
 #include <wlr/xwayland.h>
 #endif
 #include "rootston/config.h"

--- a/rootston/main.c
+++ b/rootston/main.c
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
 	}
 
 	setenv("WAYLAND_DISPLAY", socket, true);
-#ifdef WLR_HAS_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	if (server.desktop->xwayland != NULL) {
 		struct roots_seat *xwayland_seat =
 			input_get_seat(server.input, ROOTS_CONFIG_DEFAULT_SEAT_NAME);
@@ -72,7 +72,7 @@ int main(int argc, char **argv) {
 	}
 
 	wl_display_run(server.wl_display);
-#ifdef WLR_HAS_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	wlr_xwayland_destroy(server.desktop->xwayland);
 #endif
 	wl_display_destroy_clients(server.wl_display);

--- a/rootston/meson.build
+++ b/rootston/meson.build
@@ -16,7 +16,7 @@ sources = [
 	'xdg_shell_v6.c',
 ]
 
-if conf_data.get('WLR_HAS_XWAYLAND', false)
+if conf_data.get('WLR_HAS_XWAYLAND', 0) == 1
 	sources += 'xwayland.c'
 endif
 

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -86,7 +86,7 @@ static void view_for_each_surface(struct roots_view *view,
 		wlr_wl_shell_surface_for_each_surface(view->wl_shell_surface, iterator,
 			user_data);
 		break;
-#ifdef WLR_HAS_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	case ROOTS_XWAYLAND_VIEW:
 		wlr_surface_for_each_surface(view->wlr_surface, iterator, user_data);
 		break;
@@ -94,7 +94,7 @@ static void view_for_each_surface(struct roots_view *view,
 	}
 }
 
-#ifdef WLR_HAS_XWAYLAND
+#if WLR_HAS_XWAYLAND
 static void xwayland_children_for_each_surface(
 		struct wlr_xwayland_surface *surface,
 		wlr_surface_iterator_func_t iterator, struct layout_data *layout_data,
@@ -164,7 +164,7 @@ static void output_for_each_surface(struct roots_output *output,
 
 		view_for_each_surface(view, layout_data, iterator, user_data);
 
-#ifdef WLR_HAS_XWAYLAND
+#if WLR_HAS_XWAYLAND
 		if (view->type == ROOTS_XWAYLAND_VIEW) {
 			xwayland_children_for_each_surface(view->xwayland_surface,
 				iterator, layout_data, user_data);
@@ -400,7 +400,7 @@ static bool has_standalone_surface(struct roots_view *view) {
 		return wl_list_empty(&view->xdg_surface->popups);
 	case ROOTS_WL_SHELL_VIEW:
 		return wl_list_empty(&view->wl_shell_surface->popups);
-#ifdef WLR_HAS_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	case ROOTS_XWAYLAND_VIEW:
 		return wl_list_empty(&view->xwayland_surface->children);
 #endif
@@ -530,7 +530,7 @@ static void render_output(struct roots_output *output) {
 		// During normal rendering the xwayland window tree isn't traversed
 		// because all windows are rendered. Here we only want to render
 		// the fullscreen window's children so we have to traverse the tree.
-#ifdef WLR_HAS_XWAYLAND
+#if WLR_HAS_XWAYLAND
 		if (view->type == ROOTS_XWAYLAND_VIEW) {
 			xwayland_children_for_each_surface(view->xwayland_surface,
 				render_surface, &data.layout, &data);
@@ -593,7 +593,7 @@ static bool view_accept_damage(struct roots_output *output,
 	if (output->fullscreen_view == view) {
 		return true;
 	}
-#ifdef WLR_HAS_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	if (output->fullscreen_view->type == ROOTS_XWAYLAND_VIEW &&
 			view->type == ROOTS_XWAYLAND_VIEW) {
 		// Special case: accept damage from children

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -1131,7 +1131,7 @@ void roots_seat_set_focus(struct roots_seat *seat, struct roots_view *view) {
 
 	bool unfullscreen = true;
 
-#ifdef WLR_HAS_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	if (view && view->type == ROOTS_XWAYLAND_VIEW &&
 			view->xwayland_surface->override_redirect) {
 		unfullscreen = false;
@@ -1160,7 +1160,7 @@ void roots_seat_set_focus(struct roots_seat *seat, struct roots_view *view) {
 		return;
 	}
 
-#ifdef WLR_HAS_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	if (view && view->type == ROOTS_XWAYLAND_VIEW &&
 			!wlr_xwayland_or_surface_wants_focus(
 				view->xwayland_surface)) {

--- a/xwayland/meson.build
+++ b/xwayland/meson.build
@@ -23,7 +23,7 @@ foreach lib : xwayland_optional
 	dep = dependency(lib, required: get_option(lib))
 	if dep.found()
 		xwayland_libs += dep
-		conf_data.set('WLR_HAS_' + lib.underscorify().to_upper(), true)
+		conf_data.set10('WLR_HAS_' + lib.underscorify().to_upper(), true)
 	endif
 endforeach
 
@@ -48,4 +48,4 @@ lib_wlr_xwayland = static_library(
 )
 
 wlr_parts += lib_wlr_xwayland
-conf_data.set('WLR_HAS_XWAYLAND', true)
+conf_data.set10('WLR_HAS_XWAYLAND', true)

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -502,7 +502,7 @@ static void read_surface_protocols(struct wlr_xwm *xwm,
 	wlr_log(WLR_DEBUG, "WM_PROTOCOLS (%zu)", atoms_len);
 }
 
-#ifdef WLR_HAS_XCB_ICCCM
+#if WLR_HAS_XCB_ICCCM
 static void read_surface_hints(struct wlr_xwm *xwm,
 		struct wlr_xwayland_surface *xsurface,
 		xcb_get_property_reply_t *reply) {
@@ -540,7 +540,7 @@ static void read_surface_hints(struct wlr_xwm *xwm,
 }
 #endif
 
-#ifdef WLR_HAS_XCB_ICCCM
+#if WLR_HAS_XCB_ICCCM
 static void read_surface_normal_hints(struct wlr_xwm *xwm,
 		struct wlr_xwayland_surface *xsurface,
 		xcb_get_property_reply_t *reply) {
@@ -1195,7 +1195,7 @@ static void xwm_handle_focus_in(struct wlr_xwm *xwm,
 }
 
 static void xwm_handle_xcb_error(struct wlr_xwm *xwm, xcb_value_error_t *ev) {
-#ifdef WLR_HAS_XCB_ERRORS
+#if WLR_HAS_XCB_ERRORS
 	const char *major_name =
 		xcb_errors_get_name_for_major_code(xwm->errors_context,
 			ev->major_opcode);
@@ -1233,7 +1233,7 @@ log_raw:
 }
 
 static void xwm_handle_unhandled_event(struct wlr_xwm *xwm, xcb_generic_event_t *ev) {
-#ifdef WLR_HAS_XCB_ERRORS
+#if WLR_HAS_XCB_ERRORS
 	const char *extension;
 	const char *event_name =
 		xcb_errors_get_name_for_xcb_event(xwm->errors_context,
@@ -1418,7 +1418,7 @@ void xwm_destroy(struct wlr_xwm *xwm) {
 	if (xwm->event_source) {
 		wl_event_source_remove(xwm->event_source);
 	}
-#ifdef WLR_HAS_XCB_ERRORS
+#if WLR_HAS_XCB_ERRORS
 	if (xwm->errors_context) {
 		xcb_errors_context_free(xwm->errors_context);
 	}
@@ -1659,7 +1659,7 @@ struct wlr_xwm *xwm_create(struct wlr_xwayland *wlr_xwayland) {
 		return NULL;
 	}
 
-#ifdef WLR_HAS_XCB_ERRORS
+#if WLR_HAS_XCB_ERRORS
 	if (xcb_errors_context_new(xwm->xcb_conn, &xwm->errors_context)) {
 		wlr_log(WLR_ERROR, "Could not allocate error context");
 		xwm_destroy(xwm);


### PR DESCRIPTION
This prevents some annoying issues when e.g. not including wlr/config.h or
making a typo in the guard name.

For instance, [it caught a typo](https://github.com/swaywm/wlroots/pull/1372/files#diff-282b30593da47b681ecb7626496f2032R14) of `WLR_HAS_XWAYLAND` (which was written as `WLR_HAS_WAYLAND`).

Fixes https://github.com/swaywm/wlroots/issues/1365