### PR TITLE
data-device: ignore accept for selection offers

### DIFF
--- a/types/data_device/wlr_data_offer.c
+++ b/types/data_device/wlr_data_offer.c
@@ -82,6 +82,12 @@ static void data_offer_handle_accept(struct wl_client *client,
 		return;
 	}
 
+	if (offer->type != WLR_DATA_OFFER_DRAG) {
+		wlr_log(WLR_DEBUG, "Ignoring wl_data_offer.accept request on a "
+			"non-drag-and-drop offer");
+		return;
+	}
+
 	wlr_data_source_accept(offer->source, serial, mime_type);
 }
 


### PR DESCRIPTION
It doesn't make sense for clients to send "accept" requests to offers that
aren't drag-and-drop. I discussed with Daniel Stone to make it a protocol
error [1] but too many clients send it (e.g. GTK+). Let's just log it for now.

[1]: https://gitlab.freedesktop.org/wayland/wayland/merge_requests/11#note_149710