### PR TITLE
tablet-v2: fix segfault on display destroy

### DIFF
--- a/include/types/wlr_tablet_v2.h
+++ b/include/types/wlr_tablet_v2.h
@@ -6,7 +6,7 @@
 #include <wlr/types/wlr_tablet_v2.h>
 
 struct wlr_tablet_seat_v2 {
-	struct wl_list link;
+	struct wl_list link; // wlr_tablet_manager_v2::seats
 	struct wlr_seat *wlr_seat;
 	struct wlr_tablet_manager_v2 *manager;
 
@@ -14,7 +14,7 @@ struct wlr_tablet_seat_v2 {
 	struct wl_list tools;
 	struct wl_list pads;
 
-	struct wl_list clients; //wlr_tablet_seat_v2_client::link;
+	struct wl_list clients; // wlr_tablet_seat_v2_client::link
 
 	struct wl_listener seat_destroy;
 };


### PR DESCRIPTION
This fixes the second part of @Timidger's segfaults.

@Timidger: can you test these two PRs?

```
==25315== Invalid write of size 8
==25315==    at 0x4903447: wl_list_remove (wayland-util.c:55)
==25315==    by 0x489903A: handle_wlr_seat_destroy (wlr_tablet_v2.c:34)
==25315==    by 0x48C175F: wlr_signal_emit_safe (signal.c:29)
==25315==    by 0x489401E: wlr_seat_destroy (wlr_seat.c:161)
==25315==    by 0x489424A: handle_display_destroy (wlr_seat.c:204)
==25315==    by 0x48FF0FC: wl_priv_signal_final_emit (wayland-server.c:2064)
==25315==    by 0x48FF826: wl_display_destroy (wayland-server.c:1092)
==25315==    by 0x119E7E: main (main.c:79)
==25315==  Address 0x861cae0 is 32 bytes inside a block of size 88 free'd
==25315==    at 0x48389AB: free (vg_replace_malloc.c:530)
==25315==    by 0x48999A2: wlr_tablet_v2_destroy (wlr_tablet_v2.c:288)
==25315==    by 0x4899902: handle_display_destroy (wlr_tablet_v2.c:274)
==25315==    by 0x48FF0FC: wl_priv_signal_final_emit (wayland-server.c:2064)
==25315==    by 0x48FF826: wl_display_destroy (wayland-server.c:1092)
==25315==    by 0x119E7E: main (main.c:79)
==25315==  Block was alloc'd at
==25315==    at 0x4839B65: calloc (vg_replace_malloc.c:752)
==25315==    by 0x48999C0: wlr_tablet_v2_create (wlr_tablet_v2.c:293)
==25315==    by 0x115D8B: desktop_create (desktop.c:890)
==25315== by 0x119C04: main (main.c:35)
```