### PR TITLE
xwayland, data-device: fix surface state on unmap

### DIFF
--- a/types/data_device/wlr_drag.c
+++ b/types/data_device/wlr_drag.c
@@ -96,8 +96,8 @@ static void drag_icon_set_mapped(struct wlr_drag_icon *icon, bool mapped) {
 		icon->mapped = true;
 		wlr_signal_emit_safe(&icon->events.map, icon);
 	} else if (!mapped && icon->mapped) {
-		icon->mapped = false;
 		wlr_signal_emit_safe(&icon->events.unmap, icon);
+		icon->mapped = false;
 	}
 }
 

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -793,8 +793,8 @@ static void xwm_map_shell_surface(struct wlr_xwm *xwm,
 
 static void xsurface_unmap(struct wlr_xwayland_surface *surface) {
 	if (surface->mapped) {
-		surface->mapped = false;
 		wlr_signal_emit_safe(&surface->events.unmap, surface);
+		surface->mapped = false;
 		xwm_set_net_client_list(surface->xwm);
 	}
 


### PR DESCRIPTION
This commit makes sure surface->mapped is true when the unmapped event is
emitted. This is necessary because listeners can only damage surfaces that are
mapped. This is similar to the fact that the destroy event is emitted before
any destruction is actually made.

Fixes https://github.com/swaywm/sway/issues/3568