### PR TITLE
[WIP] surface-damage: add a helper to track surface damage

### DIFF
--- a/include/rootston/output.h
+++ b/include/rootston/output.h
@@ -40,6 +40,8 @@ struct roots_drag_icon;
 void output_damage_whole(struct roots_output *output);
 void output_damage_whole_view(struct roots_output *output,
 	struct roots_view *view);
+void output_damage(struct roots_output *output,
+	int ox, int oy, pixman_region32_t *damage);
 void output_damage_from_view(struct roots_output *output,
 	struct roots_view *view);
 void output_damage_whole_drag_icon(struct roots_output *output,

--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -4,6 +4,7 @@
 #include <wlr/config.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_foreign_toplevel_management_v1.h>
+#include <wlr/types/wlr_surface_damage.h>
 #include <wlr/types/wlr_surface.h>
 #include <wlr/types/wlr_xdg_decoration_v1.h>
 #include <wlr/types/wlr_xdg_shell_v6.h>
@@ -140,14 +141,14 @@ struct roots_view {
 	};
 
 	struct wlr_surface *wlr_surface;
+	struct wlr_surface_damage *surface_damage;
 	struct wl_list children; // roots_view_child::link
-
 	struct wlr_foreign_toplevel_handle_v1 *toplevel_handle;
+
+	struct wl_listener damage;
 	struct wl_listener toplevel_handle_request_maximize;
 	struct wl_listener toplevel_handle_request_activate;
 	struct wl_listener toplevel_handle_request_close;
-
-	struct wl_listener new_subsurface;
 
 	struct {
 		struct wl_signal unmap;
@@ -175,12 +176,6 @@ struct roots_view_child {
 	struct wl_listener new_subsurface;
 
 	void (*destroy)(struct roots_view_child *child);
-};
-
-struct roots_subsurface {
-	struct roots_view_child view_child;
-	struct wlr_subsurface *wlr_subsurface;
-	struct wl_listener destroy;
 };
 
 struct roots_wl_shell_popup {

--- a/include/wlr/types/meson.build
+++ b/include/wlr/types/meson.build
@@ -35,6 +35,7 @@ install_headers(
 	'wlr_screenshooter.h',
 	'wlr_seat.h',
 	'wlr_server_decoration.h',
+	'wlr_surface_damage.h',
 	'wlr_surface.h',
 	'wlr_switch.h',
 	'wlr_tablet_pad.h',

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -100,7 +100,7 @@ struct wlr_surface {
 
 	struct {
 		struct wl_signal commit;
-		struct wl_signal new_subsurface;
+		struct wl_signal new_subsurface; // wlr_subsurface
 		struct wl_signal destroy;
 	} events;
 

--- a/include/wlr/types/wlr_surface_damage.h
+++ b/include/wlr/types/wlr_surface_damage.h
@@ -1,0 +1,69 @@
+/*
+ * This an unstable interface of wlroots. No guarantees are made regarding the
+ * future consistency of this API.
+ */
+#ifndef WLR_USE_UNSTABLE
+#error "Add -DWLR_USE_UNSTABLE to enable unstable wlroots features"
+#endif
+
+#ifndef WLR_TYPES_WLR_SURFACE_DAMAGE_H
+#define WLR_TYPES_WLR_SURFACE_DAMAGE_H
+
+#include <pixman.h>
+#include <wayland-server.h>
+#include <wlr/types/wlr_surface.h>
+
+struct wlr_surface_damage;
+
+struct wlr_surface_damage_interface {
+	void (*destroy)(struct wlr_surface_damage *surface_damage);
+	void (*add_children)(struct wlr_surface_damage *surface_damage);
+};
+
+void wlr_surface_damage_init(struct wlr_surface_damage *surface_damage,
+	struct wlr_surface *surface,
+	const struct wlr_surface_damage_interface *impl);
+void wlr_surface_damage_add(struct wlr_surface_damage *surface_damage,
+	int32_t sx, int32_t sy, pixman_region32_t *damage);
+
+/**
+ * Tracks damage coming from a surface and its children.
+ *
+ * When a surface maps, unmaps or commits, the `damage` event will be emitted.
+ */
+struct wlr_surface_damage {
+	struct wlr_surface *surface;
+	const struct wlr_surface_damage_interface *impl;
+
+	struct {
+		struct wl_signal destroy;
+		struct wl_signal damage; // wlr_surface_damage_event
+	} events;
+
+	struct wl_list subsurfaces;
+
+	struct wl_listener surface_destroy;
+	struct wl_listener surface_commit;
+	struct wl_listener surface_new_subsurface;
+
+	void *data;
+};
+
+struct wlr_surface_damage_event {
+	struct wlr_surface_damage *surface_damage;
+	int32_t sx, sy;
+	pixman_region32_t *damage;
+};
+
+/**
+ * Tracks damage from a surface and its children subsurfaces.
+ */
+struct wlr_surface_damage *wlr_surface_damage_create(
+	struct wlr_surface *surface);
+void wlr_surface_damage_destroy(struct wlr_surface_damage *surface_damage);
+/**
+ * Damage the whole surface and all its children.
+ */
+void wlr_surface_damage_add_whole(struct wlr_surface_damage *surface_damage);
+
+#endif

--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -391,4 +391,15 @@ uint32_t wlr_xdg_surface_schedule_configure(struct wlr_xdg_surface *surface);
 void wlr_xdg_surface_for_each_popup(struct wlr_xdg_surface *surface,
 	wlr_surface_iterator_func_t iterator, void *user_data);
 
+struct wlr_surface_damage;
+
+/**
+ * Tracks damage from a surface and its children subsurfaces and popups.
+ */
+struct wlr_surface_damage *wlr_xdg_surface_damage_create(
+	struct wlr_xdg_surface *xdg_surface);
+struct wlr_surface_damage *wlr_xdg_popup_damage_create(
+	struct wlr_xdg_popup *popup, struct wlr_surface_damage *parent,
+	struct wl_list *list);
+
 #endif

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -715,6 +715,16 @@ void output_damage_from_view(struct roots_output *output,
 	view_for_each_surface(view, &data.layout, damage_from_surface, &data);
 }
 
+void output_damage(struct roots_output *output,
+		int ox, int oy, pixman_region32_t *damage) {
+	pixman_region32_t output_damage;
+	pixman_region32_init(&output_damage);
+	pixman_region32_copy(&output_damage, damage);
+	pixman_region32_translate(&output_damage, ox, oy);
+	wlr_output_damage_add(output->damage, &output_damage);
+	pixman_region32_fini(&output_damage);
+}
+
 static void set_mode(struct wlr_output *output,
 		struct roots_output_config *oc) {
 	int mhz = (int)(oc->mode.refresh_rate * 1000);

--- a/rootston/xdg_shell.c
+++ b/rootston/xdg_shell.c
@@ -33,13 +33,12 @@ static void popup_handle_destroy(struct wl_listener *listener, void *data) {
 
 static void popup_handle_map(struct wl_listener *listener, void *data) {
 	struct roots_xdg_popup *popup = wl_container_of(listener, popup, map);
-	view_damage_whole(popup->view_child.view);
 	input_update_cursor_focus(popup->view_child.view->desktop->server->input);
 }
 
 static void popup_handle_unmap(struct wl_listener *listener, void *data) {
 	struct roots_xdg_popup *popup = wl_container_of(listener, popup, unmap);
-	view_damage_whole(popup->view_child.view);
+	input_update_cursor_focus(popup->view_child.view->desktop->server->input);
 }
 
 static struct roots_xdg_popup *popup_create(struct roots_view *view,

--- a/types/meson.build
+++ b/types/meson.build
@@ -57,6 +57,7 @@ lib_wlr_types = static_library(
 		'wlr_screencopy_v1.c',
 		'wlr_screenshooter.c',
 		'wlr_server_decoration.c',
+		'wlr_surface_damage.c',
 		'wlr_surface.c',
 		'wlr_switch.c',
 		'wlr_tablet_pad.c',

--- a/types/wlr_surface_damage.c
+++ b/types/wlr_surface_damage.c
@@ -1,0 +1,196 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <wlr/types/wlr_surface_damage.h>
+#include <wlr/util/log.h>
+#include "util/signal.h"
+
+struct subsurface_damage {
+	struct wlr_surface_damage base;
+	struct wlr_surface_damage *parent;
+	struct wlr_subsurface *subsurface;
+	struct wl_list link;
+
+	struct wl_listener base_damage;
+	struct wl_listener subsurface_destroy;
+};
+
+static const struct wlr_surface_damage_interface subsurface_damage_impl;
+
+static void subsurface_damage_destroy(struct wlr_surface_damage *base) {
+	assert(base->impl == &subsurface_damage_impl);
+	struct subsurface_damage *subsurface_damage =
+		(struct subsurface_damage *)base;
+	wl_list_remove(&subsurface_damage->base_damage.link);
+	wl_list_remove(&subsurface_damage->subsurface_destroy.link);
+	wl_list_remove(&subsurface_damage->link);
+	free(subsurface_damage);
+}
+
+static const struct wlr_surface_damage_interface subsurface_damage_impl = {
+	.destroy = subsurface_damage_destroy,
+};
+
+static void handle_base_damage(struct wl_listener *listener, void *data) {
+	struct subsurface_damage *subsurface_damage =
+		wl_container_of(listener, subsurface_damage, base_damage);
+	struct wlr_surface_damage_event *event = data;
+	struct wlr_subsurface *subsurface = subsurface_damage->subsurface;
+
+	if (subsurface->parent == NULL) {
+		return;
+	}
+
+	int32_t sx = subsurface->current.x + event->sx;
+	int32_t sy = subsurface->current.y + event->sy;
+	wlr_surface_damage_add(subsurface_damage->parent, sx, sy, event->damage);
+}
+
+static void handle_subsurface_destroy(struct wl_listener *listener,
+		void *data) {
+	struct subsurface_damage *subsurface_damage =
+		wl_container_of(listener, subsurface_damage, subsurface_destroy);
+	wlr_surface_damage_destroy(&subsurface_damage->base);
+}
+
+struct subsurface_damage *subsurface_damage_create(
+		struct wlr_surface_damage *parent, struct wlr_subsurface *subsurface) {
+	struct subsurface_damage *subsurface_damage =
+		calloc(1, sizeof(struct subsurface_damage));
+	if (subsurface_damage == NULL) {
+		return NULL;
+	}
+
+	wlr_surface_damage_init(&subsurface_damage->base,
+		subsurface->surface, &subsurface_damage_impl);
+
+	subsurface_damage->subsurface = subsurface;
+	subsurface_damage->parent = parent;
+	wl_list_insert(&parent->subsurfaces, &subsurface_damage->link);
+
+	subsurface_damage->base_damage.notify = handle_base_damage;
+	wl_signal_add(&subsurface_damage->base.events.damage,
+		&subsurface_damage->base_damage);
+	subsurface_damage->subsurface_destroy.notify = handle_subsurface_destroy;
+	wl_signal_add(&subsurface->events.destroy,
+		&subsurface_damage->subsurface_destroy);
+	// TODO: map/unmap
+
+	return subsurface_damage;
+}
+
+
+static void handle_surface_commit(struct wl_listener *listener, void *data) {
+	struct wlr_surface_damage *surface_damage =
+		wl_container_of(listener, surface_damage, surface_commit);
+
+	if (!wlr_surface_has_buffer(surface_damage->surface)) {
+		return;
+	}
+
+	pixman_region32_t damage;
+	pixman_region32_init(&damage);
+	wlr_surface_get_effective_damage(surface_damage->surface, &damage);
+	wlr_surface_damage_add(surface_damage, 0, 0, &damage);
+	pixman_region32_fini(&damage);
+}
+
+static void handle_surface_new_subsurface(struct wl_listener *listener,
+		void *data) {
+	struct wlr_surface_damage *surface_damage =
+		wl_container_of(listener, surface_damage, surface_new_subsurface);
+	struct wlr_subsurface *subsurface = data;
+
+	subsurface_damage_create(surface_damage, subsurface);
+}
+
+static void handle_surface_destroy(struct wl_listener *listener, void *data) {
+	struct wlr_surface_damage *surface_damage =
+		wl_container_of(listener, surface_damage, surface_destroy);
+	wlr_surface_damage_destroy(surface_damage);
+}
+
+void wlr_surface_damage_init(struct wlr_surface_damage *surface_damage,
+		struct wlr_surface *surface,
+		const struct wlr_surface_damage_interface *impl) {
+	surface_damage->surface = surface;
+	surface_damage->impl = impl;
+	wl_list_init(&surface_damage->subsurfaces);
+	wl_signal_init(&surface_damage->events.destroy);
+	wl_signal_init(&surface_damage->events.damage);
+
+	surface_damage->surface_destroy.notify = handle_surface_destroy;
+	wl_signal_add(&surface->events.destroy, &surface_damage->surface_destroy);
+	surface_damage->surface_commit.notify = handle_surface_commit;
+	wl_signal_add(&surface->events.commit, &surface_damage->surface_commit);
+	surface_damage->surface_new_subsurface.notify =
+		handle_surface_new_subsurface;
+	wl_signal_add(&surface->events.new_subsurface,
+		&surface_damage->surface_new_subsurface);
+
+	struct wlr_subsurface *subsurface;
+	wl_list_for_each(subsurface, &surface->subsurfaces, parent_link) {
+		subsurface_damage_create(surface_damage, subsurface);
+	}
+}
+
+struct wlr_surface_damage *wlr_surface_damage_create(
+		struct wlr_surface *surface) {
+	struct wlr_surface_damage *surface_damage =
+		calloc(1, sizeof(struct wlr_surface_damage));
+	if (surface_damage == NULL) {
+		return NULL;
+	}
+	wlr_surface_damage_init(surface_damage, surface, NULL);
+	return surface_damage;
+}
+
+void wlr_surface_damage_destroy(struct wlr_surface_damage *surface_damage) {
+	if (surface_damage == NULL) {
+		return;
+	}
+	wlr_signal_emit_safe(&surface_damage->events.destroy, surface_damage);
+	wl_list_remove(&surface_damage->surface_destroy.link);
+	wl_list_remove(&surface_damage->surface_commit.link);
+	wl_list_remove(&surface_damage->surface_new_subsurface.link);
+	struct subsurface_damage *subsurface_damage, *tmp;
+	wl_list_for_each_safe(subsurface_damage, tmp,
+			&surface_damage->subsurfaces, link) {
+		wlr_surface_damage_destroy(&subsurface_damage->base);
+	}
+	if (surface_damage->impl && surface_damage->impl->destroy) {
+		surface_damage->impl->destroy(surface_damage);
+	} else {
+		free(surface_damage);
+	}
+}
+
+void wlr_surface_damage_add(struct wlr_surface_damage *surface_damage,
+		int32_t sx, int32_t sy, pixman_region32_t *damage) {
+	struct wlr_surface_damage_event event = {
+		.surface_damage = surface_damage,
+		.sx = sx,
+		.sy = sy,
+		.damage = damage,
+	};
+	wlr_signal_emit_safe(&surface_damage->events.damage, &event);
+}
+
+void wlr_surface_damage_add_whole(struct wlr_surface_damage *surface_damage) {
+	struct wlr_surface *surface = surface_damage->surface;
+
+	pixman_region32_t damage;
+	pixman_region32_init(&damage);
+	pixman_region32_union_rect(&damage, &damage, 0, 0,
+		surface->current.width, surface->current.height);
+	wlr_surface_damage_add(surface_damage, surface->sx, surface->sy, &damage);
+	pixman_region32_fini(&damage);
+
+	struct subsurface_damage *subsurface_damage;
+	wl_list_for_each(subsurface_damage, &surface_damage->subsurfaces, link) {
+		wlr_surface_damage_add_whole(&subsurface_damage->base);
+	}
+
+	if (surface_damage->impl && surface_damage->impl->add_children) {
+		surface_damage->impl->add_children(surface_damage);
+	}
+}


### PR DESCRIPTION
One remaining major pain point when implementing damage tracking is tracking
damage from surfaces and all of their children. Compositors need to add
new listeners for each view child type, with the appropriate new data
structures.

This commit adds a new helper to ease damage tracking: wlr_surface_damage. It
tracks damage from a surface and all its children and reports it via a "damage"
event in surface-local coordinates. This way, compositors just need to add one
listener for the whole view. There is one function per shell to create a
wlr_surface_damage, just like other helpers like wlr_surface_for_each_surface.

Additional functions are provided to allow compositors to manually damage
surfaces. wlr_surface_damage_add_whole will damage the whole surface and all
its children, this is useful when moving a view.

Of course, this helper is optional, and damage tracking done entirely in the
compositor will still work.

- [x] wl-subsurface
- [x] xdg-shell
- [ ] xdg-shell-unstable-v6
- [ ] layer-shell

Fixes https://github.com/swaywm/wlroots/issues/1543