### PR TITLE
output-damage: fix segfault after destroy

### DIFF
--- a/types/wlr_output_damage.c
+++ b/types/wlr_output_damage.c
@@ -114,6 +114,7 @@ void wlr_output_damage_destroy(struct wlr_output_damage *output_damage) {
 	wl_list_remove(&output_damage->output_scale.link);
 	wl_list_remove(&output_damage->output_needs_frame.link);
 	wl_list_remove(&output_damage->output_frame.link);
+	wl_list_remove(&output_damage->output_commit.link);
 	pixman_region32_fini(&output_damage->current);
 	for (size_t i = 0; i < WLR_OUTPUT_DAMAGE_PREVIOUS_LEN; ++i) {
 		pixman_region32_fini(&output_damage->previous[i]);


### PR DESCRIPTION
This fixes a segfault after unplug:

```
#0  0x00007f9dd1701c83 in wl_list_insert (list=0x563299a7c2b0, elm=0x7ffc68371250) at src/wayland-util.c:49
#1  0x00007f9dd1d936ba in wlr_signal_emit_safe (signal=0x5632998a4fb0, data=0x5632998a4e40) at ../subprojects/wlroots/util/signal.c:27
#2  0x00007f9dd1d81c29 in wlr_output_commit (output=0x5632998a4e40) at ../subprojects/wlroots/types/wlr_output.c:437
#3  0x000056329900ffd3 in output_render (output=0x563299d39a80, when=0x7ffc683713e0, damage=0x7ffc683713f0) at ../sway/desktop/render.c:1090
#4  0x000056329900bf19 in damage_handle_frame (listener=0x563299d39c08, data=0x563299a7bfe0) at ../sway/desktop/output.c:390
#5  0x00007f9dd1d936d2 in wlr_signal_emit_safe (signal=0x563299a7c040, data=0x563299a7bfe0) at ../subprojects/wlroots/util/signal.c:29
#6  0x00007f9dd1d7c895 in output_handle_frame (listener=0x563299a7c0d8, data=0x5632998a4e40) at ../subprojects/wlroots/types/wlr_output_damage.c:51
#7  0x00007f9dd1d936d2 in wlr_signal_emit_safe (signal=0x5632998a4f80, data=0x5632998a4e40) at ../subprojects/wlroots/util/signal.c:29
#8  0x00007f9dd1d81c9d in wlr_output_send_frame (output=0x5632998a4e40) at ../subprojects/wlroots/types/wlr_output.c:447
#9  0x00007f9dd1d3c259 in page_flip_handler (fd=9, seq=24, tv_sec=1036, tv_usec=1319, data=0x5632998a4e40) at ../subprojects/wlroots/backend/drm/drm.c:1341
#10 0x00007f9dd13b97c5 in drmHandleEvent () at /lib64/libdrm.so.2
#11 0x00007f9dd1d3c2de in handle_drm_event (fd=9, mask=1, data=0x0) at ../subprojects/wlroots/backend/drm/drm.c:1351
#12 0x00007f9dd16fedd2 in wl_event_loop_dispatch (loop=0x56329912a5e0, timeout=<optimized out>) at src/event-loop.c:641
#13 0x00007f9dd16fcdbd in wl_display_run (display=0x563299132100) at src/wayland-server.c:1260
#14 0x00005632990086d2 in server_run (server=0x56329906eec0 <server>) at ../sway/server.c:216
#15 0x0000563299007be9 in main (argc=1, argv=0x7ffc68371de8) at ../sway/main.c:398
```