### PR TITLE
rootston: refactor rendering

### DIFF
--- a/include/rootston/output.h
+++ b/include/rootston/output.h
@@ -47,6 +47,15 @@ void output_view_for_each_surface(struct roots_output *output,
 void output_drag_icons_for_each_surface(struct roots_output *output,
 	struct roots_input *input, roots_surface_iterator_func_t iterator,
 	void *user_data);
+void output_layer_for_each_surface(struct roots_output *output,
+	struct wl_list *layer_surfaces, roots_surface_iterator_func_t iterator,
+	void *user_data);
+#if WLR_HAS_XWAYLAND
+struct wlr_xwayland_surface;
+void output_xwayland_children_for_each_surface(
+	struct roots_output *output, struct wlr_xwayland_surface *surface,
+	roots_surface_iterator_func_t iterator, void *user_data);
+#endif
 void output_for_each_surface(struct roots_output *output,
 	roots_surface_iterator_func_t iterator, void *user_data);
 
@@ -66,5 +75,11 @@ void output_damage_from_local_surface(struct roots_output *output,
 	struct wlr_surface *surface, double ox, double oy);
 void output_damage_whole_local_surface(struct roots_output *output,
 	struct wlr_surface *surface, double ox, double oy);
+
+void output_render(struct roots_output *output);
+
+void scale_box(struct wlr_box *box, float scale);
+void get_decoration_box(struct roots_view *view,
+	struct roots_output *output, struct wlr_box *box);
 
 #endif

--- a/include/rootston/output.h
+++ b/include/rootston/output.h
@@ -29,8 +29,26 @@ struct roots_output {
 	struct wl_listener damage_destroy;
 };
 
+typedef void (*roots_surface_iterator_func_t)(struct roots_output *output,
+	struct wlr_surface *surface, struct wlr_box *box, float rotation,
+	void *user_data);
+
 void rotate_child_position(double *sx, double *sy, double sw, double sh,
 	double pw, double ph, float rotation);
+
+struct roots_input;
+
+void output_surface_for_each_surface(struct roots_output *output,
+	struct wlr_surface *surface, double ox, double oy,
+	roots_surface_iterator_func_t iterator, void *user_data);
+void output_view_for_each_surface(struct roots_output *output,
+	struct roots_view *view, roots_surface_iterator_func_t iterator,
+	void *user_data);
+void output_drag_icons_for_each_surface(struct roots_output *output,
+	struct roots_input *input, roots_surface_iterator_func_t iterator,
+	void *user_data);
+void output_for_each_surface(struct roots_output *output,
+	roots_surface_iterator_func_t iterator, void *user_data);
 
 void handle_new_output(struct wl_listener *listener, void *data);
 
@@ -45,8 +63,8 @@ void output_damage_from_view(struct roots_output *output,
 void output_damage_whole_drag_icon(struct roots_output *output,
 	struct roots_drag_icon *icon);
 void output_damage_from_local_surface(struct roots_output *output,
-	struct wlr_surface *surface, double ox, double oy, float rotation);
+	struct wlr_surface *surface, double ox, double oy);
 void output_damage_whole_local_surface(struct roots_output *output,
-	struct wlr_surface *surface, double ox, double oy, float rotation);
+	struct wlr_surface *surface, double ox, double oy);
 
 #endif

--- a/include/rootston/view.h
+++ b/include/rootston/view.h
@@ -20,6 +20,8 @@ struct roots_view_interface {
 	void (*maximize)(struct roots_view *view, bool maximized);
 	void (*set_fullscreen)(struct roots_view *view, bool fullscreen);
 	void (*close)(struct roots_view *view);
+	void (*for_each_surface)(struct roots_view *view,
+		wlr_surface_iterator_func_t iterator, void *user_data);
 	void (*destroy)(struct roots_view *view);
 };
 
@@ -250,6 +252,8 @@ void view_set_title(struct roots_view *view, const char *title);
 void view_set_app_id(struct roots_view *view, const char *app_id);
 void view_create_foreign_toplevel_handle(struct roots_view *view);
 void view_get_deco_box(const struct roots_view *view, struct wlr_box *box);
+void view_for_each_surface(struct roots_view *view,
+	wlr_surface_iterator_func_t iterator, void *user_data);
 
 struct roots_wl_shell_surface *roots_wl_shell_surface_from_view(
 	struct roots_view *view);

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -51,22 +51,8 @@ static bool view_at(struct roots_view *view, double lx, double ly,
 
 	double view_sx = lx - view->box.x;
 	double view_sy = ly - view->box.y;
-
-	struct wlr_surface_state *state = &view->wlr_surface->current;
-	struct wlr_box box = {
-		.x = 0, .y = 0,
-		.width = state->width, .height = state->height,
-	};
-	if (view->rotation != 0.0) {
-		// Coordinates relative to the center of the view
-		double ox = view_sx - (double)box.width/2,
-			oy = view_sy - (double)box.height/2;
-		// Rotated coordinates
-		double rx = cos(view->rotation)*ox + sin(view->rotation)*oy,
-			ry = cos(view->rotation)*oy - sin(view->rotation)*ox;
-		view_sx = rx + (double)box.width/2;
-		view_sy = ry + (double)box.height/2;
-	}
+	rotate_child_position(&view_sx, &view_sy, 0, 0,
+		view->box.width, view->box.height, -view->rotation);
 
 	double _sx, _sy;
 	struct wlr_surface *_surface = NULL;

--- a/rootston/layer_shell.c
+++ b/rootston/layer_shell.c
@@ -298,12 +298,12 @@ static void handle_surface_commit(struct wl_listener *listener, void *data) {
 
 		if (memcmp(&old_geo, &layer->geo, sizeof(struct wlr_box)) != 0) {
 			output_damage_whole_local_surface(output, layer_surface->surface,
-					old_geo.x, old_geo.y, 0);
+					old_geo.x, old_geo.y);
 			output_damage_whole_local_surface(output, layer_surface->surface,
-					layer->geo.x, layer->geo.y, 0);
+					layer->geo.x, layer->geo.y);
 		} else {
 			output_damage_from_local_surface(output, layer_surface->surface,
-					layer->geo.x, layer->geo.y, 0);
+					layer->geo.x, layer->geo.y);
 		}
 	}
 }
@@ -314,7 +314,7 @@ static void unmap(struct wlr_layer_surface_v1 *layer_surface) {
 	if (wlr_output != NULL) {
 		struct roots_output *output = wlr_output->data;
 		output_damage_whole_local_surface(output, layer_surface->surface,
-			layer->geo.x, layer->geo.y, 0);
+			layer->geo.x, layer->geo.y);
 	}
 }
 
@@ -342,7 +342,7 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	struct wlr_output *wlr_output = layer_surface->output;
 	struct roots_output *output = wlr_output->data;
 	output_damage_whole_local_surface(output, layer_surface->surface,
-		layer->geo.x, layer->geo.y, 0);
+		layer->geo.x, layer->geo.y);
 	wlr_surface_send_enter(layer_surface->surface, wlr_output);
 }
 
@@ -363,7 +363,7 @@ static void popup_handle_map(struct wl_listener *listener, void *data) {
 	int ox = popup->wlr_popup->geometry.x + layer->geo.x;
 	int oy = popup->wlr_popup->geometry.y + layer->geo.y;
 	output_damage_whole_local_surface(output, popup->wlr_popup->base->surface,
-		ox, oy, 0);
+		ox, oy);
 	input_update_cursor_focus(output->desktop->server->input);
 }
 
