### PR TITLE
backend/x11: improve output number handling

### DIFF
--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -146,8 +146,8 @@ struct wlr_output *wlr_x11_output_create(struct wlr_backend *backend) {
 
 	output_set_refresh(&output->wlr_output, 0);
 
-	snprintf(wlr_output->name, sizeof(wlr_output->name), "X11-%d",
-		wl_list_length(&x11->outputs) + 1);
+	snprintf(wlr_output->name, sizeof(wlr_output->name), "X11-%ld",
+		++x11->last_output_num);
 	parse_xcb_setup(wlr_output, x11->xcb);
 
 	uint32_t mask = XCB_CW_EVENT_MASK;

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -47,6 +47,7 @@ struct wlr_x11_backend {
 	xcb_screen_t *screen;
 
 	size_t requested_outputs;
+	size_t last_output_num;
 	struct wl_list outputs; // wlr_x11_output::link
 
 	struct wlr_keyboard keyboard;


### PR DESCRIPTION
_Same as #1615, but for the x11 backend_

This improves the way the output numbers are handled for the x11
backend. Instead of using the number of active outputs plus one, the
last used number is stored and new outputs will increment it. This
fixes the situation where you start with one output, create a second,
close the first, and create a third. Without this, both outputs will be
X11-2, which causes an issue since the identifier will also be
identical. With this, the last output is X11-3 and the outputs can be
distinguished.