### PR TITLE
primary-selection: add a serial argument

### DIFF
--- a/include/wlr/types/wlr_data_device.h
+++ b/include/wlr/types/wlr_data_device.h
@@ -166,8 +166,10 @@ void wlr_data_device_manager_destroy(struct wlr_data_device_manager *manager);
 void wlr_seat_client_send_selection(struct wlr_seat_client *seat_client);
 
 /**
- * Sets the current selection for the seat. This removes the previous one if
- * there was any.
+ * Sets the current selection for the seat. NULL can be provided to clear it.
+ * This removes the previous one if there was any. In case the selection doesn't
+ * come from a client, wl_display_next_serial() can be used to generate a
+ * serial.
  */
 void wlr_seat_set_selection(struct wlr_seat *seat,
 	struct wlr_data_source *source, uint32_t serial);

--- a/include/wlr/types/wlr_gtk_primary_selection.h
+++ b/include/wlr/types/wlr_gtk_primary_selection.h
@@ -36,7 +36,6 @@ struct wlr_gtk_primary_selection_device {
 	struct wl_list resources; // wl_resource_get_link
 
 	struct wl_list offers; // wl_resource_get_link
-	uint32_t selection_serial;
 
 	struct wl_listener seat_destroy;
 	struct wl_listener seat_focus_change;

--- a/include/wlr/types/wlr_primary_selection.h
+++ b/include/wlr/types/wlr_primary_selection.h
@@ -48,7 +48,13 @@ void wlr_primary_selection_source_send(
 	struct wlr_primary_selection_source *source, const char *mime_type,
 	int fd);
 
+/**
+ * Sets the current primary selection for the seat. NULL can be provided to
+ * clear it. This removes the previous one if there was any. In case the
+ * selection doesn't come from a client, wl_display_next_serial() can be used to
+ * generate a serial.
+ */
 void wlr_seat_set_primary_selection(struct wlr_seat *seat,
-	struct wlr_primary_selection_source *source);
+	struct wlr_primary_selection_source *source, uint32_t serial);
 
 #endif

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -200,6 +200,7 @@ struct wlr_seat {
 	uint32_t selection_serial;
 
 	struct wlr_primary_selection_source *primary_selection_source;
+	uint32_t primary_selection_serial;
 
 	// `drag` goes away before `drag_source`, when the implicit grab ends
 	struct wlr_drag *drag;

--- a/types/seat/wlr_seat.c
+++ b/types/seat/wlr_seat.c
@@ -163,7 +163,8 @@ void wlr_seat_destroy(struct wlr_seat *seat) {
 		seat->selection_source = NULL;
 	}
 
-	wlr_seat_set_primary_selection(seat, NULL);
+	wlr_seat_set_primary_selection(seat, NULL,
+		wl_display_next_serial(seat->display));
 
 	struct wlr_seat_client *client, *tmp;
 	wl_list_for_each_safe(client, tmp, &seat->clients, link) {

--- a/types/wlr_gtk_primary_selection.c
+++ b/types/wlr_gtk_primary_selection.c
@@ -208,16 +208,7 @@ static void device_handle_set_selection(struct wl_client *client,
 		source = &client_source->source;
 	}
 
-	// TODO: improve serial validation
-	if (device->seat->primary_selection_source != NULL &&
-			device->selection_serial - serial < UINT32_MAX / 2) {
-		wlr_log(WLR_DEBUG, "Rejecting set_selection request, invalid serial "
-			"(%"PRIu32" <= %"PRIu32")", serial, device->selection_serial);
-		return;
-	}
-	device->selection_serial = serial;
-
-	wlr_seat_set_primary_selection(device->seat, source);
+	wlr_seat_set_primary_selection(device->seat, source, serial);
 }
 
 static void device_handle_destroy(struct wl_client *client,

--- a/xwayland/selection/incoming.c
+++ b/xwayland/selection/incoming.c
@@ -370,7 +370,8 @@ static void xwm_selection_get_targets(struct wlr_xwm_selection *selection) {
 		bool ok = source_get_targets(selection, &source->base.mime_types,
 			&source->mime_types_atoms);
 		if (ok) {
-			wlr_seat_set_primary_selection(xwm->seat, &source->base);
+			wlr_seat_set_primary_selection(xwm->seat, &source->base,
+				wl_display_next_serial(xwm->xwayland->wl_display));
 		} else {
 			wlr_primary_selection_source_destroy(&source->base);
 		}
@@ -427,7 +428,8 @@ int xwm_handle_xfixes_selection_notify(struct wlr_xwm *xwm,
 				wlr_seat_set_selection(xwm->seat, NULL,
 					wl_display_next_serial(xwm->xwayland->wl_display));
 			} else if (selection == &xwm->primary_selection) {
-				wlr_seat_set_primary_selection(xwm->seat, NULL);
+				wlr_seat_set_primary_selection(xwm->seat, NULL,
+					wl_display_next_serial(xwm->xwayland->wl_display));
 			} else if (selection == &xwm->dnd_selection) {
 				// TODO: DND
 			} else {

--- a/xwayland/selection/selection.c
+++ b/xwayland/selection/selection.c
@@ -231,7 +231,8 @@ void xwm_selection_finish(struct wlr_xwm *xwm) {
 		if (xwm->seat->primary_selection_source &&
 				primary_selection_source_is_xwayland(
 					xwm->seat->primary_selection_source)) {
-			wlr_seat_set_primary_selection(xwm->seat, NULL);
+			wlr_seat_set_primary_selection(xwm->seat, NULL,
+				wl_display_next_serial(xwm->xwayland->wl_display));
 		}
 		wlr_xwayland_set_seat(xwm->xwayland, NULL);
 	}


### PR DESCRIPTION
The serial needs to be bumped when X11 clients set the selection, otherwise
some Wayland clients (e.g. GTK) will overwrite it when they gain focus.

For instance, copy from a GTK app will send `set_selection(serial=42, source)`, then immediately `set_selection(serial=42, NULL)`. If another app is focused and then the GTK app is focused again, GTK will send `set_selection(serial=42, NULL)` again. If X11 has updated the selection in the meantime, this will clear it (and shouldn't).

This isn't a GTK bug, that's how the Wayland protocol works. However this is silly behaviour from GTK.