### PR TITLE
Mark old protocols as obsolete

### DIFF
--- a/include/wlr/types/wlr_gtk_primary_selection.h
+++ b/include/wlr/types/wlr_gtk_primary_selection.h
@@ -1,4 +1,9 @@
 /*
+ * This protocol is obsolete and will be removed in a future version. The
+ * recommended replacement is wp-primary-selection.
+ */
+
+/*
  * This an unstable interface of wlroots. No guarantees are made regarding the
  * future consistency of this API.
  */
@@ -12,6 +17,9 @@
 #include <wayland-server.h>
 #include <wlr/types/wlr_seat.h>
 
+/**
+ * A primary selection manager which implements the GTK protocol.
+ */
 struct wlr_gtk_primary_selection_device_manager {
 	struct wl_global *global;
 	struct wl_list resources; // wl_resource_get_link

--- a/include/wlr/types/wlr_screenshooter.h
+++ b/include/wlr/types/wlr_screenshooter.h
@@ -1,4 +1,9 @@
 /*
+ * This protocol is obsolete and will be removed in a future version. The
+ * recommended replacement is wlr-screencopy.
+ */
+
+/*
  * This an unstable interface of wlroots. No guarantees are made regarding the
  * future consistency of this API.
  */
@@ -11,6 +16,9 @@
 
 #include <wayland-server.h>
 
+/**
+ * A very basic screenshooter interrface which implements the Orbital protocol.
+ */
 struct wlr_screenshooter {
 	struct wl_global *global;
 	struct wl_list screenshots; // wlr_screenshot::link

--- a/include/wlr/types/wlr_server_decoration.h
+++ b/include/wlr/types/wlr_server_decoration.h
@@ -1,4 +1,9 @@
 /*
+ * This protocol is obsolete and will be removed in a future version. The
+ * recommended replacement is xdg-decoration.
+ */
+
+/*
  * This an unstable interface of wlroots. No guarantees are made regarding the
  * future consistency of this API.
  */
@@ -34,6 +39,9 @@ enum wlr_server_decoration_manager_mode {
 	WLR_SERVER_DECORATION_MANAGER_MODE_SERVER = 2,
 };
 
+/**
+ * A decoration negociation interface which implements the KDE protocol.
+ */
 struct wlr_server_decoration_manager {
 	struct wl_global *global;
 	struct wl_list resources;

--- a/include/wlr/types/wlr_wl_shell.h
+++ b/include/wlr/types/wlr_wl_shell.h
@@ -1,4 +1,9 @@
 /*
+ * This protocol is obsolete and will be removed in a future version. The
+ * recommended replacement is xdg-shell.
+ */
+
+/*
  * This an unstable interface of wlroots. No guarantees are made regarding the
  * future consistency of this API.
  */
@@ -13,6 +18,9 @@
 #include <wayland-server.h>
 #include <wlr/types/wlr_seat.h>
 
+/**
+ * A very basic interface to provide desktop-style user interfaces.
+ */
 struct wlr_wl_shell {
 	struct wl_global *global;
 	struct wl_list resources;

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -1,4 +1,9 @@
 /*
+ * This protocol is obsolete and will be removed in a future version. The
+ * recommended replacement is xdg-shell.
+ */
+
+/*
  * This an unstable interface of wlroots. No guarantees are made regarding the
  * future consistency of this API.
  */
@@ -14,6 +19,10 @@
 #include <wlr/types/wlr_seat.h>
 #include "xdg-shell-unstable-v6-protocol.h"
 
+/**
+ * An interface enabling clients to turn their wl_surfaces into windows in a
+ * desktop environment.
+ */
 struct wlr_xdg_shell_v6 {
 	struct wl_global *global;
 	struct wl_list clients;


### PR DESCRIPTION
All of those have better replacements.

Not sure "deprecated" is the correct wording.