### PR TITLE
Post protocol error on invalid wl_surface scale

### DIFF
--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -459,6 +459,11 @@ static void surface_set_buffer_transform(struct wl_client *client,
 static void surface_set_buffer_scale(struct wl_client *client,
 		struct wl_resource *resource,
 		int32_t scale) {
+	if (scale <= 0) {
+		wl_resource_post_error(resource, WL_SURFACE_ERROR_INVALID_SCALE,
+			"Specified scale value (%d) is not positive", scale);
+		return;
+	}
 	struct wlr_surface *surface = wlr_surface_from_resource(resource);
 	surface->pending.committed |= WLR_SURFACE_STATE_SCALE;
 	surface->pending.scale = scale;


### PR DESCRIPTION
Letting the scale be set to 0 causes division by zero errors.