### PR TITLE
Refactor data-device

### DIFF
--- a/include/types/wlr_data_device.h
+++ b/include/types/wlr_data_device.h
@@ -17,7 +17,7 @@ struct wlr_client_data_source {
 extern const struct wlr_surface_role drag_icon_surface_role;
 
 struct wlr_data_offer *data_offer_create(struct wl_resource *device_resource,
-	struct wlr_data_source *source);
+	struct wlr_data_source *source, enum wlr_data_offer_type type);
 void data_offer_update_action(struct wlr_data_offer *offer);
 void data_offer_destroy(struct wlr_data_offer *offer);
 

--- a/include/types/wlr_data_device.h
+++ b/include/types/wlr_data_device.h
@@ -16,8 +16,8 @@ struct wlr_client_data_source {
 
 extern const struct wlr_surface_role drag_icon_surface_role;
 
-struct wlr_data_offer *data_offer_create(struct wl_client *client,
-	struct wlr_data_source *source, uint32_t version);
+struct wlr_data_offer *data_offer_create(struct wl_resource *device_resource,
+	struct wlr_data_source *source);
 void data_offer_update_action(struct wlr_data_offer *offer);
 void data_offer_destroy(struct wlr_data_offer *offer);
 
@@ -26,10 +26,10 @@ struct wlr_client_data_source *client_data_source_create(
 	struct wl_list *resource_list);
 struct wlr_client_data_source *client_data_source_from_resource(
 	struct wl_resource *resource);
-struct wlr_data_offer *data_source_send_offer(struct wlr_data_source *source,
-	struct wl_resource *device_resource);
 void data_source_notify_finish(struct wlr_data_source *source);
 
+struct wlr_seat_client *seat_client_from_data_device_resource(
+	struct wl_resource *resource);
 bool seat_client_start_drag(struct wlr_seat_client *client,
 	struct wlr_data_source *source, struct wlr_surface *icon_surface,
 	struct wlr_surface *origin, uint32_t serial);

--- a/include/types/wlr_data_device.h
+++ b/include/types/wlr_data_device.h
@@ -33,5 +33,13 @@ struct wlr_seat_client *seat_client_from_data_device_resource(
 bool seat_client_start_drag(struct wlr_seat_client *client,
 	struct wlr_data_source *source, struct wlr_surface *icon_surface,
 	struct wlr_surface *origin, uint32_t serial);
+/**
+ * Creates a new wl_data_offer if there is a wl_data_source currently set as
+ * the seat selection and sends it to the seat client, followed by the
+ * wl_data_device.selection() event.  If there is no current selection, the
+ * wl_data_device.selection() event will carry a NULL wl_data_offer.  If the
+ * client does not have a wl_data_device for the seat nothing will be done.
+ */
+void seat_client_send_selection(struct wlr_seat_client *seat_client);
 
 #endif

--- a/include/wlr/types/wlr_data_device.h
+++ b/include/wlr/types/wlr_data_device.h
@@ -157,15 +157,6 @@ struct wlr_data_device_manager *wlr_data_device_manager_create(
 void wlr_data_device_manager_destroy(struct wlr_data_device_manager *manager);
 
 /**
- * Creates a new wl_data_offer if there is a wl_data_source currently set as
- * the seat selection and sends it to the seat client, followed by the
- * wl_data_device.selection() event.  If there is no current selection, the
- * wl_data_device.selection() event will carry a NULL wl_data_offer.  If the
- * client does not have a wl_data_device for the seat nothing * will be done.
- */
-void wlr_seat_client_send_selection(struct wlr_seat_client *seat_client);
-
-/**
  * Requests a selection to be set for the seat.
  */
 void wlr_seat_request_set_selection(struct wlr_seat *seat,

--- a/include/wlr/types/wlr_data_device.h
+++ b/include/wlr/types/wlr_data_device.h
@@ -44,6 +44,7 @@ struct wlr_data_offer {
 	struct wl_resource *resource;
 	struct wlr_data_source *source;
 	enum wlr_data_offer_type type;
+	struct wl_list link; // wlr_seat::{selection_offers,drag_offers}
 
 	uint32_t actions;
 	enum wl_data_device_manager_dnd_action preferred_action;

--- a/include/wlr/types/wlr_data_device.h
+++ b/include/wlr/types/wlr_data_device.h
@@ -35,9 +35,15 @@ struct wlr_data_device_manager {
 	void *data;
 };
 
+enum wlr_data_offer_type {
+	WLR_DATA_OFFER_SELECTION,
+	WLR_DATA_OFFER_DRAG,
+};
+
 struct wlr_data_offer {
 	struct wl_resource *resource;
 	struct wlr_data_source *source;
+	enum wlr_data_offer_type type;
 
 	uint32_t actions;
 	enum wl_data_device_manager_dnd_action preferred_action;

--- a/include/wlr/types/wlr_data_device.h
+++ b/include/wlr/types/wlr_data_device.h
@@ -55,7 +55,7 @@ struct wlr_data_source_impl {
 		int32_t fd);
 	void (*accept)(struct wlr_data_source *source, uint32_t serial,
 		const char *mime_type);
-	void (*cancel)(struct wlr_data_source *source);
+	void (*destroy)(struct wlr_data_source *source);
 
 	void (*dnd_drop)(struct wlr_data_source *source);
 	void (*dnd_finish)(struct wlr_data_source *source);
@@ -187,11 +187,6 @@ void wlr_data_source_init(struct wlr_data_source *source,
 	const struct wlr_data_source_impl *impl);
 
 /**
- * Finishes the data source.
- */
-void wlr_data_source_finish(struct wlr_data_source *source);
-
-/**
  * Sends the data as the specified MIME type over the passed file descriptor,
  * then close it.
  */
@@ -207,9 +202,9 @@ void wlr_data_source_accept(struct wlr_data_source *source, uint32_t serial,
 
 /**
  * Notifies the data source it is no longer valid and should be destroyed. That
- * potentially destroys immediately the data source.
+ * destroys immediately the data source.
  */
-void wlr_data_source_cancel(struct wlr_data_source *source);
+void wlr_data_source_destroy(struct wlr_data_source *source);
 
 /**
  * Notifies the data source that the drop operation was performed. This does not

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -197,6 +197,7 @@ struct wlr_seat {
 
 	struct wlr_data_source *selection_source;
 	uint32_t selection_serial;
+	struct wl_list selection_offers; // wlr_data_offer::link
 
 	struct wlr_primary_selection_source *primary_selection_source;
 	uint32_t primary_selection_serial;
@@ -205,6 +206,7 @@ struct wlr_seat {
 	struct wlr_drag *drag;
 	struct wlr_data_source *drag_source;
 	uint32_t drag_serial;
+	struct wl_list drag_offers; // wlr_data_offer::link
 
 	struct wlr_seat_pointer_state pointer_state;
 	struct wlr_seat_keyboard_state keyboard_state;

--- a/types/data_device/wlr_data_device.c
+++ b/types/data_device/wlr_data_device.c
@@ -107,8 +107,8 @@ static void device_resource_send_selection(struct wl_resource *device_resource) 
 
 	struct wlr_data_source *source = seat_client->seat->selection_source;
 	if (source != NULL) {
-		struct wlr_data_offer *offer =
-			data_offer_create(device_resource, source);
+		struct wlr_data_offer *offer = data_offer_create(device_resource,
+			source, WLR_DATA_OFFER_SELECTION);
 		if (offer == NULL) {
 			wl_client_post_no_memory(seat_client->client);
 			return;

--- a/types/data_device/wlr_data_device.c
+++ b/types/data_device/wlr_data_device.c
@@ -26,6 +26,9 @@ static void data_device_set_selection(struct wl_client *client,
 		struct wl_resource *source_resource, uint32_t serial) {
 	struct wlr_seat_client *seat_client =
 		seat_client_from_data_device_resource(device_resource);
+	if (seat_client == NULL) {
+		return;
+	}
 
 	struct wlr_client_data_source *source = NULL;
 	if (source_resource != NULL) {
@@ -48,6 +51,10 @@ static void data_device_start_drag(struct wl_client *client,
 		uint32_t serial) {
 	struct wlr_seat_client *seat_client =
 		seat_client_from_data_device_resource(device_resource);
+	if (seat_client == NULL) {
+		return;
+	}
+
 	struct wlr_surface *origin = wlr_surface_from_resource(origin_resource);
 
 	struct wlr_client_data_source *source = NULL;
@@ -201,9 +208,9 @@ static void data_device_manager_get_data_device(struct wl_client *client,
 	struct wlr_seat_client *seat_client =
 		wlr_seat_client_from_resource(seat_resource);
 
+	uint32_t version = wl_resource_get_version(manager_resource);
 	struct wl_resource *resource = wl_resource_create(client,
-		&wl_data_device_interface, wl_resource_get_version(manager_resource),
-		id);
+		&wl_data_device_interface, version, id);
 	if (resource == NULL) {
 		wl_resource_post_no_memory(manager_resource);
 		return;
@@ -244,8 +251,7 @@ static void data_device_manager_bind(struct wl_client *client,
 	struct wlr_data_device_manager *manager = data;
 
 	struct wl_resource *resource = wl_resource_create(client,
-		&wl_data_device_manager_interface,
-		version, id);
+		&wl_data_device_manager_interface, version, id);
 	if (resource == NULL) {
 		wl_client_post_no_memory(client);
 		return;

--- a/types/data_device/wlr_data_device.c
+++ b/types/data_device/wlr_data_device.c
@@ -155,7 +155,7 @@ void wlr_seat_set_selection(struct wlr_seat *seat,
 		struct wlr_data_source *source, uint32_t serial) {
 	if (seat->selection_source) {
 		wl_list_remove(&seat->selection_source_destroy.link);
-		wlr_data_source_cancel(seat->selection_source);
+		wlr_data_source_destroy(seat->selection_source);
 		seat->selection_source = NULL;
 	}
 

--- a/types/data_device/wlr_data_device.c
+++ b/types/data_device/wlr_data_device.c
@@ -113,7 +113,7 @@ static void device_resource_send_selection(struct wl_resource *device_resource) 
 	}
 }
 
-void wlr_seat_client_send_selection(struct wlr_seat_client *seat_client) {
+void seat_client_send_selection(struct wlr_seat_client *seat_client) {
 	struct wlr_data_source *source = seat_client->seat->selection_source;
 	if (source != NULL) {
 		source->accepted = false;
@@ -174,7 +174,7 @@ void wlr_seat_set_selection(struct wlr_seat *seat,
 	struct wlr_seat_client *focused_client =
 		seat->keyboard_state.focused_client;
 	if (focused_client) {
-		wlr_seat_client_send_selection(focused_client);
+		seat_client_send_selection(focused_client);
 	}
 
 	if (source) {

--- a/types/data_device/wlr_data_device.c
+++ b/types/data_device/wlr_data_device.c
@@ -14,7 +14,7 @@
 
 static const struct wl_data_device_interface data_device_impl;
 
-static struct wlr_seat_client *seat_client_from_data_device_resource(
+struct wlr_seat_client *seat_client_from_data_device_resource(
 		struct wl_resource *resource) {
 	assert(wl_resource_instance_of(resource, &wl_data_device_interface,
 		&data_device_impl));
@@ -103,7 +103,7 @@ void wlr_seat_client_send_selection(struct wlr_seat_client *seat_client) {
 	wl_resource_for_each(device_resource, &seat_client->data_devices) {
 		if (source != NULL) {
 			struct wlr_data_offer *offer =
-				data_source_send_offer(source, device_resource);
+				data_offer_create(device_resource, source);
 			if (offer == NULL) {
 				wl_client_post_no_memory(seat_client->client);
 				return;

--- a/types/data_device/wlr_data_offer.c
+++ b/types/data_device/wlr_data_offer.c
@@ -181,9 +181,11 @@ void data_offer_destroy(struct wlr_data_offer *offer) {
 	}
 
 	wl_list_remove(&offer->source_destroy.link);
+	wl_list_remove(&offer->link);
 
 	// Make the resource inert
 	wl_resource_set_user_data(offer->resource, NULL);
+
 	free(offer);
 }
 
@@ -231,6 +233,15 @@ struct wlr_data_offer *data_offer_create(struct wl_resource *device_resource,
 	}
 	wl_resource_set_implementation(offer->resource, &data_offer_impl, offer,
 		data_offer_handle_resource_destroy);
+
+	switch (type) {
+	case WLR_DATA_OFFER_SELECTION:
+		wl_list_insert(&seat_client->seat->selection_offers, &offer->link);
+		break;
+	case WLR_DATA_OFFER_DRAG:
+		wl_list_insert(&seat_client->seat->drag_offers, &offer->link);
+		break;
+	}
 
 	offer->source_destroy.notify = data_offer_handle_source_destroy;
 	wl_signal_add(&source->events.destroy, &offer->source_destroy);

--- a/types/data_device/wlr_data_source.c
+++ b/types/data_device/wlr_data_source.c
@@ -40,20 +40,6 @@ void wlr_data_source_init(struct wlr_data_source *source,
 	source->actions = -1;
 }
 
-void wlr_data_source_finish(struct wlr_data_source *source) {
-	if (source == NULL) {
-		return;
-	}
-
-	wlr_signal_emit_safe(&source->events.destroy, source);
-
-	char **p;
-	wl_array_for_each(p, &source->mime_types) {
-		free(*p);
-	}
-	wl_array_release(&source->mime_types);
-}
-
 void wlr_data_source_send(struct wlr_data_source *source, const char *mime_type,
 		int32_t fd) {
 	source->impl->send(source, mime_type, fd);
@@ -67,9 +53,23 @@ void wlr_data_source_accept(struct wlr_data_source *source, uint32_t serial,
 	}
 }
 
-void wlr_data_source_cancel(struct wlr_data_source *source) {
-	if (source->impl->cancel) {
-		source->impl->cancel(source);
+void wlr_data_source_destroy(struct wlr_data_source *source) {
+	if (source == NULL) {
+		return;
+	}
+
+	wlr_signal_emit_safe(&source->events.destroy, source);
+
+	char **p;
+	wl_array_for_each(p, &source->mime_types) {
+		free(*p);
+	}
+	wl_array_release(&source->mime_types);
+
+	if (source->impl->destroy) {
+		source->impl->destroy(source);
+	} else {
+		free(source);
 	}
 }
 
@@ -127,10 +127,12 @@ static void client_data_source_send(struct wlr_data_source *wlr_source,
 	close(fd);
 }
 
-static void client_data_source_cancel(struct wlr_data_source *wlr_source) {
+static void client_data_source_destroy(struct wlr_data_source *wlr_source) {
 	struct wlr_client_data_source *source =
 		client_data_source_from_wlr_data_source(wlr_source);
 	wl_data_source_send_cancelled(source->resource);
+	wl_resource_set_user_data(source->resource, NULL);
+	free(source);
 }
 
 static void client_data_source_dnd_drop(struct wlr_data_source *wlr_source) {
@@ -167,6 +169,9 @@ static void data_source_set_actions(struct wl_client *client,
 		struct wl_resource *resource, uint32_t dnd_actions) {
 	struct wlr_client_data_source *source =
 		client_data_source_from_resource(resource);
+	if (source == NULL) {
+		return;
+	}
 
 	if (source->source.actions >= 0) {
 		wl_resource_post_error(source->resource,
@@ -196,6 +201,13 @@ static void data_source_offer(struct wl_client *client,
 		struct wl_resource *resource, const char *mime_type) {
 	struct wlr_client_data_source *source =
 		client_data_source_from_resource(resource);
+	if (source == NULL) {
+		return;
+	}
+	if (source->finalized) {
+		wlr_log(WLR_DEBUG, "offering additional MIME type after "
+			"wl_data_device.set_selection");
+	}
 
 	char **p = wl_array_add(&source->source.mime_types, sizeof(*p));
 	if (p) {
@@ -210,17 +222,18 @@ static void data_source_offer(struct wl_client *client,
 }
 
 static const struct wl_data_source_interface data_source_impl = {
-	.offer = data_source_offer,
 	.destroy = data_source_destroy,
+	.offer = data_source_offer,
 	.set_actions = data_source_set_actions,
 };
 
 static void data_source_handle_resource_destroy(struct wl_resource *resource) {
 	struct wlr_client_data_source *source =
 		client_data_source_from_resource(resource);
-	wlr_data_source_finish(&source->source);
-	wl_list_remove(wl_resource_get_link(source->resource));
-	free(source);
+	if (source != NULL) {
+		wlr_data_source_destroy(&source->source);
+	}
+	wl_list_remove(wl_resource_get_link(resource));
 }
 
 struct wlr_client_data_source *client_data_source_create(
@@ -245,7 +258,7 @@ struct wlr_client_data_source *client_data_source_create(
 
 	source->impl.accept = client_data_source_accept;
 	source->impl.send = client_data_source_send;
-	source->impl.cancel = client_data_source_cancel;
+	source->impl.destroy = client_data_source_destroy;
 
 	if (wl_resource_get_version(source->resource) >=
 			WL_DATA_SOURCE_DND_DROP_PERFORMED_SINCE_VERSION) {

--- a/types/data_device/wlr_data_source.c
+++ b/types/data_device/wlr_data_source.c
@@ -11,25 +11,6 @@
 #include "types/wlr_data_device.h"
 #include "util/signal.h"
 
-struct wlr_data_offer *data_source_send_offer(struct wlr_data_source *source,
-		struct wl_resource *device_resource) {
-	struct wl_client *client = wl_resource_get_client(device_resource);
-	uint32_t version = wl_resource_get_version(device_resource);
-	struct wlr_data_offer *offer = data_offer_create(client, source, version);
-	if (offer == NULL) {
-		return NULL;
-	}
-
-	wl_data_device_send_data_offer(device_resource, offer->resource);
-
-	char **p;
-	wl_array_for_each(p, &source->mime_types) {
-		wl_data_offer_send_offer(offer->resource, *p);
-	}
-
-	return offer;
-}
-
 void wlr_data_source_init(struct wlr_data_source *source,
 		const struct wlr_data_source_impl *impl) {
 	assert(impl->send);

--- a/types/data_device/wlr_data_source.c
+++ b/types/data_device/wlr_data_source.c
@@ -186,7 +186,7 @@ static void data_source_offer(struct wl_client *client,
 		return;
 	}
 	if (source->finalized) {
-		wlr_log(WLR_DEBUG, "offering additional MIME type after "
+		wlr_log(WLR_DEBUG, "Offering additional MIME type after "
 			"wl_data_device.set_selection");
 	}
 

--- a/types/data_device/wlr_drag.c
+++ b/types/data_device/wlr_drag.c
@@ -61,8 +61,8 @@ static void drag_set_focus(struct wlr_drag *drag,
 
 		struct wl_resource *device_resource;
 		wl_resource_for_each(device_resource, &focus_client->data_devices) {
-			struct wlr_data_offer *offer =
-				data_offer_create(device_resource, drag->source);
+			struct wlr_data_offer *offer = data_offer_create(device_resource,
+				drag->source, WLR_DATA_OFFER_DRAG);
 			if (offer == NULL) {
 				wl_resource_post_no_memory(device_resource);
 				return;

--- a/types/data_device/wlr_drag.c
+++ b/types/data_device/wlr_drag.c
@@ -174,7 +174,7 @@ static uint32_t drag_handle_pointer_button(struct wlr_seat_pointer_grab *grab,
 			};
 			wlr_signal_emit_safe(&drag->events.drop, &event);
 		} else if (drag->source->impl->dnd_finish) {
-			wlr_data_source_cancel(drag->source);
+			wlr_data_source_destroy(drag->source);
 		}
 	}
 

--- a/types/data_device/wlr_drag.c
+++ b/types/data_device/wlr_drag.c
@@ -62,7 +62,7 @@ static void drag_set_focus(struct wlr_drag *drag,
 		struct wl_resource *device_resource;
 		wl_resource_for_each(device_resource, &focus_client->data_devices) {
 			struct wlr_data_offer *offer =
-				data_source_send_offer(drag->source, device_resource);
+				data_offer_create(device_resource, drag->source);
 			if (offer == NULL) {
 				wl_resource_post_no_memory(device_resource);
 				return;

--- a/types/seat/wlr_seat.c
+++ b/types/seat/wlr_seat.c
@@ -267,6 +267,8 @@ struct wlr_seat *wlr_seat_create(struct wl_display *display, const char *name) {
 	seat->name = strdup(name);
 	wl_list_init(&seat->clients);
 	wl_list_init(&seat->drag_icons);
+	wl_list_init(&seat->selection_offers);
+	wl_list_init(&seat->drag_offers);
 
 	wl_signal_init(&seat->events.start_drag);
 	wl_signal_init(&seat->events.new_drag_icon);

--- a/types/seat/wlr_seat.c
+++ b/types/seat/wlr_seat.c
@@ -159,7 +159,7 @@ void wlr_seat_destroy(struct wlr_seat *seat) {
 
 	if (seat->selection_source) {
 		wl_list_remove(&seat->selection_source_destroy.link);
-		wlr_data_source_cancel(seat->selection_source);
+		wlr_data_source_destroy(seat->selection_source);
 		seat->selection_source = NULL;
 	}
 

--- a/types/seat/wlr_seat.c
+++ b/types/seat/wlr_seat.c
@@ -157,14 +157,8 @@ void wlr_seat_destroy(struct wlr_seat *seat) {
 
 	wl_list_remove(&seat->display_destroy.link);
 
-	if (seat->selection_source) {
-		wl_list_remove(&seat->selection_source_destroy.link);
-		wlr_data_source_destroy(seat->selection_source);
-		seat->selection_source = NULL;
-	}
-
-	wlr_seat_set_primary_selection(seat, NULL,
-		wl_display_next_serial(seat->display));
+	wlr_data_source_destroy(seat->selection_source);
+	wlr_primary_selection_source_destroy(seat->primary_selection_source);
 
 	struct wlr_seat_client *client, *tmp;
 	wl_list_for_each_safe(client, tmp, &seat->clients, link) {

--- a/types/seat/wlr_seat.c
+++ b/types/seat/wlr_seat.c
@@ -86,7 +86,12 @@ static void seat_client_handle_resource_destroy(
 		wl_resource_destroy(resource);
 	}
 	wl_resource_for_each_safe(resource, tmp, &client->data_devices) {
-		wl_resource_destroy(resource);
+		// Make the data device inert
+		wl_resource_set_user_data(resource, NULL);
+
+		struct wl_list *link = wl_resource_get_link(resource);
+		wl_list_remove(link);
+		wl_list_init(link);
 	}
 
 	wl_list_remove(&client->link);

--- a/types/seat/wlr_seat_keyboard.c
+++ b/types/seat/wlr_seat_keyboard.c
@@ -2,17 +2,18 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <time.h>
 #include <sys/mman.h>
+#include <time.h>
 #include <unistd.h>
 #include <wayland-server.h>
 #include <wlr/types/wlr_data_device.h>
-#include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_gtk_primary_selection.h>
+#include <wlr/types/wlr_input_device.h>
 #include <wlr/util/log.h>
+#include "types/wlr_data_device.h"
 #include "types/wlr_seat.h"
-#include "util/signal.h"
 #include "util/shm.h"
+#include "util/signal.h"
 
 static void default_keyboard_enter(struct wlr_seat_keyboard_grab *grab,
 		struct wlr_surface *surface, uint32_t keycodes[], size_t num_keycodes,
@@ -271,8 +272,6 @@ void wlr_seat_keyboard_enter(struct wlr_seat *seat,
 			wl_keyboard_send_enter(resource, serial, surface->resource, &keys);
 		}
 		wl_array_release(&keys);
-
-		wlr_seat_client_send_selection(client);
 	}
 
 	// reinitialize the focus destroy events
@@ -292,6 +291,8 @@ void wlr_seat_keyboard_enter(struct wlr_seat *seat,
 		// tell new client about any modifier change last,
 		// as it targets seat->keyboard_state.focused_client
 		wlr_seat_keyboard_send_modifiers(seat, modifiers);
+
+		seat_client_send_selection(client);
 	}
 
 	struct wlr_seat_keyboard_focus_change_event event = {

--- a/types/wlr_data_control_v1.c
+++ b/types/wlr_data_control_v1.c
@@ -32,11 +32,10 @@ static void client_source_send(struct wlr_data_source *wlr_source,
 	close(fd);
 }
 
-static void client_source_cancel(struct wlr_data_source *wlr_source) {
+static void client_source_destroy(struct wlr_data_source *wlr_source) {
 	struct client_data_source *source =
 		client_data_source_from_source(wlr_source);
 	zwlr_data_control_source_v1_send_cancelled(source->resource);
-	wlr_data_source_finish(wlr_source);
 	// Make the resource inert
 	wl_resource_set_user_data(source->resource, NULL);
 	free(source);
@@ -44,7 +43,7 @@ static void client_source_cancel(struct wlr_data_source *wlr_source) {
 
 static const struct wlr_data_source_impl client_source_impl = {
 	.send = client_source_send,
-	.cancel = client_source_cancel,
+	.destroy = client_source_destroy,
 };
 
 static const struct zwlr_data_control_source_v1_interface source_impl;
@@ -101,7 +100,7 @@ static void source_handle_resource_destroy(struct wl_resource *resource) {
 	if (source == NULL) {
 		return;
 	}
-	wlr_data_source_cancel(&source->source);
+	wlr_data_source_destroy(&source->source);
 }
 
 

--- a/xwayland/selection/incoming.c
+++ b/xwayland/selection/incoming.c
@@ -203,17 +203,16 @@ static void data_source_send(struct wlr_data_source *wlr_source,
 		mime_type, fd);
 }
 
-static void data_source_cancel(struct wlr_data_source *wlr_source) {
+static void data_source_destroy(struct wlr_data_source *wlr_source) {
 	struct x11_data_source *source =
 		data_source_from_wlr_data_source(wlr_source);
-	wlr_data_source_finish(&source->base);
 	wl_array_release(&source->mime_types_atoms);
 	free(source);
 }
 
 static const struct wlr_data_source_impl data_source_impl = {
 	.send = data_source_send,
-	.cancel = data_source_cancel,
+	.destroy = data_source_destroy,
 };
 
 struct x11_primary_selection_source {
@@ -353,7 +352,7 @@ static void xwm_selection_get_targets(struct wlr_xwm_selection *selection) {
 			wlr_seat_request_set_selection(xwm->seat, &source->base,
 				wl_display_next_serial(xwm->xwayland->wl_display));
 		} else {
-			wlr_data_source_cancel(&source->base);
+			wlr_data_source_destroy(&source->base);
 		}
 	} else if (selection == &xwm->primary_selection) {
 		struct x11_primary_selection_source *source =


### PR DESCRIPTION
Various refactoring commits to improve our data-device implementation.

Breaking changes:

* `wlr_seat_client_send_selection` has been removed, this is an internal function
* `wlr_data_source_finish` has been removed, this is now handled by `wlr_data_source_destroy`
* `wlr_data_source_cancel` has been renamed to `wlr_data_source_destroy`