### PR TITLE
drm: legacy: issue a NULL modeset on disable

### DIFF
--- a/backend/drm/legacy.c
+++ b/backend/drm/legacy.c
@@ -29,6 +29,12 @@ static bool legacy_conn_enable(struct wlr_drm_backend *drm,
 		struct wlr_drm_connector *conn, bool enable) {
 	int ret = drmModeConnectorSetProperty(drm->fd, conn->id, conn->props.dpms,
 		enable ? DRM_MODE_DPMS_ON : DRM_MODE_DPMS_OFF);
+
+	if (!enable) {
+		drmModeSetCrtc(drm->fd, conn->crtc->id, 0, 0, 0, NULL, 0,
+					   NULL);
+	}
+
 	return ret >= 0;
 }
 


### PR DESCRIPTION
The DRM subsystem needs a NULL modeset for connectors which disappear
from the system to disable the hardware pipes, otherwise the pixels get
rendered but are sent nowhere.

The atomic backend does the equivalent by removing the properties and
issuing a commit.

Fixes #1706

Tested by using `WLR_DRM_NO_ATOMIC=1 sway` and toggling my laptops internal eDP-1 display.