### PR TITLE
backend/session: add noop session

### DIFF
--- a/backend/meson.build
+++ b/backend/meson.build
@@ -23,6 +23,7 @@ backend_files = files(
 	'noop/backend.c',
 	'noop/output.c',
 	'session/direct-ipc.c',
+	'session/noop.c',
 	'session/session.c',
 	'wayland/backend.c',
 	'wayland/output.c',

--- a/backend/session/noop.c
+++ b/backend/session/noop.c
@@ -1,0 +1,48 @@
+#define _POSIX_C_SOURCE 200809L
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <wayland-server.h>
+#include <wlr/backend/session/interface.h>
+#include <wlr/util/log.h>
+#include "util/signal.h"
+
+const struct session_impl session_noop;
+
+static int noop_session_open(struct wlr_session *base, const char *path) {
+	return open(path, O_RDWR | O_CLOEXEC);
+}
+
+static void noop_session_close(struct wlr_session *base, int fd) {
+	close(fd);
+}
+
+static bool noop_change_vt(struct wlr_session *base, unsigned vt) {
+	return false;
+}
+
+static void noop_session_destroy(struct wlr_session *base) {
+	free(base);
+}
+
+static struct wlr_session *noop_session_create(struct wl_display *disp) {
+	struct wlr_session *session = calloc(1, sizeof(*session));
+	if (!session) {
+		wlr_log_errno(WLR_ERROR, "Allocation failed");
+		return NULL;
+	}
+
+	session->impl = &session_noop;
+
+	wlr_log(WLR_INFO, "Successfully initialized noop session");
+	return session;
+}
+
+const struct session_impl session_noop = {
+	.create = noop_session_create,
+	.destroy = noop_session_destroy,
+	.open = noop_session_open,
+	.close = noop_session_close,
+	.change_vt = noop_change_vt,
+};


### PR DESCRIPTION
This is the first step towards being able to run via DRM leasing and on render
nodes.

Test with:

    export WLR_BACKENDS=drm
    export WLR_SESSION=noop
    export WLR_DRM_DEVICES=/dev/dri/renderD128

Fixes https://github.com/swaywm/wlroots/issues/1437