### PR TITLE
Add support for drmModeAddFB2WithModifiers

### DIFF
--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -172,7 +172,7 @@ static bool atomic_crtc_set_cursor(struct wlr_drm_backend *drm,
 	atomic_begin(crtc, &atom);
 
 	if (bo) {
-		uint32_t fb_id = get_fb_for_bo(bo, plane->drm_format);
+		uint32_t fb_id = get_fb_for_bo(drm, bo, plane->drm_format);
 		set_plane_props(&atom, plane, crtc->id, fb_id, false);
 	} else {
 		atomic_add(&atom, plane->id, plane->props.fb_id, 0);

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -70,6 +70,7 @@ struct wlr_drm_backend {
 	struct wlr_drm_backend *parent;
 	const struct wlr_drm_interface *iface;
 	clockid_t clock;
+	bool has_modifiers;
 
 	int fd;
 

--- a/include/backend/drm/util.h
+++ b/include/backend/drm/util.h
@@ -1,10 +1,13 @@
 #ifndef BACKEND_DRM_UTIL_H
 #define BACKEND_DRM_UTIL_H
 
+#include <gbm.h>
 #include <stdint.h>
-#include <wlr/types/wlr_output.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
+
+struct wlr_output;
+struct wlr_drm_backend;
 
 // Calculates a more accurate refresh rate (mHz) than what mode itself provides
 int32_t calculate_refresh_rate(const drmModeModeInfo *mode);
@@ -14,7 +17,8 @@ void parse_edid(struct wlr_output *restrict output, size_t len,
 // Returns the string representation of a DRM output type
 const char *conn_get_name(uint32_t type_id);
 // Returns the DRM framebuffer id for a gbm_bo
-uint32_t get_fb_for_bo(struct gbm_bo *bo, uint32_t drm_format);
+uint32_t get_fb_for_bo(struct wlr_drm_backend *drm,
+	struct gbm_bo *bo, uint32_t drm_format);
 
 // Part of match_obj
 enum {


### PR DESCRIPTION
Fixes https://github.com/swaywm/sway/issues/4215

Apparently intel will pick and enforce a modifier, even if we didn't use `gbm_surface_create_with_modifiers`.