### PR TITLE
xdg-shell: don't destroy xdg role state on role destroy

### DIFF
--- a/types/xdg_shell/wlr_xdg_surface.c
+++ b/types/xdg_shell/wlr_xdg_surface.c
@@ -83,18 +83,6 @@ void unmap_xdg_surface(struct wlr_xdg_surface *surface) {
 	memset(&surface->next_geometry, 0, sizeof(struct wlr_box));
 }
 
-void destroy_xdg_toplevel(struct wlr_xdg_surface *surface) {
-	assert(surface->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL);
-	unmap_xdg_surface(surface);
-
-	wl_resource_set_user_data(surface->toplevel->resource, NULL);
-	free(surface->toplevel);
-	surface->toplevel = NULL;
-
-	surface->role = WLR_XDG_SURFACE_ROLE_NONE;
-}
-
-
 
 static void xdg_surface_handle_ack_configure(struct wl_client *client,
 		struct wl_resource *resource, uint32_t serial) {
@@ -474,6 +462,12 @@ void destroy_xdg_surface(struct wlr_xdg_surface *surface) {
 	case WLR_XDG_SURFACE_ROLE_NONE:
 		// This space is intentionally left blank
 		break;
+	}
+
+	if (surface->surface->role == &xdg_toplevel_surface_role) {
+		free(surface->toplevel);
+	} else if (surface->surface->role == &xdg_popup_surface_role) {
+		free(surface->popup);
 	}
 
 	wl_resource_set_user_data(surface->resource, NULL);


### PR DESCRIPTION
ie. don't destroy surface->toplevel on xdg_toplevel destroy. Instead do this on
xdg_surface destroy.

This allows compositors to add toplevel listeners when the surface appears and
remove them when the surface is destroyed.

This fixes part of @Timidger's segfaults:

```
==25315== Invalid write of size 8
==25315==    at 0x490344B: wl_list_remove (wayland-util.c:56)
==25315==    by 0x122FC7: destroy (xdg_shell.c:267)
==25315==    by 0x114806: view_destroy (desktop.c:448)
==25315==    by 0x123516: handle_destroy (xdg_shell.c:396)
==25315==    by 0x48C175F: wlr_signal_emit_safe (signal.c:29)
==25315==    by 0x48A1647: destroy_xdg_surface (wlr_xdg_surface.c:459)
==25315==    by 0x48A011C: xdg_client_handle_resource_destroy (wlr_xdg_shell.c:71)
==25315==    by 0x48FF17D: destroy_resource (wayland-server.c:688)
==25315==    by 0x49033F1: for_each_helper.isra.0 (wayland-util.c:372)
==25315==    by 0x49038DE: wl_map_for_each (wayland-util.c:385)
==25315==    by 0x48FF2DC: wl_client_destroy (wayland-server.c:847)
==25315==    by 0x48FF3B4: destroy_client_with_error (wayland-server.c:307)
==25315==    by 0x48FF3B4: wl_client_connection_data (wayland-server.c:330)
==25315==  Address 0xbf50310 is 160 bytes inside a block of size 288 free'd
==25315==    at 0x48389AB: free (vg_replace_malloc.c:530)
==25315==    by 0x48A0A05: destroy_xdg_toplevel (wlr_xdg_surface.c:91)
==25315==    by 0x48A2E57: xdg_toplevel_handle_resource_destroy (wlr_xdg_toplevel.c:448)
==25315==    by 0x48FF17D: destroy_resource (wayland-server.c:688)
==25315==    by 0x48FF1DD: wl_resource_destroy (wayland-server.c:705)
==25315==    by 0x48A2E25: xdg_toplevel_handle_destroy (wlr_xdg_toplevel.c:424)
==25315==    by 0x66561C7: ffi_call_unix64 (in /usr/lib/libffi.so.6.0.4)
==25315==    by 0x6655C29: ffi_call (in /usr/lib/libffi.so.6.0.4)
==25315==    by 0x4902AEC: wl_closure_invoke (connection.c:1006)
==25315==    by 0x48FF568: wl_client_connection_data (wayland-server.c:420)
==25315==    by 0x4900B31: wl_event_loop_dispatch (event-loop.c:641)
==25315==    by 0x48FF759: wl_display_run (wayland-server.c:1260)
==25315==  Block was alloc'd at
==25315==    at 0x4839B65: calloc (vg_replace_malloc.c:752)
==25315==    by 0x48A2EAC: create_xdg_toplevel (wlr_xdg_toplevel.c:465)
==25315==    by 0x48A0F01: xdg_surface_handle_get_toplevel (wlr_xdg_surface.c:251)
==25315==    by 0x66561C7: ffi_call_unix64 (in /usr/lib/libffi.so.6.0.4)
==25315==    by 0x6655C29: ffi_call (in /usr/lib/libffi.so.6.0.4)
==25315==    by 0x4902AEC: wl_closure_invoke (connection.c:1006)
==25315==    by 0x48FF568: wl_client_connection_data (wayland-server.c:420)
==25315==    by 0x4900B31: wl_event_loop_dispatch (event-loop.c:641)
==25315==    by 0x48FF759: wl_display_run (wayland-server.c:1260)
==25315== by 0x119E4A: main (main.c:74)
```