### PR TITLE
Don't submit too much damage

### DIFF
--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -222,11 +222,16 @@ bool wlr_output_attach_render(struct wlr_output *output, int *buffer_age);
 bool wlr_output_preferred_read_format(struct wlr_output *output,
 	enum wl_shm_format *fmt);
 /**
- * Set the damage region for the frame to be submitted.
+ * Set the damage region for the frame to be submitted. This is the region of
+ * the screen that has changed since the last frame.
  *
  * Compositors implementing damage tracking should call this function with the
  * damaged region in output-buffer-local coordinates (ie. scaled and
  * transformed).
+ *
+ * This region is not to be confused with the renderer's buffer damage, ie. the
+ * region compositors need to repaint. Compositors usually need to repaint more
+ * than what changed since last frame since multiple render buffers are used.
  */
 void wlr_output_set_damage(struct wlr_output *output,
 	pixman_region32_t *damage);

--- a/include/wlr/types/wlr_output_damage.h
+++ b/include/wlr/types/wlr_output_damage.h
@@ -66,9 +66,13 @@ void wlr_output_damage_destroy(struct wlr_output_damage *output_damage);
  * `needs_frame` will be set to true if a frame should be submitted. `damage`
  * will be set to the region of the output that needs to be repainted, in
  * output-buffer-local coordinates.
+ *
+ * The buffer damage region accumulates all damage since the buffer has last
+ * been swapped. This is not to be confused with the output surface damage,
+ * which only contains the changes between two frames.
  */
 bool wlr_output_damage_attach_render(struct wlr_output_damage *output_damage,
-	bool *needs_frame, pixman_region32_t *damage);
+	bool *needs_frame, pixman_region32_t *buffer_damage);
 /**
  * Accumulates damage and schedules a `frame` event.
  */

--- a/render/egl.c
+++ b/render/egl.c
@@ -377,6 +377,14 @@ bool wlr_egl_swap_buffers(struct wlr_egl *egl, EGLSurface surface,
 
 		pixman_region32_fini(&flipped_damage);
 
+		if (nrects == 0) {
+			// Swapping with no rects is the same as swapping with the entire
+			// surface damaged. To swap with no damage, we set the damage region
+			// to a single empty rectangle.
+			nrects = 1;
+			memset(egl_damage, 0, sizeof(egl_damage));
+		}
+
 		if (egl->exts.swap_buffers_with_damage_ext) {
 			ret = eglSwapBuffersWithDamageEXT(egl->display, surface, egl_damage,
 				nrects);


### PR DESCRIPTION
See the individual commits.

I wonder whether `wlr_output_damage_attach_render` should call `wlr_output_set_damage` for you. Compositors can always call it again to override it (or stop using `wlr_output_damage`, it's just a helper after all). @ammen99 Would this be something you'd want to override?

Fixes #1665