### PR TITLE
backend/drm: fix state for outputs loosing their CRTC

### DIFF
--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -173,8 +173,12 @@ bool wlr_output_set_custom_mode(struct wlr_output *output, int32_t width,
 void wlr_output_update_mode(struct wlr_output *output,
 		struct wlr_output_mode *mode) {
 	output->current_mode = mode;
-	wlr_output_update_custom_mode(output, mode->width, mode->height,
-		mode->refresh);
+	if (mode != NULL) {
+		wlr_output_update_custom_mode(output, mode->width, mode->height,
+			mode->refresh);
+	} else {
+		wlr_output_update_custom_mode(output, 0, 0, 0);
+	}
 }
 
 void wlr_output_update_custom_mode(struct wlr_output *output, int32_t width,


### PR DESCRIPTION
When there aren't enough CRTCs for all outputs, we try to move a CRTC from a
disabled output to an enabled one. When this happens, the old output's state
wasn't changed, so the compositor thought it was still enabled and rendering.

This commit marks the old output as WLR_DRM_CONN_NEEDS_MODESET and sets its
current mode to NULL.