### PR TITLE
Add a wlr_output_set_subpixel()

### DIFF
--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -174,6 +174,7 @@ void wlr_output_set_transform(struct wlr_output *output,
 	enum wl_output_transform transform);
 void wlr_output_set_position(struct wlr_output *output, int32_t lx, int32_t ly);
 void wlr_output_set_scale(struct wlr_output *output, float scale);
+void wlr_output_set_subpixel(struct wlr_output *output, enum wl_output_subpixel subpixel);
 void wlr_output_destroy(struct wlr_output *output);
 /**
  * Computes the transformed output resolution.

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -248,6 +248,19 @@ void wlr_output_set_scale(struct wlr_output *output, float scale) {
 	wlr_signal_emit_safe(&output->events.scale, output);
 }
 
+void wlr_output_set_subpixel(struct wlr_output *output, enum wl_output_subpixel subpixel) {
+	if (output->subpixel == subpixel) {
+		return;
+	}
+
+	output->subpixel = subpixel;
+
+	struct wl_resource *resource;
+	wl_resource_for_each(resource, &output->resources) {
+		output_send_to_resource(resource);
+	}
+}
+
 static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	struct wlr_output *output =
 		wl_container_of(listener, output, display_destroy);


### PR DESCRIPTION
drmModeConnector.subpixel doesn't seem to detect subpixel order on many displays (especially laptops). Allow subpixel order to be manually set.

My plan is to make a corresponding PR for sway that adds a subpixel output option. Then https://github.com/swaywm/sway/issues/3163 will be fixed.

I'm very unfamiliar with the wlroots codebase so it's quite likely I made a mistake in this PR.