### PR TITLE
backend/drm: Unset cursor on cleanup

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1380,6 +1380,7 @@ void restore_drm_outputs(struct wlr_drm_backend *drm) {
 
 		drmModeSetCrtc(drm->fd, crtc->crtc_id, crtc->buffer_id, crtc->x, crtc->y,
 			&conn->id, 1, &crtc->mode);
+		drmModeSetCursor(drm->fd, crtc->crtc_id, 0, 0, 0);
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/swaywm/sway/issues/3017

This will prevent the cursor from persisting on the Linux framebuffer
terminal on exit.