### PR TITLE
Refactor drag-and-drop

### DIFF
--- a/include/rootston/seat.h
+++ b/include/rootston/seat.h
@@ -40,7 +40,8 @@ struct roots_seat {
 
 	struct wl_listener request_set_selection;
 	struct wl_listener request_set_primary_selection;
-	struct wl_listener new_drag_icon;
+	struct wl_listener request_start_drag;
+	struct wl_listener start_drag;
 	struct wl_listener destroy;
 };
 

--- a/include/types/wlr_data_device.h
+++ b/include/types/wlr_data_device.h
@@ -30,9 +30,6 @@ void data_source_notify_finish(struct wlr_data_source *source);
 
 struct wlr_seat_client *seat_client_from_data_device_resource(
 	struct wl_resource *resource);
-bool seat_client_start_drag(struct wlr_seat_client *client,
-	struct wlr_data_source *source, struct wlr_surface *icon_surface,
-	struct wlr_surface *origin, uint32_t serial);
 /**
  * Creates a new wl_data_offer if there is a wl_data_source currently set as
  * the seat selection and sends it to the seat client, followed by the

--- a/include/wlr/types/wlr_data_device.h
+++ b/include/wlr/types/wlr_data_device.h
@@ -127,7 +127,7 @@ struct wlr_drag {
 	struct wlr_surface *focus; // can be NULL
 	struct wlr_data_source *source; // can be NULL
 
-	bool started, cancelling;
+	bool started, dropped, cancelling;
 	int32_t grab_touch_id, touch_id; // if WLR_DRAG_GRAB_TOUCH
 
 	struct {

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -191,7 +191,6 @@ struct wlr_seat {
 	struct wl_global *global;
 	struct wl_display *display;
 	struct wl_list clients;
-	struct wl_list drag_icons; // wlr_drag_icon::link
 
 	char *name;
 	uint32_t capabilities;
@@ -239,8 +238,9 @@ struct wlr_seat {
 		struct wl_signal request_set_primary_selection;
 		struct wl_signal set_primary_selection;
 
+		// wlr_seat_request_start_drag_event
+		struct wl_signal request_start_drag;
 		struct wl_signal start_drag; // wlr_drag
-		struct wl_signal new_drag_icon; // wlr_drag_icon
 
 		struct wl_signal destroy;
 	} events;
@@ -262,6 +262,12 @@ struct wlr_seat_request_set_selection_event {
 
 struct wlr_seat_request_set_primary_selection_event {
 	struct wlr_primary_selection_source *source;
+	uint32_t serial;
+};
+
+struct wlr_seat_request_start_drag_event {
+	struct wlr_drag *drag;
+	struct wlr_surface *origin;
 	uint32_t serial;
 };
 
@@ -597,9 +603,30 @@ bool wlr_seat_touch_has_grab(struct wlr_seat *seat);
  */
 bool wlr_seat_validate_grab_serial(struct wlr_seat *seat, uint32_t serial);
 
+/**
+ * Check whether this serial is valid to start a pointer grab action.
+ */
+bool wlr_seat_validate_pointer_grab_serial(struct wlr_seat *seat,
+	struct wlr_surface *origin, uint32_t serial);
+
+/**
+ * Check whether this serial is valid to start a touch grab action. If it's the
+ * case and point_ptr is non-NULL, *point_ptr is set to the touch point matching
+ * the serial.
+ */
+bool wlr_seat_validate_touch_grab_serial(struct wlr_seat *seat,
+	struct wlr_surface *origin, uint32_t serial,
+	struct wlr_touch_point **point_ptr);
+
+/**
+ * Get a seat client from a seat resource. Returns NULL if inert.
+ */
 struct wlr_seat_client *wlr_seat_client_from_resource(
 	struct wl_resource *resource);
 
