### PR TITLE
data-device: fix crash when setting the same selection twice

### DIFF
--- a/types/data_device/wlr_data_device.c
+++ b/types/data_device/wlr_data_device.c
@@ -167,6 +167,11 @@ static void seat_handle_selection_source_destroy(
 
 void wlr_seat_set_selection(struct wlr_seat *seat,
 		struct wlr_data_source *source, uint32_t serial) {
+	if (seat->selection_source == source) {
+		seat->selection_serial = serial;
+		return;
+	}
+
 	if (seat->selection_source) {
 		wl_list_remove(&seat->selection_source_destroy.link);
 		wlr_data_source_destroy(seat->selection_source);

--- a/types/wlr_primary_selection.c
+++ b/types/wlr_primary_selection.c
@@ -69,10 +69,8 @@ static void seat_handle_primary_selection_source_destroy(
 
 void wlr_seat_set_primary_selection(struct wlr_seat *seat,
 		struct wlr_primary_selection_source *source, uint32_t serial) {
-	if (seat->primary_selection_source != NULL &&
-			seat->primary_selection_serial - serial < UINT32_MAX / 2) {
-		wlr_log(WLR_DEBUG, "Rejecting set_selection request, invalid serial "
-			"(%"PRIu32" <= %"PRIu32")", serial, seat->primary_selection_serial);
+	if (seat->primary_selection_source == source) {
+		seat->primary_selection_serial = serial;
 		return;
 	}
 


### PR DESCRIPTION
Setting the selection destroys the previous one. If the new selection is the same as the current one, it triggers a use-after-free.

Normal clients usually don't do this. This is just a safeguard against bad clients.

```
==11235==ERROR: AddressSanitizer: heap-use-after-free on address 0x60c000034cf0 at pc 0x7f44a7cd75c0 bp 0x7ffe0c520410 sp 0x7ffe0c520400
READ of size 8 at 0x60c000034cf0 thread T0
    #0 0x7f44a7cd75bf in wl_signal_add /usr/local/include/wayland-server-core.h:431
    #1 0x7f44a7cd88ee in wlr_seat_set_selection ../types/data_device/wlr_data_device.c:182
    #2 0x55acc2e2cb60 in roots_seat_handle_request_set_selection ../rootston/seat.c:638
    #3 0x7f44a7ddb783 in wlr_signal_emit_safe ../util/signal.c:29
    #4 0x7f44a7cd8270 in wlr_seat_request_set_selection ../types/data_device/wlr_data_device.c:148
    #5 0x7f44a7cd7802 in data_device_set_selection ../types/data_device/wlr_data_device.c:44
    #6 0x7f44a609b6cf in ffi_call_unix64 (/lib64/libffi.so.6+0x66cf)
    #7 0x7f44a609b09f in ffi_call (/lib64/libffi.so.6+0x609f)
    #8 0x7f44a791b6fe  (/lib64/libwayland-server.so.0+0xc6fe)
    #9 0x7f44a79180a2  (/lib64/libwayland-server.so.0+0x90a2)
    #10 0x7f44a7919701 in wl_event_loop_dispatch (/lib64/libwayland-server.so.0+0xa701)
    #11 0x7f44a79182ab in wl_display_run (/lib64/libwayland-server.so.0+0x92ab)
    #12 0x55acc2e0fab9 in main ../rootston/main.c:74
    #13 0x7f44a6799222 in __libc_start_main (/lib64/libc.so.6+0x24222)
    #14 0x55acc2dd066d in _start (/home/simon/src/wlroots/build/rootston/rootston+0xf366d)

0x60c000034cf0 is located 48 bytes inside of 128-byte region [0x60c000034cc0,0x60c000034d40)
freed by thread T0 here:
    #0 0x7f44a82fec19 in __interceptor_free /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:66
    #1 0x7f44a7cdc91a in client_data_source_destroy ../types/data_device/wlr_data_source.c:116
    #2 0x7f44a7cdc057 in wlr_data_source_destroy ../types/data_device/wlr_data_source.c:51
    #3 0x7f44a7cd863f in wlr_seat_set_selection ../types/data_device/wlr_data_device.c:172
    #4 0x55acc2e2cb60 in roots_seat_handle_request_set_selection ../rootston/seat.c:638
    #5 0x7f44a7ddb783 in wlr_signal_emit_safe ../util/signal.c:29
    #6 0x7f44a7cd8270 in wlr_seat_request_set_selection ../types/data_device/wlr_data_device.c:148
    #7 0x7f44a7cd7802 in data_device_set_selection ../types/data_device/wlr_data_device.c:44
    #8 0x7f44a609b6cf in ffi_call_unix64 (/lib64/libffi.so.6+0x66cf)

previously allocated by thread T0 here:
    #0 0x7f44a82ff231 in __interceptor_calloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:95
    #1 0x7f44a7cdd417 in client_data_source_create ../types/data_device/wlr_data_source.c:224
    #2 0x7f44a7cd8cd8 in data_device_manager_create_data_source ../types/data_device/wlr_data_device.c:234
    #3 0x7f44a609b6cf in ffi_call_unix64 (/lib64/libffi.so.6+0x66cf)
```