### PR TITLE
Unbreak -Werror on 32-bit platforms

### DIFF
--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -128,7 +128,7 @@ struct wlr_output *wlr_headless_add_output(struct wlr_backend *wlr_backend,
 	output_set_custom_mode(wlr_output, width, height, 0);
 	strncpy(wlr_output->make, "headless", sizeof(wlr_output->make));
 	strncpy(wlr_output->model, "headless", sizeof(wlr_output->model));
-	snprintf(wlr_output->name, sizeof(wlr_output->name), "HEADLESS-%ld",
+	snprintf(wlr_output->name, sizeof(wlr_output->name), "HEADLESS-%zd",
 		++backend->last_output_num);
 
 	if (!wlr_egl_make_current(&output->backend->egl, output->egl_surface,

--- a/backend/noop/output.c
+++ b/backend/noop/output.c
@@ -68,7 +68,7 @@ struct wlr_output *wlr_noop_add_output(struct wlr_backend *wlr_backend) {
 
 	strncpy(wlr_output->make, "noop", sizeof(wlr_output->make));
 	strncpy(wlr_output->model, "noop", sizeof(wlr_output->model));
-	snprintf(wlr_output->name, sizeof(wlr_output->name), "NOOP-%ld",
+	snprintf(wlr_output->name, sizeof(wlr_output->name), "NOOP-%zd",
 		++backend->last_output_num);
 
 	wl_list_insert(&backend->outputs, &output->link);

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -290,7 +290,7 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *wlr_backend) {
 	wlr_output_update_custom_mode(wlr_output, 1280, 720, 0);
 	strncpy(wlr_output->make, "wayland", sizeof(wlr_output->make));
 	strncpy(wlr_output->model, "wayland", sizeof(wlr_output->model));
-	snprintf(wlr_output->name, sizeof(wlr_output->name), "WL-%lu",
+	snprintf(wlr_output->name, sizeof(wlr_output->name), "WL-%zd",
 		++backend->last_output_num);
 
 	output->backend = backend;

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -146,7 +146,7 @@ struct wlr_output *wlr_x11_output_create(struct wlr_backend *backend) {
 
 	output_set_refresh(&output->wlr_output, 0);
 
-	snprintf(wlr_output->name, sizeof(wlr_output->name), "X11-%ld",
+	snprintf(wlr_output->name, sizeof(wlr_output->name), "X11-%zd",
 		++x11->last_output_num);
 	parse_xcb_setup(wlr_output, x11->xcb);
 


### PR DESCRIPTION
`size_t` requires `%z`, not `%l` modifier. See error logs: [armv7](https://github.com/swaywm/wlroots/files/3055849/wlroots-0.5.0.19.log), [i386](https://github.com/swaywm/wlroots/files/3055850/wlroots-0.5.0.19.log).

Wayland backend also used `%lu` instead of `%ld` but there should be no difference given `size_t` is unsigned (unlike `ssize_t`).
