### PR TITLE
Fix a few typos

### DIFF
--- a/tinywl/tinywl.c
+++ b/tinywl/tinywl.c
@@ -475,7 +475,7 @@ static void server_cursor_button(struct wl_listener *listener, void *data) {
 	struct tinywl_server *server =
 		wl_container_of(listener, server, cursor_button);
 	struct wlr_event_pointer_button *event = data;
-	/* Notify the client with pointer focus that a button press has occured */
+	/* Notify the client with pointer focus that a button press has occurred */
 	wlr_seat_pointer_notify_button(server->seat,
 			event->time_msec, event->button, event->state);
 	double sx, sy;
@@ -552,7 +552,7 @@ static void render_surface(struct wlr_surface *surface,
 	 * Those familiar with OpenGL are also familiar with the role of matricies
 	 * in graphics programming. We need to prepare a matrix to render the view
 	 * with. wlr_matrix_project_box is a helper which takes a box with a desired
-	 * x, y coodrinates, width and height, and an output geometry, then
+	 * x, y coordinates, width and height, and an output geometry, then
 	 * prepares an orthographic projection and multiplies the necessary
 	 * transforms to produce a model-view-projection matrix.
 	 *
@@ -717,7 +717,7 @@ static void xdg_toplevel_request_move(
 	 * move, typically because the user clicked on their client-side
 	 * decorations. Note that a more sophisticated compositor should check the
 	 * provied serial against a list of button press serials sent to this
-	 * client, to prevent the client from requesting this whenver they want. */
+	 * client, to prevent the client from requesting this whenever they want. */
 	struct tinywl_view *view = wl_container_of(listener, view, request_move);
 	begin_interactive(view, TINYWL_CURSOR_MOVE, 0);
 }
@@ -728,7 +728,7 @@ static void xdg_toplevel_request_resize(
 	 * resize, typically because the user clicked on their client-side
 	 * decorations. Note that a more sophisticated compositor should check the
 	 * provied serial against a list of button press serials sent to this
-	 * client, to prevent the client from requesting this whenver they want. */
+	 * client, to prevent the client from requesting this whenever they want. */
 	struct wlr_xdg_toplevel_resize_event *event = data;
 	struct tinywl_view *view = wl_container_of(listener, view, request_resize);
 	begin_interactive(view, TINYWL_CURSOR_RESIZE, event->edges);

--- a/types/tablet_v2/wlr_tablet_v2.c
+++ b/types/tablet_v2/wlr_tablet_v2.c
@@ -196,7 +196,7 @@ static void get_tablet_seat(struct wl_client *wl_client, struct wl_resource *res
 	wl_list_insert(&manager->tablet_seats, &seat_client->client_link);
 	wl_list_insert(&tablet_seat->clients, &seat_client->seat_link);
 
-	// We need to emit the devices allready on the seat
+	// We need to emit the devices already on the seat
 	struct wlr_tablet_v2_tablet *tablet_pos;
 	wl_list_for_each(tablet_pos, &tablet_seat->tablets, link) {
 		add_tablet_client(seat_client, tablet_pos);

--- a/types/tablet_v2/wlr_tablet_v2_tool.c
+++ b/types/tablet_v2/wlr_tablet_v2_tool.c
@@ -124,17 +124,17 @@ void add_tablet_tool_client(struct wlr_tablet_seat_client_v2 *seat,
 	// Send the expected events
 	if (tool->wlr_tool->hardware_serial) {
 			zwp_tablet_tool_v2_send_hardware_serial(
-			client->resource, 
+			client->resource,
 			tool->wlr_tool->hardware_serial >> 32,
 			tool->wlr_tool->hardware_serial & 0xFFFFFFFF);
 	}
 	if (tool->wlr_tool->hardware_wacom) {
 			zwp_tablet_tool_v2_send_hardware_id_wacom(
-			client->resource, 
+			client->resource,
 			tool->wlr_tool->hardware_wacom >> 32,
 			tool->wlr_tool->hardware_wacom & 0xFFFFFFFF);
 	}
-	zwp_tablet_tool_v2_send_type(client->resource, 
+	zwp_tablet_tool_v2_send_type(client->resource,
 		tablet_type_from_wlr_type(tool->wlr_tool->type));
 
 	if (tool->wlr_tool->tilt) {
@@ -264,8 +264,10 @@ static ssize_t tablet_tool_button_update(struct wlr_tablet_v2_tablet_tool *tool,
 			tool->pressed_serials[i] = -1;
 		} else {
 			i = -1;
-			wlr_log(WLR_ERROR, "You pressed more than %d tablet tool buttons. This is currently not supporte by wlroots. Please report this with a description of your tablet, since this is either a bug, or fancy hardware",
-			        WLR_TABLET_V2_TOOL_BUTTONS_CAP);
+			wlr_log(WLR_ERROR, "You pressed more than %d tablet tool buttons. "
+				"This is currently not supported by wlroots. Please report this "
+				"with a description of your tablet, since this is either a "
+				"bug, or fancy hardware", WLR_TABLET_V2_TOOL_BUTTONS_CAP);
 		}
 	}
 	if (state == ZWP_TABLET_PAD_V2_BUTTON_STATE_RELEASED && found) {


### PR DESCRIPTION
Found with `codespell --quiet-level=3`