### PR TITLE
Fix segfault in get_relative_pointer

### DIFF
--- a/types/wlr_relative_pointer_v1.c
+++ b/types/wlr_relative_pointer_v1.c
@@ -42,6 +42,7 @@ static void relative_pointer_destroy(struct wlr_relative_pointer_v1 *relative_po
 
 	wl_list_remove(&relative_pointer->link);
 	wl_list_remove(&relative_pointer->seat_destroy.link);
+	wl_list_remove(&relative_pointer->pointer_destroy.link);
 
 	wl_resource_set_user_data(relative_pointer->resource, NULL);
 	free(relative_pointer);


### PR DESCRIPTION
Occurs on subsequent calls to
relative_pointer_manager_v1_handle_get_relative_pointer()

Steps to reproduce:
- run rootston
- run examples/relative-pointer
- switch to relative pointer more than once

Note: if done fast enough it may take more than two switches to crash.