### PR TITLE
examples/layer-shell.c: check popup exists before drawing

### DIFF
--- a/examples/layer-shell.c
+++ b/examples/layer-shell.c
@@ -87,7 +87,9 @@ static void popup_surface_frame_callback(
 		void *data, struct wl_callback *cb, uint32_t time) {
 	wl_callback_destroy(cb);
 	popup_frame_callback = NULL;
-	draw_popup();
+	if (popup) {
+		draw_popup();
+	}
 }
 
 static struct wl_callback_listener popup_frame_listener = {


### PR DESCRIPTION
Fixes a crash that occasionally occurs if you start this example and right click around a lot, I assume due to the popup being destroyed between scheduling a draw frame and the actual drawing.