### PR TITLE
Introduce wlr_format_set

### DIFF
--- a/include/wlr/render/drm_format_set.h
+++ b/include/wlr/render/drm_format_set.h
@@ -1,0 +1,27 @@
+#ifndef WLR_RENDER_DRM_FORMAT_SET_H
+#define WLR_RENDER_DRM_FORMAT_SET_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+struct wlr_drm_format {
+	uint32_t format;
+	size_t len, cap;
+	uint64_t modifiers[];
+};
+
+struct wlr_drm_format_set {
+	size_t len, cap;
+	struct wlr_drm_format **formats;
+};
+
+void wlr_drm_format_set_finish(struct wlr_drm_format_set *set);
+
+const struct wlr_drm_format *wlr_drm_format_set_get(
+	const struct wlr_drm_format_set *set, uint32_t format);
+
+bool wlr_drm_format_set_add(struct wlr_drm_format_set *set, uint32_t format,
+	uint64_t modifier);
+
+#endif

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -21,6 +21,7 @@
 #include <stdbool.h>
 #include <wayland-server.h>
 #include <wlr/render/dmabuf.h>
+#include <wlr/render/drm_format_set.h>
 
 struct wlr_egl {
 	EGLenum platform;
@@ -42,6 +43,8 @@ struct wlr_egl {
 	} exts;
 
 	struct wl_display *wl_display;
+
+	struct wlr_drm_format_set dmabuf_formats;
 };
 
 // TODO: Allocate and return a wlr_egl
