### PR TITLE
relative-pointer-v1: time is in usec, not msec

### DIFF
--- a/include/wlr/types/wlr_relative_pointer_v1.h
+++ b/include/wlr/types/wlr_relative_pointer_v1.h
@@ -64,13 +64,17 @@ void wlr_relative_pointer_manager_v1_destroy(
 	struct wlr_relative_pointer_manager_v1 *manager);
 
 /**
- * Send a relative motion event to the seat with the same wl_pointer as relative_pointer
+ * Send a relative motion event to the seat. Time is given in microseconds
+ * (unlike wl_pointer which uses milliseconds).
  */
 void wlr_relative_pointer_manager_v1_send_relative_motion(
 	struct wlr_relative_pointer_manager_v1 *manager, struct wlr_seat *seat,
-	uint64_t time_msec, double dx, double dy,
+	uint64_t time_usec, double dx, double dy,
 	double dx_unaccel, double dy_unaccel);
 
+/**
+ * Get a relative pointer from its resource. Returns NULL if inert.
+ */
 struct wlr_relative_pointer_v1 *wlr_relative_pointer_v1_from_resource(
 	struct wl_resource *resource);
 

--- a/types/wlr_relative_pointer_v1.c
+++ b/types/wlr_relative_pointer_v1.c
@@ -252,7 +252,7 @@ void wlr_relative_pointer_manager_v1_destroy(struct wlr_relative_pointer_manager
 
 void wlr_relative_pointer_manager_v1_send_relative_motion(
 		struct wlr_relative_pointer_manager_v1 *manager, struct wlr_seat *seat,
-		uint64_t time_msec, double dx, double dy,
+		uint64_t time_usec, double dx, double dy,
 		double dx_unaccel, double dy_unaccel) {
 	struct wlr_seat_client *focused = seat->pointer_state.focused_client;
 	if (focused == NULL) {
@@ -268,7 +268,7 @@ void wlr_relative_pointer_manager_v1_send_relative_motion(
 		}
 
 		zwp_relative_pointer_v1_send_relative_motion(pointer->resource,
-			(uint32_t)(time_msec >> 32), (uint32_t)time_msec,
+			(uint32_t)(time_usec >> 32), (uint32_t)time_usec,
 			wl_fixed_from_double(dx), wl_fixed_from_double(dy),
 			wl_fixed_from_double(dx_unaccel), wl_fixed_from_double(dy_unaccel));
 	}


### PR DESCRIPTION
This caused confusion here: https://github.com/swaywm/sway/pull/3516#discussion_r252367351