### PR TITLE
zwp_virtual-keyboard: fix mmap error handling

### DIFF
--- a/types/wlr_virtual_keyboard_v1.c
+++ b/types/wlr_virtual_keyboard_v1.c
@@ -51,7 +51,7 @@ static void virtual_keyboard_keymap(struct wl_client *client,
 		goto context_fail;
 	}
 	void *data = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
-	if (!data) {
+	if (data == MAP_FAILED) {
 		goto fd_fail;
 	}
 	struct xkb_keymap *keymap = xkb_keymap_new_from_string(context, data,


### PR DESCRIPTION
Fixes #1710 

If mmap fails, it will return MAP_FAILED not NULL. Since the error
handling was incorrectly checking for NULL, MAP_FAILED was being passed
to xkb_keymap_new_from_string, on mmap failure, causing a segfault.
This just fixes the error checking.