### PR TITLE
Remove WLR_DRM_NO_ATOMIC_GAMMA workaround

### DIFF
--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -211,11 +211,7 @@ static bool atomic_crtc_set_gamma(struct wlr_drm_backend *drm,
 		uint16_t *r, uint16_t *g, uint16_t *b) {
 	// Fallback to legacy gamma interface when gamma properties are not available
 	// (can happen on older Intel GPUs that support gamma but not degamma).
-	// TEMP: This is broken on AMDGPU. Provide a fallback to legacy until they
-	// get it fixed. Ref https://bugs.freedesktop.org/show_bug.cgi?id=107459
-	const char *no_atomic_str = getenv("WLR_DRM_NO_ATOMIC_GAMMA");
-	bool no_atomic = no_atomic_str != NULL && strcmp(no_atomic_str, "1") == 0;
-	if (crtc->props.gamma_lut == 0 || no_atomic) {
+	if (crtc->props.gamma_lut == 0) {
 		return legacy_iface.crtc_set_gamma(drm, crtc, size, r, g, b);
 	}
 

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -7,8 +7,6 @@ wlroots reads these environment variables
   considered the primary DRM device.
 * *WLR_DRM_NO_ATOMIC*: set to 1 to use legacy DRM interface instead of atomic
   mode setting
-* *WLR_DRM_NO_ATOMIC_GAMMA*: set to 1 to use legacy DRM interface for gamma
-  control instead of the atomic interface
 * *WLR_LIBINPUT_NO_DEVICES*: set to 1 to not fail without any input devices
 * *WLR_BACKENDS*: comma-separated list of backends to use (available backends:
   wayland, x11, headless, noop)


### PR DESCRIPTION
This is [fixed on amdgpu](https://github.com/swaywm/sway/issues/2700#issuecomment-500236109), so we don't need this any more.