### PR TITLE
Fixed loc count in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # wlroots
 
 Pluggable, composable, unopinionated modules for building a
-[Wayland](http://wayland.freedesktop.org/) compositor; or about 40,000 lines of
+[Wayland](http://wayland.freedesktop.org/) compositor; or about 50,000 lines of
 code you were going to write anyway.
 
 - wlroots provides backends that abstract the underlying display and input


### PR DESCRIPTION
According to `cloc` it's 50k lines I was going to write anyways.

```
$ cloc .
     308 text files.
     308 unique files.
      11 files ignored.

1 error:
Line count, exceeded timeout:  ./examples/cat.c

github.com/AlDanial/cloc v 1.80  T=2.38 s (125.4 files/s, 28323.1 lines/s)
-------------------------------------------------------------------------------
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
C                              149           7625           1171          44758
C/C++ Header                   111           1733           2000           6139
XML                             13            373              1           1971
NAnt script                     19             62              0            778
Markdown                         3            102              0            386
YAML                             2              0              8             99
Bourne Shell                     1             20             16             56
-------------------------------------------------------------------------------
SUM:                           298           9915           3196          54187
-------------------------------------------------------------------------------
```