### PR TITLE
seat: fix remaining wlr_button_state enum rename

### DIFF
--- a/types/seat/wlr_seat_pointer.c
+++ b/types/seat/wlr_seat_pointer.c
@@ -357,7 +357,7 @@ uint32_t wlr_seat_pointer_notify_button(struct wlr_seat *wlr_seat,
 	uint32_t serial = grab->interface->button(grab, time, button, state);
 
 	if (serial && wlr_seat->pointer_state.button_count == 1 &&
-			state == WL_POINTER_BUTTON_STATE_PRESSED) {
+			state == WLR_BUTTON_PRESSED) {
 		wlr_seat->pointer_state.grab_serial = serial;
 	}
 


### PR DESCRIPTION
Fixes regression introduced by merging #1589 and #1590 together.