### PR TITLE
Simplify FreeBSD build

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -1,64 +1,26 @@
 image: freebsd
 packages:
-- devel/automake
-- multimedia/ffmpeg
-- devel/gmake
-- devel/json-c
-- devel/libtool
-- x11/libxkbcommon
-- textproc/libxslt
-- x11-toolkits/pango
+- devel/evdev-proto
+- devel/libepoll-shim
+- devel/libudev-devd
+- devel/meson # implies ninja
 - devel/pkgconf
-- print/texinfo
-- x11/xcb-util-image
+- graphics/libdrm
+- graphics/mesa-libs
+- graphics/png
+- graphics/wayland
+- graphics/wayland-protocols
+- multimedia/ffmpeg
+- x11/libX11
+- x11/libinput
+- x11/libxcb
+- x11/libxkbcommon
+- x11/pixman
+# - x11/xcb-util-errors # too recent, not in /quarterly
 - x11/xcb-util-wm
-- python36
-- py36-setuptools
 sources:
 - https://github.com/swaywm/wlroots
 tasks:
-- setup: |
-    # Don't build unnecessary stuff
-    echo "OPTIONS_UNSET+= NLS DOCS EXAMPLES LIBWACOM" | sudo tee -a /etc/make.conf
-    # Note: this could probably be set in the FreeBSD base image
-    echo "BATCH=yes" | sudo tee -a /etc/make.conf
-- ports_tree: |
-    # This is ugly, but fetching and extracting the whole ports tree takes a
-    # really-really long time...
-    # First we need a clean tree, and renaming is faster than deleting.
-    sudo mv /usr/ports /usr/ports.orig
-    sudo mkdir /usr/ports
-    # Fetch only needed ports
-    sudo svnlite export --force https://svn.FreeBSD.org/ports/head/GIDs /usr/ports/GIDs
-    sudo svnlite export --force https://svn.FreeBSD.org/ports/head/Keywords /usr/ports/Keywords
-    sudo svnlite export --force https://svn.FreeBSD.org/ports/head/Makefile /usr/ports/Makefile
-    sudo svnlite export --force https://svn.FreeBSD.org/ports/head/Mk /usr/ports/Mk
-    sudo svnlite export --force https://svn.FreeBSD.org/ports/head/Templates /usr/ports/Templates
-    sudo svnlite export --force https://svn.FreeBSD.org/ports/head/Tools /usr/ports/Tools
-    sudo svnlite export --force https://svn.FreeBSD.org/ports/head/UIDs /usr/ports/UIDs
-    sudo svnlite export --force https://svn.FreeBSD.org/ports/head/devel/libevdev /usr/ports/devel/libevdev
-    sudo svnlite export --force https://svn.FreeBSD.org/ports/head/devel/libmtdev /usr/ports/devel/libmtdev
-    sudo svnlite export --force https://svn.FreeBSD.org/ports/head/devel/libudev-devd /usr/ports/devel/libudev-devd
-    sudo svnlite export --force https://svn.FreeBSD.org/ports/head/devel/meson /usr/ports/devel/meson
-    sudo svnlite export --force https://svn.FreeBSD.org/ports/head/devel/ninja /usr/ports/devel/ninja
-    sudo svnlite export --force https://svn.FreeBSD.org/ports/head/devel/py-evdev /usr/ports/devel/py-evdev
-    sudo svnlite export --force https://svn.FreeBSD.org/ports/head/devel/py-six /usr/ports/devel/py-six
-    sudo svnlite export --force https://svn.FreeBSD.org/ports/head/graphics/wayland-protocols /usr/ports/graphics/wayland-protocols
-    sudo svnlite export --force https://svn.FreeBSD.org/ports/head/graphics/wayland /usr/ports/graphics/wayland
-    sudo svnlite export --force https://svn.FreeBSD.org/ports/head/lang/python27 /usr/ports/lang/python27
-    sudo svnlite export --force https://svn.FreeBSD.org/ports/head/lang/python36 /usr/ports/lang/python36
-- fixup_libinput: |
-    sudo svnlite export https://github.com/FreeBSDDesktop/freebsd-ports/branches/feature/input/devel/libepoll-shim /usr/ports/devel/libepoll-shim
-    sudo svnlite export https://github.com/FreeBSDDesktop/freebsd-ports/branches/feature/input/x11/libinput /usr/ports/x11/libinput
-    sudo svnlite export https://github.com/FreeBSDDesktop/freebsd-ports/branches/feature/input/devel/evdev-proto /usr/ports/devel/evdev-proto
-    sudo svnlite export https://github.com/FreeBSDDesktop/freebsd-ports/branches/feature/input/devel/py-pyudev /usr/ports/devel/py-pyudev
-- ports_build: |
-    # v4l_compat is a dependency of libinput, but the version in the ports tree
-    # conflicts with the new evdev-proto. It can be safely removed though.
-    sudo pkg remove -fy v4l_compat
-    cd /usr/ports/devel/evdev-proto && sudo make install clean
-    cd /usr/ports/graphics/wayland-protocols/ && sudo make install
-    cd /usr/ports/x11/libinput/ && sudo make install clean
 - fixup_epoll: |
     cat << 'EOF' | sudo tee /usr/local/libdata/pkgconfig/epoll-shim.pc
     prefix=/usr/local
