### PR TITLE
gtk-primary-selection: basic serial validation

### DIFF
--- a/include/wlr/types/wlr_gtk_primary_selection.h
+++ b/include/wlr/types/wlr_gtk_primary_selection.h
@@ -36,6 +36,7 @@ struct wlr_gtk_primary_selection_device {
 	struct wl_list resources; // wl_resource_get_link
 
 	struct wl_list offers; // wl_resource_get_link
+	uint32_t selection_serial;
 
 	struct wl_listener seat_destroy;
 	struct wl_listener seat_focus_change;

--- a/types/wlr_gtk_primary_selection.c
+++ b/types/wlr_gtk_primary_selection.c
@@ -1,5 +1,6 @@
 #define _POSIX_C_SOURCE 200809L
 #include <assert.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -202,7 +203,14 @@ static void device_handle_set_selection(struct wl_client *client,
 		source = &client_source->source;
 	}
 
-	// TODO: serial checking
+	// TODO: improve serial validation
+	if (device->seat->primary_selection_source != NULL &&
+			device->selection_serial - serial < UINT32_MAX / 2) {
+		wlr_log(WLR_DEBUG, "Rejecting set_selection request, invalid serial "
+			"(%"PRIu32" <= %"PRIu32")", serial, device->selection_serial);
+		return;
+	}
+	device->selection_serial = serial;
 
 	wlr_seat_set_primary_selection(device->seat, source);
 }

--- a/types/wlr_gtk_primary_selection.c
+++ b/types/wlr_gtk_primary_selection.c
@@ -98,6 +98,7 @@ static void destroy_offer(struct wl_resource *resource) {
 struct client_data_source {
 	struct wlr_primary_selection_source source;
 	struct wl_resource *resource;
+	bool finalized;
 };
 
 static void client_source_send(
@@ -137,6 +138,9 @@ static void source_handle_offer(struct wl_client *client,
 		client_data_source_from_resource(resource);
 	if (source == NULL) {
 		return;
+	}
+	if (source->finalized) {
+		wlr_log(WLR_DEBUG, "Offering additional MIME type after set_selection");
 	}
 
 	char *dup_mime_type = strdup(mime_type);
@@ -200,6 +204,7 @@ static void device_handle_set_selection(struct wl_client *client,
 
 	struct wlr_primary_selection_source *source = NULL;
 	if (client_source != NULL) {
+		client_source->finalized = true;
 		source = &client_source->source;
 	}
 


### PR DESCRIPTION
I've discovered that some clients _rely_ on the compositor for rejecting `set_selection` requests if the serial is invalid. For instance Gedit under Wayland issues multiple `set_selection` requests with the same serial, and not doing this basic serial validation will break clipboard.

While I haven't found any clients broken for primary selection, it's probably better to add back this basic serial validation, at least until we have a new improved validation mechanism.