### PR TITLE
wlr_xdg_output_v1: only send name/description once

### DIFF
--- a/types/wlr_xdg_output_v1.c
+++ b/types/wlr_xdg_output_v1.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <wlr/types/wlr_output_layout.h>
@@ -24,7 +25,7 @@ static void output_handle_resource_destroy(struct wl_resource *resource) {
 }
 
 static void output_send_details(struct wlr_xdg_output_v1 *xdg_output,
-		struct wl_resource *resource) {
+		struct wl_resource *resource, bool updated) {
 	struct wlr_output *output = xdg_output->layout_output->output;
 
 	zxdg_output_v1_send_logical_position(resource,
@@ -32,15 +33,18 @@ static void output_send_details(struct wlr_xdg_output_v1 *xdg_output,
 	zxdg_output_v1_send_logical_size(resource,
 		xdg_output->width, xdg_output->height);
 
-	uint32_t version = wl_resource_get_version(resource);
-	if (version >= ZXDG_OUTPUT_V1_NAME_SINCE_VERSION) {
-		zxdg_output_v1_send_name(resource, output->name);
-	}
-	if (version >= ZXDG_OUTPUT_V1_DESCRIPTION_SINCE_VERSION) {
-		char description[128];
-		snprintf(description, sizeof(description), "%s %s %s (%s)",
-			output->make, output->model, output->serial, output->name);
-		zxdg_output_v1_send_description(resource, description);
+	if (!updated) {
+		// Name and description should only be sent once per output
+		uint32_t version = wl_resource_get_version(resource);
+		if (version >= ZXDG_OUTPUT_V1_NAME_SINCE_VERSION) {
+			zxdg_output_v1_send_name(resource, output->name);
+		}
+		if (version >= ZXDG_OUTPUT_V1_DESCRIPTION_SINCE_VERSION) {
+			char description[128];
+			snprintf(description, sizeof(description), "%s %s %s (%s)",
+				output->make, output->model, output->serial, output->name);
+			zxdg_output_v1_send_description(resource, description);
+		}
 	}
 
 	zxdg_output_v1_send_done(resource);
@@ -67,7 +71,7 @@ static void output_update(struct wlr_xdg_output_v1 *xdg_output) {
 	if (updated) {
 		struct wl_resource *resource;
 		wl_resource_for_each(resource, &xdg_output->resources) {
-			output_send_details(xdg_output, resource);
+			output_send_details(xdg_output, resource, true);
 		}
 	}
 }
@@ -128,7 +132,7 @@ static void output_manager_handle_get_xdg_output(struct wl_client *client,
 	wl_list_insert(&xdg_output->resources,
 		wl_resource_get_link(xdg_output_resource));
 
-	output_send_details(xdg_output, xdg_output_resource);
+	output_send_details(xdg_output, xdg_output_resource, false);
 }
 
 static const struct zxdg_output_manager_v1_interface


### PR DESCRIPTION
The xdg-output protocol states that name and description should only be
sent once per output since they do not change.

This fixes a SIGABRT in swaybg when resizing an output on the x11 and
wayland backends.