### PR TITLE
Enable RDP in .builds/freebsd.yml

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -11,6 +11,7 @@ packages:
 - graphics/wayland
 - graphics/wayland-protocols
 - multimedia/ffmpeg
+- net/freerdp
 - x11/libX11
 - x11/libinput
 - x11/libxcb
@@ -23,5 +24,5 @@ sources:
 tasks:
 - wlroots: |
     cd wlroots
-    meson build -Dauto_features=enabled -Dlogind=disabled -Dlibcap=disabled -Dfreerdp=disabled
+    meson build -Dauto_features=enabled -Dlogind=disabled -Dlibcap=disabled
     ninja -C build


### PR DESCRIPTION
FreeBSD is currently the only non-Linux platform covered by automation. Let's keep RDP code portable as well.

See [downstream build log](https://github.com/swaywm/wlroots/files/3142831/wlroots-0.6.0.log).
