### PR TITLE
backend/wayland: fix wlr_wl_pointer use-after-free

### DIFF
--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -331,6 +331,11 @@ struct wlr_wl_pointer *pointer_get_wl(struct wlr_pointer *wlr_pointer) {
 
 static void pointer_destroy(struct wlr_pointer *wlr_pointer) {
 	struct wlr_wl_pointer *pointer = pointer_get_wl(wlr_pointer);
+
+	if (pointer->output->backend->current_pointer == pointer) {
+		pointer->output->backend->current_pointer = NULL;
+	}
+
 	wl_list_remove(&pointer->output_destroy.link);
 	free(pointer);
 }


### PR DESCRIPTION
```
==31666==ERROR: AddressSanitizer: heap-use-after-free on address 0x611000033fc8 at pc 0x7f5d21f20084 bp 0x7ffcfed7b0f0 sp 0x7ffcfed7b0e0
READ of size 8 at 0x611000033fc8 thread T0
    #0 0x7f5d21f20083 in wlr_signal_emit_safe ../util/signal.c:19
    #1 0x7f5d21dd2495 in pointer_handle_frame ../backend/wayland/wl_seat.c:135
    #2 0x7f5d200ea6cf in ffi_call_unix64 (/lib64/libffi.so.6+0x66cf)
    #3 0x7f5d200ea09f in ffi_call (/lib64/libffi.so.6+0x609f)
    #4 0x7f5d207bbf8e  (/lib64/libwayland-client.so.0+0x8f8e)
    #5 0x7f5d207b86b9  (/lib64/libwayland-client.so.0+0x56b9)
    #6 0x7f5d207b9bfb in wl_display_dispatch_queue_pending (/lib64/libwayland-client.so.0+0x6bfb)
    #7 0x7f5d21dc810c in dispatch_events ../backend/wayland/backend.c:35
    #8 0x7f5d219f07f1 in wl_event_loop_dispatch (/lib64/libwayland-server.so.0+0xa7f1)
    #9 0x7f5d219ef39b in wl_display_run (/lib64/libwayland-server.so.0+0x939b)
    #10 0x55fc5d7b56c2 in main ../rootston/main.c:74
    #11 0x7f5d20a6a222 in __libc_start_main (/lib64/libc.so.6+0x24222)
    #12 0x55fc5d78076d in _start (/home/simon/src/wlroots/build/rootston/rootston+0xf476d)

0x611000033fc8 is located 72 bytes inside of 248-byte region [0x611000033f80,0x611000034078)
freed by thread T0 here:
    #0 0x7f5d224a6c19 in __interceptor_free /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:66
    #1 0x7f5d21dd448a in pointer_destroy ../backend/wayland/wl_seat.c:335
    #2 0x7f5d21ee4fed in wlr_pointer_destroy ../types/wlr_pointer.c:28
    #3 0x7f5d21ea5e51 in wlr_input_device_destroy ../types/wlr_input_device.c:42
    #4 0x7f5d21dd457c in pointer_handle_output_destroy ../backend/wayland/wl_seat.c:346
    #5 0x7f5d21f201cc in wlr_signal_emit_safe ../util/signal.c:29
    #6 0x7f5d21ed4ce0 in wlr_output_destroy ../types/wlr_output.c:307
    #7 0x7f5d21dce2dd in xdg_toplevel_handle_close ../backend/wayland/output.c:266
    #8 0x7f5d200ea6cf in ffi_call_unix64 (/lib64/libffi.so.6+0x66cf)

previously allocated by thread T0 here:
    #0 0x7f5d224a7231 in __interceptor_calloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:95
    #1 0x7f5d21dd4a54 in create_wl_pointer ../backend/wayland/wl_seat.c:363
    #2 0x7f5d21dd04a3 in wlr_wl_output_create ../backend/wayland/output.c:357
    #3 0x7f5d21dc8a4e in backend_start ../backend/wayland/backend.c:108
    #4 0x7f5d21d7de59 in wlr_backend_start ../backend/backend.c:39
    #5 0x7f5d21dbf317 in multi_backend_start ../backend/multi/backend.c:31
    #6 0x7f5d21d7de59 in wlr_backend_start ../backend/backend.c:39
    #7 0x55fc5d7b5349 in main ../rootston/main.c:48
    #8 0x7f5d20a6a222 in __libc_start_main (/lib64/libc.so.6+0x24222)
```