### PR TITLE
s/lid_switch/switch_device

### DIFF
--- a/backend/headless/input_device.c
+++ b/backend/headless/input_device.c
@@ -78,12 +78,12 @@ struct wlr_input_device *wlr_headless_add_input_device(
 		wlr_tablet_pad_init(wlr_device->tablet_pad, NULL);
 		break;
 	case WLR_INPUT_DEVICE_SWITCH:
-		wlr_device->lid_switch = calloc(1, sizeof(struct wlr_switch));
-		if (wlr_device->lid_switch == NULL) {
+		wlr_device->switch_device = calloc(1, sizeof(struct wlr_switch));
+		if (wlr_device->switch_device == NULL) {
 			wlr_log(WLR_ERROR, "Unable to allocate wlr_switch");
 			goto error;
 		}
-		wlr_switch_init(wlr_device->lid_switch, NULL);
+		wlr_switch_init(wlr_device->switch_device, NULL);
 	}
 
 	wl_list_insert(&backend->input_devices, &wlr_device->link);

--- a/backend/libinput/events.c
+++ b/backend/libinput/events.c
@@ -174,8 +174,8 @@ static void handle_device_added(struct wlr_libinput_backend *backend,
 		if (!wlr_dev) {
 			goto fail;
 		}
-		wlr_dev->lid_switch = create_libinput_switch(libinput_dev);
-		if (!wlr_dev->lid_switch) {
+		wlr_dev->switch_device = create_libinput_switch(libinput_dev);
+		if (!wlr_dev->switch_device) {
 			free(wlr_dev);
 			goto fail;
 		}

--- a/backend/libinput/switch.c
+++ b/backend/libinput/switch.c
@@ -29,7 +29,7 @@ void handle_switch_toggle(struct libinput_event *event,
 		wlr_log(WLR_DEBUG, "Got a switch event for a device with no switch?");
 		return;
 	}
-	struct libinput_event_switch *sevent = 
+	struct libinput_event_switch *sevent =
 		libinput_event_get_switch_event	(event);
 	struct wlr_event_switch_toggle wlr_event = { 0 };
 	wlr_event.device = wlr_dev;
@@ -51,5 +51,5 @@ void handle_switch_toggle(struct libinput_event *event,
 	}
 	wlr_event.time_msec =
 		usec_to_msec(libinput_event_switch_get_time_usec(sevent));
-	wlr_signal_emit_safe(&wlr_dev->lid_switch->events.toggle, &wlr_event);
+	wlr_signal_emit_safe(&wlr_dev->switch_device->events.toggle, &wlr_event);
 }

--- a/include/rootston/switch.h
+++ b/include/rootston/switch.h
@@ -12,7 +12,7 @@ struct roots_switch {
 	struct wl_list link;
 };
 
-void roots_switch_handle_toggle(struct roots_switch *lid_switch,
+void roots_switch_handle_toggle(struct roots_switch *switch_device,
 		struct wlr_event_switch_toggle *event);
 
 #endif

--- a/include/wlr/interfaces/wlr_switch.h
+++ b/include/wlr/interfaces/wlr_switch.h
@@ -12,11 +12,11 @@
 #include <wlr/types/wlr_switch.h>
 
 struct wlr_switch_impl {
-	void (*destroy)(struct wlr_switch *lid_switch);
+	void (*destroy)(struct wlr_switch *switch_device);
 };
 
-void wlr_switch_init(struct wlr_switch *lid_switch,
+void wlr_switch_init(struct wlr_switch *switch_device,
 		struct wlr_switch_impl *impl);
-void wlr_switch_destroy(struct wlr_switch *lid_switch);
+void wlr_switch_destroy(struct wlr_switch *switch_device);
 
 #endif

--- a/include/wlr/types/wlr_input_device.h
+++ b/include/wlr/types/wlr_input_device.h
@@ -48,7 +48,7 @@ struct wlr_input_device {
 		void *_device;
 		struct wlr_keyboard *keyboard;
 		struct wlr_pointer *pointer;
-		struct wlr_switch *lid_switch;
+		struct wlr_switch *switch_device;
 		struct wlr_touch *touch;
 		struct wlr_tablet *tablet;
 		struct wlr_tablet_pad *tablet_pad;

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -147,12 +147,12 @@ static void handle_pinch_end(struct wl_listener *listener, void *data) {
 }
 
 static void handle_switch_toggle(struct wl_listener *listener, void *data) {
-	struct roots_switch *lid_switch =
-		wl_container_of(listener, lid_switch, toggle);
-	struct roots_desktop *desktop = lid_switch->seat->input->server->desktop;
-	wlr_idle_notify_activity(desktop->idle, lid_switch->seat->seat);
+	struct roots_switch *switch_device =
+		wl_container_of(listener, switch_device, toggle);
+	struct roots_desktop *desktop = switch_device->seat->input->server->desktop;
+	wlr_idle_notify_activity(desktop->idle, switch_device->seat->seat);
 	struct wlr_event_switch_toggle *event = data;
-	roots_switch_handle_toggle(lid_switch, event);
+	roots_switch_handle_toggle(switch_device, event);
 }
 
 static void handle_touch_down(struct wl_listener *listener, void *data) {
@@ -877,13 +877,13 @@ static void seat_add_pointer(struct roots_seat *seat,
 }
 
 static void handle_switch_destroy(struct wl_listener *listener, void *data) {
-	struct roots_switch *lid_switch =
-		wl_container_of(listener, lid_switch, device_destroy);
-	struct roots_seat *seat = lid_switch->seat;
+	struct roots_switch *switch_device =
+		wl_container_of(listener, switch_device, device_destroy);
+	struct roots_seat *seat = switch_device->seat;
 
-	wl_list_remove(&lid_switch->link);
-	wl_list_remove(&lid_switch->device_destroy.link);
-	free(lid_switch);
+	wl_list_remove(&switch_device->link);
+	wl_list_remove(&switch_device->device_destroy.link);
+	free(switch_device);
 
 	seat_update_capabilities(seat);
 }
@@ -891,19 +891,19 @@ static void handle_switch_destroy(struct wl_listener *listener, void *data) {
 static void seat_add_switch(struct roots_seat *seat,
 		struct wlr_input_device *device) {
 	assert(device->type == WLR_INPUT_DEVICE_SWITCH);
-		struct roots_switch *lid_switch = calloc(1, sizeof(struct roots_switch));
-	if (!lid_switch) {
+	struct roots_switch *switch_device = calloc(1, sizeof(struct roots_switch));
+	if (!switch_device) {
 		wlr_log(WLR_ERROR, "could not allocate switch for seat");
 		return;
 	}
-	device->data = lid_switch;
-	lid_switch->device = device;
-	lid_switch->seat = seat;
-	wl_list_insert(&seat->switches, &lid_switch->link);
-	lid_switch->device_destroy.notify = handle_switch_destroy;
+	device->data = switch_device;
+	switch_device->device = device;
+	switch_device->seat = seat;
+	wl_list_insert(&seat->switches, &switch_device->link);
+	switch_device->device_destroy.notify = handle_switch_destroy;
 
-	lid_switch->toggle.notify = handle_switch_toggle;
-	wl_signal_add(&lid_switch->device->lid_switch->events.toggle, &lid_switch->toggle);
+	switch_device->toggle.notify = handle_switch_toggle;
+	wl_signal_add(&switch_device->device->switch_device->events.toggle, &switch_device->toggle);
 }
 
 static void handle_touch_destroy(struct wl_listener *listener, void *data) {

--- a/rootston/switch.c
+++ b/rootston/switch.c
@@ -2,10 +2,10 @@
 #include <wlr/util/log.h>
 #include "rootston/bindings.h"
 
-void roots_switch_handle_toggle(struct roots_switch *lid_switch,
+void roots_switch_handle_toggle(struct roots_switch *switch_device,
 		struct wlr_event_switch_toggle *event) {
 	struct wl_list *bound_switches =
-		&lid_switch->seat->input->server->config->switches;
+		&switch_device->seat->input->server->config->switches;
 	struct roots_switch_config *sc;
 	wl_list_for_each(sc, bound_switches, link) {
 		if ((sc->name != NULL && strcmp(event->device->name, sc->name) != 0) &&
@@ -16,7 +16,7 @@ void roots_switch_handle_toggle(struct roots_switch *lid_switch,
 				event->switch_state != sc->switch_state) {
 			continue;
 		}
-		execute_binding_command(lid_switch->seat,
-			lid_switch->seat->input, sc->command);
+		execute_binding_command(switch_device->seat,
+			switch_device->seat->input, sc->command);
 	}
 }

--- a/types/wlr_input_device.c
+++ b/types/wlr_input_device.c
@@ -42,7 +42,7 @@ void wlr_input_device_destroy(struct wlr_input_device *dev) {
 			wlr_pointer_destroy(dev->pointer);
 			break;
 		case WLR_INPUT_DEVICE_SWITCH:
-			wlr_switch_destroy(dev->lid_switch);
+			wlr_switch_destroy(dev->switch_device);
 			break;
 		case WLR_INPUT_DEVICE_TOUCH:
 			wlr_touch_destroy(dev->touch);

--- a/types/wlr_switch.c
+++ b/types/wlr_switch.c
@@ -4,19 +4,19 @@
 #include <wlr/interfaces/wlr_switch.h>
 #include <wlr/types/wlr_switch.h>
 
-void wlr_switch_init(struct wlr_switch *lid_switch,
+void wlr_switch_init(struct wlr_switch *switch_device,
 		struct wlr_switch_impl *impl) {
-	lid_switch->impl = impl;
-	wl_signal_init(&lid_switch->events.toggle);
+	switch_device->impl = impl;
+	wl_signal_init(&switch_device->events.toggle);
 }
 
-void wlr_switch_destroy(struct wlr_switch *lid_switch) {
-	if (!lid_switch) {
+void wlr_switch_destroy(struct wlr_switch *switch_device) {
+	if (!switch_device) {
 		return;
 	}
-	if (lid_switch->impl && lid_switch->impl->destroy) {
-		lid_switch->impl->destroy(lid_switch);
+	if (switch_device->impl && switch_device->impl->destroy) {
+		switch_device->impl->destroy(switch_device);
 	} else {
-		free(lid_switch);
+		free(switch_device);
 	}
 }


### PR DESCRIPTION
Rename lid_switch to switch_device to disambiguate lid and tablet mode switches. Required for https://github.com/swaywm/sway/pull/3340