### PR TITLE
pointer: add a frame event

### DIFF
--- a/backend/libinput/pointer.c
+++ b/backend/libinput/pointer.c
@@ -39,6 +39,7 @@ void handle_pointer_motion(struct libinput_event *event,
 	wlr_event.unaccel_dx = libinput_event_pointer_get_dx_unaccelerated(pevent);
 	wlr_event.unaccel_dy = libinput_event_pointer_get_dy_unaccelerated(pevent);
 	wlr_signal_emit_safe(&wlr_dev->pointer->events.motion, &wlr_event);
+	wlr_signal_emit_safe(&wlr_dev->pointer->events.frame, wlr_dev->pointer);
 }
 
 void handle_pointer_motion_abs(struct libinput_event *event,
@@ -58,6 +59,7 @@ void handle_pointer_motion_abs(struct libinput_event *event,
 	wlr_event.x = libinput_event_pointer_get_absolute_x_transformed(pevent, 1);
 	wlr_event.y = libinput_event_pointer_get_absolute_y_transformed(pevent, 1);
 	wlr_signal_emit_safe(&wlr_dev->pointer->events.motion_absolute, &wlr_event);
+	wlr_signal_emit_safe(&wlr_dev->pointer->events.frame, wlr_dev->pointer);
 }
 
 void handle_pointer_button(struct libinput_event *event,
@@ -84,6 +86,7 @@ void handle_pointer_button(struct libinput_event *event,
 		break;
 	}
 	wlr_signal_emit_safe(&wlr_dev->pointer->events.button, &wlr_event);
+	wlr_signal_emit_safe(&wlr_dev->pointer->events.frame, wlr_dev->pointer);
 }
 
 void handle_pointer_axis(struct libinput_event *event,
@@ -114,13 +117,13 @@ void handle_pointer_axis(struct libinput_event *event,
 		wlr_event.source = WLR_AXIS_SOURCE_WHEEL_TILT;
 		break;
 	}
-	enum libinput_pointer_axis axies[] = {
+	const enum libinput_pointer_axis axes[] = {
 		LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL,
 		LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL,
 	};
-	for (size_t i = 0; i < sizeof(axies) / sizeof(axies[0]); ++i) {
-		if (libinput_event_pointer_has_axis(pevent, axies[i])) {
-			switch (axies[i]) {
+	for (size_t i = 0; i < sizeof(axes) / sizeof(axes[0]); ++i) {
+		if (libinput_event_pointer_has_axis(pevent, axes[i])) {
+			switch (axes[i]) {
 			case LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL:
 				wlr_event.orientation = WLR_AXIS_ORIENTATION_VERTICAL;
 				break;
@@ -129,10 +132,11 @@ void handle_pointer_axis(struct libinput_event *event,
 				break;
 			}
 			wlr_event.delta =
-				libinput_event_pointer_get_axis_value(pevent, axies[i]);
+				libinput_event_pointer_get_axis_value(pevent, axes[i]);
 			wlr_event.delta_discrete =
-				libinput_event_pointer_get_axis_value_discrete(pevent, axies[i]);
+				libinput_event_pointer_get_axis_value_discrete(pevent, axes[i]);
 			wlr_signal_emit_safe(&wlr_dev->pointer->events.axis, &wlr_event);
 		}
 	}
+	wlr_signal_emit_safe(&wlr_dev->pointer->events.frame, wlr_dev->pointer);
 }

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -67,16 +67,13 @@ static void registry_global(void *data, struct wl_registry *registry,
 	if (strcmp(iface, wl_compositor_interface.name) == 0) {
 		wl->compositor = wl_registry_bind(registry, name,
 			&wl_compositor_interface, 4);
-
 	} else if (strcmp(iface, wl_seat_interface.name) == 0) {
 		wl->seat = wl_registry_bind(registry, name,
-			&wl_seat_interface, 2);
+			&wl_seat_interface, 5);
 		wl_seat_add_listener(wl->seat, &seat_listener, wl);
-
 	} else if (strcmp(iface, wl_shm_interface.name) == 0) {
 		wl->shm = wl_registry_bind(registry, name,
 			&wl_shm_interface, 1);
-
 	} else if (strcmp(iface, xdg_wm_base_interface.name) == 0) {
 		wl->xdg_wm_base = wl_registry_bind(registry, name,
 			&xdg_wm_base_interface, 1);

--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -126,7 +126,14 @@ static void pointer_handle_axis(void *data, struct wl_pointer *wl_pointer,
 }
 
 static void pointer_handle_frame(void *data, struct wl_pointer *wl_pointer) {
-	// This space is intentionally left blank
+	struct wlr_wl_backend *backend = data;
+	struct wlr_wl_pointer *pointer = backend->current_pointer;
+	if (pointer == NULL) {
+		return;
+	}
+
+	wlr_signal_emit_safe(&pointer->wlr_pointer.events.frame,
+		&pointer->wlr_pointer);
 }
 
 static void pointer_handle_axis_source(void *data,

--- a/backend/x11/input_device.c
+++ b/backend/x11/input_device.c
@@ -50,6 +50,7 @@ static void send_axis_event(struct wlr_x11_output *output, int32_t delta,
 		.delta_discrete = delta,
 	};
 	wlr_signal_emit_safe(&output->pointer.events.axis, &ev);
+	wlr_signal_emit_safe(&output->pointer.events.frame, &output->pointer);
 }
 
 static void send_pointer_position_event(struct wlr_x11_output *output,
@@ -61,6 +62,7 @@ static void send_pointer_position_event(struct wlr_x11_output *output,
 		.y = (double)y / output->wlr_output.height,
 	};
 	wlr_signal_emit_safe(&output->pointer.events.motion_absolute, &ev);
+	wlr_signal_emit_safe(&output->pointer.events.frame, &output->pointer);
 }
 
 void handle_x11_xinput_event(struct wlr_x11_backend *x11,

--- a/include/rootston/cursor.h
+++ b/include/rootston/cursor.h
@@ -38,6 +38,7 @@ struct roots_cursor {
 	struct wl_listener motion_absolute;
 	struct wl_listener button;
 	struct wl_listener axis;
+	struct wl_listener frame;
 
 	struct wl_listener touch_down;
 	struct wl_listener touch_up;
@@ -70,6 +71,8 @@ void roots_cursor_handle_button(struct roots_cursor *cursor,
 
 void roots_cursor_handle_axis(struct roots_cursor *cursor,
 	struct wlr_event_pointer_axis *event);
+
+void roots_cursor_handle_frame(struct roots_cursor *cursor);
 
 void roots_cursor_handle_touch_down(struct roots_cursor *cursor,
 	struct wlr_event_touch_down *event);

--- a/include/wlr/types/wlr_cursor.h
+++ b/include/wlr/types/wlr_cursor.h
@@ -51,6 +51,7 @@ struct wlr_cursor {
 		struct wl_signal motion_absolute;
 		struct wl_signal button;
 		struct wl_signal axis;
+		struct wl_signal frame;
 
 		struct wl_signal touch_up;
 		struct wl_signal touch_down;

--- a/include/wlr/types/wlr_pointer.h
+++ b/include/wlr/types/wlr_pointer.h
@@ -23,6 +23,7 @@ struct wlr_pointer {
 		struct wl_signal motion_absolute;
 		struct wl_signal button;
 		struct wl_signal axis;
+		struct wl_signal frame;
 	} events;
 
 	void *data;

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -68,6 +68,7 @@ struct wlr_pointer_grab_interface {
 	void (*axis)(struct wlr_seat_pointer_grab *grab, uint32_t time,
 			enum wlr_axis_orientation orientation, double value,
 			int32_t value_discrete, enum wlr_axis_source source);
+	void (*frame)(struct wlr_seat_pointer_grab *grab);
 	void (*cancel)(struct wlr_seat_pointer_grab *grab);
 };
 
@@ -349,6 +350,13 @@ void wlr_seat_pointer_send_axis(struct wlr_seat *wlr_seat, uint32_t time,
 		int32_t value_discrete, enum wlr_axis_source source);
 
 /**
+ * Send a frame event to the surface with pointer focus. Compositors should use
+ * `wlr_seat_pointer_notify_frame()` to send axis events to respect pointer
+ * grabs.
+ */
+void wlr_seat_pointer_send_frame(struct wlr_seat *wlr_seat);
+
+/**
  * Start a grab of the pointer of this seat. The grabber is responsible for
  * handling all pointer events until the grab ends.
  */
@@ -389,6 +397,13 @@ uint32_t wlr_seat_pointer_notify_button(struct wlr_seat *wlr_seat,
 void wlr_seat_pointer_notify_axis(struct wlr_seat *wlr_seat, uint32_t time,
 		enum wlr_axis_orientation orientation, double value,
 		int32_t value_discrete, enum wlr_axis_source source);
+
+/**
+ * Notify the seat of a frame event. Frame events are sent to end a group of
+ * events that logically belong together. Motion, button and axis events should
+ * all be followed by a frame event.
+ */
+void wlr_seat_pointer_notify_frame(struct wlr_seat *wlr_seat);
 
 /**
  * Whether or not the pointer has a grab other than the default grab.

--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -386,6 +386,10 @@ void roots_cursor_handle_axis(struct roots_cursor *cursor,
 		event->orientation, event->delta, event->delta_discrete, event->source);
 }
 
+void roots_cursor_handle_frame(struct roots_cursor *cursor) {
+	wlr_seat_pointer_notify_frame(cursor->seat->seat);
+}
+
 void roots_cursor_handle_touch_down(struct roots_cursor *cursor,
 		struct wlr_event_touch_down *event) {
 	struct roots_desktop *desktop = cursor->seat->input->server->desktop;

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -77,6 +77,14 @@ static void handle_cursor_axis(struct wl_listener *listener, void *data) {
 	roots_cursor_handle_axis(cursor, event);
 }
 
+static void handle_cursor_frame(struct wl_listener *listener, void *data) {
+	struct roots_cursor *cursor =
+		wl_container_of(listener, cursor, frame);
+	struct roots_desktop *desktop = cursor->seat->input->server->desktop;
+	wlr_idle_notify_activity(desktop->idle, cursor->seat->seat);
+	roots_cursor_handle_frame(cursor);
+}
+
 static void handle_switch_toggle(struct wl_listener *listener, void *data) {
 	struct roots_switch *lid_switch =
 		wl_container_of(listener, lid_switch, toggle);
@@ -442,6 +450,9 @@ static void roots_seat_init_cursor(struct roots_seat *seat) {
 
 	wl_signal_add(&wlr_cursor->events.axis, &seat->cursor->axis);
 	seat->cursor->axis.notify = handle_cursor_axis;
+
+	wl_signal_add(&wlr_cursor->events.frame, &seat->cursor->frame);
+	seat->cursor->frame.notify = handle_cursor_frame;
 
 	wl_signal_add(&wlr_cursor->events.touch_down, &seat->cursor->touch_down);
 	seat->cursor->touch_down.notify = handle_touch_down;

--- a/types/wlr_cursor.c
+++ b/types/wlr_cursor.c
@@ -21,6 +21,7 @@ struct wlr_cursor_device {
 	struct wl_listener motion_absolute;
 	struct wl_listener button;
 	struct wl_listener axis;
+	struct wl_listener frame;
 
 	struct wl_listener touch_down;
 	struct wl_listener touch_up;
@@ -81,6 +82,7 @@ struct wlr_cursor *wlr_cursor_create(void) {
 	wl_signal_init(&cur->events.motion_absolute);
 	wl_signal_init(&cur->events.button);
 	wl_signal_init(&cur->events.axis);
+	wl_signal_init(&cur->events.frame);
 
 	// touch signals
 	wl_signal_init(&cur->events.touch_up);
@@ -133,6 +135,7 @@ static void cursor_device_destroy(struct wlr_cursor_device *c_device) {
 		wl_list_remove(&c_device->motion_absolute.link);
 		wl_list_remove(&c_device->button.link);
 		wl_list_remove(&c_device->axis.link);
+		wl_list_remove(&c_device->frame.link);
 	} else if (dev->type == WLR_INPUT_DEVICE_TOUCH) {
 		wl_list_remove(&c_device->touch_down.link);
 		wl_list_remove(&c_device->touch_up.link);
@@ -415,6 +418,11 @@ static void handle_pointer_axis(struct wl_listener *listener, void *data) {
 	wlr_signal_emit_safe(&device->cursor->events.axis, event);
 }
 
+static void handle_pointer_frame(struct wl_listener *listener, void *data) {
+	struct wlr_cursor_device *device = wl_container_of(listener, device, frame);
+	wlr_signal_emit_safe(&device->cursor->events.frame, device->cursor);
+}
+
 static void handle_touch_up(struct wl_listener *listener, void *data) {
 	struct wlr_event_touch_up *event = data;
 	struct wlr_cursor_device *device;
@@ -538,6 +546,9 @@ static struct wlr_cursor_device *cursor_device_create(
 
 		wl_signal_add(&device->pointer->events.axis, &c_device->axis);
 		c_device->axis.notify = handle_pointer_axis;
+
+		wl_signal_add(&device->pointer->events.frame, &c_device->frame);
+		c_device->frame.notify = handle_pointer_frame;
 	} else if (device->type == WLR_INPUT_DEVICE_TOUCH) {
 		wl_signal_add(&device->touch->events.motion, &c_device->touch_motion);
 		c_device->touch_motion.notify = handle_touch_motion;

--- a/types/wlr_pointer.c
+++ b/types/wlr_pointer.c
@@ -11,6 +11,7 @@ void wlr_pointer_init(struct wlr_pointer *pointer,
 	wl_signal_init(&pointer->events.motion_absolute);
 	wl_signal_init(&pointer->events.button);
 	wl_signal_init(&pointer->events.axis);
+	wl_signal_init(&pointer->events.frame);
 }
 
 void wlr_pointer_destroy(struct wlr_pointer *pointer) {
@@ -20,10 +21,6 @@ void wlr_pointer_destroy(struct wlr_pointer *pointer) {
 	if (pointer->impl && pointer->impl->destroy) {
 		pointer->impl->destroy(pointer);
 	} else {
-		wl_list_remove(&pointer->events.motion.listener_list);
-		wl_list_remove(&pointer->events.motion_absolute.listener_list);
-		wl_list_remove(&pointer->events.button.listener_list);
-		wl_list_remove(&pointer->events.axis.listener_list);
 		free(pointer);
 	}
 }

--- a/types/wlr_relative_pointer_v1.c
+++ b/types/wlr_relative_pointer_v1.c
@@ -271,9 +271,5 @@ void wlr_relative_pointer_manager_v1_send_relative_motion(
 			(uint32_t)(time_msec >> 32), (uint32_t)time_msec,
 			wl_fixed_from_double(dx), wl_fixed_from_double(dy),
 			wl_fixed_from_double(dx_unaccel), wl_fixed_from_double(dy_unaccel));
-		uint32_t version = wl_resource_get_version(pointer->resource);
-		if (version >= WL_POINTER_FRAME_SINCE_VERSION) {
-			wl_pointer_send_frame(pointer->pointer_resource);
-		}
 	}
 }


### PR DESCRIPTION
Frame events group logically connected pointer events. It makes sense to make
the backend responsible for sending frame events, since once the events are
split (ie. once the frame events are stripped) it's not easy to figure out
which events belongs to which frame again.

This is also how Weston handles frame events.

Fixes https://github.com/swaywm/wlroots/issues/1468