### PR TITLE
output: do nothing in output_set_image if backend has no renderer

### DIFF
--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -722,7 +722,11 @@ bool wlr_output_cursor_set_image(struct wlr_output_cursor *cursor,
 		int32_t hotspot_x, int32_t hotspot_y) {
 	struct wlr_renderer *renderer =
 		wlr_backend_get_renderer(cursor->output->backend);
-	assert(renderer);
+	if (!renderer) {
+		// if the backend has no renderer, we can't draw a cursor, but this is
+		// actually okay, for ex. with the noop backend
+		return true;
+	}
 
 	output_cursor_reset(cursor);
 


### PR DESCRIPTION
This is useful when using the noop backend for example.