@@ -70,7 +32,8 @@ tasks:
     Description: epoll shim implemented using kevent
     Version: 0
     Requires:
-    Libs: -L${libdir} -L${sharedlibdir} -lepoll-shim -lthr
+    Libs: -L${libdir} -L${sharedlibdir} -lepoll-shim
+    Libs.private: -pthread -lrt
     Cflags: -I${includedir}
     EOF
 - wlroots: |

--- a/backend/session/direct-freebsd.c
+++ b/backend/session/direct-freebsd.c
@@ -1,5 +1,5 @@
 #include <assert.h>
-#include <dev/evdev/input.h>
+#include <linux/input.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <signal.h>

--- a/backend/session/direct-ipc.c
+++ b/backend/session/direct-ipc.c
@@ -1,7 +1,7 @@
 #define _POSIX_C_SOURCE 200809L
 #ifdef __FreeBSD__
 #define __BSD_VISIBLE 1
-#include <dev/evdev/input.h>
+#include <linux/input.h>
 #endif
 #include <errno.h>
 #include <fcntl.h>

--- a/backend/x11/input_device.c
+++ b/backend/x11/input_device.c
@@ -2,11 +2,7 @@
 
 #include <wlr/config.h>
 
-#ifdef __linux__
 #include <linux/input-event-codes.h>
-#elif __FreeBSD__
-#include <dev/evdev/input-event-codes.h>
-#endif
 
 #include <xcb/xcb.h>
 #include <xcb/xfixes.h>

--- a/examples/idle-inhibit.c
+++ b/examples/idle-inhibit.c
@@ -8,11 +8,7 @@
 #include "idle-inhibit-unstable-v1-client-protocol.h"
 #include "xdg-shell-client-protocol.h"
 
-#ifdef __linux__
 #include <linux/input-event-codes.h>
-#elif __FreeBSD__
-#include <dev/evdev/input-event-codes.h>
-#endif
 
 /**
  * Usage: idle-inhibit

--- a/examples/layer-shell.c
+++ b/examples/layer-shell.c
@@ -1,9 +1,5 @@
 #define _POSIX_C_SOURCE 200112L
-#ifdef __linux__
 #include <linux/input-event-codes.h>
-#elif __FreeBSD__
-#include <dev/evdev/input-event-codes.h>
-#endif
 #include <assert.h>
 #include <GLES2/gl2.h>
 #include <limits.h>

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -7,11 +7,7 @@
 #include <wlr/util/edges.h>
 #include <wlr/util/log.h>
 #include <wlr/util/region.h>
-#ifdef __linux__
 #include <linux/input-event-codes.h>
-#elif __FreeBSD__
-#include <dev/evdev/input-event-codes.h>
-#endif
 #include "rootston/cursor.h"
 #include "rootston/desktop.h"
 #include "rootston/view.h"


### PR DESCRIPTION
FreeBSD Ports recently updated libinput et al. which is now in both `/latest` and `/quarterly` package sets. `epoll-shim.pc` is still missing, so I've filed https://github.com/FreeBSDDesktop/epoll-shim/pull/1