### PR TITLE
Fixes #1689 RDP RemoteFX crash

### DIFF
--- a/backend/rdp/output.c
+++ b/backend/rdp/output.c
@@ -79,6 +79,9 @@ static bool output_attach_render(struct wlr_output *wlr_output,
 
 static bool rfx_swap_buffers(
 		struct wlr_rdp_output *output, pixman_region32_t *damage) {
+	if (!pixman_region32_not_empty(damage)) {
+		return true;
+	}
 	struct wlr_rdp_peer_context *context = output->context;
 	freerdp_peer *peer = context->peer;
 	rdpUpdate *update = peer->update;


### PR DESCRIPTION
When using the rdp backend and connecting with `xfreerdp ... --rfx`, wlroots
crashes in `backend/rdp/output.c` while attempting to `realloc(..., 0)`.

This commit guards against that and instead returns true, resulting in
no rfx message being sent. This prevents the crash and appears to work, but
it's not obvious if this is correct from a specification perspective.