@@ -375,7 +375,7 @@ static void popup_handle_unmap(struct wl_listener *listener, void *data) {
 	int ox = popup->wlr_popup->geometry.x + layer->geo.x;
 	int oy = popup->wlr_popup->geometry.y + layer->geo.y;
 	output_damage_whole_local_surface(output, popup->wlr_popup->base->surface,
-		ox, oy, 0);
+		ox, oy);
 }
 
 static void popup_handle_commit(struct wl_listener *listener, void *data) {
@@ -386,7 +386,7 @@ static void popup_handle_commit(struct wl_listener *listener, void *data) {
 	int ox = popup->wlr_popup->geometry.x + layer->geo.x;
 	int oy = popup->wlr_popup->geometry.y + layer->geo.y;
 	output_damage_from_local_surface(output, popup->wlr_popup->base->surface,
-		ox, oy, 0);
+		ox, oy);
 }
 
 static void popup_handle_destroy(struct wl_listener *listener, void *data) {

--- a/rootston/meson.build
+++ b/rootston/meson.build
@@ -9,6 +9,7 @@ sources = [
 	'layer_shell.c',
 	'main.c',
 	'output.c',
+	'render.c',
 	'seat.c',
 	'switch.c',
 	'text_input.c',

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -6,7 +6,6 @@
 #include <wlr/backend/drm.h>
 #include <wlr/config.h>
 #include <wlr/types/wlr_compositor.h>
-#include <wlr/types/wlr_matrix.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_presentation_time.h>
 #include <wlr/types/wlr_wl_shell.h>
@@ -14,6 +13,7 @@
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/util/log.h>
 #include <wlr/util/region.h>
+#include <wlr/xwayland.h>
 #include "rootston/config.h"
 #include "rootston/layers.h"
 #include "rootston/output.h"
@@ -137,7 +137,7 @@ void output_view_for_each_surface(struct roots_output *output,
 }
 
 #if WLR_HAS_XWAYLAND
-static void output_xwayland_children_for_each_surface(
+void output_xwayland_children_for_each_surface(
 		struct roots_output *output, struct wlr_xwayland_surface *surface,
 		roots_surface_iterator_func_t iterator, void *user_data) {
 	struct wlr_xwayland_surface *child;
@@ -218,105 +218,18 @@ void output_for_each_surface(struct roots_output *output,
 	}
 }
 
-
-struct render_data {
-	pixman_region32_t *damage;
-	float alpha;
-};
-
-static void scissor_output(struct wlr_output *wlr_output,
-		pixman_box32_t *rect) {
-	struct wlr_renderer *renderer =
-		wlr_backend_get_renderer(wlr_output->backend);
-	assert(renderer);
-
-	struct wlr_box box = {
-		.x = rect->x1,
-		.y = rect->y1,
-		.width = rect->x2 - rect->x1,
-		.height = rect->y2 - rect->y1,
-	};
-
-	int ow, oh;
-	wlr_output_transformed_resolution(wlr_output, &ow, &oh);
-
-	enum wl_output_transform transform =
-		wlr_output_transform_invert(wlr_output->transform);
-	wlr_box_transform(&box, &box, transform, ow, oh);
-
-	wlr_renderer_scissor(renderer, &box);
-}
-
 static int scale_length(int length, int offset, float scale) {
 	return round((offset + length) * scale) - round(offset * scale);
 }
 
-static void scale_box(struct wlr_box *box, float scale) {
+void scale_box(struct wlr_box *box, float scale) {
 	box->width = scale_length(box->width, box->x, scale);
 	box->height = scale_length(box->height, box->y, scale);
 	box->x = round(box->x * scale);
 	box->y = round(box->y * scale);
 }
 
-static void render_texture(struct wlr_output *wlr_output,
-		pixman_region32_t *output_damage, struct wlr_texture *texture,
-		const struct wlr_box *box, const float matrix[static 9],
-		float rotation, float alpha) {
-	struct wlr_renderer *renderer =
-		wlr_backend_get_renderer(wlr_output->backend);
-	assert(renderer);
-
-	struct wlr_box rotated;
-	wlr_box_rotated_bounds(&rotated, box, rotation);
-
-	pixman_region32_t damage;
-	pixman_region32_init(&damage);
-	pixman_region32_union_rect(&damage, &damage, rotated.x, rotated.y,
-		rotated.width, rotated.height);
-	pixman_region32_intersect(&damage, &damage, output_damage);
-	bool damaged = pixman_region32_not_empty(&damage);
-	if (!damaged) {
-		goto damage_finish;
-	}
-
-	int nrects;
-	pixman_box32_t *rects = pixman_region32_rectangles(&damage, &nrects);
-	for (int i = 0; i < nrects; ++i) {
-		scissor_output(wlr_output, &rects[i]);
-		wlr_render_texture_with_matrix(renderer, texture, matrix, alpha);
-	}
-
-damage_finish:
-	pixman_region32_fini(&damage);
-}
-
-static void render_surface_iterator(struct roots_output *output,
-		struct wlr_surface *surface, struct wlr_box *_box, float rotation,
-		void *_data) {
-	struct render_data *data = _data;
-	struct wlr_output *wlr_output = output->wlr_output;
-	pixman_region32_t *output_damage = data->damage;
-	float alpha = data->alpha;
-
-	struct wlr_texture *texture = wlr_surface_get_texture(surface);
-	if (!texture) {
-		return;
-	}
-
-	struct wlr_box box = *_box;
-	scale_box(&box, wlr_output->scale);
-
-	float matrix[9];
-	enum wl_output_transform transform =
-		wlr_output_transform_invert(surface->current.transform);
-	wlr_matrix_project_box(matrix, &box, transform, rotation,
-		wlr_output->transform_matrix);
-
-	render_texture(wlr_output, output_damage,
-		texture, &box, matrix, rotation, alpha);
-}
-
-static void get_decoration_box(struct roots_view *view,
+void get_decoration_box(struct roots_view *view,
 		struct roots_output *output, struct wlr_box *box) {
 	struct wlr_output *wlr_output = output->wlr_output;
 
@@ -336,231 +249,6 @@ static void get_decoration_box(struct roots_view *view,
 	box->y = y * wlr_output->scale;
 	box->width = deco_box.width * wlr_output->scale;
 	box->height = deco_box.height * wlr_output->scale;
-}
-
-static void render_decorations(struct roots_output *output,
-		struct roots_view *view, struct render_data *data) {
-	if (!view->decorated || view->wlr_surface == NULL) {
-		return;
-	}
-
-	struct wlr_renderer *renderer =
-		wlr_backend_get_renderer(output->wlr_output->backend);
-	assert(renderer);
-
-	struct wlr_box box;
-	get_decoration_box(view, output, &box);
-
-	struct wlr_box rotated;
-	wlr_box_rotated_bounds(&rotated, &box, view->rotation);
-
-	pixman_region32_t damage;
-	pixman_region32_init(&damage);
-	pixman_region32_union_rect(&damage, &damage, rotated.x, rotated.y,
-		rotated.width, rotated.height);
-	pixman_region32_intersect(&damage, &damage, data->damage);
-	bool damaged = pixman_region32_not_empty(&damage);
-	if (!damaged) {
-		goto damage_finish;
-	}
-
-	float matrix[9];
-	wlr_matrix_project_box(matrix, &box, WL_OUTPUT_TRANSFORM_NORMAL,
-		view->rotation, output->wlr_output->transform_matrix);
-	float color[] = { 0.2, 0.2, 0.2, view->alpha };
-
-	int nrects;
-	pixman_box32_t *rects =
-		pixman_region32_rectangles(&damage, &nrects);
-	for (int i = 0; i < nrects; ++i) {
-		scissor_output(output->wlr_output, &rects[i]);
-		wlr_render_quad_with_matrix(renderer, color, matrix);
-	}
-
-damage_finish:
-	pixman_region32_fini(&damage);
-}
-
-static void render_view(struct roots_output *output, struct roots_view *view,
-		struct render_data *data) {
-	// Do not render views fullscreened on other outputs
-	if (view->fullscreen_output != NULL && view->fullscreen_output != output) {
-		return;
-	}
-
-	data->alpha = view->alpha;
-	if (view->fullscreen_output == NULL) {
-		render_decorations(output, view, data);
-	}
-	output_view_for_each_surface(output, view, render_surface_iterator, data);
-}
-
-static void render_layer(struct roots_output *output,
-		pixman_region32_t *damage, struct wl_list *layer_surfaces) {
-	struct render_data data = {
-		.damage = damage,
-		.alpha = 1.0f,
-	};
-	output_layer_for_each_surface(output, layer_surfaces,
-		render_surface_iterator, &data);
-}
-
-static void render_drag_icons(struct roots_output *output,
-		pixman_region32_t *damage, struct roots_input *input) {
-	struct render_data data = {
-		.damage = damage,
-		.alpha = 1.0f,
-	};
-	output_drag_icons_for_each_surface(output, input,
-		render_surface_iterator, &data);
-}
-
-static void surface_send_frame_done_iterator(struct roots_output *output,
-		struct wlr_surface *surface, struct wlr_box *box, float rotation,
-		void *data) {
-	struct timespec *when = data;
-	wlr_surface_send_frame_done(surface, when);
-}
-
-static void render_output(struct roots_output *output) {
-	struct wlr_output *wlr_output = output->wlr_output;
-	struct roots_desktop *desktop = output->desktop;
-	struct roots_server *server = desktop->server;
-	struct wlr_renderer *renderer =
-		wlr_backend_get_renderer(wlr_output->backend);
-	assert(renderer);
-
-	if (!wlr_output->enabled) {
-		return;
-	}
-
-	struct timespec now;
-	clock_gettime(CLOCK_MONOTONIC, &now);
-
-	float clear_color[] = {0.25f, 0.25f, 0.25f, 1.0f};
-
-	const struct wlr_box *output_box =
-		wlr_output_layout_get_box(desktop->layout, wlr_output);
-
-	// Check if we can delegate the fullscreen surface to the output
-	if (output->fullscreen_view != NULL &&
-			output->fullscreen_view->wlr_surface != NULL) {
-		struct roots_view *view = output->fullscreen_view;
-
-		// Make sure the view is centered on screen
-		struct wlr_box view_box;
-		view_get_box(view, &view_box);
-		double view_x = (double)(output_box->width - view_box.width) / 2 +
-			output_box->x;
-		double view_y = (double)(output_box->height - view_box.height) / 2 +
-			output_box->y;
-		view_move(view, view_x, view_y);
-
-		// Fullscreen views are rendered on a black background
-		clear_color[0] = clear_color[1] = clear_color[2] = 0;
-	}
-
-	bool needs_swap;
-	pixman_region32_t damage;
-	pixman_region32_init(&damage);
-	if (!wlr_output_damage_make_current(output->damage, &needs_swap, &damage)) {
-		return;
-	}
-
-	struct render_data data = {
-		.damage = &damage,
-		.alpha = 1.0,
-	};
-
-	if (!needs_swap) {
-		// Output doesn't need swap and isn't damaged, skip rendering completely
-		goto damage_finish;
-	}
-
-	wlr_renderer_begin(renderer, wlr_output->width, wlr_output->height);
-
-	if (!pixman_region32_not_empty(&damage)) {
-		// Output isn't damaged but needs buffer swap
-		goto renderer_end;
-	}
-
-	if (server->config->debug_damage_tracking) {
-		wlr_renderer_clear(renderer, (float[]){1, 1, 0, 1});
-	}
-
-	int nrects;
-	pixman_box32_t *rects = pixman_region32_rectangles(&damage, &nrects);
-	for (int i = 0; i < nrects; ++i) {
-		scissor_output(output->wlr_output, &rects[i]);
-		wlr_renderer_clear(renderer, clear_color);
-	}
-
-	render_layer(output, &damage,
-		&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]);
-	render_layer(output, &damage,
-		&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM]);
-
-	// If a view is fullscreen on this output, render it
-	if (output->fullscreen_view != NULL) {
-		struct roots_view *view = output->fullscreen_view;
-
-		render_view(output, view, &data);
-
-		// During normal rendering the xwayland window tree isn't traversed
-		// because all windows are rendered. Here we only want to render
-		// the fullscreen window's children so we have to traverse the tree.
-#if WLR_HAS_XWAYLAND
-		if (view->type == ROOTS_XWAYLAND_VIEW) {
-			struct roots_xwayland_surface *xwayland_surface =
-				roots_xwayland_surface_from_view(view);
-			output_xwayland_children_for_each_surface(output,
-				xwayland_surface->xwayland_surface,
-				render_surface_iterator, &data);
-		}
-#endif
-	} else {
-		// Render all views
-		struct roots_view *view;
-		wl_list_for_each_reverse(view, &desktop->views, link) {
-			render_view(output, view, &data);
-		}
-		// Render top layer above shell views
-		render_layer(output, &damage,
-			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]);
-	}
-
-	render_drag_icons(output, &damage, server->input);
-
-	render_layer(output, &damage,
-		&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]);
-
-renderer_end:
-	wlr_output_render_software_cursors(wlr_output, &damage);
-	wlr_renderer_scissor(renderer, NULL);
-	wlr_renderer_end(renderer);
-
-	int width, height;
-	wlr_output_transformed_resolution(wlr_output, &width, &height);
-
-	if (server->config->debug_damage_tracking) {
-		pixman_region32_union_rect(&damage, &damage, 0, 0, width, height);
-	}
-
-	enum wl_output_transform transform =
-		wlr_output_transform_invert(wlr_output->transform);
-	wlr_region_transform(&damage, &damage, transform, width, height);
-
-	if (!wlr_output_damage_swap_buffers(output->damage, &now, &damage)) {
-		goto damage_finish;
-	}
-	output->last_frame = desktop->last_frame = now;
-
-damage_finish:
-	pixman_region32_fini(&damage);
-
-	// Send frame done events to all surfaces
-	output_for_each_surface(output, surface_send_frame_done_iterator,
-		&now);
 }
 
 void output_damage_whole(struct roots_output *output) {
@@ -743,7 +431,7 @@ static void output_damage_handle_frame(struct wl_listener *listener,
 		void *data) {
 	struct roots_output *output =
 		wl_container_of(listener, output, damage_frame);
-	render_output(output);
+	output_render(output);
 }
 
 static void output_damage_handle_destroy(struct wl_listener *listener,

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -30,11 +30,11 @@ void rotate_child_position(double *sx, double *sy, double sw, double sh,
 	}
 
 	// Coordinates relative to the center of the subsurface
-	double ox = *sx - pw/2 + sw/2,
-		oy = *sy - ph/2 + sh/2;
+	double cx = *sx - pw/2 + sw/2,
+		cy = *sy - ph/2 + sh/2;
 	// Rotated coordinates
-	double rx = cos(rotation)*ox - sin(rotation)*oy,
-		ry = cos(rotation)*oy + sin(rotation)*ox;
+	double rx = cos(rotation)*cx - sin(rotation)*cy,
+		ry = cos(rotation)*cy + sin(rotation)*cx;
 	*sx = rx + pw/2 - sw/2;
 	*sy = ry + ph/2 - sh/2;
 }

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -25,87 +25,118 @@
  */
 void rotate_child_position(double *sx, double *sy, double sw, double sh,
 		double pw, double ph, float rotation) {
-	if (rotation != 0.0) {
-		// Coordinates relative to the center of the subsurface
-		double ox = *sx - pw/2 + sw/2,
-			oy = *sy - ph/2 + sh/2;
-		// Rotated coordinates
-		double rx = cos(rotation)*ox - sin(rotation)*oy,
-			ry = cos(rotation)*oy + sin(rotation)*ox;
-		*sx = rx + pw/2 - sw/2;
-		*sy = ry + ph/2 - sh/2;
+	if (rotation == 0.0) {
+		return;
 	}
+
+	// Coordinates relative to the center of the subsurface
+	double ox = *sx - pw/2 + sw/2,
+		oy = *sy - ph/2 + sh/2;
+	// Rotated coordinates
+	double rx = cos(rotation)*ox - sin(rotation)*oy,
+		ry = cos(rotation)*oy + sin(rotation)*ox;
+	*sx = rx + pw/2 - sw/2;
+	*sy = ry + ph/2 - sh/2;
 }
 
-struct layout_data {
-	double x, y;
+struct surface_iterator_data {
+	roots_surface_iterator_func_t user_iterator;
+	void *user_data;
+
+	struct roots_output *output;
+	double ox, oy;
 	int width, height;
 	float rotation;
 };
 
-static void get_layout_position(struct layout_data *data,
-		double *lx, double *ly, const struct wlr_surface *surface,
-		int sx, int sy) {
-	double _sx = sx, _sy = sy;
-	rotate_child_position(&_sx, &_sy, surface->current.width,
-		surface->current.height, data->width, data->height, data->rotation);
-	*lx = data->x + _sx;
-	*ly = data->y + _sy;
+static bool get_surface_box(struct surface_iterator_data *data,
+		struct wlr_surface *surface, int sx, int sy,
+		struct wlr_box *surface_box) {
+	struct roots_output *output = data->output;
+
+	if (!wlr_surface_has_buffer(surface)) {
+		return false;
+	}
+
+	int sw = surface->current.width;
+	int sh = surface->current.height;
+
+	double _sx = sx + surface->sx;
+	double _sy = sy + surface->sy;
+	rotate_child_position(&_sx, &_sy, sw, sh, data->width, data->height,
+		data->rotation);
+
+	struct wlr_box box = {
+		.x = data->ox + _sx,
+		.y = data->oy + _sy,
+		.width = sw,
+		.height = sh,
+	};
+	if (surface_box != NULL) {
+		*surface_box = box;
+	}
+
+	struct wlr_box rotated_box;
+	wlr_box_rotated_bounds(&rotated_box, &box, data->rotation);
+
+	struct wlr_box output_box = {0};
+	wlr_output_effective_resolution(output->wlr_output,
+		&output_box.width, &output_box.height);
+
+	struct wlr_box intersection;
+	return wlr_box_intersection(&intersection, &output_box, &rotated_box);
 }
 
-static void surface_for_each_surface(struct wlr_surface *surface,
-		double lx, double ly, float rotation, struct layout_data *layout_data,
-		wlr_surface_iterator_func_t iterator, void *user_data) {
-	layout_data->x = lx;
-	layout_data->y = ly;
-	layout_data->width = surface->current.width;
-	layout_data->height = surface->current.height;
-	layout_data->rotation = rotation;
+static void output_for_each_surface_iterator(struct wlr_surface *surface,
+		int sx, int sy, void *_data) {
+	struct surface_iterator_data *data = _data;
 
-	wlr_surface_for_each_surface(surface, iterator, user_data);
-}
-
-static void view_for_each_surface(struct roots_view *view,
-		struct layout_data *layout_data, wlr_surface_iterator_func_t iterator,
-		void *user_data) {
-	if (!view->wlr_surface) {
+	struct wlr_box box;
+	bool intersects = get_surface_box(data, surface, sx, sy, &box);
+	if (!intersects) {
 		return;
 	}
 
-	layout_data->x = view->box.x;
-	layout_data->y = view->box.y;
-	layout_data->width = view->wlr_surface->current.width;
-	layout_data->height = view->wlr_surface->current.height;
-	layout_data->rotation = view->rotation;
-
-	switch (view->type) {
-	case ROOTS_XDG_SHELL_V6_VIEW:;
-		struct roots_xdg_surface_v6 *xdg_surface_v6 =
-			roots_xdg_surface_v6_from_view(view);
-		wlr_xdg_surface_v6_for_each_surface(xdg_surface_v6->xdg_surface_v6,
-			iterator, user_data);
-		break;
-	case ROOTS_XDG_SHELL_VIEW:;
-		struct roots_xdg_surface *xdg_surface =
-			roots_xdg_surface_from_view(view);
-		wlr_xdg_surface_for_each_surface(xdg_surface->xdg_surface, iterator,
-			user_data);
-		break;
-	case ROOTS_WL_SHELL_VIEW:;
-		struct roots_wl_shell_surface *wl_shell_surface =
-			roots_wl_shell_surface_from_view(view);
-		wlr_wl_shell_surface_for_each_surface(wl_shell_surface->wl_shell_surface,
-			iterator, user_data);
-		break;
-#if WLR_HAS_XWAYLAND
-	case ROOTS_XWAYLAND_VIEW:
-		wlr_surface_for_each_surface(view->wlr_surface, iterator, user_data);
-		break;
-#endif
-	}
+	data->user_iterator(data->output, surface, &box, data->rotation,
+		data->user_data);
 }
 
-#if WLR_HAS_XWAYLAND
+void output_surface_for_each_surface(struct roots_output *output,
+		struct wlr_surface *surface, double ox, double oy,
+		roots_surface_iterator_func_t iterator, void *user_data) {
+	struct surface_iterator_data data = {
+		.user_iterator = iterator,
+		.user_data = user_data,
+		.output = output,
+		.ox = ox,
+		.oy = oy,
+		.width = surface->current.width,
+		.height = surface->current.height,
+		.rotation = 0,
+	};
+
+	wlr_surface_for_each_surface(surface,
+		output_for_each_surface_iterator, &data);
+}
+
+void output_view_for_each_surface(struct roots_output *output,
+		struct roots_view *view, roots_surface_iterator_func_t iterator,
+		void *user_data) {
+	struct surface_iterator_data data = {
+		.user_iterator = iterator,
+		.user_data = user_data,
+		.output = output,
+		.ox = view->box.x - output->wlr_output->lx,
+		.oy = view->box.y - output->wlr_output->ly,
+		.width = view->box.width,
+		.height = view->box.height,
+		.rotation = view->rotation,
+	};
+
+	view_for_each_surface(view, output_for_each_surface_iterator, &data);
+}
+
+/*#if WLR_HAS_XWAYLAND
 static void xwayland_children_for_each_surface(
 		struct wlr_xwayland_surface *surface,
 		wlr_surface_iterator_func_t iterator, struct layout_data *layout_data,
@@ -120,57 +151,48 @@ static void xwayland_children_for_each_surface(
 			user_data);
 	}
 }
-#endif
+#endif*/
 
-static void drag_icons_for_each_surface(struct roots_input *input,
-		wlr_surface_iterator_func_t iterator, struct layout_data *layout_data,
+void output_layer_for_each_surface(struct roots_output *output,
+		struct wl_list *layer_surfaces, roots_surface_iterator_func_t iterator,
+		void *user_data) {
+	struct roots_layer_surface *layer_surface;
+	wl_list_for_each(layer_surface, layer_surfaces, link) {
+		struct wlr_layer_surface_v1 *wlr_layer_surface_v1 =
+			layer_surface->layer_surface;
+		output_surface_for_each_surface(output, wlr_layer_surface_v1->surface,
+			layer_surface->geo.x, layer_surface->geo.y, iterator,
+			user_data);
+	}
+}
+
+void output_drag_icons_for_each_surface(struct roots_output *output,
+		struct roots_input *input, roots_surface_iterator_func_t iterator,
 		void *user_data) {
 	struct roots_seat *seat;
 	wl_list_for_each(seat, &input->seats, link) {
 		struct roots_drag_icon *drag_icon = seat->drag_icon;
-		if (drag_icon == NULL || !drag_icon->wlr_drag_icon->mapped) {
+		if (!drag_icon || !drag_icon->wlr_drag_icon->mapped) {
 			continue;
 		}
 
-		surface_for_each_surface(drag_icon->wlr_drag_icon->surface,
-			drag_icon->x, drag_icon->y, 0, layout_data,
-			iterator, user_data);
+		double ox = drag_icon->x - output->wlr_output->lx;
+		double oy = drag_icon->y - output->wlr_output->ly;
+		output_surface_for_each_surface(output,
+			drag_icon->wlr_drag_icon->surface, ox, oy, iterator, user_data);
 	}
 }
 
-static void layer_for_each_surface(struct wl_list *layer,
-		const struct wlr_box *output_layout_box,
-		wlr_surface_iterator_func_t iterator, struct layout_data *layout_data,
-		void *user_data) {
-	struct roots_layer_surface *roots_surface;
-	wl_list_for_each(roots_surface, layer, link) {
-		struct wlr_layer_surface_v1 *layer = roots_surface->layer_surface;
-
-		layout_data->x = roots_surface->geo.x + output_layout_box->x;
-		layout_data->y = roots_surface->geo.y + output_layout_box->y;
-		layout_data->width = roots_surface->geo.width;
-		layout_data->height = roots_surface->geo.height;
-		layout_data->rotation = 0;
-		wlr_layer_surface_v1_for_each_surface(layer, iterator, user_data);
-	}
-}
-
-static void output_for_each_surface(struct roots_output *output,
-		wlr_surface_iterator_func_t iterator, struct layout_data *layout_data,
-		void *user_data) {
-	struct wlr_output *wlr_output = output->wlr_output;
+void output_for_each_surface(struct roots_output *output,
+		roots_surface_iterator_func_t iterator, void *user_data) {
 	struct roots_desktop *desktop = output->desktop;
-	struct roots_server *server = desktop->server;
-
-	const struct wlr_box *output_box =
-		wlr_output_layout_get_box(desktop->layout, wlr_output);
 
 	if (output->fullscreen_view != NULL) {
 		struct roots_view *view = output->fullscreen_view;
 
-		view_for_each_surface(view, layout_data, iterator, user_data);
+		output_view_for_each_surface(output, view, iterator, user_data);
 
-#if WLR_HAS_XWAYLAND
+/*#if WLR_HAS_XWAYLAND
 		if (view->type == ROOTS_XWAYLAND_VIEW) {
 			struct roots_xwayland_surface *xwayland_surface =
 				roots_xwayland_surface_from_view(view);
@@ -178,65 +200,34 @@ static void output_for_each_surface(struct roots_output *output,
 				xwayland_surface->xwayland_surface,
 				iterator, layout_data, user_data);
 		}
-#endif
+#endif*/
 	} else {
 		struct roots_view *view;
 		wl_list_for_each_reverse(view, &desktop->views, link) {
-			view_for_each_surface(view, layout_data, iterator, user_data);
+			output_view_for_each_surface(output, view, iterator, user_data);
 		}
-
-		drag_icons_for_each_surface(server->input, iterator,
-			layout_data, user_data);
 	}
+
+	output_drag_icons_for_each_surface(output, desktop->server->input,
+		iterator, user_data);
 
 	size_t len = sizeof(output->layers) / sizeof(output->layers[0]);
 	for (size_t i = 0; i < len; ++i) {
-		layer_for_each_surface(&output->layers[i], output_box,
-			iterator, layout_data, user_data);
+		output_layer_for_each_surface(output, &output->layers[i],
+			iterator, user_data);
 	}
 }
 
 
 struct render_data {
-	struct layout_data layout;
-	struct roots_output *output;
-	struct timespec *when;
 	pixman_region32_t *damage;
 	float alpha;
 };
 
-/**
- * Checks whether a surface at (lx, ly) intersects an output. If `box` is not
- * NULL, it populates it with the surface box in the output, in output-local
- * coordinates.
- */
-static bool surface_intersect_output(struct wlr_surface *surface,
-		struct wlr_output_layout *output_layout, struct wlr_output *wlr_output,
-		double lx, double ly, float rotation, struct wlr_box *box) {
-	double ox = lx, oy = ly;
-	wlr_output_layout_output_coords(output_layout, wlr_output, &ox, &oy);
-
-	ox += surface->sx;
-	oy += surface->sy;
-
-	if (box != NULL) {
-		box->x = ox * wlr_output->scale;
-		box->y = oy * wlr_output->scale;
-		box->width = surface->current.width * wlr_output->scale;
-		box->height = surface->current.height * wlr_output->scale;
-	}
-
-	struct wlr_box layout_box = {
-		.x = lx, .y = ly,
-		.width = surface->current.width, .height = surface->current.height,
-	};
-	wlr_box_rotated_bounds(&layout_box, &layout_box, rotation);
-	return wlr_output_layout_intersects(output_layout, wlr_output, &layout_box);
-}
-
-static void scissor_output(struct roots_output *output, pixman_box32_t *rect) {
-	struct wlr_output *wlr_output = output->wlr_output;
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(wlr_output->backend);
+static void scissor_output(struct wlr_output *wlr_output,
+		pixman_box32_t *rect) {
+	struct wlr_renderer *renderer =
+		wlr_backend_get_renderer(wlr_output->backend);
 	assert(renderer);
 
 	struct wlr_box box = {
@@ -256,59 +247,68 @@ static void scissor_output(struct roots_output *output, pixman_box32_t *rect) {
 	wlr_renderer_scissor(renderer, &box);
 }
 
-static void render_surface(struct wlr_surface *surface, int sx, int sy,
-		void *_data) {
-	struct render_data *data = _data;
-	struct roots_output *output = data->output;
-	float rotation = data->layout.rotation;
+static int scale_length(int length, int offset, float scale) {
+	return round((offset + length) * scale) - round(offset * scale);
+}
 
-	struct wlr_texture *texture = wlr_surface_get_texture(surface);
-	if (texture == NULL) {
-		return;
-	}
+static void scale_box(struct wlr_box *box, float scale) {
+	box->width = scale_length(box->width, box->x, scale);
+	box->height = scale_length(box->height, box->y, scale);
+	box->x = round(box->x * scale);
+	box->y = round(box->y * scale);
+}
 
+static void render_texture(struct wlr_output *wlr_output,
+		pixman_region32_t *output_damage, struct wlr_texture *texture,
+		const struct wlr_box *box, const float matrix[static 9], float alpha) {
 	struct wlr_renderer *renderer =
-		wlr_backend_get_renderer(output->wlr_output->backend);
+		wlr_backend_get_renderer(wlr_output->backend);
 	assert(renderer);
-
-	double lx, ly;
-	get_layout_position(&data->layout, &lx, &ly, surface, sx, sy);
-
-	struct wlr_box box;
-	bool intersects = surface_intersect_output(surface, output->desktop->layout,
-		output->wlr_output, lx, ly, rotation, &box);
-	if (!intersects) {
-		return;
-	}
-
-	struct wlr_box rotated;
-	wlr_box_rotated_bounds(&rotated, &box, rotation);
 
 	pixman_region32_t damage;
 	pixman_region32_init(&damage);
-	pixman_region32_union_rect(&damage, &damage, rotated.x, rotated.y,
-		rotated.width, rotated.height);
-	pixman_region32_intersect(&damage, &damage, data->damage);
+	pixman_region32_union_rect(&damage, &damage, box->x, box->y,
+		box->width, box->height);
+	pixman_region32_intersect(&damage, &damage, output_damage);
 	bool damaged = pixman_region32_not_empty(&damage);
 	if (!damaged) {
 		goto damage_finish;
 	}
 
-	float matrix[9];
-	enum wl_output_transform transform =
-		wlr_output_transform_invert(surface->current.transform);
-	wlr_matrix_project_box(matrix, &box, transform, rotation,
-		output->wlr_output->transform_matrix);
-
 	int nrects;
 	pixman_box32_t *rects = pixman_region32_rectangles(&damage, &nrects);
 	for (int i = 0; i < nrects; ++i) {
-		scissor_output(output, &rects[i]);
-		wlr_render_texture_with_matrix(renderer, texture, matrix, data->alpha);
+		scissor_output(wlr_output, &rects[i]);
+		wlr_render_texture_with_matrix(renderer, texture, matrix, alpha);
 	}
 
 damage_finish:
 	pixman_region32_fini(&damage);
+}
+
+static void render_surface_iterator(struct roots_output *output,
+		struct wlr_surface *surface, struct wlr_box *_box, float rotation,
+		void *_data) {
+	struct render_data *data = _data;
+	struct wlr_output *wlr_output = output->wlr_output;
+	pixman_region32_t *output_damage = data->damage;
+	float alpha = data->alpha;
+
+	struct wlr_texture *texture = wlr_surface_get_texture(surface);
+	if (!texture) {
+		return;
+	}
+
+	struct wlr_box box = *_box;
+	scale_box(&box, wlr_output->scale);
+
+	float matrix[9];
+	enum wl_output_transform transform =
+		wlr_output_transform_invert(surface->current.transform);
+	wlr_matrix_project_box(matrix, &box, transform, rotation,
+		wlr_output->transform_matrix);
+
+	render_texture(wlr_output, output_damage, texture, &box, matrix, alpha);
 }
 
 static void get_decoration_box(struct roots_view *view,
@@ -333,13 +333,12 @@ static void get_decoration_box(struct roots_view *view,
 	box->height = deco_box.height * wlr_output->scale;
 }
 
-static void render_decorations(struct roots_view *view,
-		struct render_data *data) {
+static void render_decorations(struct roots_output *output,
+		struct roots_view *view, struct render_data *data) {
 	if (!view->decorated || view->wlr_surface == NULL) {
 		return;
 	}
 
-	struct roots_output *output = data->output;
 	struct wlr_renderer *renderer =
 		wlr_backend_get_renderer(output->wlr_output->backend);
 	assert(renderer);
@@ -369,7 +368,7 @@ static void render_decorations(struct roots_view *view,
 	pixman_box32_t *rects =
 		pixman_region32_rectangles(&damage, &nrects);
 	for (int i = 0; i < nrects; ++i) {
-		scissor_output(output, &rects[i]);
+		scissor_output(output->wlr_output, &rects[i]);
 		wlr_render_quad_with_matrix(renderer, color, matrix);
 	}
 
@@ -377,41 +376,44 @@ damage_finish:
 	pixman_region32_fini(&damage);
 }
 
-static void render_view(struct roots_view *view, struct render_data *data) {
+static void render_view(struct roots_output *output, struct roots_view *view,
+		struct render_data *data) {
 	// Do not render views fullscreened on other outputs
-	if (view->fullscreen_output != NULL &&
-			view->fullscreen_output != data->output) {
+	if (view->fullscreen_output != NULL && view->fullscreen_output != output) {
 		return;
 	}
 
 	data->alpha = view->alpha;
-	render_decorations(view, data);
-	view_for_each_surface(view, &data->layout, render_surface, data);
+	if (view->fullscreen_output == NULL) {
+		render_decorations(output, view, data);
+	}
+	output_view_for_each_surface(output, view, render_surface_iterator, data);
 }
 
 static void render_layer(struct roots_output *output,
-		const struct wlr_box *output_layout_box, struct render_data *data,
-		struct wl_list *layer) {
-	data->alpha = 1;
-	layer_for_each_surface(layer, output_layout_box, render_surface,
-		&data->layout, data);
+		pixman_region32_t *damage, struct wl_list *layer_surfaces) {
+	struct render_data data = {
+		.damage = damage,
+		.alpha = 1.0f,
+	};
+	output_layer_for_each_surface(output, layer_surfaces,
+		render_surface_iterator, &data);
 }
 
-static void surface_send_frame_done(struct wlr_surface *surface, int sx, int sy,
-		void *_data) {
-	struct render_data *data = _data;
-	struct roots_output *output = data->output;
-	struct timespec *when = data->when;
-	float rotation = data->layout.rotation;
+static void render_drag_icons(struct roots_output *output,
+		pixman_region32_t *damage, struct roots_input *input) {
+	struct render_data data = {
+		.damage = damage,
+		.alpha = 1.0f,
+	};
+	output_drag_icons_for_each_surface(output, input,
+		render_surface_iterator, &data);
+}
 
-	double lx, ly;
-	get_layout_position(&data->layout, &lx, &ly, surface, sx, sy);
-
-	if (!surface_intersect_output(surface, output->desktop->layout,
-			output->wlr_output, lx, ly, rotation, NULL)) {
-		return;
-	}
-
+static void surface_send_frame_done_iterator(struct roots_output *output,
+		struct wlr_surface *surface, struct wlr_box *box, float rotation,
+		void *data) {
+	struct timespec *when = data;
 	wlr_surface_send_frame_done(surface, when);
 }
 
@@ -419,7 +421,8 @@ static void render_output(struct roots_output *output) {
 	struct wlr_output *wlr_output = output->wlr_output;
 	struct roots_desktop *desktop = output->desktop;
 	struct roots_server *server = desktop->server;
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(wlr_output->backend);
+	struct wlr_renderer *renderer =
+		wlr_backend_get_renderer(wlr_output->backend);
 	assert(renderer);
 
 	if (!wlr_output->enabled) {
@@ -460,8 +463,6 @@ static void render_output(struct roots_output *output) {
 	}
 
 	struct render_data data = {
-		.output = output,
-		.when = &now,
 		.damage = &damage,
 		.alpha = 1.0,
 	};
@@ -485,27 +486,25 @@ static void render_output(struct roots_output *output) {
 	int nrects;
 	pixman_box32_t *rects = pixman_region32_rectangles(&damage, &nrects);
 	for (int i = 0; i < nrects; ++i) {
-		scissor_output(output, &rects[i]);
+		scissor_output(output->wlr_output, &rects[i]);
 		wlr_renderer_clear(renderer, clear_color);
 	}
 
-	render_layer(output, output_box, &data,
-			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]);
-	render_layer(output, output_box, &data,
-			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM]);
+	render_layer(output, &damage,
+		&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]);
+	render_layer(output, &damage,
+		&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM]);
 
 	// If a view is fullscreen on this output, render it
 	if (output->fullscreen_view != NULL) {
 		struct roots_view *view = output->fullscreen_view;
 
-		if (view->wlr_surface != NULL) {
-			view_for_each_surface(view, &data.layout, render_surface, &data);
-		}
+		render_view(output, view, &data);
 
 		// During normal rendering the xwayland window tree isn't traversed
 		// because all windows are rendered. Here we only want to render
 		// the fullscreen window's children so we have to traverse the tree.
-#if WLR_HAS_XWAYLAND
+/*#if WLR_HAS_XWAYLAND
 		if (view->type == ROOTS_XWAYLAND_VIEW) {
 			struct roots_xwayland_surface *xwayland_surface =
 				roots_xwayland_surface_from_view(view);
@@ -513,25 +512,22 @@ static void render_output(struct roots_output *output) {
 				xwayland_surface->xwayland_surface,
 				render_surface, &data.layout, &data);
 		}
-#endif
+#endif*/
 	} else {
 		// Render all views
 		struct roots_view *view;
 		wl_list_for_each_reverse(view, &desktop->views, link) {
-			render_view(view, &data);
+			render_view(output, view, &data);
 		}
 		// Render top layer above shell views
-		render_layer(output, output_box, &data,
-				&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]);
+		render_layer(output, &damage,
+			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]);
 	}
 
-	// Render drag icons
-	data.alpha = 1.0;
-	drag_icons_for_each_surface(server->input, render_surface, &data.layout,
-		&data);
+	render_drag_icons(output, &damage, server->input);
 
-	render_layer(output, output_box, &data,
-			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]);
+	render_layer(output, &damage,
+		&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]);
 
 renderer_end:
 	wlr_output_render_software_cursors(wlr_output, &damage);
@@ -558,8 +554,8 @@ damage_finish:
 	pixman_region32_fini(&damage);
 
 	// Send frame done events to all surfaces
-	output_for_each_surface(output, surface_send_frame_done,
-		&data.layout, &data);
+	output_for_each_surface(output, surface_send_frame_done_iterator,
+		&now);
 }
 
 void output_damage_whole(struct roots_output *output) {
@@ -596,46 +592,48 @@ static bool view_accept_damage(struct roots_output *output,
 	return false;
 }
 
-struct damage_data {
-	struct layout_data layout;
-	struct roots_output *output;
-};
+static void damage_surface_iterator(struct roots_output *output,
+		struct wlr_surface *surface, struct wlr_box *_box, float rotation,
+		void *data) {
+	bool *whole = data;
 
-static void damage_whole_surface(struct wlr_surface *surface, int sx, int sy,
-		void *_data) {
-	struct damage_data *data = _data;
-	struct roots_output *output = data->output;
-	float rotation = data->layout.rotation;
+	struct wlr_box box = *_box;
+	scale_box(&box, output->wlr_output->scale);
 
-	double lx, ly;
-	get_layout_position(&data->layout, &lx, &ly, surface, sx, sy);
+	int center_x = box.x + box.width/2;
+	int center_y = box.y + box.height/2;
 
-	if (!wlr_surface_has_buffer(surface)) {
-		return;
+	if (pixman_region32_not_empty(&surface->buffer_damage)) {
+		pixman_region32_t damage;
+		pixman_region32_init(&damage);
+		wlr_surface_get_effective_damage(surface, &damage);
+		wlr_region_scale(&damage, &damage, output->wlr_output->scale);
+		if (ceil(output->wlr_output->scale) > surface->current.scale) {
+			// When scaling up a surface, it'll become blurry so we need to
+			// expand the damage region
+			wlr_region_expand(&damage, &damage,
+				ceil(output->wlr_output->scale) - surface->current.scale);
+		}
+		pixman_region32_translate(&damage, box.x, box.y);
+		wlr_region_rotated_bounds(&damage, &damage, rotation,
+			center_x, center_y);
+		wlr_output_damage_add(output->damage, &damage);
+		pixman_region32_fini(&damage);
 	}
 
-	int ow, oh;
-	wlr_output_transformed_resolution(output->wlr_output, &ow, &oh);
-
-	struct wlr_box box;
-	bool intersects = surface_intersect_output(surface, output->desktop->layout,
-		output->wlr_output, lx, ly, rotation, &box);
-	if (!intersects) {
-		return;
+	if (*whole) {
+		wlr_box_rotated_bounds(&box, &box, rotation);
+		wlr_output_damage_add_box(output->damage, &box);
 	}
 
-	wlr_box_rotated_bounds(&box, &box, rotation);
-
-	wlr_output_damage_add_box(output->damage, &box);
+	wlr_output_schedule_frame(output->wlr_output);
 }
 
 void output_damage_whole_local_surface(struct roots_output *output,
-		struct wlr_surface *surface, double ox, double oy, float rotation) {
-	struct wlr_output_layout_output *layout = wlr_output_layout_get(
-		output->desktop->layout, output->wlr_output);
-	struct damage_data data = { .output = output };
-	surface_for_each_surface(surface, ox + layout->x, oy + layout->y, 0,
-		&data.layout, damage_whole_surface, &data);
+		struct wlr_surface *surface, double ox, double oy) {
+	bool whole = true;
+	output_surface_for_each_surface(output, surface, ox, oy,
+		damage_surface_iterator, &whole);
 }
 
 static void damage_whole_decoration(struct roots_view *view,
@@ -660,65 +658,22 @@ void output_damage_whole_view(struct roots_output *output,
 
 	damage_whole_decoration(view, output);
 
-	struct damage_data data = { .output = output };
-	view_for_each_surface(view, &data.layout, damage_whole_surface, &data);
+	bool whole = true;
+	output_view_for_each_surface(output, view, damage_surface_iterator, &whole);
 }
 
 void output_damage_whole_drag_icon(struct roots_output *output,
 		struct roots_drag_icon *icon) {
-	struct damage_data data = { .output = output };
-	surface_for_each_surface(icon->wlr_drag_icon->surface, icon->x, icon->y, 0,
-		&data.layout, damage_whole_surface, &data);
-}
-
-static void damage_from_surface(struct wlr_surface *surface, int sx, int sy,
-		void *_data) {
-	struct damage_data *data = _data;
-	struct roots_output *output = data->output;
-	struct wlr_output *wlr_output = output->wlr_output;
-	float rotation = data->layout.rotation;
-
-	double lx, ly;
-	get_layout_position(&data->layout, &lx, &ly, surface, sx, sy);
-
-	if (!wlr_surface_has_buffer(surface)) {
-		return;
-	}
-
-	int ow, oh;
-	wlr_output_transformed_resolution(wlr_output, &ow, &oh);
-
-	struct wlr_box box;
-	surface_intersect_output(surface, output->desktop->layout,
-		wlr_output, lx, ly, rotation, &box);
-
-	int center_x = box.x + box.width/2;
-	int center_y = box.y + box.height/2;
-
-	pixman_region32_t damage;
-	pixman_region32_init(&damage);
-	wlr_surface_get_effective_damage(surface, &damage);
-
-	wlr_region_scale(&damage, &damage, wlr_output->scale);
-	if (ceil(wlr_output->scale) > surface->current.scale) {
-		// When scaling up a surface, it'll become blurry so we need to
-		// expand the damage region
-		wlr_region_expand(&damage, &damage,
-			ceil(wlr_output->scale) - surface->current.scale);
-	}
-	pixman_region32_translate(&damage, box.x, box.y);
-	wlr_region_rotated_bounds(&damage, &damage, rotation, center_x, center_y);
-	wlr_output_damage_add(output->damage, &damage);
-	pixman_region32_fini(&damage);
+	bool whole = true;
+	output_surface_for_each_surface(output, icon->wlr_drag_icon->surface,
+		icon->x, icon->y, damage_surface_iterator, &whole);
 }
 
 void output_damage_from_local_surface(struct roots_output *output,
-		struct wlr_surface *surface, double ox, double oy, float rotation) {
-	struct wlr_output_layout_output *layout = wlr_output_layout_get(
-		output->desktop->layout, output->wlr_output);
-	struct damage_data data = { .output = output };
-	surface_for_each_surface(surface, ox + layout->x, oy + layout->y, 0,
-		&data.layout, damage_from_surface, &data);
+		struct wlr_surface *surface, double ox, double oy) {
+	bool whole = false;
+	output_surface_for_each_surface(output, surface, ox, oy,
+		damage_surface_iterator, &whole);
 }
 
 void output_damage_from_view(struct roots_output *output,
@@ -727,8 +682,8 @@ void output_damage_from_view(struct roots_output *output,
 		return;
 	}
 
-	struct damage_data data = { .output = output };
-	view_for_each_surface(view, &data.layout, damage_from_surface, &data);
+	bool whole = false;
+	output_view_for_each_surface(output, view, damage_surface_iterator, &whole);
 }
 
 static void set_mode(struct wlr_output *output,
@@ -805,28 +760,12 @@ static void output_handle_transform(struct wl_listener *listener, void *data) {
 	arrange_layers(output);
 }
 
-struct presentation_data {
-	struct layout_data layout;
-	struct roots_output *output;
-	struct wlr_presentation_event *event;
-};
-
-static void surface_send_presented(struct wlr_surface *surface, int sx, int sy,
-		void *_data) {
-	struct presentation_data *data = _data;
-	struct roots_output *output = data->output;
-	float rotation = data->layout.rotation;
-
-	double lx, ly;
-	get_layout_position(&data->layout, &lx, &ly, surface, sx, sy);
-
-	if (!surface_intersect_output(surface, output->desktop->layout,
-			output->wlr_output, lx, ly, rotation, NULL)) {
-		return;
-	}
-
+static void surface_send_presented_iterator(struct roots_output *output,
+		struct wlr_surface *surface, struct wlr_box *_box, float rotation,
+		void *data) {
+	struct wlr_presentation_event *event = data;
 	wlr_presentation_send_surface_presented(output->desktop->presentation,
-		surface, data->event);
+		surface, event);
 }
 
 static void output_handle_present(struct wl_listener *listener, void *data) {
@@ -843,12 +782,8 @@ static void output_handle_present(struct wl_listener *listener, void *data) {
 		.flags = output_event->flags,
 	};
 
-	struct presentation_data presentation_data = {
-		.output = output,
-		.event = &event,
-	};
-	output_for_each_surface(output, surface_send_presented,
-		&presentation_data.layout, &presentation_data);
+	output_for_each_surface(output,
+		surface_send_presented_iterator, &event);
 }
 
 void handle_new_output(struct wl_listener *listener, void *data) {

--- a/rootston/render.c
+++ b/rootston/render.c
@@ -1,0 +1,324 @@
+#define _POSIX_C_SOURCE 200809L
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <time.h>
+#include <wlr/config.h>
+#include <wlr/types/wlr_compositor.h>
+#include <wlr/types/wlr_matrix.h>
+#include <wlr/util/log.h>
+#include <wlr/util/region.h>
+#include "rootston/layers.h"
+#include "rootston/output.h"
+#include "rootston/server.h"
+
+struct render_data {
+	pixman_region32_t *damage;
+	float alpha;
+};
+
+static void scissor_output(struct wlr_output *wlr_output,
+		pixman_box32_t *rect) {
+	struct wlr_renderer *renderer =
+		wlr_backend_get_renderer(wlr_output->backend);
+	assert(renderer);
+
+	struct wlr_box box = {
+		.x = rect->x1,
+		.y = rect->y1,
+		.width = rect->x2 - rect->x1,
+		.height = rect->y2 - rect->y1,
+	};
+
+	int ow, oh;
+	wlr_output_transformed_resolution(wlr_output, &ow, &oh);
+
+	enum wl_output_transform transform =
+		wlr_output_transform_invert(wlr_output->transform);
+	wlr_box_transform(&box, &box, transform, ow, oh);
+
+	wlr_renderer_scissor(renderer, &box);
+}
+
+static void render_texture(struct wlr_output *wlr_output,
+		pixman_region32_t *output_damage, struct wlr_texture *texture,
+		const struct wlr_box *box, const float matrix[static 9],
+		float rotation, float alpha) {
+	struct wlr_renderer *renderer =
+		wlr_backend_get_renderer(wlr_output->backend);
+	assert(renderer);
+
+	struct wlr_box rotated;
+	wlr_box_rotated_bounds(&rotated, box, rotation);
+
+	pixman_region32_t damage;
+	pixman_region32_init(&damage);
+	pixman_region32_union_rect(&damage, &damage, rotated.x, rotated.y,
+		rotated.width, rotated.height);
+	pixman_region32_intersect(&damage, &damage, output_damage);
+	bool damaged = pixman_region32_not_empty(&damage);
+	if (!damaged) {
+		goto damage_finish;
+	}
+
+	int nrects;
+	pixman_box32_t *rects = pixman_region32_rectangles(&damage, &nrects);
+	for (int i = 0; i < nrects; ++i) {
+		scissor_output(wlr_output, &rects[i]);
+		wlr_render_texture_with_matrix(renderer, texture, matrix, alpha);
+	}
+
+damage_finish:
+	pixman_region32_fini(&damage);
+}
+
+static void render_surface_iterator(struct roots_output *output,
+		struct wlr_surface *surface, struct wlr_box *_box, float rotation,
+		void *_data) {
+	struct render_data *data = _data;
+	struct wlr_output *wlr_output = output->wlr_output;
+	pixman_region32_t *output_damage = data->damage;
+	float alpha = data->alpha;
+
+	struct wlr_texture *texture = wlr_surface_get_texture(surface);
+	if (!texture) {
+		return;
+	}
+
+	struct wlr_box box = *_box;
+	scale_box(&box, wlr_output->scale);
+
+	float matrix[9];
+	enum wl_output_transform transform =
+		wlr_output_transform_invert(surface->current.transform);
+	wlr_matrix_project_box(matrix, &box, transform, rotation,
+		wlr_output->transform_matrix);
+
+	render_texture(wlr_output, output_damage,
+		texture, &box, matrix, rotation, alpha);
+}
+
+static void render_decorations(struct roots_output *output,
+		struct roots_view *view, struct render_data *data) {
+	if (!view->decorated || view->wlr_surface == NULL) {
+		return;
+	}
+
+	struct wlr_renderer *renderer =
+		wlr_backend_get_renderer(output->wlr_output->backend);
+	assert(renderer);
+
+	struct wlr_box box;
+	get_decoration_box(view, output, &box);
+
+	struct wlr_box rotated;
+	wlr_box_rotated_bounds(&rotated, &box, view->rotation);
+
+	pixman_region32_t damage;
+	pixman_region32_init(&damage);
+	pixman_region32_union_rect(&damage, &damage, rotated.x, rotated.y,
+		rotated.width, rotated.height);
+	pixman_region32_intersect(&damage, &damage, data->damage);
+	bool damaged = pixman_region32_not_empty(&damage);
+	if (!damaged) {
+		goto damage_finish;
+	}
+
+	float matrix[9];
+	wlr_matrix_project_box(matrix, &box, WL_OUTPUT_TRANSFORM_NORMAL,
+		view->rotation, output->wlr_output->transform_matrix);
+	float color[] = { 0.2, 0.2, 0.2, view->alpha };
+
+	int nrects;
+	pixman_box32_t *rects =
+		pixman_region32_rectangles(&damage, &nrects);
+	for (int i = 0; i < nrects; ++i) {
+		scissor_output(output->wlr_output, &rects[i]);
+		wlr_render_quad_with_matrix(renderer, color, matrix);
+	}
+
+damage_finish:
+	pixman_region32_fini(&damage);
+}
+
+static void render_view(struct roots_output *output, struct roots_view *view,
+		struct render_data *data) {
+	// Do not render views fullscreened on other outputs
+	if (view->fullscreen_output != NULL && view->fullscreen_output != output) {
+		return;
+	}
+
+	data->alpha = view->alpha;
+	if (view->fullscreen_output == NULL) {
+		render_decorations(output, view, data);
+	}
+	output_view_for_each_surface(output, view, render_surface_iterator, data);
+}
+
+static void render_layer(struct roots_output *output,
+		pixman_region32_t *damage, struct wl_list *layer_surfaces) {
+	struct render_data data = {
+		.damage = damage,
+		.alpha = 1.0f,
+	};
+	output_layer_for_each_surface(output, layer_surfaces,
+		render_surface_iterator, &data);
+}
+
+static void render_drag_icons(struct roots_output *output,
+		pixman_region32_t *damage, struct roots_input *input) {
+	struct render_data data = {
+		.damage = damage,
+		.alpha = 1.0f,
+	};
+	output_drag_icons_for_each_surface(output, input,
+		render_surface_iterator, &data);
+}
+
+static void surface_send_frame_done_iterator(struct roots_output *output,
+		struct wlr_surface *surface, struct wlr_box *box, float rotation,
+		void *data) {
+	struct timespec *when = data;
+	wlr_surface_send_frame_done(surface, when);
+}
+
+void output_render(struct roots_output *output) {
+	struct wlr_output *wlr_output = output->wlr_output;
+	struct roots_desktop *desktop = output->desktop;
+	struct roots_server *server = desktop->server;
+	struct wlr_renderer *renderer =
+		wlr_backend_get_renderer(wlr_output->backend);
+	assert(renderer);
+
+	if (!wlr_output->enabled) {
+		return;
+	}
+
+	struct timespec now;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+
+	float clear_color[] = {0.25f, 0.25f, 0.25f, 1.0f};
+
+	const struct wlr_box *output_box =
+		wlr_output_layout_get_box(desktop->layout, wlr_output);
+
+	// Check if we can delegate the fullscreen surface to the output
+	if (output->fullscreen_view != NULL &&
+			output->fullscreen_view->wlr_surface != NULL) {
+		struct roots_view *view = output->fullscreen_view;
+
+		// Make sure the view is centered on screen
+		struct wlr_box view_box;
+		view_get_box(view, &view_box);
+		double view_x = (double)(output_box->width - view_box.width) / 2 +
+			output_box->x;
+		double view_y = (double)(output_box->height - view_box.height) / 2 +
+			output_box->y;
+		view_move(view, view_x, view_y);
+
+		// Fullscreen views are rendered on a black background
+		clear_color[0] = clear_color[1] = clear_color[2] = 0;
+	}
+
+	bool needs_swap;
+	pixman_region32_t damage;
+	pixman_region32_init(&damage);
+	if (!wlr_output_damage_make_current(output->damage, &needs_swap, &damage)) {
+		return;
+	}
+
+	struct render_data data = {
+		.damage = &damage,
+		.alpha = 1.0,
+	};
+
+	if (!needs_swap) {
+		// Output doesn't need swap and isn't damaged, skip rendering completely
+		goto damage_finish;
+	}
+
+	wlr_renderer_begin(renderer, wlr_output->width, wlr_output->height);
+
+	if (!pixman_region32_not_empty(&damage)) {
+		// Output isn't damaged but needs buffer swap
+		goto renderer_end;
+	}
+
+	if (server->config->debug_damage_tracking) {
+		wlr_renderer_clear(renderer, (float[]){1, 1, 0, 1});
+	}
+
+	int nrects;
+	pixman_box32_t *rects = pixman_region32_rectangles(&damage, &nrects);
+	for (int i = 0; i < nrects; ++i) {
+		scissor_output(output->wlr_output, &rects[i]);
+		wlr_renderer_clear(renderer, clear_color);
+	}
+
+	render_layer(output, &damage,
+		&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]);
+	render_layer(output, &damage,
+		&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM]);
+
+	// If a view is fullscreen on this output, render it
+	if (output->fullscreen_view != NULL) {
+		struct roots_view *view = output->fullscreen_view;
+
+		render_view(output, view, &data);
+
+		// During normal rendering the xwayland window tree isn't traversed
+		// because all windows are rendered. Here we only want to render
+		// the fullscreen window's children so we have to traverse the tree.
+#if WLR_HAS_XWAYLAND
+		if (view->type == ROOTS_XWAYLAND_VIEW) {
+			struct roots_xwayland_surface *xwayland_surface =
+				roots_xwayland_surface_from_view(view);
+			output_xwayland_children_for_each_surface(output,
+				xwayland_surface->xwayland_surface,
+				render_surface_iterator, &data);
+		}
+#endif
+	} else {
+		// Render all views
+		struct roots_view *view;
+		wl_list_for_each_reverse(view, &desktop->views, link) {
+			render_view(output, view, &data);
+		}
+		// Render top layer above shell views
+		render_layer(output, &damage,
+			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]);
+	}
+
+	render_drag_icons(output, &damage, server->input);
+
+	render_layer(output, &damage,
+		&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]);
+
+renderer_end:
+	wlr_output_render_software_cursors(wlr_output, &damage);
+	wlr_renderer_scissor(renderer, NULL);
+	wlr_renderer_end(renderer);
+
+	int width, height;
+	wlr_output_transformed_resolution(wlr_output, &width, &height);
+
+	if (server->config->debug_damage_tracking) {
+		pixman_region32_union_rect(&damage, &damage, 0, 0, width, height);
+	}
+
+	enum wl_output_transform transform =
+		wlr_output_transform_invert(wlr_output->transform);
+	wlr_region_transform(&damage, &damage, transform, width, height);
+
+	if (!wlr_output_damage_swap_buffers(output->damage, &now, &damage)) {
+		goto damage_finish;
+	}
+	output->last_frame = desktop->last_frame = now;
+
+damage_finish:
+	pixman_region32_fini(&damage);
+
+	// Send frame done events to all surfaces
+	output_for_each_surface(output, surface_send_frame_done_iterator,
+		&now);
+}

--- a/rootston/view.c
+++ b/rootston/view.c
@@ -559,6 +559,15 @@ void view_damage_whole(struct roots_view *view) {
 	}
 }
 
+void view_for_each_surface(struct roots_view *view,
+		wlr_surface_iterator_func_t iterator, void *user_data) {
+	if (view->impl->for_each_surface) {
+		view->impl->for_each_surface(view, iterator, user_data);
+	} else if (view->wlr_surface) {
+		wlr_surface_for_each_surface(view->wlr_surface, iterator, user_data);
+	}
+}
+
 void view_update_position(struct roots_view *view, int x, int y) {
 	if (view->box.x == x && view->box.y == y) {
 		return;

--- a/rootston/wl_shell.c
+++ b/rootston/wl_shell.c
@@ -80,6 +80,13 @@ static void close(struct roots_view *view) {
 	wl_client_destroy(surf->client);
 }
 
+static void for_each_surface(struct roots_view *view,
+		wlr_surface_iterator_func_t iterator, void *user_data) {
+	struct wlr_wl_shell_surface *surf =
+		roots_wl_shell_surface_from_view(view)->wl_shell_surface;
+	wlr_wl_shell_surface_for_each_surface(surf, iterator, user_data);
+}
+
 static void destroy(struct roots_view *view) {
 	struct roots_wl_shell_surface *roots_surface =
 		roots_wl_shell_surface_from_view(view);
@@ -98,6 +105,7 @@ static void destroy(struct roots_view *view) {
 static const struct roots_view_interface view_impl = {
 	.resize = resize,
 	.close = close,
+	.for_each_surface = for_each_surface,
 	.destroy = destroy,
 };
 

--- a/rootston/xdg_shell.c
+++ b/rootston/xdg_shell.c
@@ -256,6 +256,13 @@ static void close(struct roots_view *view) {
 	wlr_xdg_toplevel_send_close(xdg_surface);
 }
 
+static void for_each_surface(struct roots_view *view,
+		wlr_surface_iterator_func_t iterator, void *user_data) {
+	struct wlr_xdg_surface *xdg_surface =
+		roots_xdg_surface_from_view(view)->xdg_surface;
+	wlr_xdg_surface_for_each_surface(xdg_surface, iterator, user_data);
+}
+
 static void destroy(struct roots_view *view) {
 	struct roots_xdg_surface *roots_xdg_surface =
 		roots_xdg_surface_from_view(view);
@@ -281,6 +288,7 @@ static const struct roots_view_interface view_impl = {
 	.maximize = maximize,
 	.set_fullscreen = set_fullscreen,
 	.close = close,
+	.for_each_surface = for_each_surface,
 	.destroy = destroy,
 };
 

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -255,6 +255,13 @@ static void close(struct roots_view *view) {
 	wlr_xdg_surface_v6_send_close(surface);
 }
 
+static void for_each_surface(struct roots_view *view,
+		wlr_surface_iterator_func_t iterator, void *user_data) {
+	struct wlr_xdg_surface_v6 *surface =
+		roots_xdg_surface_v6_from_view(view)->xdg_surface_v6;
+	wlr_xdg_surface_v6_for_each_surface(surface, iterator, user_data);
+}
+
 static void destroy(struct roots_view *view) {
 	struct roots_xdg_surface_v6 *roots_xdg_surface =
 		roots_xdg_surface_v6_from_view(view);
@@ -279,6 +286,7 @@ static const struct roots_view_interface view_impl = {
 	.maximize = maximize,
 	.set_fullscreen = set_fullscreen,
 	.close = close,
+	.for_each_surface = for_each_surface,
 	.destroy = destroy,
 };
 


### PR DESCRIPTION
- [x] Add surface iterators
- [x] Fix rotated views rendering
- [x] Fix input events offset with rotated views (maybe due to window geometry?)
- [x] Fix fullscreen Xwayland surface children not rendered
- [x] Split rendering code in `render.c`

Updates https://github.com/swaywm/wlroots/issues/839