### PR TITLE
Add missing frame events to shell pointer grabs

### DIFF
--- a/types/wlr_wl_shell.c
+++ b/types/wlr_wl_shell.c
@@ -98,12 +98,17 @@ static void shell_pointer_grab_axis(struct wlr_seat_pointer_grab *grab,
 		value_discrete, source);
 }
 
+static void shell_pointer_grab_frame(struct wlr_seat_pointer_grab *grab) {
+	wlr_seat_pointer_send_frame(grab->seat);
+}
+
 static const struct wlr_pointer_grab_interface shell_pointer_grab_impl = {
 	.enter = shell_pointer_grab_enter,
 	.motion = shell_pointer_grab_motion,
 	.button = shell_pointer_grab_button,
 	.cancel = shell_pointer_grab_cancel,
 	.axis = shell_pointer_grab_axis,
+	.frame = shell_pointer_grab_frame,
 };
 
 static const struct wl_shell_surface_interface shell_surface_impl;

--- a/types/xdg_shell/wlr_xdg_popup.c
+++ b/types/xdg_shell/wlr_xdg_popup.c
@@ -50,6 +50,10 @@ static void xdg_pointer_grab_axis(struct wlr_seat_pointer_grab *grab,
 		value_discrete, source);
 }
 
+static void xdg_pointer_grab_frame(struct wlr_seat_pointer_grab *grab) {
+	wlr_seat_pointer_send_frame(grab->seat);
+}
+
 static void xdg_pointer_grab_cancel(struct wlr_seat_pointer_grab *grab) {
 	xdg_pointer_grab_end(grab);
 }
@@ -60,6 +64,7 @@ static const struct wlr_pointer_grab_interface xdg_pointer_grab_impl = {
 	.button = xdg_pointer_grab_button,
 	.cancel = xdg_pointer_grab_cancel,
 	.axis = xdg_pointer_grab_axis,
+	.frame = xdg_pointer_grab_frame,
 };
 
 static void xdg_keyboard_grab_enter(struct wlr_seat_keyboard_grab *grab,

--- a/types/xdg_shell_v6/wlr_xdg_popup_v6.c
+++ b/types/xdg_shell_v6/wlr_xdg_popup_v6.c
@@ -60,6 +60,10 @@ static void xdg_pointer_grab_axis(struct wlr_seat_pointer_grab *grab,
 		value_discrete, source);
 }
 
+static void xdg_pointer_grab_frame(struct wlr_seat_pointer_grab *grab) {
+	wlr_seat_pointer_send_frame(grab->seat);
+}
+
 static void xdg_pointer_grab_cancel(struct wlr_seat_pointer_grab *grab) {
 	xdg_pointer_grab_end(grab);
 }
@@ -70,6 +74,7 @@ static const struct wlr_pointer_grab_interface xdg_pointer_grab_impl = {
 	.button = xdg_pointer_grab_button,
 	.cancel = xdg_pointer_grab_cancel,
 	.axis = xdg_pointer_grab_axis,
+	.frame = xdg_pointer_grab_frame,
 };
 
 static void xdg_keyboard_grab_enter(struct wlr_seat_keyboard_grab *grab,


### PR DESCRIPTION
Test plan: open gnome-calculator, switch to "Programming mode", click on the "Binary/Octal/Decimal/Hexadecimal" combo button. Options should be highlighted as the pointer is moved.