### PR TITLE
Add support for libinput_switch input devices

### DIFF
--- a/backend/headless/input_device.c
+++ b/backend/headless/input_device.c
@@ -6,6 +6,7 @@
 #include <wlr/interfaces/wlr_tablet_pad.h>
 #include <wlr/interfaces/wlr_tablet_tool.h>
 #include <wlr/interfaces/wlr_touch.h>
+#include <wlr/interfaces/wlr_switch.h>
 #include <wlr/util/log.h>
 #include "backend/headless.h"
 #include "util/signal.h"
@@ -76,6 +77,13 @@ struct wlr_input_device *wlr_headless_add_input_device(
 		}
 		wlr_tablet_pad_init(wlr_device->tablet_pad, NULL);
 		break;
+	case WLR_INPUT_DEVICE_SWITCH:
+		wlr_device->lid_switch = calloc(1, sizeof(struct wlr_switch));
+		if (wlr_device->lid_switch == NULL) {
+			wlr_log(WLR_ERROR, "Unable to allocate wlr_switch");
+			goto error;
+		}
+		wlr_switch_init(wlr_device->lid_switch, NULL);
 	}
 
 	wl_list_insert(&backend->input_devices, &wlr_device->link);

--- a/backend/libinput/switch.c
+++ b/backend/libinput/switch.c
@@ -1,0 +1,55 @@
+#include <assert.h>
+#include <libinput.h>
+#include <stdlib.h>
+#include <wlr/backend/session.h>
+#include <wlr/interfaces/wlr_switch.h>
+#include <wlr/types/wlr_input_device.h>
+#include <wlr/util/log.h>
+#include "backend/libinput.h"
+#include "util/signal.h"
+
+struct wlr_switch *create_libinput_switch(
+		struct libinput_device *libinput_dev) {
+	assert(libinput_dev);
+	struct wlr_switch *wlr_switch = calloc(1, sizeof(struct wlr_switch));
+	if (!wlr_switch) {
+		wlr_log(WLR_ERROR, "Unable to allocate wlr_switch");
+		return NULL;
+	}
+	wlr_switch_init(wlr_switch, NULL);
+	wlr_log(WLR_DEBUG, "Created switch for device %s", libinput_device_get_name(libinput_dev));
+	return wlr_switch;
+}
+
+void handle_switch_toggle(struct libinput_event *event,
+		struct libinput_device *libinput_dev) {
+	struct wlr_input_device *wlr_dev =
+		get_appropriate_device(WLR_INPUT_DEVICE_SWITCH, libinput_dev);
+	if (!wlr_dev) {
+		wlr_log(WLR_DEBUG, "Got a switch event for a device with no switch?");
+		return;
+	}
+	struct libinput_event_switch *sevent = 
+		libinput_event_get_switch_event	(event);
+	struct wlr_event_switch_toggle wlr_event = { 0 };
+	wlr_event.device = wlr_dev;
+	switch (libinput_event_switch_get_switch(sevent)) {
+	case LIBINPUT_SWITCH_LID:
+		wlr_event.switch_type = WLR_SWITCH_TYPE_LID;
+		break;
+	case LIBINPUT_SWITCH_TABLET_MODE:
+		wlr_event.switch_type = WLR_SWITCH_TYPE_TABLET_MODE;
+		break;
+	}
+	switch (libinput_event_switch_get_switch_state(sevent)) {
+	case LIBINPUT_SWITCH_STATE_OFF:
+		wlr_event.switch_state = WLR_SWITCH_STATE_OFF;
+		break;
+	case LIBINPUT_SWITCH_STATE_ON:
+		wlr_event.switch_state = WLR_SWITCH_STATE_ON;
+		break;
+	}
+	wlr_event.time_msec =
+		usec_to_msec(libinput_event_switch_get_time_usec(sevent));
+	wlr_signal_emit_safe(&wlr_dev->lid_switch->events.toggle, &wlr_event);
+}

