### PR TITLE
meson: remove -Wredundant-decls

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -31,7 +31,6 @@ add_project_arguments(cc.get_supported_arguments([
 	'-Wpointer-arith',
 	'-Winit-self',
 	'-Wstrict-prototypes',
-	'-Wredundant-decls',
 	'-Wimplicit-fallthrough=2',
 	'-Wendif-labels',
 	'-Wstrict-aliasing=2',


### PR DESCRIPTION
This is causing issues with wayland-scanner generated files. The client and
server headers are declaring the same structs. We include both in the Wayland
backend.

See https://gitlab.freedesktop.org/wayland/wayland/issues/82