### PR TITLE
Add wlr_x11_output_set_title

### DIFF
--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -187,9 +187,7 @@ struct wlr_output *wlr_x11_output_create(struct wlr_backend *backend) {
 
 	char title[32];
 	if (snprintf(title, sizeof(title), "wlroots - %s", wlr_output->name)) {
-		xcb_change_property(x11->xcb, XCB_PROP_MODE_REPLACE, output->win,
-			x11->atoms.net_wm_name, x11->atoms.utf8_string, 8,
-			strlen(title), title);
+		wlr_x11_output_set_title(wlr_output, title);
 	}
 
 	xcb_map_window(x11->xcb, output->win);
@@ -233,4 +231,12 @@ void handle_x11_configure_notify(struct wlr_x11_output *output,
 
 bool wlr_output_is_x11(struct wlr_output *wlr_output) {
 	return wlr_output->impl == &output_impl;
+}
+
+void wlr_x11_output_set_title(struct wlr_output *output, const char *title) {
+	struct wlr_x11_output *x11_output = get_x11_output_from_output(output);
+
+	xcb_change_property(x11_output->x11->xcb, XCB_PROP_MODE_REPLACE, x11_output->win,
+		x11_output->x11->atoms.net_wm_name, x11_output->x11->atoms.utf8_string, 8,
+		strlen(title), title);
 }

--- a/include/wlr/backend/x11.h
+++ b/include/wlr/backend/x11.h
@@ -42,4 +42,9 @@ bool wlr_input_device_is_x11(struct wlr_input_device *device);
  */
 bool wlr_output_is_x11(struct wlr_output *output);
 
+/**
+ * Sets the title of a wlr_output which is an X11 window.
+ */
+void wlr_x11_output_set_title(struct wlr_output *output, const char *title);
+
 #endif

--- a/include/wlr/backend/x11.h
+++ b/include/wlr/backend/x11.h
@@ -9,12 +9,37 @@
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_output.h>
 
+/**
+ * Creates a new wlr_x11_backend. This backend will be created with no outputs;
+ * you must use wlr_x11_output_create to add them.
+ *
+ * The `x11_display` argument is the name of the X Display socket. Set
+ * to NULL for the default behaviour of XOpenDisplay.
+ */
 struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
 	const char *x11_display, wlr_renderer_create_func_t create_renderer_func);
+
+/**
+ * Adds a new output to this backend. You may remove outputs by destroying them.
+ * Note that if called before initializing the backend, this will return NULL
+ * and your outputs will be created during initialization (and given to you via
+ * the output_add signal).
+ */
 struct wlr_output *wlr_x11_output_create(struct wlr_backend *backend);
 
+/**
+ * True if the given backend is a wlr_x11_backend.
+ */
 bool wlr_backend_is_x11(struct wlr_backend *backend);
+
+/**
+ * True if the given input device is a wlr_x11_input_device.
+ */
 bool wlr_input_device_is_x11(struct wlr_input_device *device);
+
+/**
+ * True if the given output is a wlr_x11_output.
+ */
 bool wlr_output_is_x11(struct wlr_output *output);
 
 #endif


### PR DESCRIPTION
This brings the X11 backend in line with the Wayland backend. I can imagine it's useful here too :) I tested this in Cage.