### PR TITLE
output: switch swap_buffers damage to output-buffer-local coords

### DIFF
--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -121,7 +121,7 @@ struct wlr_output {
 struct wlr_output_event_swap_buffers {
 	struct wlr_output *output;
 	struct timespec *when;
-	pixman_region32_t *damage;
+	pixman_region32_t *damage; // output-buffer-local coordinates
 };
 
 enum wlr_output_present_flag {
@@ -202,6 +202,9 @@ bool wlr_output_preferred_read_format(struct wlr_output *output,
  * Swaps the output buffers. If the time of the frame isn't known, set `when` to
  * NULL. If the compositor doesn't support damage tracking, set `damage` to
  * NULL.
+ *
+ * Damage is given in output-buffer-local coordinates (ie. scaled and
+ * transformed).
  *
  * Swapping buffers schedules a `frame` event.
  */

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -522,11 +522,16 @@ renderer_end:
 	wlr_renderer_scissor(renderer, NULL);
 	wlr_renderer_end(renderer);
 
+	int width, height;
+	wlr_output_transformed_resolution(wlr_output, &width, &height);
+
 	if (server->config->debug_damage_tracking) {
-		int width, height;
-		wlr_output_transformed_resolution(wlr_output, &width, &height);
 		pixman_region32_union_rect(&damage, &damage, 0, 0, width, height);
 	}
+
+	enum wl_output_transform transform =
+		wlr_output_transform_invert(wlr_output->transform);
+	wlr_region_transform(&damage, &damage, transform, width, height);
 
 	if (!wlr_output_damage_swap_buffers(output->damage, &now, &damage)) {
 		goto damage_finish;


### PR DESCRIPTION
This is one more step towards [1]. This gives more freedom to the compositor
wrt. how it handles damage.

[1]: https://github.com/swaywm/wlroots/issues/1363