### PR TITLE
session/logind: specify seat exactly

### DIFF
--- a/backend/session/logind.c
+++ b/backend/session/logind.c
@@ -136,7 +136,7 @@ static bool logind_change_vt(struct wlr_session *base, unsigned vt) {
 	sd_bus_error error = SD_BUS_ERROR_NULL;
 
 	ret = sd_bus_call_method(session->bus, "org.freedesktop.login1",
-		"/org/freedesktop/login1/seat/self", "org.freedesktop.login1.Seat", "SwitchTo",
+		"/org/freedesktop/login1/seat/seat0", "org.freedesktop.login1.Seat", "SwitchTo",
 		&error, &msg, "u", (uint32_t)vt);
 	if (ret < 0) {
 		wlr_log(WLR_ERROR, "Failed to change to vt '%d'", vt);


### PR DESCRIPTION
"/org/freedesktop/login1/seat/self" path triggers seat-finding code path in logind,
which currently relies on getting the session based on caller's PID.
This behaviour is deprecated in logind as it doesn't work eg. with systemd user units,
which run outside of user session.

We check for "seat0" in logind_change_vt() already as introduced in 47985d2dc56a6af469ac9375e7548136765aff16,
so hard-coding it here is not a problem, otherwise sd_session_get_seat() could be used.