### PR TITLE
Advertise wl_seat version 7

### DIFF
--- a/types/seat/wlr_seat.c
+++ b/types/seat/wlr_seat.c
@@ -12,7 +12,7 @@
 #include "types/wlr_seat.h"
 #include "util/signal.h"
 
-#define SEAT_VERSION 6
+#define SEAT_VERSION 7
 
 static void seat_handle_get_pointer(struct wl_client *client,
 		struct wl_resource *seat_resource, uint32_t id) {


### PR DESCRIPTION
This does not require any code changes, as we already copy the keymap
data separately for each client.

For details, see https://gitlab.freedesktop.org/wayland/wayland/commit/905c0a341ddf0a885811d19e2b79c65a3f1d210c

---
Relevant code: https://github.com/swaywm/wlroots/blob/460a630a43c3aa914a84e2a2a0f879f8042d6c7f/types/seat/wlr_seat_keyboard.c#L346-L373

We **could** implement that with proper fd sealing, but since that's linux-specific, I doubt that's going to happen.