### PR TITLE
Drop fixup_epoll in .builds/freebsd.yml

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -21,21 +21,6 @@ packages:
 sources:
 - https://github.com/swaywm/wlroots
 tasks:
-- fixup_epoll: |
-    cat << 'EOF' | sudo tee /usr/local/libdata/pkgconfig/epoll-shim.pc
-    prefix=/usr/local
-    exec_prefix=\$\{\$prefix\}
-    libdir=${prefix}/lib
-    sharedlibdir=${prefix}/lib
-    includedir=${prefix}/include/libepoll-shim
-    Name: epoll-shim
-    Description: epoll shim implemented using kevent
-    Version: 0
-    Requires:
-    Libs: -L${libdir} -L${sharedlibdir} -lepoll-shim
-    Libs.private: -pthread -lrt
-    Cflags: -I${includedir}
-    EOF
 - wlroots: |
     cd wlroots
     meson build


### PR DESCRIPTION
`/latest` has `epoll-shim.pc` as it contains https://github.com/FreeBSDDesktop/epoll-shim/pull/1 after https://github.com/freebsd/freebsd-ports/commit/68b90c9df610ee3d99c719360256fcacf2e83603

Same as #1671.
