### PR TITLE
Set .editorconfig ident_size

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,8 +4,9 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 charset = utf-8
-indent_style = tab
 trim_trailing_whitespace = true
+indent_style = tab
+indent_size = 4
 
 [*.xml]
 indent_style = space


### PR DESCRIPTION
Useful for 80-char limit.