### PR TITLE
Add build-*/ to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 bin/
 test/
 build/
+build-*/
 wayland-*-protocol.*
 wlr-example.ini
 rootston.ini


### PR DESCRIPTION
This brings it in line with Sway's gitignore.

The original justification was that it allows for simultaneous gcc and clang builds.