### PR TITLE
Fix two issues found with Clang's static analyzer

### DIFF
--- a/examples/dmabuf-capture.c
+++ b/examples/dmabuf-capture.c
@@ -228,13 +228,14 @@ static const struct wl_registry_listener registry_listener = {
 static void frame_free(void *opaque, uint8_t *data) {
 	AVDRMFrameDescriptor *desc = (AVDRMFrameDescriptor *)data;
 
-	for (int i = 0; i < desc->nb_objects; ++i) {
-		close(desc->objects[i].fd);
+	if (desc) {
+		for (int i = 0; i < desc->nb_objects; ++i) {
+			close(desc->objects[i].fd);
+		}
+		av_free(data);
 	}
 
 	zwlr_export_dmabuf_frame_v1_destroy(opaque);
-
-	av_free(data);
 }
 
 static void frame_start(void *data, struct zwlr_export_dmabuf_frame_v1 *frame,

--- a/rootston/config.c
+++ b/rootston/config.c
@@ -201,9 +201,10 @@ void add_binding_config(struct wl_list *bindings, const char* combination,
 	}
 }
 
-void add_switch_config(struct wl_list *switches, const char *switch_name, const char *action,
-		const char* command) {
-	struct roots_switch_config *sc = calloc(1, sizeof(struct roots_switch_config));
+void add_switch_config(struct wl_list *switches, const char *switch_name,
+		const char *action, const char *command) {
+	struct roots_switch_config *sc =
+		calloc(1, sizeof(struct roots_switch_config));
 
 	if (strcmp(switch_name, "tablet") == 0) {
 		sc->switch_type = WLR_SWITCH_TYPE_TABLET_MODE;
@@ -213,6 +214,7 @@ void add_switch_config(struct wl_list *switches, const char *switch_name, const 
 		sc->switch_type = -1;
 		sc->name = strdup(switch_name);
 	}
+
 	if (strcmp(action, "on") == 0) {
 		sc->switch_state = WLR_SWITCH_STATE_ON;
 	} else if (strcmp(action, "off") == 0) {
@@ -220,10 +222,12 @@ void add_switch_config(struct wl_list *switches, const char *switch_name, const 
 	} else if (strcmp(action, "toggle") == 0) {
 		sc->switch_state = WLR_SWITCH_STATE_TOGGLE;
 	} else {
-		wlr_log(WLR_ERROR, "Invalid switch action %s/n for switch %s:%s",
-		        action, switch_name, action);
+		wlr_log(WLR_ERROR, "Invalid switch action %s for switch %s:%s",
+			action, switch_name, action);
+		free(sc);
 		return;
 	}
+
 	sc->command = strdup(command);
 	wl_list_insert(switches, &sc->link);
 }


### PR DESCRIPTION
Clang still generates one false-positive:

```
../../../rootston/desktop.c:925:3: warning: 3rd function call argument is an uninitialized value
                roots_cursor_constrain(seat->cursor, wlr_constraint, sx, sy);
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```