### PR TITLE
wlr_output: Add preferred property

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1207,6 +1207,9 @@ void scan_drm_connectors(struct wlr_drm_backend *drm) {
 				mode->wlr_mode.width = mode->drm_mode.hdisplay;
 				mode->wlr_mode.height = mode->drm_mode.vdisplay;
 				mode->wlr_mode.refresh = calculate_refresh_rate(&mode->drm_mode);
+				if (mode->drm_mode.type & DRM_MODE_TYPE_PREFERRED) {
+					mode->wlr_mode.preferred = true;
+				}
 
 				wlr_log(WLR_INFO, "  %"PRId32"x%"PRId32"@%"PRId32,
 					mode->wlr_mode.width, mode->wlr_mode.height,

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -71,7 +71,7 @@ struct wlr_output {
 	int32_t phys_width, phys_height; // mm
 
 	// Note: some backends may have zero modes
-	struct wl_list modes;
+	struct wl_list modes; // wlr_output_mode::link
 	struct wlr_output_mode *current_mode;
 	int32_t width, height;
 	int32_t refresh; // mHz, may be zero

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -20,6 +20,7 @@ struct wlr_output_mode {
 	uint32_t flags; // enum wl_output_mode
 	int32_t width, height;
 	int32_t refresh; // mHz
+	bool preferred;
 	struct wl_list link;
 };
 


### PR DESCRIPTION
I was wondering why wlr-randr wouldn't show the preferred mode until I noticed we're not currently setting it. This patch adds support for it to the drm backend. 

#1608 then only needs [this](https://github.com/agx/wlroots/commit/43d31b4847c8b066658d081f96d0ac278c953a7e) trivial patch to make it work.