### PR TITLE
wlr_output: do not modeset to current mode

### DIFF
--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -159,6 +159,9 @@ bool wlr_output_set_mode(struct wlr_output *output,
 	if (!output->impl || !output->impl->set_mode) {
 		return false;
 	}
+	if (output->current_mode == mode) {
+		return true;
+	}
 	return output->impl->set_mode(output, mode);
 }
 
@@ -166,6 +169,10 @@ bool wlr_output_set_custom_mode(struct wlr_output *output, int32_t width,
 		int32_t height, int32_t refresh) {
 	if (!output->impl || !output->impl->set_custom_mode) {
 		return false;
+	}
+	if (output->width == width && output->height == height &&
+			output->refresh == refresh) {
+		return true;
 	}
 	return output->impl->set_custom_mode(output, width, height, refresh);
 }


### PR DESCRIPTION
Supersedes #1545 which was reverted in #1550 due to
swaywm/sway#3685, which is a sway issue and has
swaywm/sway#3704 open to fix it. 

Fixes swaywm/sway#3659

There is no point in modesetting an output to a mode that it is already
set to. Modesetting will cause the output to briefly flicker which is
undesirable for a noop. This prevents modesetting any wlr_output,
regardless of the backend, to it's currently set mode.