### PR TITLE
backend/wayland: use xdg-decoration-unstable-v1

### DIFF
--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -16,6 +16,7 @@
 
 #include "backend/wayland.h"
 #include "util/signal.h"
+#include "xdg-decoration-unstable-v1-client-protocol.h"
 #include "xdg-shell-client-protocol.h"
 
 struct wlr_wl_backend *get_wl_backend_from_backend(struct wlr_backend *backend) {
@@ -76,6 +77,9 @@ static void registry_global(void *data, struct wl_registry *registry,
 		wl->xdg_wm_base = wl_registry_bind(registry, name,
 			&xdg_wm_base_interface, 1);
 		xdg_wm_base_add_listener(wl->xdg_wm_base, &xdg_wm_base_listener, NULL);
+	} else if (strcmp(iface, zxdg_decoration_manager_v1_interface.name) == 0) {
+		wl->zxdg_decoration_manager_v1 = wl_registry_bind(registry, name,
+			&zxdg_decoration_manager_v1_interface, 1);
 	}
 }
 
@@ -147,6 +151,9 @@ static void backend_destroy(struct wlr_backend *backend) {
 	}
 	if (wl->shm) {
 		wl_shm_destroy(wl->shm);
+	}
+	if (wl->zxdg_decoration_manager_v1) {
+		zxdg_decoration_manager_v1_destroy(wl->zxdg_decoration_manager_v1);
 	}
 	xdg_wm_base_destroy(wl->xdg_wm_base);
 	wl_compositor_destroy(wl->compositor);

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -16,6 +16,7 @@
 
 #include "backend/wayland.h"
 #include "util/signal.h"
+#include "xdg-decoration-unstable-v1-client-protocol.h"
 #include "xdg-shell-client-protocol.h"
 
 static struct wlr_wl_output *get_wl_output_from_output(
@@ -187,6 +188,9 @@ static void output_destroy(struct wlr_output *wlr_output) {
 
 	wlr_egl_destroy_surface(&output->backend->egl, output->egl_surface);
 	wl_egl_window_destroy(output->egl_window);
+	if (output->zxdg_toplevel_decoration_v1) {
+		zxdg_toplevel_decoration_v1_destroy(output->zxdg_toplevel_decoration_v1);
+	}
 	xdg_toplevel_destroy(output->xdg_toplevel);
 	xdg_surface_destroy(output->xdg_surface);
 	wl_surface_destroy(output->surface);
@@ -316,6 +320,18 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *wlr_backend) {
 	if (!output->xdg_toplevel) {
 		wlr_log_errno(WLR_ERROR, "Could not get xdg toplevel");
 		goto error;
+	}
+
+	if (backend->zxdg_decoration_manager_v1) {
+		output->zxdg_toplevel_decoration_v1 =
+			zxdg_decoration_manager_v1_get_toplevel_decoration(
+			backend->zxdg_decoration_manager_v1, output->xdg_toplevel);
+		if (!output->xdg_toplevel) {
+			wlr_log_errno(WLR_ERROR, "Could not get xdg toplevel decoration");
+			goto error;
+		}
+		zxdg_toplevel_decoration_v1_set_mode(output->zxdg_toplevel_decoration_v1,
+			ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE);
 	}
 
 	wlr_wl_output_set_title(wlr_output, NULL);

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -32,6 +32,7 @@ struct wlr_wl_backend {
 	struct wl_registry *registry;
 	struct wl_compositor *compositor;
 	struct xdg_wm_base *xdg_wm_base;
+	struct zxdg_decoration_manager_v1 *zxdg_decoration_manager_v1;
 	struct wl_shm *shm;
 	struct wl_seat *seat;
 	struct wl_pointer *pointer;
@@ -50,6 +51,7 @@ struct wlr_wl_output {
 	struct wl_callback *frame_callback;
 	struct xdg_surface *xdg_surface;
 	struct xdg_toplevel *xdg_toplevel;
+	struct zxdg_toplevel_decoration_v1 *zxdg_toplevel_decoration_v1;
 	struct wl_egl_window *egl_window;
 	EGLSurface egl_surface;
 


### PR DESCRIPTION
This allows the toplevel to have proper decorations on compositors that support
xdg-decoration-unstable-v1.