### PR TITLE
seat: guard against button count corruption

### DIFF
--- a/types/seat/wlr_seat_pointer.c
+++ b/types/seat/wlr_seat_pointer.c
@@ -346,7 +346,11 @@ uint32_t wlr_seat_pointer_notify_button(struct wlr_seat *wlr_seat,
 		}
 		wlr_seat->pointer_state.button_count++;
 	} else {
-		wlr_seat->pointer_state.button_count--;
+		if (wlr_seat->pointer_state.button_count == 0) {
+			wlr_log(WLR_ERROR, "Corrupted seat button count");
+		} else {
+			wlr_seat->pointer_state.button_count--;
+		}
 	}
 
 	struct wlr_seat_pointer_grab *grab = wlr_seat->pointer_state.grab;


### PR DESCRIPTION
This is still a compositor bug, and bad events will be sent to clients. We'll
need to track each button separately to handle this in wlroots.

Fixes https://github.com/swaywm/sway/issues/3538
Fixes https://github.com/swaywm/wlroots/issues/1576