@@ -88,13 +91,7 @@ EGLImageKHR wlr_egl_create_image_from_dmabuf(struct wlr_egl *egl,
 /**
  * Get the available dmabuf formats
  */
-int wlr_egl_get_dmabuf_formats(struct wlr_egl *egl, int **formats);
-
-/**
- * Get the available dmabuf modifiers for a given format
- */
-int wlr_egl_get_dmabuf_modifiers(struct wlr_egl *egl, int format,
-	uint64_t **modifiers);
+const struct wlr_drm_format_set *wlr_egl_get_dmabuf_formats(struct wlr_egl *egl);
 
 bool wlr_egl_export_image_to_dmabuf(struct wlr_egl *egl, EGLImageKHR image,
 	int32_t width, int32_t height, uint32_t flags,

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -46,9 +46,8 @@ struct wlr_renderer_impl {
 		struct wl_resource *resource);
 	void (*wl_drm_buffer_get_size)(struct wlr_renderer *renderer,
 		struct wl_resource *buffer, int *width, int *height);
-	int (*get_dmabuf_formats)(struct wlr_renderer *renderer, int **formats);
-	int (*get_dmabuf_modifiers)(struct wlr_renderer *renderer, int format,
-		uint64_t **modifiers);
+	const struct wlr_drm_format_set *(*get_dmabuf_formats)(
+		struct wlr_renderer *renderer);
 	enum wl_shm_format (*preferred_read_format)(struct wlr_renderer *renderer);
 	bool (*read_pixels)(struct wlr_renderer *renderer, enum wl_shm_format fmt,
 		uint32_t *flags, uint32_t stride, uint32_t width, uint32_t height,

--- a/include/wlr/render/meson.build
+++ b/include/wlr/render/meson.build
@@ -1,9 +1,10 @@
 install_headers(
 	'dmabuf.h',
 	'egl.h',
+	'drm_format_set.h',
 	'gles2.h',
 	'interface.h',
 	'wlr_renderer.h',
 	'wlr_texture.h',
-	subdir: 'wlr/render'
+	subdir: 'wlr/render',
 )

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -20,6 +20,7 @@ enum wlr_renderer_read_pixels_flags {
 };
 
 struct wlr_renderer_impl;
+struct wlr_drm_format_set;
 
 struct wlr_renderer {
 	const struct wlr_renderer_impl *impl;
@@ -87,15 +88,10 @@ bool wlr_renderer_resource_is_wl_drm_buffer(struct wlr_renderer *renderer,
 void wlr_renderer_wl_drm_buffer_get_size(struct wlr_renderer *renderer,
 	struct wl_resource *buffer, int *width, int *height);
 /**
- * Get the available dmabuf formats
+ * Get the available DMA-BUF formats.
  */
-int wlr_renderer_get_dmabuf_formats(struct wlr_renderer *renderer,
-	int **formats);
-/**
- * Get the available dmabuf modifiers for a given format
- */
-int wlr_renderer_get_dmabuf_modifiers(struct wlr_renderer *renderer, int format,
-	uint64_t **modifiers);
+const struct wlr_drm_format_set *wlr_renderer_get_dmabuf_formats(
+	struct wlr_renderer *renderer);
 /**
  * Reads out of pixels of the currently bound surface into data. `stride` is in
  * bytes.

--- a/render/drm_format_set.c
+++ b/render/drm_format_set.c
@@ -1,0 +1,105 @@
+#include <drm_fourcc.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wlr/render/drm_format_set.h>
+#include <wlr/util/log.h>
+
+void wlr_drm_format_set_finish(struct wlr_drm_format_set *set) {
+	for (size_t i = 0; i < set->len; ++i) {
+		free(set->formats[i]);
+	}
+	free(set->formats);
+
+	set->len = 0;
+	set->cap = 0;
+	set->formats = NULL;
+}
+
+static struct wlr_drm_format **format_set_get_ref(struct wlr_drm_format_set *set,
+		uint32_t format) {
+	for (size_t i = 0; i < set->len; ++i) {
+		if (set->formats[i]->format == format) {
+			return &set->formats[i];
+		}
+	}
+
+	return NULL;
+}
+
+const struct wlr_drm_format *wlr_drm_format_set_get(
+		const struct wlr_drm_format_set *set, uint32_t format) {
+	struct wlr_drm_format **ptr =
+		format_set_get_ref((struct wlr_drm_format_set *)set, format);
+	return ptr ? *ptr : NULL;
+}
+
+bool wlr_drm_format_set_add(struct wlr_drm_format_set *set, uint32_t format,
+		uint64_t modifier) {
+	struct wlr_drm_format **ptr = format_set_get_ref(set, format);
+
+	if (ptr) {
+		struct wlr_drm_format *fmt = *ptr;
+
+		if (modifier == DRM_FORMAT_MOD_INVALID) {
+			return true;
+		}
+
+		for (size_t i = 0; i < fmt->len; ++i) {
+			if (fmt->modifiers[i] == modifier) {
+				return true;
+			}
+		}
+
+		if (fmt->len == fmt->cap) {
+			size_t cap = fmt->cap ? fmt->cap * 2 : 4;
+
+			fmt = realloc(fmt, sizeof(*fmt) + sizeof(fmt->modifiers[0]) * cap);
+			if (!fmt) {
+				wlr_log_errno(WLR_ERROR, "Allocation failed");
+				return false;
+			}
+
+			fmt->cap = cap;
+			*ptr = fmt;
+		}
+
+		fmt->modifiers[fmt->len++] = modifier;
+		return true;
+	}
+
+	size_t cap = modifier != DRM_FORMAT_MOD_INVALID ? 4 : 0;
+
+	struct wlr_drm_format *fmt =
+		calloc(1, sizeof(*fmt) + sizeof(fmt->modifiers[0]) * cap);
+	if (!fmt) {
+		wlr_log_errno(WLR_ERROR, "Allocation failed");
+		return false;
+	}
+
+	fmt->format = format;
+	if (cap) {
+		fmt->cap = cap;
+		fmt->len = 1;
+		fmt->modifiers[0] = modifier;
+	}
+
+	if (set->len == set->cap) {
+		size_t new = set->cap ? set->cap * 2 : 4;
+
+		struct wlr_drm_format **tmp = realloc(set->formats,
+			sizeof(*fmt) + sizeof(fmt->modifiers[0]) * new);
+		if (!tmp) {
+			wlr_log_errno(WLR_ERROR, "Allocation failed");
+			free(fmt);
+			return false;
+		}
+
+		set->cap = new;
+		set->formats = tmp;
+	}
+
+	set->formats[set->len++] = fmt;
+	return true;
+}

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -247,16 +247,10 @@ static void gles2_wl_drm_buffer_get_size(struct wlr_renderer *wlr_renderer,
 	eglQueryWaylandBufferWL(renderer->egl->display, buffer, EGL_HEIGHT, height);
 }
 
-static int gles2_get_dmabuf_formats(struct wlr_renderer *wlr_renderer,
-		int **formats) {
+static const struct wlr_drm_format_set *gles2_get_dmabuf_formats(
+		struct wlr_renderer *wlr_renderer) {
 	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
-	return wlr_egl_get_dmabuf_formats(renderer->egl, formats);
-}
-
-static int gles2_get_dmabuf_modifiers(struct wlr_renderer *wlr_renderer,
-		int format, uint64_t **modifiers) {
-	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
-	return wlr_egl_get_dmabuf_modifiers(renderer->egl, format, modifiers);
+	return wlr_egl_get_dmabuf_formats(renderer->egl);
 }
 
 static enum wl_shm_format gles2_preferred_read_format(
@@ -402,7 +396,6 @@ static const struct wlr_renderer_impl renderer_impl = {
 	.resource_is_wl_drm_buffer = gles2_resource_is_wl_drm_buffer,
 	.wl_drm_buffer_get_size = gles2_wl_drm_buffer_get_size,
 	.get_dmabuf_formats = gles2_get_dmabuf_formats,
-	.get_dmabuf_modifiers = gles2_get_dmabuf_modifiers,
 	.preferred_read_format = gles2_preferred_read_format,
 	.read_pixels = gles2_read_pixels,
 	.texture_from_pixels = gles2_texture_from_pixels,

--- a/render/meson.build
+++ b/render/meson.build
@@ -12,6 +12,7 @@ lib_wlr_render = static_library(
 	files(
 		'dmabuf.c',
 		'egl.c',
+		'drm_format_set.c',
 		'gles2/pixel_format.c',
 		'gles2/renderer.c',
 		'gles2/shaders.c',
@@ -27,7 +28,7 @@ lib_wlr_render = static_library(
 		drm.partial_dependency(compile_args: true), # <drm_fourcc.h>
 		glesv2,
 		pixman,
-		wayland_server
+		wayland_server,
 	],
 )
 

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -123,20 +123,12 @@ void wlr_renderer_wl_drm_buffer_get_size(struct wlr_renderer *r,
 	return r->impl->wl_drm_buffer_get_size(r, buffer, width, height);
 }
 
-int wlr_renderer_get_dmabuf_formats(struct wlr_renderer *r,
-		int **formats) {
+const struct wlr_drm_format_set *wlr_renderer_get_dmabuf_formats(
+		struct wlr_renderer *r) {
 	if (!r->impl->get_dmabuf_formats) {
-		return -1;
+		return NULL;
 	}
-	return r->impl->get_dmabuf_formats(r, formats);
-}
-
-int wlr_renderer_get_dmabuf_modifiers(struct wlr_renderer *r, int format,
-		uint64_t **modifiers) {
-	if (!r->impl->get_dmabuf_modifiers) {
-		return -1;
-	}
-	return r->impl->get_dmabuf_modifiers(r, format, modifiers);
+	return r->impl->get_dmabuf_formats(r);
 }
 
 bool wlr_renderer_read_pixels(struct wlr_renderer *r, enum wl_shm_format fmt,


### PR DESCRIPTION
This type adds a container for formats + modifiers.

This is cherry-picked from #1355. `wlr_format_set` is only used in one place for now, but it'll be useful in other places too in #1641.