### PR TITLE
Add wlr_output_preferred_mode

### DIFF
--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -158,6 +158,11 @@ bool wlr_output_enable(struct wlr_output *output, bool enable);
 void wlr_output_create_global(struct wlr_output *output);
 void wlr_output_destroy_global(struct wlr_output *output);
 /**
+ * Returns the preferred mode for this output. If the output doesn't support
+ * modes, returns NULL.
+ */
+struct wlr_output_mode *wlr_output_preferred_mode(struct wlr_output *output);
+/**
  * Sets the output mode. Enables the output if it's currently disabled.
  */
 bool wlr_output_set_mode(struct wlr_output *output,

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -643,12 +643,8 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 	struct roots_output_config *output_config =
 		roots_config_get_output(config, wlr_output);
 
-	if ((!output_config || output_config->enable) && !wl_list_empty(&wlr_output->modes)) {
-		struct wlr_output_mode *mode =
-			wl_container_of(wlr_output->modes.prev, mode, link);
-		wlr_output_set_mode(wlr_output, mode);
-	}
-
+	struct wlr_output_mode *preferred_mode =
+		wlr_output_preferred_mode(wlr_output);
 	if (output_config) {
 		if (output_config->enable) {
 			if (wlr_output_is_drm(wlr_output)) {
@@ -662,6 +658,8 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 
 			if (output_config->mode.width) {
 				set_mode(wlr_output, output_config);
+			} else if (preferred_mode != NULL) {
+				wlr_output_set_mode(wlr_output, preferred_mode);
 			}
 
 			wlr_output_set_scale(wlr_output, output_config->scale);
@@ -672,6 +670,9 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 			wlr_output_enable(wlr_output, false);
 		}
 	} else {
+		if (preferred_mode != NULL) {
+			wlr_output_set_mode(wlr_output, preferred_mode);
+		}
 		wlr_output_layout_add_auto(desktop->layout, wlr_output);
 	}
 

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -344,6 +344,22 @@ void wlr_output_effective_resolution(struct wlr_output *output,
 	*height /= output->scale;
 }
 
+struct wlr_output_mode *wlr_output_preferred_mode(struct wlr_output *output) {
+	if (wl_list_empty(&output->modes)) {
+		return NULL;
+	}
+
+	struct wlr_output_mode *mode;
+	wl_list_for_each(mode, &output->modes, link) {
+		if (mode->preferred) {
+			return mode;
+		}
+	}
+
+	// No preferred mode, choose the last one
+	return mode;
+}
+
 bool wlr_output_make_current(struct wlr_output *output, int *buffer_age) {
 	return output->impl->make_current(output, buffer_age);
 }


### PR DESCRIPTION
This is a little more robust than assuming the last mode is the preferred one. This also makes compositors' code clearer.

The second commit also fixes rootston setting the preferred mode and then changing it to the configured mode (which causes delays at startup).