### PR TITLE
backend/drm: fix disappeared output indices

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -993,11 +993,10 @@ static void realloc_crtcs(struct wlr_drm_backend *drm, bool *changed_outputs) {
 
 static uint32_t get_possible_crtcs(int fd, drmModeRes *res,
 		drmModeConnector *conn, bool is_mst) {
-	drmModeEncoder *enc;
 	uint32_t ret = 0;
 
-	for (int i = 0; !enc && i < conn->count_encoders; ++i) {
-		enc = drmModeGetEncoder(fd, conn->encoders[i]);
+	for (int i = 0; i < conn->count_encoders; ++i) {
+		drmModeEncoder *enc = drmModeGetEncoder(fd, conn->encoders[i]);
 		if (!enc) {
 			continue;
 		}
@@ -1016,7 +1015,7 @@ static uint32_t get_possible_crtcs(int fd, drmModeRes *res,
 	}
 
 	for (int i = 0; i < res->count_encoders; ++i) {
-		enc = drmModeGetEncoder(fd, res->encoders[i]);
+		drmModeEncoder *enc = drmModeGetEncoder(fd, res->encoders[i]);
 		if (!enc) {
 			continue;
 		}

--- a/backend/drm/properties.c
+++ b/backend/drm/properties.c
@@ -22,6 +22,7 @@ static const struct prop_info connector_info[] = {
 	{ "CRTC_ID",     INDEX(crtc_id) },
 	{ "DPMS",        INDEX(dpms) },
 	{ "EDID",        INDEX(edid) },
+	{ "PATH",        INDEX(path) },
 	{ "link-status", INDEX(link_status) },
 #undef INDEX
 };

--- a/include/backend/drm/properties.h
+++ b/include/backend/drm/properties.h
@@ -15,6 +15,7 @@ union wlr_drm_connector_props {
 		uint32_t edid;
 		uint32_t dpms;
 		uint32_t link_status; // not guaranteed to exist
+		uint32_t path;
 
 		// atomic-modesetting only
 


### PR DESCRIPTION
This commit changes `scan_drm_connectors` to add new outputs to the end of the
list. That way, it's easier to understand what's going on with indices.

When we need to destroy outputs, we now walk the list in reverse order. This
ensures indices remain correct while iterating and removing items from the
list.

We now also make outputs without a CRTC disappear (those are in
WLR_DRM_CONN_NEEDS_MODESET state).