### PR TITLE
Fix software cursor rendering for tinywl and some examples

### DIFF
--- a/examples/multi-pointer.c
+++ b/examples/multi-pointer.c
@@ -100,6 +100,7 @@ void output_frame_notify(struct wl_listener *listener, void *data) {
 		sample->clear_color[2], sample->clear_color[3]);
 	glClear(GL_COLOR_BUFFER_BIT);
 
+	wlr_output_render_software_cursors(wlr_output, NULL);
 	wlr_output_swap_buffers(wlr_output, NULL, NULL);
 }
 

--- a/examples/pointer.c
+++ b/examples/pointer.c
@@ -101,6 +101,7 @@ void output_frame_notify(struct wl_listener *listener, void *data) {
 	wlr_output_make_current(wlr_output, NULL);
 	wlr_renderer_begin(renderer, wlr_output->width, wlr_output->height);
 	wlr_renderer_clear(renderer, state->clear_color);
+	wlr_output_render_software_cursors(wlr_output, NULL);
 	wlr_output_swap_buffers(wlr_output, NULL, NULL);
 	wlr_renderer_end(renderer);
 }

--- a/tinywl/tinywl.c
+++ b/tinywl/tinywl.c
@@ -610,6 +610,14 @@ static void output_frame(struct wl_listener *listener, void *data) {
 				render_surface, &rdata);
 	}
 
+	/* Hardware cursors are rendered by the GPU on a separate plane, and can be
+	 * moved around without re-rendering what's beneath them - which is more
+	 * efficient. However, not all hardware supports hardware cursors. For this
+	 * reason, wlroots provides a software fallback, which we ask it to render
+	 * here. wlr_cursor handles configuring hardware vs software cursors for you,
+	 * and this function is a no-op when hardware cursors are in use. */
+	wlr_output_render_software_cursors(output->wlr_output, NULL);
+
 	/* Conclude rendering and swap the buffers, showing the final frame
 	 * on-screen. */
 	wlr_renderer_end(renderer);


### PR DESCRIPTION
Since #1366 was merged, a call to ``wlr_output_render_software_cursors`` is needed to render software cursors. This PR adds a call to that function for:
- examples/pointer
- examples/multi-pointer
- tinywl

I think that's all of them, but let me know if I missed one.