### PR TITLE
ci: enable Meson auto features

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -12,12 +12,13 @@ packages:
   - wayland-dev
   - wayland-protocols
   - xcb-util-image-dev
+  - xcb-util-wm-dev
 sources:
   - https://github.com/swaywm/wlroots
 tasks:
   - setup: |
       cd wlroots
-      meson build
+      meson build -Dauto_features=enabled -Dlogind=disabled -Dxcb-errors=disabled
   - build: |
       cd wlroots
       ninja -C build

--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -11,14 +11,16 @@ packages:
   - pixman
   - wayland
   - wayland-protocols
+  - xcb-util-errors
   - xcb-util-image
+  - xcb-util-wm
 sources:
   - https://github.com/swaywm/wlroots
 tasks:
   - setup: |
       cd wlroots
-      CC=gcc meson build-gcc
-      CC=clang meson build-clang
+      CC=gcc meson build-gcc -Dauto_features=enabled
+      CC=clang meson build-clang -Dauto_features=enabled
   - gcc: |
       cd wlroots/build-gcc
       ninja

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -23,5 +23,5 @@ sources:
 tasks:
 - wlroots: |
     cd wlroots
-    meson build
+    meson build -Dauto_features=enabled -Dlogind=disabled -Dlibcap=disabled -Dfreerdp=disabled
     ninja -C build


### PR DESCRIPTION
This makes it so we don't miss build failures because the CI misses a
dependency.