### PR TITLE
wlr_xdg_toplevel{,_v6}: store pending fullscreen output

### DIFF
--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -105,6 +105,12 @@ struct wlr_xdg_toplevel_state {
 	uint32_t width, height;
 	uint32_t max_width, max_height;
 	uint32_t min_width, min_height;
+
+	// Since the fullscreen request may be made before the toplevel's surface
+	// is mapped, this is used to store the requested fullscreen output (if
+	// any) for wlr_xdg_toplevel::client_pending.
+	struct wlr_output *fullscreen_output;
+	struct wl_listener fullscreen_output_destroy;
 };
 
 struct wlr_xdg_toplevel {

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -112,6 +112,12 @@ struct wlr_xdg_toplevel_v6_state {
 	uint32_t width, height;
 	uint32_t max_width, max_height;
 	uint32_t min_width, min_height;
+
+	// Since the fullscreen request may be made before the toplevel's surface
+	// is mapped, this is used to store the requested fullscreen output (if
+	// any) for wlr_xdg_toplevel_v6::client_pending.
+	struct wlr_output *fullscreen_output;
+	struct wl_listener fullscreen_output_destroy;
 };
 
 /**

--- a/types/xdg_shell/wlr_xdg_surface.c
+++ b/types/xdg_shell/wlr_xdg_surface.c
@@ -459,6 +459,11 @@ void reset_xdg_surface(struct wlr_xdg_surface *xdg_surface) {
 		wl_resource_set_user_data(xdg_surface->toplevel->resource, NULL);
 		xdg_surface->toplevel->resource = NULL;
 
+		if (xdg_surface->toplevel->client_pending.fullscreen_output) {
+			struct wlr_xdg_toplevel_state *client_pending =
+				&xdg_surface->toplevel->client_pending;
+			wl_list_remove(&client_pending->fullscreen_output_destroy.link);
+		}
 		free(xdg_surface->toplevel);
 		xdg_surface->toplevel = NULL;
 		break;


### PR DESCRIPTION
Related to swaywm/sway#1813
Required for swaywm/sway#3966

Since the fullscreen request may be made before the toplevel's surface
is mapped, the requested fullscreen output needs to be stored so it
can be retrieved on map (along with the existing fullscreen property).