### PR TITLE
data-device, primary-selection: add request_set_selection

### DIFF
--- a/include/rootston/seat.h
+++ b/include/rootston/seat.h
@@ -38,6 +38,8 @@ struct roots_seat {
 	struct wl_list tablets;
 	struct wl_list tablet_pads;
 
+	struct wl_listener request_set_selection;
+	struct wl_listener request_set_primary_selection;
 	struct wl_listener new_drag_icon;
 	struct wl_listener destroy;
 };

--- a/include/wlr/types/wlr_data_control_v1.h
+++ b/include/wlr/types/wlr_data_control_v1.h
@@ -34,7 +34,7 @@ struct wlr_data_control_device_v1 {
 	struct wl_resource *selection_offer_resource; // current selection offer
 
 	struct wl_listener seat_destroy;
-	struct wl_listener seat_selection;
+	struct wl_listener seat_set_selection;
 };
 
 struct wlr_data_control_manager_v1 *wlr_data_control_manager_v1_create(

--- a/include/wlr/types/wlr_data_device.h
+++ b/include/wlr/types/wlr_data_device.h
@@ -166,6 +166,12 @@ void wlr_data_device_manager_destroy(struct wlr_data_device_manager *manager);
 void wlr_seat_client_send_selection(struct wlr_seat_client *seat_client);
 
 /**
+ * Requests a selection to be set for the seat.
+ */
+void wlr_seat_request_set_selection(struct wlr_seat *seat,
+	struct wlr_data_source *source, uint32_t serial);
+
+/**
  * Sets the current selection for the seat. NULL can be provided to clear it.
  * This removes the previous one if there was any. In case the selection doesn't
  * come from a client, wl_display_next_serial() can be used to generate a

--- a/include/wlr/types/wlr_gtk_primary_selection.h
+++ b/include/wlr/types/wlr_gtk_primary_selection.h
@@ -39,7 +39,7 @@ struct wlr_gtk_primary_selection_device {
 
 	struct wl_listener seat_destroy;
 	struct wl_listener seat_focus_change;
-	struct wl_listener seat_primary_selection;
+	struct wl_listener seat_set_primary_selection;
 
 	void *data;
 };

--- a/include/wlr/types/wlr_primary_selection.h
+++ b/include/wlr/types/wlr_primary_selection.h
@@ -48,6 +48,8 @@ void wlr_primary_selection_source_send(
 	struct wlr_primary_selection_source *source, const char *mime_type,
 	int fd);
 
+void wlr_seat_request_set_primary_selection(struct wlr_seat *seat,
+	struct wlr_primary_selection_source *source, uint32_t serial);
 /**
  * Sets the current primary selection for the seat. NULL can be provided to
  * clear it. This removes the previous one if there was any. In case the

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -23,6 +23,7 @@
 struct wlr_seat_client {
 	struct wl_client *client;
 	struct wlr_seat *seat;
+	struct wl_list link;
 
 	// lists of wl_resource
 	struct wl_list resources;
@@ -34,8 +35,6 @@ struct wlr_seat_client {
 	struct {
 		struct wl_signal destroy;
 	} events;
-
-	struct wl_list link;
 };
 
 struct wlr_touch_point {
@@ -226,13 +225,18 @@ struct wlr_seat {
 		struct wl_signal touch_grab_begin;
 		struct wl_signal touch_grab_end;
 
+		// wlr_seat_pointer_request_set_cursor_event
 		struct wl_signal request_set_cursor;
 
-		struct wl_signal selection;
-		struct wl_signal primary_selection;
+		// wlr_seat_request_set_selection_event
+		struct wl_signal request_set_selection;
+		struct wl_signal set_selection;
+		// wlr_seat_request_set_primary_selection_event
+		struct wl_signal request_set_primary_selection;
+		struct wl_signal set_primary_selection;
 
-		struct wl_signal start_drag;
-		struct wl_signal new_drag_icon;
+		struct wl_signal start_drag; // wlr_drag
+		struct wl_signal new_drag_icon; // wlr_drag_icon
 
 		struct wl_signal destroy;
 	} events;
@@ -245,6 +249,16 @@ struct wlr_seat_pointer_request_set_cursor_event {
 	struct wlr_surface *surface;
 	uint32_t serial;
 	int32_t hotspot_x, hotspot_y;
+};
+
+struct wlr_seat_request_set_selection_event {
+	struct wlr_data_source *source;
+	uint32_t serial;
+};
+
+struct wlr_seat_request_set_primary_selection_event {
+	struct wlr_primary_selection_source *source;
+	uint32_t serial;
 };
 
 struct wlr_seat_pointer_focus_change_event {

--- a/include/xwayland/xwm.h
+++ b/include/xwayland/xwm.h
@@ -128,8 +128,8 @@ struct wlr_xwm {
 
 	struct wl_listener compositor_new_surface;
 	struct wl_listener compositor_destroy;
-	struct wl_listener seat_selection;
-	struct wl_listener seat_primary_selection;
+	struct wl_listener seat_set_selection;
+	struct wl_listener seat_set_primary_selection;
 	struct wl_listener seat_start_drag;
 	struct wl_listener seat_drag_focus;
 	struct wl_listener seat_drag_motion;

--- a/types/seat/wlr_seat.c
+++ b/types/seat/wlr_seat.c
@@ -274,8 +274,10 @@ struct wlr_seat *wlr_seat_create(struct wl_display *display, const char *name) {
 
 	wl_signal_init(&seat->events.request_set_cursor);
 
-	wl_signal_init(&seat->events.selection);
-	wl_signal_init(&seat->events.primary_selection);
+	wl_signal_init(&seat->events.request_set_selection);
+	wl_signal_init(&seat->events.set_selection);
+	wl_signal_init(&seat->events.request_set_primary_selection);
+	wl_signal_init(&seat->events.set_primary_selection);
 
 	wl_signal_init(&seat->events.pointer_grab_begin);
 	wl_signal_init(&seat->events.pointer_grab_end);

--- a/types/wlr_gtk_primary_selection.c
+++ b/types/wlr_gtk_primary_selection.c
@@ -208,7 +208,7 @@ static void device_handle_set_selection(struct wl_client *client,
 		source = &client_source->source;
 	}
 
-	wlr_seat_set_primary_selection(device->seat, source, serial);
+	wlr_seat_request_set_primary_selection(device->seat, source, serial);
 }
 
 static void device_handle_destroy(struct wl_client *client,
@@ -272,10 +272,10 @@ static void device_handle_seat_focus_change(struct wl_listener *listener,
 	device_send_selection(device);
 }
 
-static void device_handle_seat_primary_selection(struct wl_listener *listener,
-		void *data) {
+static void device_handle_seat_set_primary_selection(
+		struct wl_listener *listener, void *data) {
 	struct wlr_gtk_primary_selection_device *device =
-		wl_container_of(listener, device, seat_primary_selection);
+		wl_container_of(listener, device, seat_set_primary_selection);
 
 	struct wl_resource *resource, *tmp;
 	wl_resource_for_each_safe(resource, tmp, &device->offers) {
@@ -314,10 +314,10 @@ static struct wlr_gtk_primary_selection_device *get_or_create_device(
 	wl_signal_add(&seat->keyboard_state.events.focus_change,
 		&device->seat_focus_change);
 
-	device->seat_primary_selection.notify =
-		device_handle_seat_primary_selection;
-	wl_signal_add(&seat->events.primary_selection,
-		&device->seat_primary_selection);
+	device->seat_set_primary_selection.notify =
+		device_handle_seat_set_primary_selection;
+	wl_signal_add(&seat->events.set_primary_selection,
+		&device->seat_set_primary_selection);
 
 	return device;
 }
@@ -329,7 +329,7 @@ static void device_destroy(struct wlr_gtk_primary_selection_device *device) {
 	wl_list_remove(&device->link);
 	wl_list_remove(&device->seat_destroy.link);
 	wl_list_remove(&device->seat_focus_change.link);
-	wl_list_remove(&device->seat_primary_selection.link);
+	wl_list_remove(&device->seat_set_primary_selection.link);
 	struct wl_resource *resource, *resource_tmp;
 	wl_resource_for_each_safe(resource, resource_tmp, &device->offers) {
 		destroy_offer(resource);

--- a/xwayland/selection/incoming.c
+++ b/xwayland/selection/incoming.c
@@ -350,7 +350,7 @@ static void xwm_selection_get_targets(struct wlr_xwm_selection *selection) {
 		bool ok = source_get_targets(selection, &source->base.mime_types,
 			&source->mime_types_atoms);
 		if (ok) {
-			wlr_seat_set_selection(xwm->seat, &source->base,
+			wlr_seat_request_set_selection(xwm->seat, &source->base,
 				wl_display_next_serial(xwm->xwayland->wl_display));
 		} else {
 			wlr_data_source_cancel(&source->base);
@@ -425,10 +425,10 @@ int xwm_handle_xfixes_selection_notify(struct wlr_xwm *xwm,
 			// A real X client selection went away, not our
 			// proxy selection
 			if (selection == &xwm->clipboard_selection) {
-				wlr_seat_set_selection(xwm->seat, NULL,
+				wlr_seat_request_set_selection(xwm->seat, NULL,
 					wl_display_next_serial(xwm->xwayland->wl_display));
 			} else if (selection == &xwm->primary_selection) {
-				wlr_seat_set_primary_selection(xwm->seat, NULL,
+				wlr_seat_request_set_primary_selection(xwm->seat, NULL,
 					wl_display_next_serial(xwm->xwayland->wl_display));
 			} else if (selection == &xwm->dnd_selection) {
 				// TODO: DND


### PR DESCRIPTION
~~Depends on https://github.com/swaywm/wlroots/pull/1397~~
~~Depends on https://github.com/swaywm/wlroots/pull/1485~~

This makes compositors able to block and/or customize set_selection requests
coming from clients. For instance, it's possible for a compositor to disable
rich selection content (by removing all MIME types except text/plain). This
commit implements the design proposed in [1].

Two new events are added to wlr_seat: request_set_selection and
request_set_primary_selection. Compositors need to listen to these events and
either destroy the source or effectively set the selection.

Fixes #1138

[1]: https://github.com/swaywm/wlroots/issues/1367#issuecomment-442403454