### PR TITLE
session/logind: keep active for pause_device gone

### DIFF
--- a/backend/session/logind.c
+++ b/backend/session/logind.c
@@ -274,7 +274,7 @@ static int pause_device(sd_bus_message *msg, void *userdata,
 		goto error;
 	}
 
-	if (major == DRM_MAJOR) {
+	if (major == DRM_MAJOR && strcmp(type, "gone") != 0) {
 		assert(session->has_drm);
 		session->base.active = false;
 		wlr_signal_emit_safe(&session->base.session_signal, session);


### PR DESCRIPTION
This appears to be a quick fix for compositors freezing when a dock is
disconnected. Disconnection of the dock is causing `pause_device` for
the DRM devices associated with the dock. Since these devices major
number is `DRM_MAJOR`, the session was being set to inactive. This just
makes it so the session is not set to inactive when the device's state
is `gone`.