### PR TITLE
backend/wayland: improve output number handling

### DIFF
--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -290,8 +290,8 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *wlr_backend) {
 	wlr_output_update_custom_mode(wlr_output, 1280, 720, 0);
 	strncpy(wlr_output->make, "wayland", sizeof(wlr_output->make));
 	strncpy(wlr_output->model, "wayland", sizeof(wlr_output->model));
-	snprintf(wlr_output->name, sizeof(wlr_output->name), "WL-%d",
-		wl_list_length(&backend->outputs) + 1);
+	snprintf(wlr_output->name, sizeof(wlr_output->name), "WL-%lu",
+		++backend->last_output_num);
 
 	output->backend = backend;
 

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -24,6 +24,7 @@ struct wlr_wl_backend {
 	struct wlr_egl egl;
 	struct wlr_renderer *renderer;
 	size_t requested_outputs;
+	size_t last_output_num;
 	struct wl_listener local_display_destroy;
 	/* remote state */
 	struct wl_display *remote_display;


### PR DESCRIPTION
This improves the way the output numbers are handled for the wayland
backend. Instead of using the number of active outputs plus one, the
last used number is stored and new outputs will increment it. This
fixes the situation where you start with one output, create a second,
close the first, and create a third. Without this, both outputs will be
`WL-2`, which causes an issue since the identifier will also be
identical. With this, the last output is `WL-3` and the outputs can be
distinguished.

I'll submit a PR to do the same for the x11 backend after this gets merged