### PR TITLE
send proximity_out in proximity in for tablet_v2

### DIFF
--- a/types/tablet_v2/wlr_tablet_v2_tool.c
+++ b/types/tablet_v2/wlr_tablet_v2_tool.c
@@ -314,6 +314,8 @@ void wlr_send_tablet_v2_tablet_tool_proximity_in(
 		return;
 	}
 
+	wlr_send_tablet_v2_tablet_tool_proximity_out(tool);
+
 	struct wlr_tablet_client_v2 *tablet_tmp;
 	struct wlr_tablet_client_v2 *tablet_client = NULL;
 	wl_list_for_each(tablet_tmp, &tablet->clients, tablet_link) {


### PR DESCRIPTION
When the proximity_in event is sent for tablet_v2 and there's already a
surface that currently has tablet (tool) focus, it should be told that
this is no longer the case, so we need to send the proximity_out event.