### PR TITLE
layer-shell-v1, xdg-shell: destroy popups on layer shell destroy

### DIFF
--- a/include/types/wlr_xdg_shell.h
+++ b/include/types/wlr_xdg_shell.h
@@ -33,7 +33,6 @@ void create_xdg_popup(struct wlr_xdg_surface *xdg_surface,
 void handle_xdg_surface_popup_committed(struct wlr_xdg_surface *surface);
 struct wlr_xdg_popup_grab *get_xdg_shell_popup_grab_from_seat(
 	struct wlr_xdg_shell *shell, struct wlr_seat *seat);
-void destroy_xdg_popup(struct wlr_xdg_surface *surface);
 
 void create_xdg_toplevel(struct wlr_xdg_surface *xdg_surface,
 	uint32_t id);

--- a/include/wlr/types/wlr_layer_shell_v1.h
+++ b/include/wlr/types/wlr_layer_shell_v1.h
@@ -46,7 +46,7 @@ struct wlr_layer_shell_v1 {
 };
 
 struct wlr_layer_surface_v1_state {
-	uint32_t anchor;
+	uint32_t anchor; // zwlr_layer_surface_v1_anchor
 	int32_t exclusive_zone;
 	struct {
 		uint32_t top, right, bottom, left;
@@ -77,8 +77,7 @@ struct wlr_layer_surface_v1 {
 	uint32_t configure_serial;
 	struct wl_event_source *configure_idle;
 	uint32_t configure_next_serial;
-	struct wl_list configure_list;
-
+	struct wl_list configure_list; // wlr_layer_surface_v1_configure::link
 	struct wlr_layer_surface_v1_configure *acked_configure;
 
 	struct wlr_layer_surface_v1_state client_pending;

--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -69,7 +69,7 @@ struct wlr_xdg_popup {
 	struct wl_list link;
 
 	struct wl_resource *resource;
-	bool committed;
+	bool committed, done;
 	struct wlr_surface *parent;
 	struct wlr_seat *seat;
 
@@ -327,6 +327,11 @@ void wlr_xdg_popup_get_toplevel_coords(struct wlr_xdg_popup *popup,
  */
 void wlr_xdg_popup_unconstrain_from_box(struct wlr_xdg_popup *popup,
 		struct wlr_box *toplevel_sx_box);
+
+/**
+ * Destroy a popup.
+ */
+void wlr_xdg_popup_destroy(struct wlr_xdg_popup *popup);
 
 /**
   Invert the right/left anchor and gravity for this positioner. This can be

--- a/types/xdg_shell/wlr_xdg_surface.c
+++ b/types/xdg_shell/wlr_xdg_surface.c
@@ -477,10 +477,9 @@ void reset_xdg_surface(struct wlr_xdg_surface *xdg_surface) {
 void destroy_xdg_surface(struct wlr_xdg_surface *surface) {
 	reset_xdg_surface(surface);
 
-	struct wlr_xdg_popup *popup_state, *next;
-	wl_list_for_each_safe(popup_state, next, &surface->popups, link) {
-		xdg_popup_send_popup_done(popup_state->resource);
-		destroy_xdg_popup(popup_state->base);
+	struct wlr_xdg_popup *popup, *popup_tmp;
+	wl_list_for_each_safe(popup, popup_tmp, &surface->popups, link) {
+		wlr_xdg_popup_destroy(popup);
 	}
 
 	wl_resource_set_user_data(surface->resource, NULL);
@@ -523,13 +522,12 @@ void wlr_xdg_surface_send_close(struct wlr_xdg_surface *surface) {
 		assert(0 && "not reached");
 		break;
 	case WLR_XDG_SURFACE_ROLE_TOPLEVEL:
-		if (surface->toplevel) {
-			xdg_toplevel_send_close(surface->toplevel->resource);
-		}
+		xdg_toplevel_send_close(surface->toplevel->resource);
 		break;
 	case WLR_XDG_SURFACE_ROLE_POPUP:
-		if (surface->popup) {
+		if (!surface->popup->done) {
 			xdg_popup_send_popup_done(surface->popup->resource);
+			surface->popup->done = true;
 		}
 		break;
 	}


### PR DESCRIPTION
This commit makes it so that wlr_xdg_surface_send_close only sends the "done"
event once to popup objects, so we can call it multiple times without issues.

A new function wlr_xdg_popup_destroy destroys popup by closing them and then
making them inert.

@wmww: can you test this?

Fixes https://github.com/swaywm/wlroots/issues/1408