### PR TITLE
Protect against redefining MESA_EGL_NO_X11_HEADERS

### DIFF
--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -11,7 +11,7 @@
 
 #include <wlr/config.h>
 
-#if !WLR_HAS_X11_BACKEND && !WLR_HAS_XWAYLAND
+#if !WLR_HAS_X11_BACKEND && !WLR_HAS_XWAYLAND && !defined MESA_EGL_NO_X11_HEADERS
 #define MESA_EGL_NO_X11_HEADERS
 #endif
 

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -11,7 +11,7 @@
 
 #include <wlr/config.h>
 
-#if !WLR_HAS_X11_BACKEND && !WLR_HAS_XWAYLAND
+#if !WLR_HAS_X11_BACKEND && !WLR_HAS_XWAYLAND && !defined MESA_EGL_NO_X11_HEADERS
 #define MESA_EGL_NO_X11_HEADERS
 #endif
 


### PR DESCRIPTION
When building wlroots for an embedded Linux (hobby) project with Wayland only, I run into errors where `MESA_EGL_NO_X11_HEADERS` is redefined several times.

This PR simply adds a check if it is already defined, before defining it.