### PR TITLE
Allow cursor render surface to be used as fb

### DIFF
--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -104,7 +104,7 @@ static void session_signal(struct wl_listener *listener, void *data) {
 
 			struct wlr_drm_plane *plane = conn->crtc->cursor;
 			drm->iface->crtc_set_cursor(drm, conn->crtc,
-				(plane && plane->cursor_enabled) ? plane->cursor_bo : NULL);
+				(plane && plane->cursor_enabled) ? plane->surf.back : NULL);
 			drm->iface->crtc_move_cursor(drm, conn->crtc, conn->cursor_x,
 				conn->cursor_y);
 

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -30,7 +30,6 @@ struct wlr_drm_plane {
 
 	// Only used by cursor
 	float matrix[9];
-	struct gbm_bo *cursor_bo;
 	bool cursor_enabled;
 	int32_t cursor_hotspot_x, cursor_hotspot_y;
 


### PR DESCRIPTION
While trying to implement a fix for #1323, I found that when exporting the rendered surface into a DMA-BUF and reimporting it with `GBM_BO_USE_CURSOR`, the resulting object does not appear to be valid. After some digging (turning on drm-kms debugging and switching to legacy mode), I managed to extract the following error:
```
[drm:__setplane_check.isra.1 [drm]] Invalid pixel format AR24 little-endian (0x34325241), modifier 0x100000000000001
```
The format itself refers to ARGB8888 which is the same format as `renderer->gbm_format` used in master to create the cursor bo. However, using `gbm_bo_create` with `GBM_BO_USE_CURSOR` results in a modifier of 0. A modifier of zero represents a linear buffer while the modifier of the surface that is rendered to is  `I915_FORMAT_MOD_X_TILED` (see https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/include/uapi/drm/drm_fourcc.h?h=v4.20.6#n263). In order to fix this mismatch in modifier, I added the `GBM_BO_USE_LINEAR` to the render surface and everything started to work just fine. I wondered however, whether the export and import is really necessary. I then decided to test if the back buffer of the render surface works as well, and at least on my hardware (Intel HD 530 and Intel UHD 620) it does. This is the patch in this PR and this requires no exporting and importing.

I have to note that I cheated in order to import DMA_BUFs into a cursor bo when doing the first tests, since on import the Intel drivers check that the cursor is 64x64. This is strange since cursor sizes other than 64x64 have been around for quite some time now (https://lists.freedesktop.org/archives/mesa-commit/2014-June/050268.html). Removing this check made everything work fine. I later (while writing this PR) found out that `__DRI_IMAGE_USE_CURSOR` (to which `GBM_BO_USE_CURSOR` translates) has been deprecated in mesa (https://gitlab.freedesktop.org/mesa/mesa/blob/master/include/GL/internal/dri_interface.h#L1296), which makes me wonder what the usecase of `GBM_BO_USE_CURSOR` is. The reason we never encountered this is that when specifying `GBM_BO_USE_WRITE`, a dumb buffer is created trough DRM and the usage flag never reaches the Intel driver directly. The relevant code is in https://gitlab.freedesktop.org/mesa/mesa/blob/master/src/gbm/backends/dri/gbm_dri.c#L1011-1089 . From this it seems that as long as the size, format and modifiers are right, any surface can be used as a cursor.

Since this is somewhat an empirical result, it will probably need testing on hardware other than the one I used (Intel HD 530 and Intel UHD 620).

If this patch is fine, I'd first like to rewrite the commit message to explain more of the rational as I have done here.

It might also be possible to remove `wlr_drm_plane.cursor_bo` as this is the only place where it is used and it no longer holds something that needs to be explicitly destroyed. (in fact, it even causes a crash on exit with this patch and maybe at other moments)