### PR TITLE
rootston: create foreign toplevel handle before sending outputs

### DIFF
--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -542,8 +542,8 @@ void view_setup(struct roots_view *view) {
 		view_center(view);
 	}
 
-	view_update_output(view, NULL);
 	view_create_foreign_toplevel_handle(view);
+	view_update_output(view, NULL);
 }
 
 void view_apply_damage(struct roots_view *view) {


### PR DESCRIPTION
Otherwise the initial list of outputs isn't sent to foreign-toplevel clients.