### PR TITLE
backend/drm: fix modeset on drm fd resume

### DIFF
--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -93,7 +93,8 @@ static void session_signal(struct wl_listener *listener, void *data) {
 		struct wlr_drm_connector *conn;
 		wl_list_for_each(conn, &drm->outputs, link){
 			if (conn->output.enabled) {
-				wlr_output_set_mode(&conn->output, conn->output.current_mode);
+				drm_connector_set_mode(&conn->output,
+						conn->output.current_mode);
 			} else {
 				enable_drm_connector(&conn->output, false);
 			}

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -392,9 +392,6 @@ static void drm_connector_start_renderer(struct wlr_drm_connector *conn) {
 	}
 }
 
-static bool drm_connector_set_mode(struct wlr_output *output,
-	struct wlr_output_mode *mode);
-
 static void realloc_crtcs(struct wlr_drm_backend *drm, bool *changed_outputs);
 
 static void attempt_enable_needs_modeset(struct wlr_drm_backend *drm) {
@@ -522,7 +519,7 @@ static void realloc_planes(struct wlr_drm_backend *drm, const uint32_t *crtc_in,
 
 static void drm_connector_cleanup(struct wlr_drm_connector *conn);
 
-static bool drm_connector_set_mode(struct wlr_output *output,
+bool drm_connector_set_mode(struct wlr_output *output,
 		struct wlr_output_mode *mode) {
 	struct wlr_drm_connector *conn = get_drm_connector_from_output(output);
 	struct wlr_drm_backend *drm = get_drm_backend_from_backend(output->backend);

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -159,5 +159,7 @@ int handle_drm_event(int fd, uint32_t mask, void *data);
 bool enable_drm_connector(struct wlr_output *output, bool enable);
 bool set_drm_connector_gamma(struct wlr_output *output, size_t size,
 	const uint16_t *r, const uint16_t *g, const uint16_t *b);
+bool drm_connector_set_mode(struct wlr_output *output,
+	struct wlr_output_mode *mode);
 
 #endif


### PR DESCRIPTION
Fixes #1560 

On DRM resume, such as switching back to a TTY, the output needs to be
modeset to the current mode. However, wlr_output_set_mode will return
early when attempting to set the mode to the current mode. This just
steps around wlr_output_set_mode and calls drm_connector_set_mode
directly.