### PR TITLE
seat: only store serial if pressing a button

### DIFF
--- a/types/seat/wlr_seat_pointer.c
+++ b/types/seat/wlr_seat_pointer.c
@@ -356,7 +356,8 @@ uint32_t wlr_seat_pointer_notify_button(struct wlr_seat *wlr_seat,
 	struct wlr_seat_pointer_grab *grab = wlr_seat->pointer_state.grab;
 	uint32_t serial = grab->interface->button(grab, time, button, state);
 
-	if (serial && wlr_seat->pointer_state.button_count == 1) {
+	if (serial && wlr_seat->pointer_state.button_count == 1 &&
+			state == WL_POINTER_BUTTON_STATE_PRESSED) {
 		wlr_seat->pointer_state.grab_serial = serial;
 	}
 


### PR DESCRIPTION
The grab serial can be used to start a pointer grab. A button pressed event
should be used for this purpose.

Thus, we should only save the grab serial if it's the first button pressed
event we send. This commit makes it so the serial is not saved if a button is
released while another button is still pressed.