### PR TITLE
xwm: use min size as base size hint if it is missing and vice versa

### DIFF
--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -583,10 +583,22 @@ static void read_surface_normal_hints(struct wlr_xwm *xwm,
 	memcpy(xsurface->size_hints, &size_hints,
 		sizeof(struct wlr_xwayland_surface_size_hints));
 
-	if ((size_hints.flags & XCB_ICCCM_SIZE_HINT_P_MIN_SIZE) == 0) {
+	bool has_min_size_hints = (size_hints.flags & XCB_ICCCM_SIZE_HINT_P_MIN_SIZE) == 0;
+	bool has_base_size_hints = (size_hints.flags & XCB_ICCCM_SIZE_HINT_BASE_SIZE) == 0;
+	/* ICCCM says that if absent, min size is equal to base size and vice versa */
+	if (!has_min_size_hints && !has_base_size_hints) {
 		xsurface->size_hints->min_width = -1;
 		xsurface->size_hints->min_height = -1;
+		xsurface->size_hints->base_width = -1;
+		xsurface->size_hints->base_height = -1;
+	} else if (!has_base_size_hints) {
+		xsurface->size_hints->base_width = xsurface->size_hints->min_width;
+		xsurface->size_hints->base_height = xsurface->size_hints->min_height;
+	} else if (!has_min_size_hints) {
+		xsurface->size_hints->base_width = xsurface->size_hints->min_width;
+		xsurface->size_hints->base_height = xsurface->size_hints->min_height;
 	}
+
 	if ((size_hints.flags & XCB_ICCCM_SIZE_HINT_P_MAX_SIZE) == 0) {
 		xsurface->size_hints->max_width = -1;
 		xsurface->size_hints->max_height = -1;


### PR DESCRIPTION
This is what ICCCM states that a WM should do.