--- a/backend/meson.build
+++ b/backend/meson.build
@@ -15,6 +15,7 @@ backend_files = files(
 	'libinput/events.c',
 	'libinput/keyboard.c',
 	'libinput/pointer.c',
+	'libinput/switch.c',
 	'libinput/tablet_pad.c',
 	'libinput/tablet_tool.c',
 	'libinput/touch.c',

--- a/include/backend/libinput.h
+++ b/include/backend/libinput.h
@@ -55,6 +55,11 @@ void handle_pointer_button(struct libinput_event *event,
 void handle_pointer_axis(struct libinput_event *event,
 		struct libinput_device *device);
 
+struct wlr_switch *create_libinput_switch(
+		struct libinput_device *device);
+void handle_switch_toggle(struct libinput_event *event,
+		struct libinput_device *device);
+
 struct wlr_touch *create_libinput_touch(
 		struct libinput_device *device);
 void handle_touch_down(struct libinput_event *event,

--- a/include/rootston/bindings.h
+++ b/include/rootston/bindings.h
@@ -4,6 +4,6 @@
 #include "rootston/seat.h"
 #include "rootston/input.h"
 
-void execute_binding_command (struct roots_seat *seat, struct roots_input *input, const char *command);
+void execute_binding_command(struct roots_seat *seat, struct roots_input *input, const char *command);
 
 #endif //ROOTSTON_BINDINGS_H

--- a/include/rootston/bindings.h
+++ b/include/rootston/bindings.h
@@ -1,0 +1,9 @@
+#ifndef ROOTSTON_BINDINGS_H
+#define ROOTSTON_BINDINGS_H
+
+#include "rootston/seat.h"
+#include "rootston/input.h"
+
+void execute_binding_command (struct roots_seat *seat, struct roots_input *input, const char *command);
+
+#endif //ROOTSTON_BINDINGS_H

--- a/include/rootston/config.h
+++ b/include/rootston/config.h
@@ -3,6 +3,7 @@
 
 #include <xf86drmMode.h>
 #include <wlr/types/wlr_input_device.h>
+#include <wlr/types/wlr_switch.h>
 #include <wlr/types/wlr_output_layout.h>
 
 #define ROOTS_CONFIG_DEFAULT_SEAT_NAME "seat0"
@@ -65,6 +66,14 @@ struct roots_cursor_config {
 	struct wl_list link;
 };
 
+struct roots_switch_config {
+	enum wlr_switch_type switch_type;
+	enum wlr_switch_state switch_state;
+	bool run_on_toggle;
+	char *command;
+	struct wl_list link;
+};
+
 struct roots_config {
 	bool xwayland;
 	bool xwayland_lazy;
@@ -74,6 +83,7 @@ struct roots_config {
 	struct wl_list bindings;
 	struct wl_list keyboards;
 	struct wl_list cursors;
+	struct wl_list switches;
 
 	char *config_path;
 	char *startup_cmd;

--- a/include/rootston/config.h
+++ b/include/rootston/config.h
@@ -67,9 +67,9 @@ struct roots_cursor_config {
 };
 
 struct roots_switch_config {
+	char *name;
 	enum wlr_switch_type switch_type;
 	enum wlr_switch_state switch_state;
-	bool run_on_toggle;
 	char *command;
 	struct wl_list link;
 };

--- a/include/rootston/seat.h
+++ b/include/rootston/seat.h
@@ -32,6 +32,7 @@ struct roots_seat {
 
 	struct wl_list keyboards;
 	struct wl_list pointers;
+	struct wl_list switches;
 	struct wl_list touch;
 	struct wl_list tablets;
 	struct wl_list tablet_pads;
@@ -71,6 +72,15 @@ struct roots_pointer {
 	struct roots_seat *seat;
 	struct wlr_input_device *device;
 	struct wl_listener device_destroy;
+	struct wl_list link;
+};
+
+struct roots_switch {
+	struct roots_seat *seat;
+	struct wlr_input_device *device;
+	struct wl_listener device_destroy;
+
+	struct wl_listener toggle;
 	struct wl_list link;
 };
 

--- a/include/rootston/seat.h
+++ b/include/rootston/seat.h
@@ -5,6 +5,7 @@
 #include "rootston/input.h"
 #include "rootston/keyboard.h"
 #include "rootston/layers.h"
+#include "rootston/switch.h"
 #include "rootston/text_input.h"
 
 struct roots_seat {
@@ -72,15 +73,6 @@ struct roots_pointer {
 	struct roots_seat *seat;
 	struct wlr_input_device *device;
 	struct wl_listener device_destroy;
-	struct wl_list link;
-};
-
-struct roots_switch {
-	struct roots_seat *seat;
-	struct wlr_input_device *device;
-	struct wl_listener device_destroy;
-
-	struct wl_listener toggle;
 	struct wl_list link;
 };
 

--- a/include/rootston/switch.h
+++ b/include/rootston/switch.h
@@ -1,0 +1,18 @@
+#ifndef ROOTSTON_SWITCH_H
+#define ROOTSTON_SWITCH_H
+
+#include "rootston/input.h"
+
+struct roots_switch {
+    struct roots_seat *seat;
+    struct wlr_input_device *device;
+    struct wl_listener device_destroy;
+
+    struct wl_listener toggle;
+    struct wl_list link;
+};
+
+void roots_switch_handle_toggle(struct roots_switch *lid_switch,
+        struct wlr_event_switch_toggle *event);
+
+#endif // ROOTSTON_SWITCH_H

--- a/include/wlr/interfaces/meson.build
+++ b/include/wlr/interfaces/meson.build
@@ -3,6 +3,7 @@ install_headers(
 	'wlr_keyboard.h',
 	'wlr_output.h',
 	'wlr_pointer.h',
+	'wlr_switch.h',
 	'wlr_tablet_pad.h',
 	'wlr_tablet_tool.h',
 	'wlr_touch.h',

--- a/include/wlr/interfaces/wlr_switch.h
+++ b/include/wlr/interfaces/wlr_switch.h
@@ -1,0 +1,22 @@
+/*
+ * This an unstable interface of wlroots. No guarantees are made regarding the
+ * future consistency of this API.
+ */
+#ifndef WLR_USE_UNSTABLE
+#error "Add -DWLR_USE_UNSTABLE to enable unstable wlroots features"
+#endif
+
+#ifndef WLR_INTERFACES_WLR_SWITCH_H
+#define WLR_INTERFACES_WLR_SWITCH_H
+
+#include <wlr/types/wlr_switch.h>
+
+struct wlr_switch_impl {
+	void (*destroy)(struct wlr_switch *lid_switch);
+};
+
+void wlr_switch_init(struct wlr_switch *lid_switch,
+		struct wlr_switch_impl *impl);
+void wlr_switch_destroy(struct wlr_switch *lid_switch);
+
+#endif

--- a/include/wlr/types/meson.build
+++ b/include/wlr/types/meson.build
@@ -32,6 +32,7 @@ install_headers(
 	'wlr_seat.h',
 	'wlr_server_decoration.h',
 	'wlr_surface.h',
+	'wlr_switch.h',
 	'wlr_tablet_pad.h',
 	'wlr_tablet_tool.h',
 	'wlr_tablet_v2.h',

--- a/include/wlr/types/wlr_input_device.h
+++ b/include/wlr/types/wlr_input_device.h
@@ -20,6 +20,7 @@ enum wlr_input_device_type {
 	WLR_INPUT_DEVICE_TOUCH,
 	WLR_INPUT_DEVICE_TABLET_TOOL,
 	WLR_INPUT_DEVICE_TABLET_PAD,
+	WLR_INPUT_DEVICE_SWITCH,
 };
 
 /* Note: these are circular dependencies */
@@ -28,6 +29,7 @@ enum wlr_input_device_type {
 #include <wlr/types/wlr_touch.h>
 #include <wlr/types/wlr_tablet_tool.h>
 #include <wlr/types/wlr_tablet_pad.h>
+#include <wlr/types/wlr_switch.h>
 
 struct wlr_input_device_impl;
 
@@ -46,6 +48,7 @@ struct wlr_input_device {
 		void *_device;
 		struct wlr_keyboard *keyboard;
 		struct wlr_pointer *pointer;
+		struct wlr_switch *lid_switch;
 		struct wlr_touch *touch;
 		struct wlr_tablet *tablet;
 		struct wlr_tablet_pad *tablet_pad;

--- a/include/wlr/types/wlr_switch.h
+++ b/include/wlr/types/wlr_switch.h
@@ -1,0 +1,46 @@
+/*
+ * This an unstable interface of wlroots. No guarantees are made regarding the
+ * future consistency of this API.
+ */
+#ifndef WLR_USE_UNSTABLE
+#error "Add -DWLR_USE_UNSTABLE to enable unstable wlroots features"
+#endif
+
+#ifndef WLR_TYPES_WLR_SWITCH_H
+#define WLR_TYPES_WLR_SWITCH_H
+
+#include <stdint.h>
+#include <wayland-server.h>
+#include <wlr/types/wlr_input_device.h>
+#include <wlr/types/wlr_list.h>
+
+struct wlr_switch_impl;
+
+struct wlr_switch {
+	struct wlr_switch_impl *impl;
+
+	struct {
+		struct wl_signal toggle;
+	} events;
+
+	void *data;
+};
+
+enum wlr_switch_type {
+	WLR_SWITCH_TYPE_LID = 1,
+	WLR_SWITCH_TYPE_TABLET_MODE,
+};
+
+enum wlr_switch_state {
+	WLR_SWITCH_STATE_OFF = 0,
+	WLR_SWITCH_STATE_ON = 1,
+};
+
+struct wlr_event_switch_toggle {
+	struct wlr_input_device *device;
+	uint32_t time_msec;
+	enum wlr_switch_type switch_type;
+	enum wlr_switch_state switch_state;
+};
+
+#endif

--- a/include/wlr/types/wlr_switch.h
+++ b/include/wlr/types/wlr_switch.h
@@ -33,7 +33,8 @@ enum wlr_switch_type {
 
 enum wlr_switch_state {
 	WLR_SWITCH_STATE_OFF = 0,
-	WLR_SWITCH_STATE_ON = 1,
+	WLR_SWITCH_STATE_ON,
+	WLR_SWITCH_STATE_TOGGLE
 };
 
 struct wlr_event_switch_toggle {

--- a/rootston/bindings.c
+++ b/rootston/bindings.c
@@ -1,0 +1,109 @@
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include <wlr/util/log.h>
+
+#include "rootston/bindings.h"
+
+static bool outputs_enabled = true;
+
+static const char *exec_prefix = "exec ";
+
+static void double_fork_shell_cmd(const char *shell_cmd) {
+    pid_t pid = fork();
+    if (pid < 0) {
+        wlr_log(WLR_ERROR, "cannot execute binding command: fork() failed");
+        return;
+    }
+
+    if (pid == 0) {
+        pid = fork();
+        if (pid == 0) {
+            execl("/bin/sh", "/bin/sh", "-c", shell_cmd, NULL);
+            _exit(EXIT_FAILURE);
+        } else {
+            _exit(pid == -1);
+        }
+    }
+
+    int status;
+    while (waitpid(pid, &status, 0) < 0) {
+        if (errno == EINTR) {
+            continue;
+        }
+        wlr_log_errno(WLR_ERROR, "waitpid() on first child failed");
+        return;
+    }
+
+    if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+        return;
+    }
+
+    wlr_log(WLR_ERROR, "first child failed to fork command");
+}
+
+void execute_binding_command (struct roots_seat *seat, struct roots_input *input, const char *command) {
+    if (strcmp(command, "exit") == 0) {
+        wl_display_terminate(input->server->wl_display);
+    } else if (strcmp(command, "close") == 0) {
+        struct roots_view *focus = roots_seat_get_focus(seat);
+        if (focus != NULL) {
+            view_close(focus);
+        }
+    } else if (strcmp(command, "fullscreen") == 0) {
+        struct roots_view *focus = roots_seat_get_focus(seat);
+        if (focus != NULL) {
+            bool is_fullscreen = focus->fullscreen_output != NULL;
+            view_set_fullscreen(focus, !is_fullscreen, NULL);
+        }
+    } else if (strcmp(command, "next_window") == 0) {
+        roots_seat_cycle_focus(seat);
+    } else if (strcmp(command, "alpha") == 0) {
+        struct roots_view *focus = roots_seat_get_focus(seat);
+        if (focus != NULL) {
+            view_cycle_alpha(focus);
+        }
+    } else if (strncmp(exec_prefix, command, strlen(exec_prefix)) == 0) {
+        const char *shell_cmd = command + strlen(exec_prefix);
+        double_fork_shell_cmd(shell_cmd);
+    } else if (strcmp(command, "maximize") == 0) {
+        struct roots_view *focus = roots_seat_get_focus(seat);
+        if (focus != NULL) {
+            view_maximize(focus, !focus->maximized);
+        }
+    } else if (strcmp(command, "nop") == 0) {
+        wlr_log(WLR_DEBUG, "nop command");
+    } else if (strcmp(command, "toggle_outputs") == 0) {
+        outputs_enabled = !outputs_enabled;
+        struct roots_output *output;
+        wl_list_for_each(output, &input->server->desktop->outputs, link) {
+            wlr_output_enable(output->wlr_output, outputs_enabled);
+        }
+    } else if (strcmp(command, "toggle_decoration_mode") == 0) {
+        struct roots_view *focus = roots_seat_get_focus(seat);
+        if (focus != NULL && focus->type == ROOTS_XDG_SHELL_VIEW) {
+            struct roots_xdg_toplevel_decoration *decoration =
+                focus->roots_xdg_surface->xdg_toplevel_decoration;
+            if (decoration != NULL) {
+                enum wlr_xdg_toplevel_decoration_v1_mode mode =
+                    decoration->wlr_decoration->current_mode;
+                mode = mode == WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE
+                    ? WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE
+                    : WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE;
+                wlr_xdg_toplevel_decoration_v1_set_mode(
+                    decoration->wlr_decoration, mode);
+            }
+        }
+    } else if (strcmp(command, "break_pointer_constraint") == 0) {
+        struct wl_list *list =
+            &input->seats;
+        struct roots_seat *seat;
+        wl_list_for_each(seat, list, link) {
+            roots_cursor_constrain(seat->cursor, NULL, NAN, NAN);
+        }
+    } else {
+        wlr_log(WLR_ERROR, "unknown binding command: %s", command);
+    }
+}

--- a/rootston/bindings.c
+++ b/rootston/bindings.c
@@ -2,9 +2,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/wait.h>
-
 #include <wlr/util/log.h>
-
 #include "rootston/bindings.h"
 
 static bool outputs_enabled = true;
@@ -44,7 +42,8 @@ static void double_fork_shell_cmd(const char *shell_cmd) {
     wlr_log(WLR_ERROR, "first child failed to fork command");
 }
 
-void execute_binding_command (struct roots_seat *seat, struct roots_input *input, const char *command) {
+void execute_binding_command(struct roots_seat *seat, 
+        struct roots_input *input, const char *command) {
     if (strcmp(command, "exit") == 0) {
         wl_display_terminate(input->server->wl_display);
     } else if (strcmp(command, "close") == 0) {
@@ -97,8 +96,7 @@ void execute_binding_command (struct roots_seat *seat, struct roots_input *input
             }
         }
     } else if (strcmp(command, "break_pointer_constraint") == 0) {
-        struct wl_list *list =
-            &input->seats;
+        struct wl_list *list = &input->seats;
         struct roots_seat *seat;
         wl_list_for_each(seat, list, link) {
             roots_cursor_constrain(seat->cursor, NULL, NAN, NAN);

--- a/rootston/config.c
+++ b/rootston/config.c
@@ -201,6 +201,11 @@ void add_binding_config(struct wl_list *bindings, const char* combination,
 	}
 }
 
+void add_switch_config(struct wl_list *switches, const char *switch_name,
+		const char* command) {
+	wlr_log(WLR_DEBUG, "config switch %s: %s", switch_name, command);
+}
+
 static void config_handle_cursor(struct roots_config *config,
 		const char *seat_name, const char *name, const char *value) {
 	struct roots_cursor_config *cc;
@@ -436,6 +441,8 @@ static int config_ini_handler(void *user, const char *section, const char *name,
 		config_handle_keyboard(config, device_name, name, value);
 	} else if (strcmp(section, "bindings") == 0) {
 		add_binding_config(&config->bindings, name, value);
+	} else if (strcmp(section, "switches") == 0) {
+		add_switch_config(&config->bindings, name, value);
 	} else {
 		wlr_log(WLR_ERROR, "got unknown config section: %s", section);
 	}
@@ -456,6 +463,7 @@ struct roots_config *roots_config_create_from_args(int argc, char *argv[]) {
 	wl_list_init(&config->keyboards);
 	wl_list_init(&config->cursors);
 	wl_list_init(&config->bindings);
+	wl_list_init(&config->switches);
 
 	int c;
 	unsigned int log_verbosity = WLR_DEBUG;

--- a/rootston/config.c
+++ b/rootston/config.c
@@ -201,7 +201,7 @@ void add_binding_config(struct wl_list *bindings, const char* combination,
 	}
 }
 
-void add_switch_config(struct wl_list *switches, const char *switch_name, const char *action, 
+void add_switch_config(struct wl_list *switches, const char *switch_name, const char *action,
 		const char* command) {
 	struct roots_switch_config *sc = calloc(1, sizeof(struct roots_switch_config));
 
@@ -218,10 +218,11 @@ void add_switch_config(struct wl_list *switches, const char *switch_name, const 
 	} else if (strcmp(action, "off") == 0) {
 		sc->switch_state = WLR_SWITCH_STATE_OFF;
 	} else if (strcmp(action, "toggle") == 0) {
-		sc->switch_state = -1;
+		sc->switch_state = WLR_SWITCH_STATE_TOGGLE;
 	} else {
 		wlr_log(WLR_ERROR, "Invalid switch action %s/n for switch %s:%s",
 		        action, switch_name, action);
+		return;
 	}
 	sc->command = strdup(command);
 	wl_list_insert(switches, &sc->link);
@@ -465,7 +466,7 @@ static int config_ini_handler(void *user, const char *section, const char *name,
 		add_binding_config(&config->bindings, name, value);
 	} else if (strncmp(switch_prefix, section, strlen(switch_prefix)) == 0) {
 		const char *switch_name = section + strlen(switch_prefix);
-		add_switch_config(&config->bindings, switch_name, name, value);
+		add_switch_config(&config->switches, switch_name, name, value);
 	} else {
 		wlr_log(WLR_ERROR, "got unknown config section: %s", section);
 	}

--- a/rootston/config.c
+++ b/rootston/config.c
@@ -203,7 +203,6 @@ void add_binding_config(struct wl_list *bindings, const char* combination,
 
 void add_switch_config(struct wl_list *switches, const char *switch_name, const char *action, 
 		const char* command) {
-	wlr_log(WLR_DEBUG, "config switch %s: %s = %s", switch_name, action, command);
 	struct roots_switch_config *sc = calloc(1, sizeof(struct roots_switch_config));
 
 	if (strcmp(switch_name, "tablet") == 0) {
@@ -226,7 +225,6 @@ void add_switch_config(struct wl_list *switches, const char *switch_name, const 
 	}
 	sc->command = strdup(command);
 	wl_list_insert(switches, &sc->link);
-	wlr_log(WLR_DEBUG, "config %s: type %i state %i command %s", switch_name, sc->switch_type, sc->switch_state, sc->command);
 }
 
 static void config_handle_cursor(struct roots_config *config,

--- a/rootston/input.c
+++ b/rootston/input.c
@@ -23,6 +23,8 @@ static const char *device_type(enum wlr_input_device_type type) {
 		return "keyboard";
 	case WLR_INPUT_DEVICE_POINTER:
 		return "pointer";
+	case WLR_INPUT_DEVICE_SWITCH:
+		return "switch";
 	case WLR_INPUT_DEVICE_TOUCH:
 		return "touch";
 	case WLR_INPUT_DEVICE_TABLET_TOOL:

--- a/rootston/keyboard.c
+++ b/rootston/keyboard.c
@@ -2,8 +2,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <sys/wait.h>
-#include <unistd.h>
 #include <wayland-server.h>
 #include <wlr/backend/session.h>
 #include <wlr/types/wlr_input_device.h>
@@ -11,6 +9,7 @@
 #include <wlr/types/wlr_pointer.h>
 #include <wlr/util/log.h>
 #include <xkbcommon/xkbcommon.h>
+#include "rootston/bindings.h"
 #include "rootston/input.h"
 #include "rootston/keyboard.h"
 #include "rootston/seat.h"
@@ -85,107 +84,9 @@ static void pressed_keysyms_update(xkb_keysym_t *pressed_keysyms,
 	}
 }
 
-static void double_fork_shell_cmd(const char *shell_cmd) {
-	pid_t pid = fork();
-	if (pid < 0) {
-		wlr_log(WLR_ERROR, "cannot execute binding command: fork() failed");
-		return;
-	}
-
-	if (pid == 0) {
-		pid = fork();
-		if (pid == 0) {
-			execl("/bin/sh", "/bin/sh", "-c", shell_cmd, NULL);
-			_exit(EXIT_FAILURE);
-		} else {
-			_exit(pid == -1);
-		}
-	}
-
-	int status;
-	while (waitpid(pid, &status, 0) < 0) {
-		if (errno == EINTR) {
-			continue;
-		}
-		wlr_log_errno(WLR_ERROR, "waitpid() on first child failed");
-		return;
-	}
-
-	if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
-		return;
-	}
-
-	wlr_log(WLR_ERROR, "first child failed to fork command");
-}
-
-static const char *exec_prefix = "exec ";
-
-static bool outputs_enabled = true;
-
 static void keyboard_binding_execute(struct roots_keyboard *keyboard,
 		const char *command) {
-	struct roots_seat *seat = keyboard->seat;
-	if (strcmp(command, "exit") == 0) {
-		wl_display_terminate(keyboard->input->server->wl_display);
-	} else if (strcmp(command, "close") == 0) {
-		struct roots_view *focus = roots_seat_get_focus(seat);
-		if (focus != NULL) {
-			view_close(focus);
-		}
-	} else if (strcmp(command, "fullscreen") == 0) {
-		struct roots_view *focus = roots_seat_get_focus(seat);
-		if (focus != NULL) {
-			bool is_fullscreen = focus->fullscreen_output != NULL;
-			view_set_fullscreen(focus, !is_fullscreen, NULL);
-		}
-	} else if (strcmp(command, "next_window") == 0) {
-		roots_seat_cycle_focus(seat);
-	} else if (strcmp(command, "alpha") == 0) {
-		struct roots_view *focus = roots_seat_get_focus(seat);
-		if (focus != NULL) {
-			view_cycle_alpha(focus);
-		}
-	} else if (strncmp(exec_prefix, command, strlen(exec_prefix)) == 0) {
-		const char *shell_cmd = command + strlen(exec_prefix);
-		double_fork_shell_cmd(shell_cmd);
-	} else if (strcmp(command, "maximize") == 0) {
-		struct roots_view *focus = roots_seat_get_focus(seat);
-		if (focus != NULL) {
-			view_maximize(focus, !focus->maximized);
-		}
-	} else if (strcmp(command, "nop") == 0) {
-		wlr_log(WLR_DEBUG, "nop command");
-	} else if (strcmp(command, "toggle_outputs") == 0) {
-		outputs_enabled = !outputs_enabled;
-		struct roots_output *output;
-		wl_list_for_each(output, &keyboard->input->server->desktop->outputs, link) {
-			wlr_output_enable(output->wlr_output, outputs_enabled);
-		}
-	} else if (strcmp(command, "toggle_decoration_mode") == 0) {
-		struct roots_view *focus = roots_seat_get_focus(seat);
-		if (focus != NULL && focus->type == ROOTS_XDG_SHELL_VIEW) {
-			struct roots_xdg_toplevel_decoration *decoration =
-				focus->roots_xdg_surface->xdg_toplevel_decoration;
-			if (decoration != NULL) {
-				enum wlr_xdg_toplevel_decoration_v1_mode mode =
-					decoration->wlr_decoration->current_mode;
-				mode = mode == WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE
-					? WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE
-					: WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE;
-				wlr_xdg_toplevel_decoration_v1_set_mode(
-					decoration->wlr_decoration, mode);
-			}
-		}
-	} else if (strcmp(command, "break_pointer_constraint") == 0) {
-		struct wl_list *list =
-			&keyboard->input->seats;
-		struct roots_seat *seat;
-		wl_list_for_each(seat, list, link) {
-			roots_cursor_constrain(seat->cursor, NULL, NAN, NAN);
-		}
-	} else {
-		wlr_log(WLR_ERROR, "unknown binding command: %s", command);
-	}
+	execute_binding_command(keyboard->seat, keyboard->input, command);
 }
 
 /**

--- a/rootston/meson.build
+++ b/rootston/meson.build
@@ -1,4 +1,5 @@
 sources = [
+	'bindings.c',
 	'config.c',
 	'cursor.c',
 	'desktop.c',

--- a/rootston/meson.build
+++ b/rootston/meson.build
@@ -10,6 +10,7 @@ sources = [
 	'main.c',
 	'output.c',
 	'seat.c',
+	'switch.c',
 	'text_input.c',
 	'virtual_keyboard.c',
 	'wl_shell.c',

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -82,8 +82,7 @@ static void handle_switch_toggle(struct wl_listener *listener, void *data) {
 	struct roots_desktop *desktop = lid_switch->seat->input->server->desktop;
 	wlr_idle_notify_activity(desktop->idle, lid_switch->seat->seat);
 	struct wlr_event_switch_toggle *event = data;
-	wlr_log(WLR_DEBUG, "Switch event %s: type %i state %i", event->device->name, event->switch_type, event->switch_state);
-	//roots_switch_handle_toggle(lid_switch, event);
+	roots_switch_handle_toggle(lid_switch, event);
 }
 
 static void handle_touch_down(struct wl_listener *listener, void *data) {
@@ -742,7 +741,6 @@ static void seat_add_switch(struct roots_seat *seat,
 		wlr_log(WLR_ERROR, "could not allocate switch for seat");
 		return;
 	}
-
 	device->data = lid_switch;
 	lid_switch->device = device;
 	lid_switch->seat = seat;

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -751,8 +751,6 @@ static void seat_add_switch(struct roots_seat *seat,
 
 	lid_switch->toggle.notify = handle_switch_toggle;
 	wl_signal_add(&lid_switch->device->lid_switch->events.toggle, &lid_switch->toggle);
-
-	wl_signal_add(&lid_switch->device->events.destroy, &lid_switch->device_destroy);
 }
 
 static void handle_touch_destroy(struct wl_listener *listener, void *data) {

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -9,6 +9,7 @@
 #include <wlr/config.h>
 #include <wlr/types/wlr_idle.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
+#include "wlr/types/wlr_switch.h"
 #include <wlr/types/wlr_tablet_v2.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/util/log.h>
@@ -73,6 +74,16 @@ static void handle_cursor_axis(struct wl_listener *listener, void *data) {
 	wlr_idle_notify_activity(desktop->idle, cursor->seat->seat);
 	struct wlr_event_pointer_axis *event = data;
 	roots_cursor_handle_axis(cursor, event);
+}
+
+static void handle_switch_toggle(struct wl_listener *listener, void *data) {
+	struct roots_switch *lid_switch =
+		wl_container_of(listener, lid_switch, toggle);
+	struct roots_desktop *desktop = lid_switch->seat->input->server->desktop;
+	wlr_idle_notify_activity(desktop->idle, lid_switch->seat->seat);
+	struct wlr_event_switch_toggle *event = data;
+	wlr_log(WLR_DEBUG, "Switch event %s: type %i state %i", event->device->name, event->switch_type, event->switch_state);
+	//roots_switch_handle_toggle(lid_switch, event);
 }
 
 static void handle_touch_down(struct wl_listener *listener, void *data) {
@@ -587,6 +598,7 @@ struct roots_seat *roots_seat_create(struct roots_input *input, char *name) {
 	wl_list_init(&seat->touch);
 	wl_list_init(&seat->tablets);
 	wl_list_init(&seat->tablet_pads);
+	wl_list_init(&seat->switches);
 	wl_list_init(&seat->views);
 	wl_list_init(&seat->drag_icons);
 
@@ -708,6 +720,39 @@ static void seat_add_pointer(struct roots_seat *seat,
 
 	wlr_cursor_attach_input_device(seat->cursor->cursor, device);
 	roots_seat_configure_cursor(seat);
+}
+
+static void handle_switch_destroy(struct wl_listener *listener, void *data) {
+	struct roots_switch *lid_switch =
+		wl_container_of(listener, lid_switch, device_destroy);
+	struct roots_seat *seat = lid_switch->seat;
+
+	wl_list_remove(&lid_switch->link);
+	wl_list_remove(&lid_switch->device_destroy.link);
+	free(lid_switch);
+
+	seat_update_capabilities(seat);
+}
+
+static void seat_add_switch(struct roots_seat *seat,
+		struct wlr_input_device *device) {
+	assert(device->type == WLR_INPUT_DEVICE_SWITCH);
+		struct roots_switch *lid_switch = calloc(1, sizeof(struct roots_switch));
+	if (!lid_switch) {
+		wlr_log(WLR_ERROR, "could not allocate switch for seat");
+		return;
+	}
+
+	device->data = lid_switch;
+	lid_switch->device = device;
+	lid_switch->seat = seat;
+	wl_list_insert(&seat->switches, &lid_switch->link);
+	lid_switch->device_destroy.notify = handle_switch_destroy;
+
+	lid_switch->toggle.notify = handle_switch_toggle;
+	wl_signal_add(&lid_switch->device->lid_switch->events.toggle, &lid_switch->toggle);
+
+	wl_signal_add(&lid_switch->device->events.destroy, &lid_switch->device_destroy);
 }
 
 static void handle_touch_destroy(struct wl_listener *listener, void *data) {
@@ -952,6 +997,9 @@ void roots_seat_add_device(struct roots_seat *seat,
 		break;
 	case WLR_INPUT_DEVICE_POINTER:
 		seat_add_pointer(seat, device);
+		break;
+	case WLR_INPUT_DEVICE_SWITCH:
+		seat_add_switch(seat, device);
 		break;
 	case WLR_INPUT_DEVICE_TOUCH:
 		seat_add_touch(seat, device);

--- a/rootston/switch.c
+++ b/rootston/switch.c
@@ -1,0 +1,33 @@
+#include <stdlib.h>
+
+#include <wlr/util/log.h>
+
+#include "rootston/bindings.h"
+#include "rootston/config.h"
+#include "rootston/input.h"
+#include "rootston/seat.h"
+#include "rootston/switch.h"
+
+void roots_switch_handle_toggle(struct roots_switch *lid_switch,
+        struct wlr_event_switch_toggle *event) {
+    struct wl_list *bound_switches = &lid_switch->seat->input->server->config->switches;
+    struct roots_switch_config *sc;
+    wl_list_for_each(sc, bound_switches, link) {
+        bool device_match = false;
+        bool state_match = false;
+        if ((sc->name != NULL && strcmp(event->device->name, sc->name) == 0) ||
+                (sc->name == NULL && event->switch_type == sc->switch_type)) {
+            device_match = true;
+        }
+        if (!device_match) {
+            break;
+        }
+        if (sc->switch_state == WLR_SWITCH_STATE_TOGGLE ||
+                event->switch_state == sc->switch_state) {
+            state_match = true;
+        }
+        if (device_match && state_match) {
+            execute_binding_command(lid_switch->seat, lid_switch->seat->input, sc->command);
+        }
+    }
+}

--- a/rootston/switch.c
+++ b/rootston/switch.c
@@ -13,8 +13,6 @@ void roots_switch_handle_toggle(struct roots_switch *lid_switch,
     struct wl_list *bound_switches = &lid_switch->seat->input->server->config->switches;
     struct roots_switch_config *sc;
     wl_list_for_each(sc, bound_switches, link) {
-        bool device_match = false;
-        bool state_match = false;
         if ((sc->name != NULL && strcmp(event->device->name, sc->name) != 0) &&
                 (sc->name == NULL && event->switch_type != sc->switch_type)) {
             continue;

--- a/rootston/switch.c
+++ b/rootston/switch.c
@@ -15,19 +15,14 @@ void roots_switch_handle_toggle(struct roots_switch *lid_switch,
     wl_list_for_each(sc, bound_switches, link) {
         bool device_match = false;
         bool state_match = false;
-        if ((sc->name != NULL && strcmp(event->device->name, sc->name) == 0) ||
-                (sc->name == NULL && event->switch_type == sc->switch_type)) {
-            device_match = true;
+        if ((sc->name != NULL && strcmp(event->device->name, sc->name) != 0) &&
+                (sc->name == NULL && event->switch_type != sc->switch_type)) {
+            continue;
         }
-        if (!device_match) {
-            break;
+        if (sc->switch_state != WLR_SWITCH_STATE_TOGGLE &&
+                event->switch_state != sc->switch_state) {
+            continue;
         }
-        if (sc->switch_state == WLR_SWITCH_STATE_TOGGLE ||
-                event->switch_state == sc->switch_state) {
-            state_match = true;
-        }
-        if (device_match && state_match) {
-            execute_binding_command(lid_switch->seat, lid_switch->seat->input, sc->command);
-        }
+        execute_binding_command(lid_switch->seat, lid_switch->seat->input, sc->command);
     }
 }

--- a/types/meson.build
+++ b/types/meson.build
@@ -54,6 +54,7 @@ lib_wlr_types = static_library(
 		'wlr_screenshooter.c',
 		'wlr_server_decoration.c',
 		'wlr_surface.c',
+		'wlr_switch.c',
 		'wlr_tablet_pad.c',
 		'wlr_tablet_tool.c',
 		'wlr_text_input_v3.c',

--- a/types/wlr_input_device.c
+++ b/types/wlr_input_device.c
@@ -5,6 +5,7 @@
 #include <wlr/interfaces/wlr_input_device.h>
 #include <wlr/interfaces/wlr_keyboard.h>
 #include <wlr/interfaces/wlr_pointer.h>
+#include <wlr/interfaces/wlr_switch.h>
 #include <wlr/interfaces/wlr_tablet_pad.h>
 #include <wlr/interfaces/wlr_tablet_tool.h>
 #include <wlr/interfaces/wlr_touch.h>
@@ -39,6 +40,9 @@ void wlr_input_device_destroy(struct wlr_input_device *dev) {
 			break;
 		case WLR_INPUT_DEVICE_POINTER:
 			wlr_pointer_destroy(dev->pointer);
+			break;
+		case WLR_INPUT_DEVICE_SWITCH:
+			wlr_switch_destroy(dev->lid_switch);
 			break;
 		case WLR_INPUT_DEVICE_TOUCH:
 			wlr_touch_destroy(dev->touch);

--- a/types/wlr_switch.c
+++ b/types/wlr_switch.c
@@ -1,0 +1,22 @@
+#include <stdlib.h>
+#include <string.h>
+#include <wayland-server.h>
+#include <wlr/interfaces/wlr_switch.h>
+#include <wlr/types/wlr_switch.h>
+
+void wlr_switch_init(struct wlr_switch *lid_switch,
+		struct wlr_switch_impl *impl) {
+	lid_switch->impl = impl;
+	wl_signal_init(&lid_switch->events.toggle);
+}
+
+void wlr_switch_destroy(struct wlr_switch *lid_switch) {
+	if (!lid_switch) {
+		return;
+	}
+	if (lid_switch->impl && lid_switch->impl->destroy) {
+		lid_switch->impl->destroy(lid_switch);
+	} else {
+		free(lid_switch);
+	}
+}


### PR DESCRIPTION
These are used primarily by laptops to signal
the state of the lid (open/closed) and tablet
mode if supported, based on ACPI events.

AFAICT this should be feature-complete for wlroots itself, I've added what looks correct for rootston but am unsure if this is all I need. 

Seems to be working well within sway, but I assume sway will also need some formal support for these new events.

```
2018-11-15 00:13:53 - [backend/libinput/events.c:94] Added Lid Switch [0:5]
2018-11-15 00:13:53 - [backend/libinput/events.c:173] Switch capability match for device Lid Switch
2018-11-15 00:13:53 - [backend/libinput/switch.c:20] Created switch for device Lid Switch
2018-11-15 00:13:53 - [backend/libinput/events.c:173] Switch capability match for device ThinkPad Extra Buttons
2018-11-15 00:13:53 - [backend/libinput/switch.c:20] Created switch for device ThinkPad Extra Buttons
2018-11-15 00:14:37 - [backend/libinput/switch.c:41] Got switch event type 2 state 1 from ThinkPad Extra Buttons
2018-11-15 00:14:58 - [backend/libinput/switch.c:41] Got switch event type 2 state 0 from ThinkPad Extra Buttons
2018-11-15 00:15:12 - [backend/libinput/switch.c:41] Got switch event type 1 state 1 from Lid Switch
2018-11-15 00:15:16 - [backend/libinput/switch.c:41] Got switch event type 1 state 0 from Lid Switch
```
Just an RFC currently, this is my first delve into the guts of wlroots.