### PR TITLE
Add ability to distinguish between touchpads and mice.

### DIFF
--- a/backend/headless/input_device.c
+++ b/backend/headless/input_device.c
@@ -51,7 +51,7 @@ struct wlr_input_device *wlr_headless_add_input_device(
 			wlr_log(WLR_ERROR, "Unable to allocate wlr_pointer");
 			goto error;
 		}
-		wlr_pointer_init(wlr_device->pointer, NULL);
+		wlr_pointer_init(wlr_device->pointer, NULL, false);
 		break;
 	case WLR_INPUT_DEVICE_TOUCH:
 		wlr_device->touch = calloc(1, sizeof(struct wlr_touch));

--- a/backend/libinput/pointer.c
+++ b/backend/libinput/pointer.c
@@ -16,7 +16,8 @@ struct wlr_pointer *create_libinput_pointer(
 		wlr_log(WLR_ERROR, "Unable to allocate wlr_pointer");
 		return NULL;
 	}
-	wlr_pointer_init(wlr_pointer, NULL);
+	wlr_pointer_init(wlr_pointer, NULL,
+		libinput_device_config_tap_get_finger_count(libinput_dev) > 0);
 	return wlr_pointer;
 }
 

--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -383,7 +383,7 @@ void create_wl_pointer(struct wl_pointer *wl_pointer, struct wlr_wl_output *outp
 	wlr_dev = &dev->wlr_input_device;
 	wlr_dev->pointer = &pointer->wlr_pointer;
 	wlr_dev->output_name = strdup(output->wlr_output.name);
-	wlr_pointer_init(wlr_dev->pointer, &pointer_impl);
+	wlr_pointer_init(wlr_dev->pointer, &pointer_impl, false);
 
 	wlr_signal_emit_safe(&backend->backend.events.new_input, wlr_dev);
 }

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -200,7 +200,7 @@ struct wlr_output *wlr_x11_output_create(struct wlr_backend *backend) {
 
 	wlr_input_device_init(&output->pointer_dev, WLR_INPUT_DEVICE_POINTER,
 		&input_device_impl, "X11 pointer", 0, 0);
-	wlr_pointer_init(&output->pointer, &pointer_impl);
+	wlr_pointer_init(&output->pointer, &pointer_impl, false);
 	output->pointer_dev.pointer = &output->pointer;
 	output->pointer_dev.output_name = strdup(wlr_output->name);
 

--- a/include/wlr/interfaces/wlr_pointer.h
+++ b/include/wlr/interfaces/wlr_pointer.h
@@ -16,7 +16,8 @@ struct wlr_pointer_impl {
 };
 
 void wlr_pointer_init(struct wlr_pointer *pointer,
-		const struct wlr_pointer_impl *impl);
+		const struct wlr_pointer_impl *impl,
+		bool is_touchpad);
 void wlr_pointer_destroy(struct wlr_pointer *pointer);
 
 #endif

--- a/include/wlr/types/wlr_pointer.h
+++ b/include/wlr/types/wlr_pointer.h
@@ -18,6 +18,8 @@ struct wlr_pointer_impl;
 struct wlr_pointer {
 	const struct wlr_pointer_impl *impl;
 
+	bool is_touchpad;
+
 	struct {
 		struct wl_signal motion;
 		struct wl_signal motion_absolute;

--- a/rootston/input.c
+++ b/rootston/input.c
@@ -17,12 +17,15 @@
 #include "rootston/seat.h"
 #include "rootston/server.h"
 
-static const char *device_type(enum wlr_input_device_type type) {
-	switch (type) {
+static const char *device_type(struct wlr_input_device *device) {
+	switch (device->type) {
 	case WLR_INPUT_DEVICE_KEYBOARD:
 		return "keyboard";
 	case WLR_INPUT_DEVICE_POINTER:
-		return "pointer";
+		if (device->pointer->is_touchpad) {
+			return "touchpad";
+		}
+		return "mouse";
 	case WLR_INPUT_DEVICE_SWITCH:
 		return "switch";
 	case WLR_INPUT_DEVICE_TOUCH:
@@ -65,7 +68,7 @@ static void handle_new_input(struct wl_listener *listener, void *data) {
 	}
 
 	wlr_log(WLR_DEBUG, "New input device: %s (%d:%d) %s seat:%s", device->name,
-			device->vendor, device->product, device_type(device->type), seat_name);
+			device->vendor, device->product, device_type(device), seat_name);
 
 	roots_seat_add_device(seat, device);
 

--- a/types/wlr_pointer.c
+++ b/types/wlr_pointer.c
@@ -5,7 +5,9 @@
 #include <wlr/types/wlr_pointer.h>
 
 void wlr_pointer_init(struct wlr_pointer *pointer,
-		const struct wlr_pointer_impl *impl) {
+		const struct wlr_pointer_impl *impl,
+		bool is_touchpad) {
+	pointer->is_touchpad = is_touchpad;
 	pointer->impl = impl;
 	wl_signal_init(&pointer->events.motion);
 	wl_signal_init(&pointer->events.motion_absolute);


### PR DESCRIPTION
Currently, both touchpads and mice are `WLR_INPUT_DEVICE_POINTER`, with no ability to distinguish between touchpad and mice.

This is necessary for swaywm/sway#3784, which allows users to create default input configs per device type (i.e. natural scrolling for all touchpads, but no natural scrolling for all mice).

To test this change, rootston was updated to reflect this, printing out `mouse` or `touchpad` depending on the input device. On my machine (XPS 9560), it was confirmed to work:
```
2019-03-14 11:55:04 - [rootston/input.c:71] New input device: DLL07BE:01 06CB:7A13 Touchpad (1739:31251) touchpad seat:seat0
2019-03-14 11:55:04 - [rootston/input.c:71] New input device: Logitech USB Receiver (1133:50487) mouse seat:seat0
```