### PR TITLE
Do not use pkg-config to find wayland-scanner when cross building

### DIFF
--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -1,6 +1,11 @@
 wl_protocol_dir = wayland_protos.get_pkgconfig_variable('pkgdatadir')
 
-wayland_scanner_dep = dependency('wayland-scanner', required: false, native: true)
+if meson.is_cross_build()
+	wayland_scanner_dep = disabler()
+else
+	wayland_scanner_dep = dependency('wayland-scanner', required: false, native: true)
+endif
+
 if wayland_scanner_dep.found()
 	wayland_scanner = find_program(
 		wayland_scanner_dep.get_pkgconfig_variable('wayland_scanner'),


### PR DESCRIPTION
When cross-compiling it is still needed to run a native `wayland-scanner`, but many tools for the task will still have `pkg-config` return the location of `wayland-scanner` for the target in some location which may be the same as for some native installation of `wayland-scanner`; but which is not the copy of the program that the compilation system wants packages to use (which are typically in a “host tools” directory elsewhere).

This disables usage of `pkg-config` to find `wayland-scanner` when cross-compiling because most tools for the job will set `$PATH` in a way that the correct installation of the tool will be found first.

----

We noticed this issue while [trying to add a wlroots package to Buildroot](https://patchwork.ozlabs.org/comment/2173780/), where the compilation host installation of the tool was being used:

```
Native dependency wayland-scanner found: YES 1.17.0
Program /usr/bin/wayland-scanner found: YES (/usr/bin/wayland-scanner)
```

On the other hand, with this patch applied, the correct installation from Buildroot's “host tools” directory is correctly used:

```
Program wayland-scanner found: YES (/home/aperez/buildroot/output-rpi3/host/bin/wayland-scanner)                                                                                     
```