### PR TITLE
types/meson.build: Add compile args for libinput to lib_wlr_types

### DIFF
--- a/types/meson.build
+++ b/types/meson.build
@@ -73,6 +73,7 @@ lib_wlr_types = static_library(
 	include_directories: wlr_inc,
 	dependencies: [
 		drm.partial_dependency(compile_args: true), # <drm_fourcc.h>
+		libinput.partial_dependency(compile_args: true),
 		pixman,
 		wayland_server,
 		wlr_protos,

--- a/types/meson.build
+++ b/types/meson.build
@@ -73,7 +73,6 @@ lib_wlr_types = static_library(
 	include_directories: wlr_inc,
 	dependencies: [
 		drm.partial_dependency(compile_args: true), # <drm_fourcc.h>
-		libinput.partial_dependency(compile_args: true),
 		pixman,
 		wayland_server,
 		wlr_protos,

--- a/types/tablet_v2/wlr_tablet_v2.c
+++ b/types/tablet_v2/wlr_tablet_v2.c
@@ -3,7 +3,6 @@
 #endif
 
 #include <assert.h>
-#include <libinput.h>
 #include <stdlib.h>
 #include <string.h>
 #include <wayland-server.h>


### PR DESCRIPTION
Build otherwise fails on openSUSE Tumbleweed with the following output:
```
[1/106] Compiling C object 'types/8d84602@@wlr_types@sta/tablet_v2_wlr_tablet_v2.c.o'.
FAILED: types/8d84602@@wlr_types@sta/tablet_v2_wlr_tablet_v2.c.o 
cc -Itypes/8d84602@@wlr_types@sta -Itypes -I../types -I. -I../ -Iinclude -I../include -Iprotocol -I/usr/include/libdrm -I/usr/include/pixman-1 -I/usr/include/wayland -I/usr/include/libxkbcommon -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -std=c11 -g '-DWLR_SRC_DIR="/home/stuart/Applications/wlroots"' -DWLR_USE_UNSTABLE -Wundef -Wlogical-op -Wmissing-include-dirs -Wold-style-definition -Wpointer-arith -Winit-self -Wstrict-prototypes -Wimplicit-fallthrough=2 -Wendif-labels -Wstrict-aliasing=2 -Woverflow -Wno-missing-braces -Wno-missing-field-initializers -Wno-unused-parameter -DWL_HIDE_DEPRECATED -fPIC -MD -MQ 'types/8d84602@@wlr_types@sta/tablet_v2_wlr_tablet_v2.c.o' -MF 'types/8d84602@@wlr_types@sta/tablet_v2_wlr_tablet_v2.c.o.d' -o 'types/8d84602@@wlr_types@sta/tablet_v2_wlr_tablet_v2.c.o' -c ../types/tablet_v2/wlr_tablet_v2.c
../types/tablet_v2/wlr_tablet_v2.c:6:10: fatal error: libinput.h: No such file or directory
 #include <libinput.h>
          ^~~~~~~~~~~~
compilation terminated.
[6/106] Compiling C object 'types/8d84602@@wlr_types@sta/xdg_shell_wlr_xdg_toplevel.c.o'.
ninja: build stopped: subcommand failed.
```