### PR TITLE
seat: add debug logs when validating grab serials

### DIFF
--- a/types/seat/wlr_seat_pointer.c
+++ b/types/seat/wlr_seat_pointer.c
@@ -412,10 +412,16 @@ bool wlr_seat_validate_pointer_grab_serial(struct wlr_seat *seat,
 		struct wlr_surface *origin, uint32_t serial) {
 	if (seat->pointer_state.button_count != 1 ||
 			seat->pointer_state.grab_serial != serial) {
+		wlr_log(WLR_DEBUG, "Pointer grab serial validation failed: "
+			"button_count=%"PRIu32" grab_serial=%"PRIu32" (got %"PRIu32")",
+			seat->pointer_state.button_count,
+			seat->pointer_state.grab_serial, serial);
 		return false;
 	}
 
 	if (origin != NULL && seat->pointer_state.focused_surface != origin) {
+		wlr_log(WLR_DEBUG, "Pointer grab serial validation failed: "
+			"invalid origin surface");
 		return false;
 	}
 

--- a/types/seat/wlr_seat_touch.c
+++ b/types/seat/wlr_seat_touch.c
@@ -365,6 +365,10 @@ bool wlr_seat_validate_touch_grab_serial(struct wlr_seat *seat,
 		struct wlr_touch_point **point_ptr) {
 	if (wlr_seat_touch_num_points(seat) != 1 ||
 			seat->touch_state.grab_serial != serial) {
+		wlr_log(WLR_DEBUG, "Touch grab serial validation failed: "
+			"num_points=%d grab_serial=%"PRIu32" (got %"PRIu32")",
+			wlr_seat_touch_num_points(seat),
+			seat->touch_state.grab_serial, serial);
 		return false;
 	}
 
@@ -378,5 +382,7 @@ bool wlr_seat_validate_touch_grab_serial(struct wlr_seat *seat,
 		}
 	}
 
+	wlr_log(WLR_DEBUG, "Touch grab serial validation failed: "
+		"invalid origin surface");
 	return false;
 }


### PR DESCRIPTION
Makes it easier to debug when something goes wrong, e.g. button_count stuck
to 2 because the compositor ate a button release event.