### PR TITLE
build: bump versino to 0.2.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
 	'wlroots',
 	'c',
-	version: '0.1.0',
+	version: '0.2.0',
 	license: 'MIT',
 	meson_version: '>=0.48.0',
 	default_options: [


### PR DESCRIPTION
It seems it was forgotten to bump the version in meson.build when 0.2.0 was tagged for release.