### PR TITLE
wlr_output_layout_get_box: handle empty layout

### DIFF
--- a/types/wlr_output_layout.c
+++ b/types/wlr_output_layout.c
@@ -380,22 +380,24 @@ struct wlr_box *wlr_output_layout_get_box(
 		}
 	} else {
 		// layout extents
-		int min_x = INT_MAX, min_y = INT_MAX;
-		int max_x = INT_MIN, max_y = INT_MIN;
-		wl_list_for_each(l_output, &layout->outputs, link) {
-			struct wlr_box *box = output_layout_output_get_box(l_output);
-
-			if (box->x < min_x) {
-				min_x = box->x;
-			}
-			if (box->y < min_y) {
-				min_y = box->y;
-			}
-			if (box->x + box->width > max_x) {
-				max_x = box->x + box->width;
-			}
-			if (box->y + box->height > max_y) {
-				max_y = box->y + box->height;
+		int min_x = 0, max_x = 0, min_y = 0, max_y = 0;
+		if (!wl_list_empty(&layout->outputs)) {
+			min_x = min_y = INT_MAX;
+			max_x = max_y = INT_MIN;
+			wl_list_for_each(l_output, &layout->outputs, link) {
+				struct wlr_box *box = output_layout_output_get_box(l_output);
+				if (box->x < min_x) {
+					min_x = box->x;
+				}
+				if (box->y < min_y) {
+					min_y = box->y;
+				}
+				if (box->x + box->width > max_x) {
+					max_x = box->x + box->width;
+				}
+				if (box->y + box->height > max_y) {
+					max_y = box->y + box->height;
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes swaywm/sway#3734

If there were no outputs in the output layout,
wlr_output_layout_get_box would return the box:

```
{
  .x = INT_MIN,
  .y = INT_MIN,
  .width = INT_MIN - INT_MAX,
  .height = INT_MIN - INT_MAX
}
```

which results in an integer underflow for both the width and height.

This changes the logic to have the box be all zeroes, since an empty
output layout does not have a width or height and the location of
something without a size is irrelevant so this just uses the origin.