### PR TITLE
Fix missing headers when building without X11

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -2,8 +2,6 @@
 #include <assert.h>
 #include <drm_fourcc.h>
 #include <drm_mode.h>
-#include <EGL/egl.h>
-#include <EGL/eglext.h>
 #include <errno.h>
 #include <gbm.h>
 #include <GLES2/gl2.h>

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -1,6 +1,4 @@
 #include <assert.h>
-#include <EGL/egl.h>
-#include <EGL/eglext.h>
 #include <gbm.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -1,6 +1,4 @@
 #include <assert.h>
-#include <EGL/egl.h>
-#include <EGL/eglext.h>
 #include <stdlib.h>
 #include <wlr/interfaces/wlr_output.h>
 #include <wlr/render/wlr_renderer.h>

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -5,8 +5,6 @@
 
 #include <wlr/config.h>
 
-#include <EGL/egl.h>
-#include <EGL/eglext.h>
 #include <wayland-server.h>
 
 #include <wlr/backend/interface.h>

--- a/glgen.sh
+++ b/glgen.sh
@@ -62,6 +62,11 @@ cat > "$OUTDIR/$BASE.h" << EOF
 #define $INCLUDE_GUARD
 
 #include <stdbool.h>
+#include <wlr/config.h>
+
+#if !WLR_HAS_X11_BACKEND && !WLR_HAS_XWAYLAND && !defined MESA_EGL_NO_X11_HEADERS
+#define MESA_EGL_NO_X11_HEADERS
+#endif
 
 #include <EGL/egl.h>
 #include <EGL/eglext.h>

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -1,8 +1,6 @@
 #ifndef RENDER_GLES2_H
 #define RENDER_GLES2_H
 
-#include <EGL/egl.h>
-#include <EGL/eglext.h>
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 #include <stdbool.h>

--- a/render/egl.c
+++ b/render/egl.c
@@ -1,5 +1,3 @@
-#include <EGL/egl.h>
-#include <EGL/eglext.h>
 #include <assert.h>
 #include <drm_fourcc.h>
 #include <stdio.h>

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -13,7 +13,6 @@
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/util/log.h>
 #include <wlr/util/region.h>
-#include <wlr/xwayland.h>
 #include "rootston/config.h"
 #include "rootston/layers.h"
 #include "rootston/output.h"


### PR DESCRIPTION
The deleted includes are redundant, because other headers will include the necessary files. Additionally, they cause build failures, because including EGL/egl.h or EGL/eglext.h directly, instead of through wlr/render/egl.h or wlr/render/interface.h, will mean that `MESA_EGL_NO_X11_HEADERS` will not have been defined, and so the EGL headers will attempt to pull in unnecessary X11 headers that may not exist on the system.

For the headers produced by glgen.sh, the includes couldn't simply be deleted, because no other header would include the EGL headers. Neither wlr/render/egl.h or wlr/render/interface.h felt appropriate to include, so I opted instead to copy the `MESA_EGL_NO_X11_HEADERS` definition before
the EGL includes.