### PR TITLE
Add support for direct scan-out

### DIFF
--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -172,7 +172,8 @@ static bool atomic_crtc_set_cursor(struct wlr_drm_backend *drm,
 	atomic_begin(crtc, &atom);
 
 	if (bo) {
-		uint32_t fb_id = get_fb_for_bo(bo, plane->drm_format);
+		uint32_t fb_id =
+			get_fb_for_bo(bo, plane->drm_format, drm->addfb2_modifiers);
 		set_plane_props(&atom, plane, crtc->id, fb_id, false);
 	} else {
 		atomic_add(&atom, plane->id, plane->props.fb_id, 0);

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -820,6 +820,52 @@ static bool drm_connector_schedule_frame(struct wlr_output *output) {
 	return true;
 }
 
+static bool drm_connector_set_dmabuf(struct wlr_output *output,
+		struct wlr_dmabuf_attributes *attribs) {
+	struct wlr_drm_connector *conn = get_drm_connector_from_output(output);
+	struct wlr_drm_backend *drm = get_drm_backend_from_backend(output->backend);
+	if (!drm->session->active) {
+		return false;
+	}
+
+	struct wlr_drm_crtc *crtc = conn->crtc;
+	if (!crtc) {
+		return false;
+	}
+
+	// TODO: check plane input formats
+
+	if (attribs->width != output->width || attribs->height != output->height) {
+		return false;
+	}
+
+	struct gbm_bo *bo = import_gbm_bo(&drm->renderer, attribs);
+	if (bo == NULL) {
+		wlr_log(WLR_ERROR, "import_gbm_bo failed");
+		return NULL;
+	}
+
+	uint32_t fb_id = get_fb_for_bo(bo, gbm_bo_get_format(bo));
+	if (fb_id == 0) {
+		wlr_log(WLR_ERROR, "get_fb_for_bo failed");
+		return false;
+	}
+
+	if (conn->pageflip_pending) {
+		wlr_log(WLR_ERROR, "Skipping pageflip on output '%s'", conn->output.name);
+		return false;
+	}
+
+	if (!drm->iface->crtc_pageflip(drm, conn, crtc, fb_id, NULL)) {
+		wlr_log(WLR_ERROR, "crtc_pageflip failed");
+		return false;
+	}
+
+	conn->pageflip_pending = true;
+	wlr_output_update_enabled(output, true);
+	return true;
+}
+
 static void drm_connector_destroy(struct wlr_output *output) {
 	struct wlr_drm_connector *conn = get_drm_connector_from_output(output);
 	drm_connector_cleanup(conn);
@@ -842,6 +888,7 @@ static const struct wlr_output_impl output_impl = {
 	.get_gamma_size = drm_connector_get_gamma_size,
 	.export_dmabuf = drm_connector_export_dmabuf,
 	.schedule_frame = drm_connector_schedule_frame,
+	.set_dmabuf = drm_connector_set_dmabuf,
 };
 
 bool wlr_output_is_drm(struct wlr_output *output) {

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -924,6 +924,9 @@ static bool drm_connector_attach_buffer(struct wlr_output *output,
 		return false;
 	}
 
+	if (attribs.flags != 0) {
+		return false;
+	}
 	if (attribs.width != output->width || attribs.height != output->height) {
 		return false;
 	}

--- a/backend/drm/properties.c
+++ b/backend/drm/properties.c
@@ -19,38 +19,39 @@ struct prop_info {
 
 static const struct prop_info connector_info[] = {
 #define INDEX(name) (offsetof(union wlr_drm_connector_props, name) / sizeof(uint32_t))
-	{ "CRTC_ID",     INDEX(crtc_id) },
-	{ "DPMS",        INDEX(dpms) },
-	{ "EDID",        INDEX(edid) },
-	{ "PATH",        INDEX(path) },
+	{ "CRTC_ID", INDEX(crtc_id) },
+	{ "DPMS", INDEX(dpms) },
+	{ "EDID", INDEX(edid) },
+	{ "PATH", INDEX(path) },
 	{ "link-status", INDEX(link_status) },
 #undef INDEX
 };
 
 static const struct prop_info crtc_info[] = {
 #define INDEX(name) (offsetof(union wlr_drm_crtc_props, name) / sizeof(uint32_t))
-	{ "ACTIVE",         INDEX(active) },
-	{ "GAMMA_LUT",      INDEX(gamma_lut) },
+	{ "ACTIVE", INDEX(active) },
+	{ "GAMMA_LUT", INDEX(gamma_lut) },
 	{ "GAMMA_LUT_SIZE", INDEX(gamma_lut_size) },
-	{ "MODE_ID",        INDEX(mode_id) },
-	{ "rotation",       INDEX(rotation) },
-	{ "scaling mode",   INDEX(scaling_mode) },
+	{ "MODE_ID", INDEX(mode_id) },
+	{ "rotation", INDEX(rotation) },
+	{ "scaling mode", INDEX(scaling_mode) },
 #undef INDEX
 };
 
 static const struct prop_info plane_info[] = {
 #define INDEX(name) (offsetof(union wlr_drm_plane_props, name) / sizeof(uint32_t))
-	{ "CRTC_H",  INDEX(crtc_h) },
+	{ "CRTC_H", INDEX(crtc_h) },
 	{ "CRTC_ID", INDEX(crtc_id) },
-	{ "CRTC_W",  INDEX(crtc_w) },
-	{ "CRTC_X",  INDEX(crtc_x) },
-	{ "CRTC_Y",  INDEX(crtc_y) },
-	{ "FB_ID",   INDEX(fb_id) },
-	{ "SRC_H",   INDEX(src_h) },
-	{ "SRC_W",   INDEX(src_w) },
-	{ "SRC_X",   INDEX(src_x) },
-	{ "SRC_Y",   INDEX(src_y) },
-	{ "type",    INDEX(type) },
+	{ "CRTC_W", INDEX(crtc_w) },
+	{ "CRTC_X", INDEX(crtc_x) },
+	{ "CRTC_Y", INDEX(crtc_y) },
+	{ "FB_ID", INDEX(fb_id) },
+	{ "IN_FORMATS", INDEX(in_formats) },
+	{ "SRC_H", INDEX(src_h) },
+	{ "SRC_W", INDEX(src_w) },
+	{ "SRC_X", INDEX(src_x) },
+	{ "SRC_Y", INDEX(src_y) },
+	{ "type", INDEX(type) },
 #undef INDEX
 };
 

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -163,6 +163,30 @@ void post_drm_surface(struct wlr_drm_surface *surf) {
 	}
 }
 
+struct gbm_bo *import_gbm_bo(struct wlr_drm_renderer *renderer,
+		struct wlr_dmabuf_attributes *attribs) {
+	struct gbm_import_fd_modifier_data data = {
+		.width = attribs->width,
+		.height = attribs->height,
+		.format = attribs->format,
+		.num_fds = attribs->n_planes,
+		.modifier = attribs->modifier,
+	};
+
+	if ((size_t)attribs->n_planes > sizeof(data.fds) / sizeof(data.fds[0])) {
+		return NULL;
+	}
+
+	for (size_t i = 0; i < (size_t)attribs->n_planes; ++i) {
+		data.fds[i] = attribs->fd[i];
+		data.strides[i] = attribs->stride[i];
+		data.offsets[i] = attribs->offset[i];
+	}
+
+	return gbm_bo_import(renderer->gbm, GBM_BO_IMPORT_FD_MODIFIER,
+		&data, GBM_BO_USE_SCANOUT);
+}
+
 bool export_drm_bo(struct gbm_bo *bo, struct wlr_dmabuf_attributes *attribs) {
 	memset(attribs, 0, sizeof(struct wlr_dmabuf_attributes));
 

--- a/backend/drm/util.c
+++ b/backend/drm/util.c
@@ -178,7 +178,8 @@ static void free_fb(struct gbm_bo *bo, void *data) {
 	}
 }
 
-uint32_t get_fb_for_bo(struct gbm_bo *bo, uint32_t drm_format) {
+uint32_t get_fb_for_bo(struct gbm_bo *bo, uint32_t drm_format,
+		bool with_modifiers) {
 	uint32_t id = (uintptr_t)gbm_bo_get_user_data(bo);
 	if (id) {
 		return id;
@@ -192,11 +193,18 @@ uint32_t get_fb_for_bo(struct gbm_bo *bo, uint32_t drm_format) {
 	uint32_t handles[4] = {gbm_bo_get_handle(bo).u32};
 	uint32_t strides[4] = {gbm_bo_get_stride(bo)};
 	uint32_t offsets[4] = {gbm_bo_get_offset(bo, 0)};
-	uint64_t modifiers[4] = {gbm_bo_get_modifier(bo)};
 
-	if (drmModeAddFB2WithModifiers(fd, width, height, drm_format,
-			handles, strides, offsets, modifiers, &id, DRM_MODE_FB_MODIFIERS)) {
-		wlr_log_errno(WLR_ERROR, "Unable to add DRM framebuffer");
+	if (with_modifiers && gbm_bo_get_modifier(bo) != DRM_FORMAT_MOD_INVALID) {
+		uint64_t modifiers[4] = {gbm_bo_get_modifier(bo)};
+		if (drmModeAddFB2WithModifiers(fd, width, height, drm_format, handles,
+				strides, offsets, modifiers, &id, DRM_MODE_FB_MODIFIERS)) {
+			wlr_log_errno(WLR_ERROR, "Unable to add DRM framebuffer");
+		}
+	} else {
+		if (drmModeAddFB2(fd, width, height, drm_format, handles, strides,
+				offsets, &id, 0)) {
+			wlr_log_errno(WLR_ERROR, "Unable to add DRM framebuffer");
+		}
 	}
 
 	gbm_bo_set_user_data(bo, (void *)(uintptr_t)id, free_fb);

--- a/backend/drm/util.c
+++ b/backend/drm/util.c
@@ -184,21 +184,18 @@ uint32_t get_fb_for_bo(struct gbm_bo *bo, uint32_t drm_format) {
 		return id;
 	}
 
-	assert(gbm_bo_get_format(bo) == GBM_FORMAT_ARGB8888);
-	assert(drm_format == DRM_FORMAT_ARGB8888 ||
-		drm_format == DRM_FORMAT_XRGB8888);
-
 	struct gbm_device *gbm = gbm_bo_get_device(bo);
 
 	int fd = gbm_device_get_fd(gbm);
 	uint32_t width = gbm_bo_get_width(bo);
 	uint32_t height = gbm_bo_get_height(bo);
 	uint32_t handles[4] = {gbm_bo_get_handle(bo).u32};
-	uint32_t pitches[4] = {gbm_bo_get_stride(bo)};
+	uint32_t strides[4] = {gbm_bo_get_stride(bo)};
 	uint32_t offsets[4] = {gbm_bo_get_offset(bo, 0)};
+	uint64_t modifiers[4] = {gbm_bo_get_modifier(bo)};
 
-	if (drmModeAddFB2(fd, width, height, drm_format,
-			handles, pitches, offsets, &id, 0)) {
+	if (drmModeAddFB2WithModifiers(fd, width, height, drm_format,
+			handles, strides, offsets, modifiers, &id, DRM_MODE_FB_MODIFIERS)) {
 		wlr_log_errno(WLR_ERROR, "Unable to add DRM framebuffer");
 	}
 

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -148,6 +148,8 @@ struct wlr_drm_connector {
 	bool pageflip_pending;
 	struct wl_event_source *retry_pageflip;
 	struct wl_list link;
+
+	struct wlr_dmabuf_attributes pending_dmabuf;
 };
 
 struct wlr_drm_backend *get_drm_backend_from_backend(

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -72,6 +72,7 @@ struct wlr_drm_backend {
 	struct wlr_drm_backend *parent;
 	const struct wlr_drm_interface *iface;
 	clockid_t clock;
+	bool addfb2_modifiers;
 
 	int fd;
 

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -149,7 +149,12 @@ struct wlr_drm_connector {
 	struct wl_event_source *retry_pageflip;
 	struct wl_list link;
 
+	// DMA-BUF to be displayed on next commit
 	struct wlr_dmabuf_attributes pending_dmabuf;
+	// Buffer submitted to the kernel but not yet displayed
+	struct wlr_buffer *pending_buffer;
+	// Buffer currently being displayed
+	struct wlr_buffer *current_buffer;
 };
 
 struct wlr_drm_backend *get_drm_backend_from_backend(

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -11,6 +11,7 @@
 #include <wayland-util.h>
 #include <wlr/backend/drm.h>
 #include <wlr/backend/session.h>
+#include <wlr/render/drm_format_set.h>
 #include <wlr/render/egl.h>
 #include <xf86drmMode.h>
 #include "iface.h"
@@ -27,6 +28,7 @@ struct wlr_drm_plane {
 	struct wlr_drm_surface mgpu_surf;
 
 	uint32_t drm_format; // ARGB8888 or XRGB8888
+	struct wlr_drm_format_set formats;
 
 	// Only used by cursor
 	float matrix[9];

--- a/include/backend/drm/properties.h
+++ b/include/backend/drm/properties.h
@@ -44,6 +44,7 @@ union wlr_drm_plane_props {
 	struct {
 		uint32_t type;
 		uint32_t rotation; // Not guaranteed to exist
+		uint32_t in_formats; // Not guaranteed to exist
 
 		// atomic-modesetting only
 
@@ -58,7 +59,7 @@ union wlr_drm_plane_props {
 		uint32_t fb_id;
 		uint32_t crtc_id;
 	};
-	uint32_t props[12];
+	uint32_t props[13];
 };
 
 bool get_drm_connector_props(int fd, uint32_t id,

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -54,6 +54,8 @@ struct gbm_bo *get_drm_surface_front(struct wlr_drm_surface *surf);
 void post_drm_surface(struct wlr_drm_surface *surf);
 struct gbm_bo *copy_drm_surface_mgpu(struct wlr_drm_surface *dest,
 	struct gbm_bo *src);
+struct gbm_bo *import_gbm_bo(struct wlr_drm_renderer *renderer,
+	struct wlr_dmabuf_attributes *attribs);
 bool export_drm_bo(struct gbm_bo *bo, struct wlr_dmabuf_attributes *attribs);
 
 #endif

--- a/include/backend/drm/util.h
+++ b/include/backend/drm/util.h
@@ -14,7 +14,8 @@ void parse_edid(struct wlr_output *restrict output, size_t len,
 // Returns the string representation of a DRM output type
 const char *conn_get_name(uint32_t type_id);
 // Returns the DRM framebuffer id for a gbm_bo
-uint32_t get_fb_for_bo(struct gbm_bo *bo, uint32_t drm_format);
+uint32_t get_fb_for_bo(struct gbm_bo *bo, uint32_t drm_format,
+	bool with_modifiers);
 
 // Part of match_obj
 enum {

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -34,8 +34,7 @@ struct wlr_output_impl {
 	bool (*export_dmabuf)(struct wlr_output *output,
 		struct wlr_dmabuf_attributes *attribs);
 	bool (*schedule_frame)(struct wlr_output *output);
-	bool (*set_dmabuf)(struct wlr_output *output,
-		struct wlr_dmabuf_attributes *attribs);
+	bool (*attach_buffer)(struct wlr_output *output, struct wlr_buffer *buffer);
 };
 
 void wlr_output_init(struct wlr_output *output, struct wlr_backend *backend,

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -34,6 +34,8 @@ struct wlr_output_impl {
 	bool (*export_dmabuf)(struct wlr_output *output,
 		struct wlr_dmabuf_attributes *attribs);
 	bool (*schedule_frame)(struct wlr_output *output);
+	bool (*set_dmabuf)(struct wlr_output *output,
+		struct wlr_dmabuf_attributes *attribs);
 };
 
 void wlr_output_init(struct wlr_output *output, struct wlr_backend *backend,

--- a/include/wlr/render/dmabuf.h
+++ b/include/wlr/render/dmabuf.h
@@ -9,6 +9,7 @@
 #ifndef WLR_RENDER_DMABUF_H
 #define WLR_RENDER_DMABUF_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #define WLR_DMABUF_MAX_PLANES 4
@@ -35,5 +36,10 @@ struct wlr_dmabuf_attributes {
  * Closes all file descriptors in the DMA-BUF attributes.
  */
 void wlr_dmabuf_attributes_finish(struct wlr_dmabuf_attributes *attribs);
+/**
+ * Clones the DMA-BUF attributes.
+ */
+bool wlr_dmabuf_attributes_copy(struct wlr_dmabuf_attributes *dst,
+	struct wlr_dmabuf_attributes *src);
 
 #endif

--- a/include/wlr/render/drm_format_set.h
+++ b/include/wlr/render/drm_format_set.h
@@ -21,6 +21,9 @@ void wlr_drm_format_set_finish(struct wlr_drm_format_set *set);
 const struct wlr_drm_format *wlr_drm_format_set_get(
 	const struct wlr_drm_format_set *set, uint32_t format);
 
+bool wlr_drm_format_set_has(const struct wlr_drm_format_set *set,
+	uint32_t format, uint64_t modifier);
+
 bool wlr_drm_format_set_add(struct wlr_drm_format_set *set, uint32_t format,
 	uint64_t modifier);
 

--- a/include/wlr/types/wlr_buffer.h
+++ b/include/wlr/types/wlr_buffer.h
@@ -11,6 +11,7 @@
 
 #include <pixman.h>
 #include <wayland-server.h>
+#include <wlr/render/dmabuf.h>
 
 /**
  * A client buffer.
@@ -67,5 +68,11 @@ void wlr_buffer_unref(struct wlr_buffer *buffer);
  */
 struct wlr_buffer *wlr_buffer_apply_damage(struct wlr_buffer *buffer,
 	struct wl_resource *resource, pixman_region32_t *damage);
+/**
+ * Reads the DMA-BUF attributes of the buffer. If this buffer isn't a DMA-BUF,
+ * returns false.
+ */
+bool wlr_buffer_get_dmabuf(struct wlr_buffer *buffer,
+		struct wlr_dmabuf_attributes *attribs);
 
 #endif

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -15,6 +15,7 @@
 #include <wayland-server.h>
 #include <wayland-util.h>
 #include <wlr/render/dmabuf.h>
+#include <wlr/types/wlr_buffer.h>
 
 struct wlr_output_mode {
 	uint32_t flags; // enum wl_output_mode
@@ -224,6 +225,12 @@ void wlr_output_effective_resolution(struct wlr_output *output,
  */
 bool wlr_output_attach_render(struct wlr_output *output, int *buffer_age);
 /**
+ * Attach a buffer to the output. Compositors should call `wlr_output_commit`
+ * to submit the new frame.
+ */
+bool wlr_output_attach_buffer(struct wlr_output *output,
+	struct wlr_buffer *buffer);
+/**
  * Get the preferred format for reading pixels.
  * This function might change the current rendering context.
  */
@@ -243,8 +250,6 @@ bool wlr_output_preferred_read_format(struct wlr_output *output,
  */
 void wlr_output_set_damage(struct wlr_output *output,
 	pixman_region32_t *damage);
-bool wlr_output_set_dmabuf(struct wlr_output *output,
-	struct wlr_dmabuf_attributes *attribs);
 /**
  * Commit the pending output state. If `wlr_output_attach_render` has been
  * called, the pending frame will be submitted for display.

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -52,12 +52,21 @@ enum wlr_output_state_field {
 	WLR_OUTPUT_STATE_DAMAGE = 1 << 1,
 };
 
+enum wlr_output_state_buffer_type {
+	WLR_OUTPUT_STATE_BUFFER_RENDER,
+	WLR_OUTPUT_STATE_BUFFER_SCANOUT,
+};
+
 /**
  * Holds the double-buffered output state.
  */
 struct wlr_output_state {
 	uint32_t committed; // enum wlr_output_state_field
 	pixman_region32_t damage; // output-buffer-local coordinates
+
+	// only valid if WLR_OUTPUT_STATE_BUFFER
+	enum wlr_output_state_buffer_type buffer_type;
+	struct wlr_buffer *buffer; // if WLR_OUTPUT_STATE_BUFFER_SCANOUT
 };
 
 struct wlr_output_impl;

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -137,6 +137,8 @@ struct wlr_output {
 	struct wl_event_source *idle_frame;
 	struct wl_event_source *idle_done;
 
+	int attach_render_locks; // number of locks forcing rendering
+
 	struct wl_list cursors; // wlr_output_cursor::link
 	struct wlr_output_cursor *hardware_cursor;
 	int software_cursor_locks; // number of locks forcing software cursors
@@ -287,6 +289,13 @@ bool wlr_output_set_gamma(struct wlr_output *output, size_t size,
 bool wlr_output_export_dmabuf(struct wlr_output *output,
 	struct wlr_dmabuf_attributes *attribs);
 struct wlr_output *wlr_output_from_resource(struct wl_resource *resource);
+/**
+ * Locks the output to only use rendering instead of direct scan-out. This is
+ * useful if direct scan-out needs to be temporarily disabled (e.g. during
+ * screen capture). There must be as many unlocks as there have been locks to
+ * restore the original state. There should never be an unlock before a lock.
+ */
+void wlr_output_lock_attach_render(struct wlr_output *output, bool lock);
 /**
  * Locks the output to only use software cursors instead of hardware cursors.
  * This is useful if hardware cursors need to be temporarily disabled (e.g.

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -243,6 +243,8 @@ bool wlr_output_preferred_read_format(struct wlr_output *output,
  */
 void wlr_output_set_damage(struct wlr_output *output,
 	pixman_region32_t *damage);
+bool wlr_output_set_dmabuf(struct wlr_output *output,
+	struct wlr_dmabuf_attributes *attribs);
 /**
  * Commit the pending output state. If `wlr_output_attach_render` has been
  * called, the pending frame will be submitted for display.

--- a/render/dmabuf.c
+++ b/render/dmabuf.c
@@ -1,10 +1,28 @@
+#define _POSIX_C_SOURCE 200809L
+#include <fcntl.h>
 #include <unistd.h>
 #include <wlr/render/dmabuf.h>
+#include <wlr/util/log.h>
 
-void wlr_dmabuf_attributes_finish( struct wlr_dmabuf_attributes *attribs) {
+void wlr_dmabuf_attributes_finish(struct wlr_dmabuf_attributes *attribs) {
 	for (int i = 0; i < attribs->n_planes; ++i) {
 		close(attribs->fd[i]);
 		attribs->fd[i] = -1;
 	}
 	attribs->n_planes = 0;
+}
+
+bool wlr_dmabuf_attributes_copy(struct wlr_dmabuf_attributes *dst,
+		struct wlr_dmabuf_attributes *src) {
+	memcpy(dst, src, sizeof(struct wlr_dmabuf_attributes));
+
+	for (int i = 0; i < src->n_planes; ++i) {
+		dst->fd[i] = fcntl(src->fd[i], F_DUPFD_CLOEXEC, 0);
+		if (dst->fd[i] < 0) {
+			wlr_log_errno(WLR_ERROR, "fcntl(F_DUPFD_CLOEXEC) failed");
+			return false;
+		}
+	}
+
+	return true;
 }

--- a/render/drm_format_set.c
+++ b/render/drm_format_set.c
@@ -35,6 +35,26 @@ const struct wlr_drm_format *wlr_drm_format_set_get(
 	return ptr ? *ptr : NULL;
 }
 
+bool wlr_drm_format_set_has(const struct wlr_drm_format_set *set,
+		uint32_t format, uint64_t modifier) {
+	const struct wlr_drm_format *fmt = wlr_drm_format_set_get(set, format);
+	if (!fmt) {
+		return false;
+	}
+
+	if (modifier == DRM_FORMAT_MOD_INVALID) {
+		return true;
+	}
+
+	for (size_t i = 0; i < fmt->len; ++i) {
+		if (fmt->modifiers[i] == modifier) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 bool wlr_drm_format_set_add(struct wlr_drm_format_set *set, uint32_t format,
 		uint64_t modifier) {
 	struct wlr_drm_format **ptr = format_set_get_ref(set, format);

--- a/types/wlr_buffer.c
+++ b/types/wlr_buffer.c
@@ -203,3 +203,21 @@ struct wlr_buffer *wlr_buffer_apply_damage(struct wlr_buffer *buffer,
 	buffer->released = true;
 	return buffer;
 }
+
+bool wlr_buffer_get_dmabuf(struct wlr_buffer *buffer,
+		struct wlr_dmabuf_attributes *attribs) {
+	if (buffer->resource == NULL) {
+		return false;
+	}
+
+	struct wl_resource *buffer_resource = buffer->resource;
+	if (!wlr_dmabuf_v1_resource_is_buffer(buffer_resource)) {
+		return false;
+	}
+
+	struct wlr_dmabuf_v1_buffer *dmabuf_buffer =
+		wlr_dmabuf_v1_buffer_from_buffer_resource(buffer_resource);
+	memcpy(attribs, &dmabuf_buffer->attributes,
+		sizeof(struct wlr_dmabuf_attributes));
+	return true;
+}

--- a/types/wlr_export_dmabuf_v1.c
+++ b/types/wlr_export_dmabuf_v1.c
@@ -34,6 +34,7 @@ static void frame_destroy(struct wlr_export_dmabuf_frame_v1 *frame) {
 	if (frame == NULL) {
 		return;
 	}
+	wlr_output_lock_attach_render(frame->output, false);
 	if (frame->cursor_locked) {
 		wlr_output_lock_software_cursors(frame->output, false);
 	}
@@ -126,6 +127,7 @@ static void manager_handle_capture_output(struct wl_client *client,
 		return;
 	}
 
+	wlr_output_lock_attach_render(frame->output, true);
 	if (overlay_cursor) {
 		wlr_output_lock_software_cursors(frame->output, true);
 		frame->cursor_locked = true;

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -493,6 +493,9 @@ bool wlr_output_attach_buffer(struct wlr_output *output,
 	if (!output->impl->attach_buffer) {
 		return false;
 	}
+	if (output->attach_render_locks > 0) {
+		return false;
+	}
 
 	// If the output has at least one software cursor, refuse to attach the
 	// buffer
@@ -608,6 +611,18 @@ struct wlr_output *wlr_output_from_resource(struct wl_resource *resource) {
 	assert(wl_resource_instance_of(resource, &wl_output_interface,
 		&output_impl));
 	return wl_resource_get_user_data(resource);
+}
+
+void wlr_output_lock_attach_render(struct wlr_output *output, bool lock) {
+	if (lock) {
+		++output->attach_render_locks;
+	} else {
+		assert(output->attach_render_locks > 0);
+		--output->attach_render_locks;
+	}
+	wlr_log(WLR_DEBUG, "%s direct scan-out on output '%s' (locks: %d)",
+		lock ? "Disabling" : "Enabling", output->name,
+		output->attach_render_locks);
 }
 
 static void output_cursor_damage_whole(struct wlr_output_cursor *cursor);

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -400,6 +400,7 @@ bool wlr_output_attach_render(struct wlr_output *output, int *buffer_age) {
 	}
 
 	output->pending.committed |= WLR_OUTPUT_STATE_BUFFER;
+	output->pending.buffer_type = WLR_OUTPUT_STATE_BUFFER_RENDER;
 	return true;
 }
 
@@ -476,15 +477,6 @@ bool wlr_output_commit(struct wlr_output *output) {
 
 bool wlr_output_attach_buffer(struct wlr_output *output,
 		struct wlr_buffer *buffer) {
-	if (output->frame_pending) {
-		wlr_log(WLR_ERROR, "Tried to swap buffers when a frame is pending");
-		return false;
-	}
-	if (output->idle_frame != NULL) {
-		wl_event_source_remove(output->idle_frame);
-		output->idle_frame = NULL;
-	}
-
 	if (!output->impl->attach_buffer) {
 		return false;
 	}
@@ -492,9 +484,8 @@ bool wlr_output_attach_buffer(struct wlr_output *output,
 		return false;
 	}
 
-	output->frame_pending = true;
-	output->needs_frame = false;
-	pixman_region32_clear(&output->damage);
+	output->pending.committed |= WLR_OUTPUT_STATE_BUFFER;
+	output->pending.buffer_type = WLR_OUTPUT_STATE_BUFFER_SCANOUT;
 	return true;
 }
 

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -493,6 +493,17 @@ bool wlr_output_attach_buffer(struct wlr_output *output,
 	if (!output->impl->attach_buffer) {
 		return false;
 	}
+
+	// If the output has at least one software cursor, refuse to attach the
+	// buffer
+	struct wlr_output_cursor *cursor;
+	wl_list_for_each(cursor, &output->cursors, link) {
+		if (cursor->enabled && cursor->visible &&
+				cursor != output->hardware_cursor) {
+			return false;
+		}
+	}
+
 	if (!output->impl->attach_buffer(output, buffer)) {
 		return false;
 	}

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -394,11 +394,23 @@ struct wlr_output_mode *wlr_output_preferred_mode(struct wlr_output *output) {
 	return mode;
 }
 
+static void output_state_clear_buffer(struct wlr_output_state *state) {
+	if (!(state->committed & WLR_OUTPUT_STATE_BUFFER)) {
+		return;
+	}
+
+	wlr_buffer_unref(state->buffer);
+	state->buffer = NULL;
+
+	state->committed &= ~WLR_OUTPUT_STATE_BUFFER;
+}
+
 bool wlr_output_attach_render(struct wlr_output *output, int *buffer_age) {
 	if (!output->impl->attach_render(output, buffer_age)) {
 		return false;
 	}
 
+	output_state_clear_buffer(&output->pending);
 	output->pending.committed |= WLR_OUTPUT_STATE_BUFFER;
 	output->pending.buffer_type = WLR_OUTPUT_STATE_BUFFER_RENDER;
 	return true;
@@ -426,8 +438,9 @@ void wlr_output_set_damage(struct wlr_output *output,
 }
 
 static void output_state_clear(struct wlr_output_state *state) {
-	state->committed = 0;
+	output_state_clear_buffer(state);
 	pixman_region32_clear(&state->damage);
+	state->committed = 0;
 }
 
 bool wlr_output_commit(struct wlr_output *output) {
@@ -484,8 +497,10 @@ bool wlr_output_attach_buffer(struct wlr_output *output,
 		return false;
 	}
 
+	output_state_clear_buffer(&output->pending);
 	output->pending.committed |= WLR_OUTPUT_STATE_BUFFER;
 	output->pending.buffer_type = WLR_OUTPUT_STATE_BUFFER_SCANOUT;
+	output->pending.buffer = wlr_buffer_ref(buffer);
 	return true;
 }
 

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -474,6 +474,30 @@ bool wlr_output_commit(struct wlr_output *output) {
 	return true;
 }
 
+bool wlr_output_set_dmabuf(struct wlr_output *output,
+		struct wlr_dmabuf_attributes *attribs) {
+	if (output->frame_pending) {
+		wlr_log(WLR_ERROR, "Tried to swap buffers when a frame is pending");
+		return false;
+	}
+	if (output->idle_frame != NULL) {
+		wl_event_source_remove(output->idle_frame);
+		output->idle_frame = NULL;
+	}
+
+	if (!output->impl->set_dmabuf) {
+		return false;
+	}
+	if (!output->impl->set_dmabuf(output, attribs)) {
+		return false;
+	}
+
+	output->frame_pending = true;
+	output->needs_swap = false;
+	pixman_region32_clear(&output->damage);
+	return true;
+}
+
 void wlr_output_send_frame(struct wlr_output *output) {
 	output->frame_pending = false;
 	wlr_signal_emit_safe(&output->events.frame, output);

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -474,8 +474,8 @@ bool wlr_output_commit(struct wlr_output *output) {
 	return true;
 }
 
-bool wlr_output_set_dmabuf(struct wlr_output *output,
-		struct wlr_dmabuf_attributes *attribs) {
+bool wlr_output_attach_buffer(struct wlr_output *output,
+		struct wlr_buffer *buffer) {
 	if (output->frame_pending) {
 		wlr_log(WLR_ERROR, "Tried to swap buffers when a frame is pending");
 		return false;
@@ -485,15 +485,15 @@ bool wlr_output_set_dmabuf(struct wlr_output *output,
 		output->idle_frame = NULL;
 	}
 
-	if (!output->impl->set_dmabuf) {
+	if (!output->impl->attach_buffer) {
 		return false;
 	}
-	if (!output->impl->set_dmabuf(output, attribs)) {
+	if (!output->impl->attach_buffer(output, buffer)) {
 		return false;
 	}
 
 	output->frame_pending = true;
-	output->needs_swap = false;
+	output->needs_frame = false;
 	pixman_region32_clear(&output->damage);
 	return true;
 }

--- a/types/wlr_screencopy_v1.c
+++ b/types/wlr_screencopy_v1.c
@@ -23,6 +23,7 @@ static void frame_destroy(struct wlr_screencopy_frame_v1 *frame) {
 	if (frame == NULL) {
 		return;
 	}
+	wlr_output_lock_attach_render(frame->output, false);
 	if (frame->cursor_locked) {
 		wlr_output_lock_software_cursors(frame->output, false);
 	}
@@ -143,6 +144,7 @@ static void frame_handle_copy(struct wl_client *client,
 	output->needs_frame = true;
 	wlr_output_schedule_frame(output);
 
+	wlr_output_lock_attach_render(output, true);
 	if (frame->overlay_cursor) {
 		wlr_output_lock_software_cursors(output, true);
 		frame->cursor_locked = true;


### PR DESCRIPTION
This adds support for direct scan-out. This is a required feature before working on planes.

This PR tries to to as little changes as possible to make it easy to review and avoid re-writing everything. The current DRM backend and interface are not great but refactoring can happen incrementally with future PRs.

A new `wlr_output_attach_buffer` function has been introduced.

TODO:

- [x] We need to hold client buffers for longer than usual. When compositing, we need to hold buffers until the buffer swap (and the kernel will take care of the rest with implicit synchronization). When scanning out, we need to hold buffers as long as they're visible on screen.
- [x] Handle transformed surfaces
- [x] Handle DMA-BUF flags
- [x] Make software cursors force composition
- [x] Make screen capture force composition
- [x] Update wlr_output_damage: when switching from direct scan-out to rendering, we need to re-render all damage accumulated while scanning out
- [x] Test as many clients as possible

Test plan: try those fullscreen

- `weston-simple-dmabuf-drm`
- `weston-simple-dmabuf-egl`
- `weston-simple-egl`
- mpv
- a glfw demo

Follow-up issues:
- Use atomic test mode to check whether a configuration works
- Support Y_INVERT DMA-BUFs by setting "rotation" = "reflect-y" on planes

Fixes https://github.com/swaywm/wlroots/issues/193