### PR TITLE
Install xcb-errors on FreeBSD builder

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -16,7 +16,7 @@ packages:
 - x11/libxcb
 - x11/libxkbcommon
 - x11/pixman
-# - x11/xcb-util-errors # too recent, not in /quarterly
+- x11/xcb-util-errors
 - x11/xcb-util-wm
 sources:
 - https://github.com/swaywm/wlroots


### PR DESCRIPTION
Other builders don't test optional dependencies. Let's see if this works after d1409e338175. 