### PR TITLE
Prevent NULL dereference in tablet_tool handler

### DIFF
--- a/types/tablet_v2/wlr_tablet_v2_tool.c
+++ b/types/tablet_v2/wlr_tablet_v2_tool.c
@@ -23,7 +23,7 @@ static void handle_tablet_tool_v2_set_cursor(struct wl_client *client,
 		struct wl_resource *surface_resource,
 		int32_t hotspot_x, int32_t hotspot_y) {
 	struct wlr_tablet_tool_client_v2 *tool = tablet_tool_client_from_resource(resource);
-	if (!tool) {
+	if (!tool || !tool->tool) {
 		return;
 	}
 


### PR DESCRIPTION
In case a tool was removed, but not yet destroyed by the client, the
tool_client's tool can be NULL. We have to check that as well in the
set_cursor handler to prevent using inert resources

Should fix https://github.com/swaywm/wlroots/issues/1536#issuecomment-463971534

This probably only ever happens with tablets that don't track unique tools (or maybe on unplug?), so I can't test this well.
@wsinnema please test this for me, I can't reproduce it with my hardware.