### PR TITLE
output: refactor frame submission API

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -338,7 +338,7 @@ bool set_drm_connector_gamma(struct wlr_output *output, size_t size,
 
 	bool ok = drm->iface->crtc_set_gamma(drm, conn->crtc, size, _r, _g, _b);
 	if (ok) {
-		wlr_output_update_needs_commit(output);
+		wlr_output_update_needs_frame(output);
 
 		free(conn->crtc->gamma_table);
 		conn->crtc->gamma_table = gamma_table;
@@ -677,7 +677,7 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 			return false;
 		}
 
-		wlr_output_update_needs_commit(output);
+		wlr_output_update_needs_frame(output);
 	}
 
 	if (!update_texture) {
@@ -737,7 +737,7 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 	}
 	bool ok = drm->iface->crtc_set_cursor(drm, crtc, bo);
 	if (ok) {
-		wlr_output_update_needs_commit(output);
+		wlr_output_update_needs_frame(output);
 	}
 	return ok;
 }
@@ -774,7 +774,7 @@ static bool drm_connector_move_cursor(struct wlr_output *output,
 
 	bool ok = drm->iface->crtc_move_cursor(drm, conn->crtc, box.x, box.y);
 	if (ok) {
-		wlr_output_update_needs_commit(output);
+		wlr_output_update_needs_frame(output);
 	}
 	return ok;
 }
@@ -1435,7 +1435,7 @@ static void drm_connector_cleanup(struct wlr_drm_connector *conn) {
 			wl_event_source_remove(conn->output.idle_frame);
 			conn->output.idle_frame = NULL;
 		}
-		conn->output.needs_commit = false;
+		conn->output.needs_frame = false;
 		conn->output.frame_pending = false;
 
 		/* Fallthrough */

--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -56,15 +56,15 @@ static void output_transform(struct wlr_output *wlr_output,
 	output->wlr_output.transform = transform;
 }
 