+/**
+ * Get a seat client from a pointer resource. Returns NULL if inert.
+ */
 struct wlr_seat_client *wlr_seat_client_from_pointer_resource(
 	struct wl_resource *resource);
 

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -624,6 +624,7 @@ static void roots_seat_handle_request_start_drag(struct wl_listener *listener,
 
 	wlr_log(WLR_DEBUG, "Ignoring start_drag request: "
 		"could not validate pointer or touch serial %" PRIu32, event->serial);
+	wlr_data_source_destroy(event->drag->source);
 }
 
 static void roots_seat_handle_start_drag(struct wl_listener *listener,

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -603,10 +603,37 @@ static void roots_drag_icon_handle_destroy(struct wl_listener *listener,
 	free(icon);
 }
 
-static void roots_seat_handle_new_drag_icon(struct wl_listener *listener,
+static void roots_seat_handle_request_start_drag(struct wl_listener *listener,
 		void *data) {
-	struct roots_seat *seat = wl_container_of(listener, seat, new_drag_icon);
-	struct wlr_drag_icon *wlr_drag_icon = data;
+	struct roots_seat *seat =
+		wl_container_of(listener, seat, request_start_drag);
+	struct wlr_seat_request_start_drag_event *event = data;
+
+	if (wlr_seat_validate_pointer_grab_serial(seat->seat,
+			event->origin, event->serial)) {
+		wlr_seat_start_pointer_drag(seat->seat, event->drag, event->serial);
+		return;
+	}
+
+	struct wlr_touch_point *point;
+	if (wlr_seat_validate_touch_grab_serial(seat->seat,
+			event->origin, event->serial, &point)) {
+		wlr_seat_start_touch_drag(seat->seat, event->drag, event->serial, point);
+		return;
+	}
+
+	wlr_log(WLR_DEBUG, "Ignoring start_drag request: "
+		"could not validate pointer or touch serial %" PRIu32, event->serial);
+}
+
+static void roots_seat_handle_start_drag(struct wl_listener *listener,
+		void *data) {
+	struct roots_seat *seat = wl_container_of(listener, seat, start_drag);
+	struct wlr_drag *wlr_drag = data;
+	struct wlr_drag_icon *wlr_drag_icon = wlr_drag->icon;
+	if (wlr_drag_icon == NULL) {
+		return;
+	}
 
 	struct roots_drag_icon *icon = calloc(1, sizeof(struct roots_drag_icon));
 	if (icon == NULL) {
@@ -649,20 +676,27 @@ static void roots_seat_handle_request_set_primary_selection(
 void roots_drag_icon_update_position(struct roots_drag_icon *icon) {
 	roots_drag_icon_damage_whole(icon);
 
-	struct wlr_drag_icon *wlr_icon = icon->wlr_drag_icon;
 	struct roots_seat *seat = icon->seat;
-	struct wlr_cursor *cursor = seat->cursor->cursor;
-	if (wlr_icon->is_pointer) {
+	struct wlr_drag *wlr_drag = icon->wlr_drag_icon->drag;
+	assert(wlr_drag != NULL);
+
+	switch (seat->seat->drag->grab_type) {
+	case WLR_DRAG_GRAB_KEYBOARD:
+		assert(false);
+	case WLR_DRAG_GRAB_KEYBOARD_POINTER:;
+		struct wlr_cursor *cursor = seat->cursor->cursor;
 		icon->x = cursor->x;
 		icon->y = cursor->y;
-	} else {
+		break;
+	case WLR_DRAG_GRAB_KEYBOARD_TOUCH:;
 		struct wlr_touch_point *point =
-			wlr_seat_touch_get_point(seat->seat, wlr_icon->touch_id);
+			wlr_seat_touch_get_point(seat->seat, wlr_drag->touch_id);
 		if (point == NULL) {
 			return;
 		}
 		icon->x = seat->touch_x;
 		icon->y = seat->touch_y;
+		break;
 	}
 
 	roots_drag_icon_damage_whole(icon);
@@ -738,8 +772,11 @@ struct roots_seat *roots_seat_create(struct roots_input *input, char *name) {
 		roots_seat_handle_request_set_primary_selection;
 	wl_signal_add(&seat->seat->events.request_set_primary_selection,
 		&seat->request_set_primary_selection);
-	seat->new_drag_icon.notify = roots_seat_handle_new_drag_icon;
-	wl_signal_add(&seat->seat->events.new_drag_icon, &seat->new_drag_icon);
+	seat->request_start_drag.notify = roots_seat_handle_request_start_drag;
+	wl_signal_add(&seat->seat->events.request_start_drag,
+		&seat->request_start_drag);
+	seat->start_drag.notify = roots_seat_handle_start_drag;
+	wl_signal_add(&seat->seat->events.start_drag, &seat->start_drag);
 	seat->destroy.notify = roots_seat_handle_destroy;
 	wl_signal_add(&seat->seat->events.destroy, &seat->destroy);
 

--- a/types/data_device/wlr_data_device.c
+++ b/types/data_device/wlr_data_device.c
@@ -73,8 +73,8 @@ static void data_device_start_drag(struct wl_client *client,
 
 	struct wlr_data_source *wlr_source =
 		source != NULL ? &source->source : NULL;
-	if (!seat_client_start_drag(seat_client, wlr_source, icon,
-			origin, serial)) {
+	struct wlr_drag *drag = wlr_drag_create(seat_client, wlr_source, icon);
+	if (drag == NULL) {
 		wl_resource_post_no_memory(device_resource);
 		return;
 	}
@@ -82,6 +82,8 @@ static void data_device_start_drag(struct wl_client *client,
 	if (source != NULL) {
 		source->finalized = true;
 	}
+
+	wlr_seat_request_start_drag(seat_client->seat, drag, origin, serial);
 }
 
 static void data_device_release(struct wl_client *client,

--- a/types/data_device/wlr_data_offer.c
+++ b/types/data_device/wlr_data_offer.c
@@ -135,6 +135,27 @@ static void data_offer_handle_finish(struct wl_client *client,
 		return;
 	}
 
+	// TODO: also fail while we have a drag-and-drop grab
+	if (offer->type != WLR_DATA_OFFER_DRAG) {
+		wl_resource_post_error(offer->resource,
+			WL_DATA_OFFER_ERROR_INVALID_FINISH, "Offer is not drag-and-drop");
+		return;
+	}
+	if (!offer->source->accepted) {
+		wl_resource_post_error(offer->resource,
+			WL_DATA_OFFER_ERROR_INVALID_FINISH, "Premature finish request");
+		return;
+	}
+	enum wl_data_device_manager_dnd_action action =
+		offer->source->current_dnd_action;
+	if (action == WL_DATA_DEVICE_MANAGER_DND_ACTION_NONE ||
+			action == WL_DATA_DEVICE_MANAGER_DND_ACTION_ASK) {
+		wl_resource_post_error(offer->resource,
+			WL_DATA_OFFER_ERROR_INVALID_FINISH,
+			"Offer finished with an invalid action");
+		return;
+	}
+
 	data_offer_dnd_finish(offer);
 	data_offer_destroy(offer);
 }

--- a/types/seat/wlr_seat.c
+++ b/types/seat/wlr_seat.c
@@ -266,12 +266,11 @@ struct wlr_seat *wlr_seat_create(struct wl_display *display, const char *name) {
 	seat->display = display;
 	seat->name = strdup(name);
 	wl_list_init(&seat->clients);
-	wl_list_init(&seat->drag_icons);
 	wl_list_init(&seat->selection_offers);
 	wl_list_init(&seat->drag_offers);
 
+	wl_signal_init(&seat->events.request_start_drag);
 	wl_signal_init(&seat->events.start_drag);
-	wl_signal_init(&seat->events.new_drag_icon);
 
 	wl_signal_init(&seat->events.request_set_cursor);
 

--- a/types/seat/wlr_seat_pointer.c
+++ b/types/seat/wlr_seat_pointer.c
@@ -402,3 +402,17 @@ void seat_client_destroy_pointer(struct wl_resource *resource) {
 	}
 	wl_resource_set_user_data(resource, NULL);
 }
+
+bool wlr_seat_validate_pointer_grab_serial(struct wlr_seat *seat,
+		struct wlr_surface *origin, uint32_t serial) {
+	if (seat->pointer_state.button_count != 1 ||
+			seat->pointer_state.grab_serial != serial) {
+		return false;
+	}
+
+	if (origin != NULL && seat->pointer_state.focused_surface != origin) {
+		return false;
+	}
+
+	return true;
+}

--- a/types/seat/wlr_seat_touch.c
+++ b/types/seat/wlr_seat_touch.c
@@ -359,3 +359,24 @@ void seat_client_destroy_touch(struct wl_resource *resource) {
 	}
 	wl_resource_set_user_data(resource, NULL);
 }
+
+bool wlr_seat_validate_touch_grab_serial(struct wlr_seat *seat,
+		struct wlr_surface *origin, uint32_t serial,
+		struct wlr_touch_point **point_ptr) {
+	if (wlr_seat_touch_num_points(seat) != 1 ||
+			seat->touch_state.grab_serial != serial) {
+		return false;
+	}
+
+	struct wlr_touch_point *point;
+	wl_list_for_each(point, &seat->touch_state.touch_points, link) {
+		if (origin == NULL || point->surface == origin) {
+			if (point_ptr != NULL) {
+				*point_ptr = point;
+			}
+			return true;
+		}
+	}
+
+	return false;
+}


### PR DESCRIPTION
- [x] Only one drag icon per seat at a time
- [x] Cleanup `wlr_drag_icon`
- [x] Allow for third-parties to start drag-and-drop (enables future Xwayland work)
- [x] Add `request_start_drag`

Test plan:
- [x] `weston-dnd`
- [x] Firefox Nightly
- [x] Nautilus

Maybe consider https://github.com/swaywm/wlroots/issues/1516?