### PR TITLE
xwm: stack below on map

### DIFF
--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -889,6 +889,12 @@ static void xwm_handle_map_request(struct wlr_xwm *xwm,
 
 	xsurface_set_wm_state(xsurface, ICCCM_NORMAL_STATE);
 	xsurface_set_net_wm_state(xsurface);
+
+	uint32_t values[1];
+	values[0] = XCB_STACK_MODE_BELOW;
+	xcb_configure_window(xwm->xcb_conn, ev->window,
+			XCB_CONFIG_WINDOW_STACK_MODE, values);
+
 	xcb_map_window(xwm->xcb_conn, ev->window);
 }
 


### PR DESCRIPTION
Fixes swaywm/sway#2899
Supersedes #1534 

Since xwm only manipulates the stack when focusing a window, newly
mapped windows should be stacked below the focused window. This prevents
the newly mapped window from stealing focus due to being on the top of
the stack.

Thanks psychon for the insight! See https://github.com/swaywm/wlroots/pull/1534#issuecomment-463191842 for the full explanation