-static bool output_make_current(struct wlr_output *wlr_output, int *buffer_age) {
+static bool output_attach_render(struct wlr_output *wlr_output,
+		int *buffer_age) {
 	struct wlr_headless_output *output =
 		headless_output_from_output(wlr_output);
 	return wlr_egl_make_current(&output->backend->egl, output->egl_surface,
 		buffer_age);
 }
 
-static bool output_swap_buffers(struct wlr_output *wlr_output,
-		pixman_region32_t *damage) {
+static bool output_commit(struct wlr_output *wlr_output) {
 	// Nothing needs to be done for pbuffers
 	wlr_output_send_present(wlr_output, NULL);
 	return true;
@@ -86,8 +86,8 @@ static const struct wlr_output_impl output_impl = {
 	.set_custom_mode = output_set_custom_mode,
 	.transform = output_transform,
 	.destroy = output_destroy,
-	.make_current = output_make_current,
-	.swap_buffers = output_swap_buffers,
+	.attach_render = output_attach_render,
+	.commit = output_commit,
 };
 
 bool wlr_output_is_headless(struct wlr_output *wlr_output) {

--- a/backend/noop/output.c
+++ b/backend/noop/output.c
@@ -23,12 +23,12 @@ static bool output_set_custom_mode(struct wlr_output *wlr_output,
 	return true;
 }
 
-static bool output_make_current(struct wlr_output *wlr_output, int *buffer_age) {
+static bool output_attach_render(struct wlr_output *wlr_output,
+		int *buffer_age) {
 	return true;
 }
 
-static bool output_swap_buffers(struct wlr_output *wlr_output,
-		pixman_region32_t *damage) {
+static bool output_commit(struct wlr_output *wlr_output) {
 	return true;
 }
 
@@ -45,8 +45,8 @@ static const struct wlr_output_impl output_impl = {
 	.transform = output_transform,
 	.set_custom_mode = output_set_custom_mode,
 	.destroy = output_destroy,
-	.make_current = output_make_current,
-	.swap_buffers = output_swap_buffers,
+	.attach_render = output_attach_render,
+	.commit = output_commit,
 };
 
 bool wlr_output_is_noop(struct wlr_output *wlr_output) {

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -46,7 +46,7 @@ static void handle_x11_event(struct wlr_x11_backend *x11,
 		struct wlr_x11_output *output =
 			get_x11_output_from_window_id(x11, ev->window);
 		if (output != NULL) {
-			wlr_output_update_needs_swap(&output->wlr_output);
+			wlr_output_update_needs_commit(&output->wlr_output);
 		}
 		break;
 	}

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -46,7 +46,7 @@ static void handle_x11_event(struct wlr_x11_backend *x11,
 		struct wlr_x11_output *output =
 			get_x11_output_from_window_id(x11, ev->window);
 		if (output != NULL) {
-			wlr_output_update_needs_commit(&output->wlr_output);
+			wlr_output_update_needs_frame(&output->wlr_output);
 		}
 		break;
 	}

--- a/examples/fullscreen-shell.c
+++ b/examples/fullscreen-shell.c
@@ -89,7 +89,7 @@ static void output_handle_frame(struct wl_listener *listener, void *data) {
 	int width, height;
 	wlr_output_effective_resolution(output->wlr_output, &width, &height);
 
-	if (!wlr_output_make_current(output->wlr_output, NULL)) {
+	if (!wlr_output_attach_render(output->wlr_output, NULL)) {
 		return;
 	}
 
@@ -108,7 +108,7 @@ static void output_handle_frame(struct wl_listener *listener, void *data) {
 	}
 
 	wlr_renderer_end(renderer);
-	wlr_output_swap_buffers(output->wlr_output, NULL, NULL);
+	wlr_output_commit(output->wlr_output);
 }
 
 static void output_set_surface(struct fullscreen_output *output,

--- a/examples/multi-pointer.c
+++ b/examples/multi-pointer.c
@@ -94,14 +94,14 @@ void output_frame_notify(struct wl_listener *listener, void *data) {
 	struct sample_state *sample = output->sample;
 	struct wlr_output *wlr_output = output->output;
 
-	wlr_output_make_current(wlr_output, NULL);
+	wlr_output_attach_render(wlr_output, NULL);
 
 	glClearColor(sample->clear_color[0], sample->clear_color[1],
 		sample->clear_color[2], sample->clear_color[3]);
 	glClear(GL_COLOR_BUFFER_BIT);
 
 	wlr_output_render_software_cursors(wlr_output, NULL);
-	wlr_output_swap_buffers(wlr_output, NULL, NULL);
+	wlr_output_commit(wlr_output);
 }
 
 static void handle_cursor_motion(struct wl_listener *listener, void *data) {

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -115,7 +115,7 @@ void output_frame_notify(struct wl_listener *listener, void *data) {
 
 	struct wlr_output *wlr_output = output->output;
 
-	wlr_output_make_current(wlr_output, NULL);
+	wlr_output_attach_render(wlr_output, NULL);
 	wlr_renderer_begin(sample->renderer, wlr_output->width, wlr_output->height);
 	wlr_renderer_clear(sample->renderer, (float[]){0.25f, 0.25f, 0.25f, 1});
 
@@ -137,7 +137,7 @@ void output_frame_notify(struct wl_listener *listener, void *data) {
 	}
 
 	wlr_renderer_end(sample->renderer);
-	wlr_output_swap_buffers(wlr_output, NULL, NULL);
+	wlr_output_commit(wlr_output);
 }
 
 static void update_velocities(struct sample_state *sample,

--- a/examples/pointer.c
+++ b/examples/pointer.c
@@ -98,11 +98,11 @@ void output_frame_notify(struct wl_listener *listener, void *data) {
 	struct wlr_renderer *renderer = wlr_backend_get_renderer(wlr_output->backend);
 	assert(renderer);
 
-	wlr_output_make_current(wlr_output, NULL);
+	wlr_output_attach_render(wlr_output, NULL);
 	wlr_renderer_begin(renderer, wlr_output->width, wlr_output->height);
 	wlr_renderer_clear(renderer, state->clear_color);
 	wlr_output_render_software_cursors(wlr_output, NULL);
-	wlr_output_swap_buffers(wlr_output, NULL, NULL);
+	wlr_output_commit(wlr_output);
 	wlr_renderer_end(renderer);
 }
 

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -60,7 +60,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	int32_t width, height;
 	wlr_output_effective_resolution(wlr_output, &width, &height);
 
-	wlr_output_make_current(wlr_output, NULL);
+	wlr_output_attach_render(wlr_output, NULL);
 	wlr_renderer_begin(sample->renderer, wlr_output->width, wlr_output->height);
 	wlr_renderer_clear(sample->renderer, (float[]){0.25f, 0.25f, 0.25f, 1});
 
@@ -72,7 +72,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	}
 
 	wlr_renderer_end(sample->renderer);
-	wlr_output_swap_buffers(wlr_output, NULL, NULL);
+	wlr_output_commit(wlr_output);
 
 	long ms = (now.tv_sec - sample->last_frame.tv_sec) * 1000 +
 		(now.tv_nsec - sample->last_frame.tv_nsec) / 1000000;

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -56,12 +56,12 @@ void output_frame_notify(struct wl_listener *listener, void *data) {
 		sample->dec = inc;
 	}
 
-	wlr_output_make_current(sample_output->output, NULL);
+	wlr_output_attach_render(sample_output->output, NULL);
 
 	glClearColor(sample->color[0], sample->color[1], sample->color[2], 1.0);
 	glClear(GL_COLOR_BUFFER_BIT);
 
-	wlr_output_swap_buffers(sample_output->output, NULL, NULL);
+	wlr_output_commit(sample_output->output);
 	sample->last_frame = now;
 }
 

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -86,7 +86,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	int32_t width, height;
 	wlr_output_effective_resolution(wlr_output, &width, &height);
 
-	wlr_output_make_current(wlr_output, NULL);
+	wlr_output_attach_render(wlr_output, NULL);
 	wlr_renderer_begin(sample->renderer, wlr_output->width, wlr_output->height);
 	wlr_renderer_clear(sample->renderer, (float[]){0.25f, 0.25f, 0.25f, 1});
 
@@ -129,7 +129,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	}
 
 	wlr_renderer_end(sample->renderer);
-	wlr_output_swap_buffers(wlr_output, NULL, NULL);
+	wlr_output_commit(wlr_output);
 	sample->last_frame = now;
 }
 

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -73,7 +73,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	int32_t width, height;
 	wlr_output_effective_resolution(wlr_output, &width, &height);
 
-	wlr_output_make_current(wlr_output, NULL);
+	wlr_output_attach_render(wlr_output, NULL);
 	wlr_renderer_begin(sample->renderer, wlr_output->width, wlr_output->height);
 	wlr_renderer_clear(sample->renderer, (float[]){0.25f, 0.25f, 0.25f, 1});
 
@@ -89,7 +89,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	}
 
 	wlr_renderer_end(sample->renderer);
-	wlr_output_swap_buffers(wlr_output, NULL, NULL);
+	wlr_output_commit(wlr_output);
 	sample->last_frame = now;
 }
 

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -26,8 +26,8 @@ struct wlr_output_impl {
 		int32_t hotspot_x, int32_t hotspot_y, bool update_texture);
 	bool (*move_cursor)(struct wlr_output *output, int x, int y);
 	void (*destroy)(struct wlr_output *output);
-	bool (*make_current)(struct wlr_output *output, int *buffer_age);
-	bool (*swap_buffers)(struct wlr_output *output, pixman_region32_t *damage);
+	bool (*attach_render)(struct wlr_output *output, int *buffer_age);
+	bool (*commit)(struct wlr_output *output);
 	bool (*set_gamma)(struct wlr_output *output, size_t size,
 		const uint16_t *r, const uint16_t *g, const uint16_t *b);
 	size_t (*get_gamma_size)(struct wlr_output *output);
@@ -43,7 +43,7 @@ void wlr_output_update_mode(struct wlr_output *output,
 void wlr_output_update_custom_mode(struct wlr_output *output, int32_t width,
 	int32_t height, int32_t refresh);
 void wlr_output_update_enabled(struct wlr_output *output, bool enabled);
-void wlr_output_update_needs_swap(struct wlr_output *output);
+void wlr_output_update_needs_commit(struct wlr_output *output);
 void wlr_output_damage_whole(struct wlr_output *output);
 void wlr_output_send_frame(struct wlr_output *output);
 void wlr_output_send_present(struct wlr_output *output,

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -43,7 +43,7 @@ void wlr_output_update_mode(struct wlr_output *output,
 void wlr_output_update_custom_mode(struct wlr_output *output, int32_t width,
 	int32_t height, int32_t refresh);
 void wlr_output_update_enabled(struct wlr_output *output, bool enabled);
-void wlr_output_update_needs_commit(struct wlr_output *output);
+void wlr_output_update_needs_frame(struct wlr_output *output);
 void wlr_output_damage_whole(struct wlr_output *output);
 void wlr_output_send_frame(struct wlr_output *output);
 void wlr_output_send_present(struct wlr_output *output,

--- a/include/wlr/types/wlr_export_dmabuf_v1.h
+++ b/include/wlr/types/wlr_export_dmabuf_v1.h
@@ -35,7 +35,7 @@ struct wlr_export_dmabuf_frame_v1 {
 
 	bool cursor_locked;
 
-	struct wl_listener output_swap_buffers;
+	struct wl_listener output_precommit;
 };
 
 struct wlr_export_dmabuf_manager_v1 *wlr_export_dmabuf_manager_v1_create(

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -97,7 +97,7 @@ struct wlr_output {
 	enum wl_output_subpixel subpixel;
 	enum wl_output_transform transform;
 
-	bool needs_swap;
+	bool needs_commit;
 	// damage for cursors and fullscreen surface, in output-local coordinates
 	pixman_region32_t damage;
 	bool frame_pending;
@@ -110,7 +110,7 @@ struct wlr_output {
 		struct wl_signal frame;
 		// Emitted when buffers need to be swapped (because software cursors or
 		// fullscreen damage or because of backend-specific logic)
-		struct wl_signal needs_swap;
+		struct wl_signal needs_commit;
 		// Emitted right before buffer swap
 		struct wl_signal swap_buffers; // wlr_output_event_swap_buffers
 		// Emitted right after the buffer has been presented to the user

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -97,7 +97,7 @@ struct wlr_output {
 	enum wl_output_subpixel subpixel;
 	enum wl_output_transform transform;
 
-	bool needs_commit;
+	bool needs_frame;
 	// damage for cursors and fullscreen surface, in output-local coordinates
 	pixman_region32_t damage;
 	bool frame_pending;
@@ -110,7 +110,7 @@ struct wlr_output {
 		struct wl_signal frame;
 		// Emitted when buffers need to be swapped (because software cursors or
 		// fullscreen damage or because of backend-specific logic)
-		struct wl_signal needs_commit;
+		struct wl_signal needs_frame;
 		// Emitted right before commit
 		struct wl_signal precommit; // wlr_output_event_precommit
 		// Emitted right after commit

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -56,7 +56,7 @@ enum wlr_output_state_field {
  */
 struct wlr_output_state {
 	uint32_t committed; // enum wlr_output_state_field
-	pixman_region32_t damage;
+	pixman_region32_t damage; // output-buffer-local coordinates
 };
 
 struct wlr_output_impl;
@@ -111,8 +111,8 @@ struct wlr_output {
 		// Emitted when buffers need to be swapped (because software cursors or
 		// fullscreen damage or because of backend-specific logic)
 		struct wl_signal needs_commit;
-		// Emitted right before buffer swap
-		struct wl_signal swap_buffers; // wlr_output_event_swap_buffers
+		// Emitted right before buffer commit
+		struct wl_signal precommit; // wlr_output_event_precommit
 		// Emitted right after the buffer has been presented to the user
 		struct wl_signal present; // wlr_output_event_present
 		struct wl_signal enable;
@@ -133,10 +133,9 @@ struct wlr_output {
 	void *data;
 };
 
-struct wlr_output_event_swap_buffers {
+struct wlr_output_event_precommit {
 	struct wlr_output *output;
 	struct timespec *when;
-	pixman_region32_t *damage; // output-buffer-local coordinates
 };
 
 enum wlr_output_present_flag {

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -111,8 +111,10 @@ struct wlr_output {
 		// Emitted when buffers need to be swapped (because software cursors or
 		// fullscreen damage or because of backend-specific logic)
 		struct wl_signal needs_commit;
-		// Emitted right before buffer commit
+		// Emitted right before commit
 		struct wl_signal precommit; // wlr_output_event_precommit
+		// Emitted right after commit
+		struct wl_signal commit;
 		// Emitted right after the buffer has been presented to the user
 		struct wl_signal present; // wlr_output_event_present
 		struct wl_signal enable;

--- a/include/wlr/types/wlr_output_damage.h
+++ b/include/wlr/types/wlr_output_damage.h
@@ -48,7 +48,7 @@ struct wlr_output_damage {
 	struct wl_listener output_mode;
 	struct wl_listener output_transform;
 	struct wl_listener output_scale;
-	struct wl_listener output_needs_swap;
+	struct wl_listener output_needs_commit;
 	struct wl_listener output_frame;
 };
 

--- a/include/wlr/types/wlr_output_damage.h
+++ b/include/wlr/types/wlr_output_damage.h
@@ -51,7 +51,7 @@ struct wlr_output_damage {
 	struct wl_listener output_mode;
 	struct wl_listener output_transform;
 	struct wl_listener output_scale;
-	struct wl_listener output_needs_commit;
+	struct wl_listener output_needs_frame;
 	struct wl_listener output_frame;
 	struct wl_listener output_commit;
 };
@@ -63,12 +63,12 @@ void wlr_output_damage_destroy(struct wlr_output_damage *output_damage);
  * function before rendering. After they are done rendering, they should call
  * `wlr_output_set_damage` and `wlr_output_commit` to submit the new frame.
  *
- * `needs_commit` will be set to true if a frame should be submitted. `damage`
+ * `needs_frame` will be set to true if a frame should be submitted. `damage`
  * will be set to the region of the output that needs to be repainted, in
  * output-buffer-local coordinates.
  */
 bool wlr_output_damage_attach_render(struct wlr_output_damage *output_damage,
-	bool *needs_commit, pixman_region32_t *damage);
+	bool *needs_frame, pixman_region32_t *damage);
 /**
  * Accumulates damage and schedules a `frame` event.
  */

--- a/include/wlr/types/wlr_screencopy_v1.h
+++ b/include/wlr/types/wlr_screencopy_v1.h
@@ -42,7 +42,7 @@ struct wlr_screencopy_frame_v1 {
 	struct wl_listener buffer_destroy;
 
 	struct wlr_output *output;
-	struct wl_listener output_swap_buffers;
+	struct wl_listener output_precommit;
 
 	void *data;
 };

--- a/rootston/render.c
+++ b/rootston/render.c
@@ -220,10 +220,10 @@ void output_render(struct roots_output *output) {
 		clear_color[0] = clear_color[1] = clear_color[2] = 0;
 	}
 
-	bool needs_swap;
+	bool needs_frame;
 	pixman_region32_t damage;
 	pixman_region32_init(&damage);
-	if (!wlr_output_damage_attach_render(output->damage, &needs_swap, &damage)) {
+	if (!wlr_output_damage_attach_render(output->damage, &needs_frame, &damage)) {
 		return;
 	}
 
@@ -232,7 +232,7 @@ void output_render(struct roots_output *output) {
 		.alpha = 1.0,
 	};
 
-	if (!needs_swap) {
+	if (!needs_frame) {
 		// Output doesn't need swap and isn't damaged, skip rendering completely
 		goto damage_finish;
 	}

--- a/tinywl/tinywl.c
+++ b/tinywl/tinywl.c
@@ -591,8 +591,8 @@ static void output_frame(struct wl_listener *listener, void *data) {
 	struct timespec now;
 	clock_gettime(CLOCK_MONOTONIC, &now);
 
-	/* wlr_output_make_current makes the OpenGL context current. */
-	if (!wlr_output_make_current(output->wlr_output, NULL)) {
+	/* wlr_output_attach_render makes the OpenGL context current. */
+	if (!wlr_output_attach_render(output->wlr_output, NULL)) {
 		return;
 	}
 	/* The "effective" resolution can change if you rotate your outputs. */
@@ -635,7 +635,7 @@ static void output_frame(struct wl_listener *listener, void *data) {
 	/* Conclude rendering and swap the buffers, showing the final frame
 	 * on-screen. */
 	wlr_renderer_end(renderer);
-	wlr_output_swap_buffers(output->wlr_output, NULL, NULL);
+	wlr_output_commit(output->wlr_output);
 }
 
 static void server_new_output(struct wl_listener *listener, void *data) {

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -274,7 +274,7 @@ void wlr_output_init(struct wlr_output *output, struct wlr_backend *backend,
 	wl_list_init(&output->resources);
 	wl_signal_init(&output->events.frame);
 	wl_signal_init(&output->events.needs_commit);
-	wl_signal_init(&output->events.swap_buffers);
+	wl_signal_init(&output->events.precommit);
 	wl_signal_init(&output->events.present);
 	wl_signal_init(&output->events.enable);
 	wl_signal_init(&output->events.mode);
@@ -415,17 +415,11 @@ bool wlr_output_commit(struct wlr_output *output) {
 	struct timespec now;
 	clock_gettime(CLOCK_MONOTONIC, &now);
 
-	pixman_region32_t *damage = NULL;
-	if (output->pending.committed & WLR_OUTPUT_STATE_DAMAGE) {
-		damage = &output->pending.damage;
-	}
-
-	struct wlr_output_event_swap_buffers event = {
+	struct wlr_output_event_precommit event = {
 		.output = output,
 		.when = &now,
-		.damage = damage,
 	};
-	wlr_signal_emit_safe(&output->events.swap_buffers, &event);
+	wlr_signal_emit_safe(&output->events.precommit, &event);
 
 	if (!output->impl->commit(output)) {
 		return false;

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -273,7 +273,7 @@ void wlr_output_init(struct wlr_output *output, struct wlr_backend *backend,
 	wl_list_init(&output->cursors);
 	wl_list_init(&output->resources);
 	wl_signal_init(&output->events.frame);
-	wl_signal_init(&output->events.needs_commit);
+	wl_signal_init(&output->events.needs_frame);
 	wl_signal_init(&output->events.precommit);
 	wl_signal_init(&output->events.commit);
 	wl_signal_init(&output->events.present);
@@ -437,7 +437,7 @@ bool wlr_output_commit(struct wlr_output *output) {
 	wlr_signal_emit_safe(&output->events.commit, output);
 
 	output->frame_pending = true;
-	output->needs_commit = false;
+	output->needs_frame = false;
 	output_state_clear(&output->pending);
 	return true;
 }
@@ -517,9 +517,9 @@ bool wlr_output_export_dmabuf(struct wlr_output *output,
 	return output->impl->export_dmabuf(output, attribs);
 }
 
-void wlr_output_update_needs_commit(struct wlr_output *output) {
-	output->needs_commit = true;
-	wlr_signal_emit_safe(&output->events.needs_commit, output);
+void wlr_output_update_needs_frame(struct wlr_output *output) {
+	output->needs_frame = true;
+	wlr_signal_emit_safe(&output->events.needs_frame, output);
 }
 
 void wlr_output_damage_whole(struct wlr_output *output) {
@@ -528,7 +528,7 @@ void wlr_output_damage_whole(struct wlr_output *output) {
 
 	pixman_region32_union_rect(&output->damage, &output->damage, 0, 0,
 		width, height);
-	wlr_output_update_needs_commit(output);
+	wlr_output_update_needs_frame(output);
 }
 
 struct wlr_output *wlr_output_from_resource(struct wl_resource *resource) {
@@ -674,7 +674,7 @@ static void output_cursor_damage_whole(struct wlr_output_cursor *cursor) {
 	output_cursor_get_box(cursor, &box);
 	pixman_region32_union_rect(&cursor->output->damage, &cursor->output->damage,
 		box.x, box.y, box.width, box.height);
-	wlr_output_update_needs_commit(cursor->output);
+	wlr_output_update_needs_frame(cursor->output);
 }
 
 static void output_cursor_reset(struct wlr_output_cursor *cursor) {

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -275,6 +275,7 @@ void wlr_output_init(struct wlr_output *output, struct wlr_backend *backend,
 	wl_signal_init(&output->events.frame);
 	wl_signal_init(&output->events.needs_commit);
 	wl_signal_init(&output->events.precommit);
+	wl_signal_init(&output->events.commit);
 	wl_signal_init(&output->events.present);
 	wl_signal_init(&output->events.enable);
 	wl_signal_init(&output->events.mode);
@@ -432,6 +433,8 @@ bool wlr_output_commit(struct wlr_output *output) {
 		}
 		wlr_surface_send_frame_done(cursor->surface, &now);
 	}
+
+	wlr_signal_emit_safe(&output->events.commit, output);
 
 	output->frame_pending = true;
 	output->needs_commit = false;

--- a/types/wlr_output_damage.c
+++ b/types/wlr_output_damage.c
@@ -106,7 +106,7 @@ bool wlr_output_damage_make_current(struct wlr_output_damage *output_damage,
 	struct wlr_output *output = output_damage->output;
 
 	int buffer_age = -1;
-	if (!wlr_output_make_current(output, &buffer_age)) {
+	if (!wlr_output_attach_render(output, &buffer_age)) {
 		return false;
 	}
 
@@ -142,7 +142,10 @@ bool wlr_output_damage_make_current(struct wlr_output_damage *output_damage,
 
 bool wlr_output_damage_swap_buffers(struct wlr_output_damage *output_damage,
 		struct timespec *when, pixman_region32_t *damage) {
-	if (!wlr_output_swap_buffers(output_damage->output, when, damage)) {
+	if (damage != NULL) {
+		wlr_output_set_damage(output_damage->output, damage);
+	}
+	if (!wlr_output_commit(output_damage->output)) {
 		return false;
 	}
 

--- a/types/wlr_screencopy_v1.c
+++ b/types/wlr_screencopy_v1.c
@@ -135,8 +135,8 @@ static void frame_handle_copy(struct wl_client *client,
 	wl_resource_add_destroy_listener(buffer_resource, &frame->buffer_destroy);
 	frame->buffer_destroy.notify = frame_handle_buffer_destroy;
 
-	// Schedule a buffer swap
-	output->needs_swap = true;
+	// Schedule a buffer commit
+	output->needs_commit = true;
 	wlr_output_schedule_frame(output);
 
 	if (frame->overlay_cursor) {

--- a/types/wlr_screencopy_v1.c
+++ b/types/wlr_screencopy_v1.c
@@ -140,7 +140,7 @@ static void frame_handle_copy(struct wl_client *client,
 	frame->buffer_destroy.notify = frame_handle_buffer_destroy;
 
 	// Schedule a buffer commit
-	output->needs_commit = true;
+	output->needs_frame = true;
 	wlr_output_schedule_frame(output);
 
 	if (frame->overlay_cursor) {

--- a/types/wlr_screenshooter.c
+++ b/types/wlr_screenshooter.c
@@ -150,7 +150,7 @@ static void screenshooter_shoot(struct wl_client *client,
 	wl_signal_add(&output->events.precommit, &state->frame_listener);
 
 	// Schedule a buffer commit
-	output->needs_commit = true;
+	output->needs_frame = true;
 	wlr_output_schedule_frame(output);
 }
 

--- a/types/wlr_screenshooter.c
+++ b/types/wlr_screenshooter.c
@@ -145,8 +145,8 @@ static void screenshooter_shoot(struct wl_client *client,
 	state->frame_listener.notify = output_handle_frame;
 	wl_signal_add(&output->events.swap_buffers, &state->frame_listener);
 
-	// Schedule a buffer swap
-	output->needs_swap = true;
+	// Schedule a buffer commit
+	output->needs_commit = true;
 	wlr_output_schedule_frame(output);
 }
 

--- a/types/wlr_screenshooter.c
+++ b/types/wlr_screenshooter.c
@@ -45,6 +45,10 @@ static void output_handle_frame(struct wl_listener *listener, void *_data) {
 	struct wlr_renderer *renderer = wlr_backend_get_renderer(output->backend);
 	struct wl_shm_buffer *shm_buffer = state->shm_buffer;
 
+	if (!(output->pending.committed & WLR_OUTPUT_STATE_BUFFER)) {
+		return;
+	}
+
 	enum wl_shm_format format = wl_shm_buffer_get_format(shm_buffer);
 	int32_t width = wl_shm_buffer_get_width(shm_buffer);
 	int32_t height = wl_shm_buffer_get_height(shm_buffer);
@@ -143,7 +147,7 @@ static void screenshooter_shoot(struct wl_client *client,
 	state->shm_buffer = shm_buffer;
 	state->screenshot = screenshot;
 	state->frame_listener.notify = output_handle_frame;
-	wl_signal_add(&output->events.swap_buffers, &state->frame_listener);
+	wl_signal_add(&output->events.precommit, &state->frame_listener);
 
 	// Schedule a buffer commit
 	output->needs_commit = true;


### PR DESCRIPTION
This is necessary for direct scan-out and other upcoming features. This patch
changes the output API to look like the wl_surface API.

Outputs now have some double-buffered state: the frame to be submitted
(currently only wlr_renderer frames are supported) and the damaged region.
To attach a pending frame, use wlr_output_attach_render. To set the pending
damaged region, use wlr_output_set_damage.

To submit the pending state, call wlr_output_commit. This will submit the
pending frame to the backend.

To migrate from the old API to the new one:

- Replace wlr_output_make_current calls by wlr_output_attach_render
- Replace wlr_output_swap_buffers calls by wlr_output_set_damage and
  wlr_output_commit
- Replace wlr_output_damage_make_current calls by wlr_output_damage_attach_render
- Replace wlr_output_damage_swap_buffers with wlr_output_set_damage and wlr_output_commit
- Replace wlr_output.needs_swap with wlr_output.needs_frame
- Replace wlr_output.events.swap_buffers with wlr_output.events.precommit