### PR TITLE
backend/x11 & backend/wayland: make set_title NULL-safe

### DIFF
--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -314,10 +314,7 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *wlr_backend) {
 		goto error;
 	}
 
-	char title[32];
-	if (snprintf(title, sizeof(title), "wlroots - %s", wlr_output->name)) {
-		xdg_toplevel_set_title(output->xdg_toplevel, title);
-	}
+	wlr_wl_output_set_title(wlr_output, NULL);
 
 	xdg_toplevel_set_app_id(output->xdg_toplevel, "wlroots");
 	xdg_surface_add_listener(output->xdg_surface,
@@ -369,5 +366,14 @@ error:
 
 void wlr_wl_output_set_title(struct wlr_output *output, const char *title) {
 	struct wlr_wl_output *wl_output = get_wl_output_from_output(output);
+
+	char wl_title[32];
+	if (title == NULL) {
+		if (snprintf(wl_title, sizeof(wl_title), "wlroots - %s", output->name) <= 0) {
+			return;
+		}
+		title = wl_title;
+	}
+
 	xdg_toplevel_set_title(wl_output->xdg_toplevel, title);
 }

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -185,10 +185,7 @@ struct wlr_output *wlr_x11_output_create(struct wlr_backend *backend) {
 		x11->atoms.wm_protocols, XCB_ATOM_ATOM, 32, 1,
 		&x11->atoms.wm_delete_window);
 
-	char title[32];
-	if (snprintf(title, sizeof(title), "wlroots - %s", wlr_output->name)) {
-		wlr_x11_output_set_title(wlr_output, title);
-	}
+	wlr_x11_output_set_title(wlr_output, NULL);
 
 	xcb_map_window(x11->xcb, output->win);
 	xcb_flush(x11->xcb);
@@ -235,6 +232,14 @@ bool wlr_output_is_x11(struct wlr_output *wlr_output) {
 
 void wlr_x11_output_set_title(struct wlr_output *output, const char *title) {
 	struct wlr_x11_output *x11_output = get_x11_output_from_output(output);
+
+	char wl_title[32];
+	if (title == NULL) {
+		if (snprintf(wl_title, sizeof(wl_title), "wlroots - %s", output->name) <= 0) {
+			return;
+		}
+		title = wl_title;
+	}
 
 	xcb_change_property(x11_output->x11->xcb, XCB_PROP_MODE_REPLACE, x11_output->win,
 		x11_output->x11->atoms.net_wm_name, x11_output->x11->atoms.utf8_string, 8,


### PR DESCRIPTION
Set the default "wlroots - " title when the title argument to the set_title functions is NULL. Otherwise, for at least the Wayland backend, we'd crash because xdg_toplevel_set_title doesn't handle a NULL pointer.