### PR TITLE
backend/headless: improve output number handling

### DIFF
--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -128,8 +128,8 @@ struct wlr_output *wlr_headless_add_output(struct wlr_backend *wlr_backend,
 	output_set_custom_mode(wlr_output, width, height, 0);
 	strncpy(wlr_output->make, "headless", sizeof(wlr_output->make));
 	strncpy(wlr_output->model, "headless", sizeof(wlr_output->model));
-	snprintf(wlr_output->name, sizeof(wlr_output->name), "HEADLESS-%d",
-		wl_list_length(&backend->outputs) + 1);
+	snprintf(wlr_output->name, sizeof(wlr_output->name), "HEADLESS-%ld",
+		++backend->last_output_num);
 
 	if (!wlr_egl_make_current(&output->backend->egl, output->egl_surface,
 			NULL)) {

--- a/include/backend/headless.h
+++ b/include/backend/headless.h
@@ -12,6 +12,7 @@ struct wlr_headless_backend {
 	struct wlr_renderer *renderer;
 	struct wl_display *display;
 	struct wl_list outputs;
+	size_t last_output_num;
 	struct wl_list input_devices;
 	struct wl_listener display_destroy;
 	bool started;


### PR DESCRIPTION
_Same as #1615, but for the headless backend_

This improves the way the output numbers are handled for the headless
backend. Instead of using the number of active outputs plus one, the
last used number is stored and new outputs will increment it. This
fixes the situation where you start with one output, create a second,
close the first, and create a third. Without this, both outputs will be
HEADLESS-2, which causes an issue since the identifier will also be
identical. With this, the last output is HEADLESS-3 and the outputs can
be distinguished.