### PR TITLE
wlr_keyboard: add xkb_state parameter to wlr_keyboard_set_layout

### DIFF
--- a/examples/multi-pointer.c
+++ b/examples/multi-pointer.c
@@ -245,7 +245,7 @@ void new_input_notify(struct wl_listener *listener, void *data) {
 			wlr_log(WLR_ERROR, "Failed to create XKB keymap");
 			exit(1);
 		}
-		wlr_keyboard_set_keymap(device->keyboard, keymap);
+		wlr_keyboard_set_keymap(device->keyboard, keymap, NULL);
 		xkb_keymap_unref(keymap);
 		xkb_context_unref(context);
 		break;

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -244,7 +244,7 @@ void new_input_notify(struct wl_listener *listener, void *data) {
 			wlr_log(WLR_ERROR, "Failed to create XKB keymap");
 			exit(1);
 		}
-		wlr_keyboard_set_keymap(device->keyboard, keymap);
+		wlr_keyboard_set_keymap(device->keyboard, keymap, NULL);
 		xkb_keymap_unref(keymap);
 		xkb_context_unref(context);
 		break;

--- a/examples/pointer.c
+++ b/examples/pointer.c
@@ -310,7 +310,7 @@ void new_input_notify(struct wl_listener *listener, void *data) {
 			wlr_log(WLR_ERROR, "Failed to create XKB keymap");
 			exit(1);
 		}
-		wlr_keyboard_set_keymap(device->keyboard, keymap);
+		wlr_keyboard_set_keymap(device->keyboard, keymap, NULL);
 		xkb_keymap_unref(keymap);
 		xkb_context_unref(context);
 		break;

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -194,7 +194,7 @@ void new_input_notify(struct wl_listener *listener, void *data) {
 			wlr_log(WLR_ERROR, "Failed to create XKB keymap");
 			exit(1);
 		}
-		wlr_keyboard_set_keymap(device->keyboard, keymap);
+		wlr_keyboard_set_keymap(device->keyboard, keymap, NULL);
 		xkb_keymap_unref(keymap);
 		xkb_context_unref(context);
 		break;

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -147,7 +147,7 @@ void new_input_notify(struct wl_listener *listener, void *data) {
 			wlr_log(WLR_ERROR, "Failed to create XKB keymap");
 			exit(1);
 		}
-		wlr_keyboard_set_keymap(device->keyboard, keymap);
+		wlr_keyboard_set_keymap(device->keyboard, keymap, NULL);
 		xkb_keymap_unref(keymap);
 		xkb_context_unref(context);
 		break;

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -303,7 +303,7 @@ void new_input_notify(struct wl_listener *listener, void *data) {
 			wlr_log(WLR_ERROR, "Failed to create XKB keymap");
 			exit(1);
 		}
-		wlr_keyboard_set_keymap(device->keyboard, keymap);
+		wlr_keyboard_set_keymap(device->keyboard, keymap, NULL);
 		xkb_keymap_unref(keymap);
 		xkb_context_unref(context);
 		break;

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -216,7 +216,7 @@ void new_input_notify(struct wl_listener *listener, void *data) {
 			wlr_log(WLR_ERROR, "Failed to create XKB keymap");
 			exit(1);
 		}
-		wlr_keyboard_set_keymap(device->keyboard, keymap);
+		wlr_keyboard_set_keymap(device->keyboard, keymap, NULL);
 		xkb_keymap_unref(keymap);
 		xkb_context_unref(context);
 		break;

--- a/include/wlr/types/wlr_keyboard.h
+++ b/include/wlr/types/wlr_keyboard.h
@@ -102,7 +102,7 @@ struct wlr_event_keyboard_key {
 };
 
 void wlr_keyboard_set_keymap(struct wlr_keyboard *kb,
-	struct xkb_keymap *keymap);
+	struct xkb_keymap *keymap, struct xkb_state *state);
 /**
  * Sets the keyboard repeat info. `rate` is in key repeats/second and delay is
  * in milliseconds.

--- a/rootston/keyboard.c
+++ b/rootston/keyboard.c
@@ -430,7 +430,7 @@ struct roots_keyboard *roots_keyboard_create(struct wlr_input_device *device,
 		return NULL;
 	}
 
-	wlr_keyboard_set_keymap(device->keyboard, keymap);
+	wlr_keyboard_set_keymap(device->keyboard, keymap, NULL);
 	xkb_keymap_unref(keymap);
 	xkb_context_unref(context);
 

--- a/types/wlr_keyboard.c
+++ b/types/wlr_keyboard.c
@@ -150,15 +150,19 @@ void wlr_keyboard_led_update(struct wlr_keyboard *kb, uint32_t leds) {
 }
 
 void wlr_keyboard_set_keymap(struct wlr_keyboard *kb,
-		struct xkb_keymap *keymap) {
+		struct xkb_keymap *keymap, struct xkb_state *state) {
 	xkb_keymap_unref(kb->keymap);
 	kb->keymap = xkb_keymap_ref(keymap);
 
 	xkb_state_unref(kb->xkb_state);
-	kb->xkb_state = xkb_state_new(kb->keymap);
-	if (kb->xkb_state == NULL) {
-		wlr_log(WLR_ERROR, "Failed to create XKB state");
-		goto err;
+	if (state != NULL) {
+		kb->xkb_state = xkb_state_ref(state);
+	} else {
+		kb->xkb_state = xkb_state_new(kb->keymap);
+		if (kb->xkb_state == NULL) {
+			wlr_log(WLR_ERROR, "Failed to create XKB state");
+			goto err;
+		}
 	}
 
 	const char *led_names[WLR_LED_COUNT] = {

--- a/types/wlr_virtual_keyboard_v1.c
+++ b/types/wlr_virtual_keyboard_v1.c
@@ -60,7 +60,7 @@ static void virtual_keyboard_keymap(struct wl_client *client,
 	if (!keymap) {
 		goto keymap_fail;
 	}
-	wlr_keyboard_set_keymap(keyboard->input_device.keyboard, keymap);
+	wlr_keyboard_set_keymap(keyboard->input_device.keyboard, keymap, NULL);
 	xkb_keymap_unref(keymap);
 	xkb_context_unref(context);
 	return;


### PR DESCRIPTION
This allows the compositor to share the keyboard state between multiple
keyboards with the same layout.