### PR TITLE
drm: do not modeset to current mode

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -537,6 +537,10 @@ static bool drm_connector_set_mode(struct wlr_output *output,
 		conn->desired_mode = mode;
 		return false;
 	}
+	if (conn->output.current_mode == mode) {
+		// Nothing to do
+		return true;
+	}
 
 	wlr_log(WLR_INFO, "Modesetting '%s' with '%ux%u@%u mHz'",
 		conn->output.name, mode->width, mode->height, mode->refresh);


### PR DESCRIPTION
Fixes swaywm/sway#3659
Supersedes swaywm/sway#3161

There is no point in modesetting an output to a mode that it is already
set to. Modesetting will cause the output to briefly flicker which is
undesirable for a noop. This returns early in `drm_connector_set_mode`
when attempting to modeset to the current mode.