### PR TITLE
relative-pointer-v1: move pointer iteration in wlroots

### DIFF
--- a/include/wlr/types/wlr_relative_pointer_v1.h
+++ b/include/wlr/types/wlr_relative_pointer_v1.h
@@ -11,19 +11,16 @@
 
 #include <wayland-server.h>
 
-
 /**
  * This protocol specifies a set of interfaces used for making clients able to
  * receive relative pointer events not obstructed by barriers (such as the
  * monitor edge or pointer constraints).
  */
 
-
 /**
  * A global interface used for getting the relative pointer object for a given
  * pointer.
  */
-
 struct wlr_relative_pointer_manager_v1 {
 	struct wl_global *global;
 	struct wl_list resources; // wl_resource_get_link()
@@ -31,7 +28,7 @@ struct wlr_relative_pointer_manager_v1 {
 
 	struct {
 		struct wl_signal destroy;
-		struct wl_signal new_relative_pointer; //wlr_relative_pointer_v1
+		struct wl_signal new_relative_pointer; // wlr_relative_pointer_v1
 	} events;
 
 	struct wl_listener display_destroy_listener;
@@ -39,17 +36,15 @@ struct wlr_relative_pointer_manager_v1 {
 	void *data;
 };
 
-
 /**
  * A wp_relative_pointer object is an extension to the wl_pointer interface
  * used for emitting relative pointer events. It shares the same focus as
  * wl_pointer objects of the same seat and will only emit events when it has
  * focus.
  */
-
 struct wlr_relative_pointer_v1 {
 	struct wl_resource *resource;
-	struct wl_resource *pointer;
+	struct wl_resource *pointer_resource;
 	struct wlr_seat *seat;
 	struct wl_list link; // wlr_relative_pointer_manager_v1::relative_pointers
 
@@ -66,14 +61,15 @@ struct wlr_relative_pointer_v1 {
 struct wlr_relative_pointer_manager_v1 *wlr_relative_pointer_manager_v1_create(
 	struct wl_display *display);
 void wlr_relative_pointer_manager_v1_destroy(
-	struct wlr_relative_pointer_manager_v1 *relative_pointer_manager);
+	struct wlr_relative_pointer_manager_v1 *manager);
 
 /**
  * Send a relative motion event to the seat with the same wl_pointer as relative_pointer
  */
-void wlr_relative_pointer_v1_send_relative_motion(
-	struct wlr_relative_pointer_v1 *relative_pointer, uint64_t time_msec,
-	double dx, double dy, double dx_unaccel, double dy_unaccel);
+void wlr_relative_pointer_manager_v1_send_relative_motion(
+	struct wlr_relative_pointer_manager_v1 *manager, struct wlr_seat *seat,
+	uint64_t time_msec, double dx, double dy,
+	double dx_unaccel, double dy_unaccel);
 
 struct wlr_relative_pointer_v1 *wlr_relative_pointer_v1_from_resource(
 	struct wl_resource *resource);


### PR DESCRIPTION
This makes sure we always send events to the right client.