### PR TITLE
meson: fix wayland-server minimum required version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -95,7 +95,7 @@ if cc.get_id() == 'clang'
 	add_project_arguments('-Wno-missing-braces', language: 'c')
 endif
 
-wayland_server = dependency('wayland-server', version: '>=1.16')
+wayland_server = dependency('wayland-server', version: '>=1.17')
 wayland_client = dependency('wayland-client')
 wayland_egl = dependency('wayland-egl')
 wayland_protos = dependency('wayland-protocols', version: '>=1.17')

--- a/types/seat/wlr_seat.c
+++ b/types/seat/wlr_seat.c
@@ -254,13 +254,8 @@ struct wlr_seat *wlr_seat_create(struct wl_display *display, const char *name) {
 	seat->touch_state.seat = seat;
 	wl_list_init(&seat->touch_state.touch_points);
 
-	// TODO: always use SEAT_VERSION (requires libwayland 1.17)
-	uint32_t version = SEAT_VERSION;
-	if (wl_seat_interface.version < SEAT_VERSION) {
-		version = wl_seat_interface.version;
-	}
 	seat->global = wl_global_create(display, &wl_seat_interface,
-		version, seat, seat_handle_bind);
+		SEAT_VERSION, seat, seat_handle_bind);
 	if (seat->global == NULL) {
 		free(touch_grab);
 		free(pointer_grab);


### PR DESCRIPTION
Having 1.16 results in the following error when running the compositor:

  2019-04-27 17:30:50 - [wayland] wl_global_create: implemented version for 'wl_seat' higher than interface version (7 > 6)
  2019-04-27 17:30:50 - [sway/input/seat.c:428] seat_create:could not allocate seat

We require wayland-server >= 1.17 for wl_seat version 7.

Fixes: a671fc51d25c2adb723d2edf96c36011211f4b81

cc @ascent12 