### PR TITLE
xwayland: don't set DISPLAY

### DIFF
--- a/include/wlr/xwayland.h
+++ b/include/wlr/xwayland.h
@@ -24,7 +24,6 @@ struct wlr_xwayland {
 	pid_t pid;
 	struct wl_client *client;
 	struct wl_event_source *sigusr1_source;
-	struct wl_listener client_destroy;
 	struct wlr_xwm *xwm;
 	struct wlr_xwayland_cursor *cursor;
 	int wm_fd[2], wl_fd[2];
@@ -34,10 +33,9 @@ struct wlr_xwayland {
 	/* Anything above display is reset on Xwayland restart, rest is conserved */
 
 	int display;
+	char display_name[16];
 	int x_fd[2];
 	struct wl_event_source *x_fd_read_event[2];
-	struct wl_listener display_destroy;
-
 	bool lazy;
 
 	struct wl_display *wl_display;
@@ -49,14 +47,16 @@ struct wlr_xwayland {
 		struct wl_signal new_surface;
 	} events;
 
-	struct wl_listener seat_destroy;
-
 	/**
 	 * Add a custom event handler to xwayland. Return 1 if the event was
 	 * handled or 0 to use the default wlr-xwayland handler. wlr-xwayland will
 	 * free the event.
 	 */
 	int (*user_event_handler)(struct wlr_xwm *xwm, xcb_generic_event_t *event);
+
+	struct wl_listener client_destroy;
+	struct wl_listener display_destroy;
+	struct wl_listener seat_destroy;
 
 	void *data;
 };

--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -396,6 +396,8 @@ struct roots_desktop *desktop_create(struct roots_server *server,
 			&desktop->xwayland_surface);
 		desktop->xwayland_surface.notify = handle_xwayland_surface;
 
+		setenv("DISPLAY", desktop->xwayland->display_name, true);
+
 		if (wlr_xcursor_manager_load(desktop->xcursor_manager, 1)) {
 			wlr_log(WLR_ERROR, "Cannot load XWayland XCursor theme");
 		}

--- a/xwayland/xwayland.c
+++ b/xwayland/xwayland.c
@@ -165,11 +165,8 @@ static void xwayland_finish_display(struct wlr_xwayland *wlr_xwayland) {
 
 	unlink_display_sockets(wlr_xwayland->display);
 	wlr_xwayland->display = -1;
-	unsetenv("DISPLAY");
+	wlr_xwayland->display_name[0] = '\0';
 }
-
-static bool xwayland_start_display(struct wlr_xwayland *wlr_xwayland,
-	struct wl_display *wl_display);
 
 static bool xwayland_start_server(struct wlr_xwayland *wlr_xwayland);
 static bool xwayland_start_server_lazy(struct wlr_xwayland *wlr_xwayland);
@@ -284,10 +281,8 @@ static bool xwayland_start_display(struct wlr_xwayland *wlr_xwayland,
 		return false;
 	}
 
-	char display_name[16];
-	snprintf(display_name, sizeof(display_name), ":%d", wlr_xwayland->display);
-	setenv("DISPLAY", display_name, true);
-
+	snprintf(wlr_xwayland->display_name, sizeof(wlr_xwayland->display_name),
+		":%d", wlr_xwayland->display);
 	return true;
 }
 


### PR DESCRIPTION
Let the compositor set it. This allows for multiple Xwayland instances to run
at the same time.

Fixes https://github.com/swaywm/wlroots/issues/1442

* * *

Breaking change: compositors now need to set `DISPLAY` after initializing Xwayland. The value `DISPLAY` needs to be set to is stored in `wlr_xwayland.display_name`.