### PR TITLE
Copy cursor surface to secondery gpu if necessary

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -632,13 +632,25 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 		ret = drmGetCap(drm->fd, DRM_CAP_CURSOR_HEIGHT, &h);
 		h = ret ? 64 : h;
 
-		struct wlr_drm_renderer *renderer =
-			drm->parent ? &drm->parent->renderer : &drm->renderer;
 
-		if (!init_drm_surface(&plane->surf, renderer, w, h,
-				renderer->gbm_format, GBM_BO_USE_LINEAR | GBM_BO_USE_SCANOUT)) {
-			wlr_log(WLR_ERROR, "Cannot allocate cursor resources");
-			return false;
+		if (!drm->parent) {
+			if (!init_drm_surface(&plane->surf, &drm->renderer, w, h,
+					drm->renderer.gbm_format, GBM_BO_USE_LINEAR | GBM_BO_USE_SCANOUT)) {
+				wlr_log(WLR_ERROR, "Cannot allocate cursor resources");
+				return false;
+			}
+		} else {
+			if (!init_drm_surface(&plane->surf, &drm->parent->renderer, w, h,
+					drm->parent->renderer.gbm_format, GBM_BO_USE_LINEAR)) {
+				wlr_log(WLR_ERROR, "Cannot allocate cursor resources");
+				return false;
+			}
+
+			if (!init_drm_surface(&plane->mgpu_surf, &drm->renderer, w, h,
+					drm->renderer.gbm_format, GBM_BO_USE_LINEAR | GBM_BO_USE_SCANOUT)) {
+				wlr_log(WLR_ERROR, "Cannot allocate cursor resources");
+				return false;
+			}
 		}
 	}
 
@@ -708,6 +720,11 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 	}
 
 	struct gbm_bo *bo = plane->cursor_enabled ? plane->surf.back : NULL;
+
+	if (drm->parent) {
+		bo = copy_drm_surface_mgpu(&plane->mgpu_surf, plane->surf.back);
+	}
+
 	bool ok = drm->iface->crtc_set_cursor(drm, crtc, bo);
 	if (ok) {
 		wlr_output_update_needs_swap(output);

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -230,7 +230,7 @@ struct gbm_bo *copy_drm_surface_mgpu(struct wlr_drm_surface *dest,
 
 	struct wlr_renderer *renderer = dest->renderer->wlr_rend;
 	wlr_renderer_begin(renderer, dest->width, dest->height);
-	wlr_renderer_clear(renderer, (float[]){ 0.0, 0.0, 0.0, 1.0 });
+	wlr_renderer_clear(renderer, (float[]){ 0.0, 0.0, 0.0, 0.0 });
 	wlr_render_texture_with_matrix(renderer, tex, mat, 1.0f);
 	wlr_renderer_end(renderer);
 


### PR DESCRIPTION
I have not been able to test this as I do not have a device with multiple supported GPU's, but this should allow #1526 to work in a multi GPU setup.