### PR TITLE
backend/noop: improve output number handling

### DIFF
--- a/backend/noop/output.c
+++ b/backend/noop/output.c
@@ -61,8 +61,8 @@ struct wlr_output *wlr_noop_add_output(struct wlr_backend *wlr_backend) {
 
 	strncpy(wlr_output->make, "noop", sizeof(wlr_output->make));
 	strncpy(wlr_output->model, "noop", sizeof(wlr_output->model));
-	snprintf(wlr_output->name, sizeof(wlr_output->name), "NOOP-%d",
-		wl_list_length(&backend->outputs) + 1);
+	snprintf(wlr_output->name, sizeof(wlr_output->name), "NOOP-%ld",
+		++backend->last_output_num);
 
 	wl_list_insert(&backend->outputs, &output->link);
 

--- a/include/backend/noop.h
+++ b/include/backend/noop.h
@@ -8,6 +8,7 @@ struct wlr_noop_backend {
 	struct wlr_backend backend;
 	struct wl_display *display;
 	struct wl_list outputs;
+	size_t last_output_num;
 	bool started;
 };
 


### PR DESCRIPTION
_Same as #1615, but for the noop backend_

This improves the way the output numbers are handled for the noop
backend. Instead of using the number of active outputs plus one, the
last used number is stored and new outputs will increment it. This
fixes the situation where you start with one output, create a second,
close the first, and create a third. Without this, both outputs will be
NOOP-2, which causes an issue since the identifier will also be
identical. With this, the last output is NOOP-3 and the outputs can be
distinguished.