### PR TITLE
Minor output cleanup

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -678,11 +678,6 @@ bool wlr_drm_connector_add_mode(struct wlr_output *output,
 	return true;
 }
 
-static void drm_connector_transform(struct wlr_output *output,
-		enum wl_output_transform transform) {
-	output->transform = transform;
-}
-
 static bool drm_connector_set_cursor(struct wlr_output *output,
 		struct wlr_texture *texture, int32_t scale,
 		enum wl_output_transform transform,
@@ -963,7 +958,6 @@ static void drm_connector_destroy(struct wlr_output *output) {
 static const struct wlr_output_impl output_impl = {
 	.enable = enable_drm_connector,
 	.set_mode = drm_connector_set_mode,
-	.transform = drm_connector_transform,
 	.set_cursor = drm_connector_set_cursor,
 	.move_cursor = drm_connector_move_cursor,
 	.destroy = drm_connector_destroy,

--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -49,13 +49,6 @@ static bool output_set_custom_mode(struct wlr_output *wlr_output, int32_t width,
 	return true;
 }
 
-static void output_transform(struct wlr_output *wlr_output,
-		enum wl_output_transform transform) {
-	struct wlr_headless_output *output =
-		headless_output_from_output(wlr_output);
-	output->wlr_output.transform = transform;
-}
-
 static bool output_attach_render(struct wlr_output *wlr_output,
 		int *buffer_age) {
 	struct wlr_headless_output *output =
@@ -84,7 +77,6 @@ static void output_destroy(struct wlr_output *wlr_output) {
 
 static const struct wlr_output_impl output_impl = {
 	.set_custom_mode = output_set_custom_mode,
-	.transform = output_transform,
 	.destroy = output_destroy,
 	.attach_render = output_attach_render,
 	.commit = output_commit,

--- a/backend/noop/output.c
+++ b/backend/noop/output.c
@@ -12,11 +12,6 @@ static struct wlr_noop_output *noop_output_from_output(
 	return (struct wlr_noop_output *)wlr_output;
 }
 
-static void output_transform(struct wlr_output *wlr_output,
-		enum wl_output_transform transform) {
-	// empty
-}
-
 static bool output_set_custom_mode(struct wlr_output *wlr_output,
 		int32_t width, int32_t height, int32_t refresh) {
 	wlr_output_update_custom_mode(wlr_output, width, height, refresh);
@@ -42,7 +37,6 @@ static void output_destroy(struct wlr_output *wlr_output) {
 }
 
 static const struct wlr_output_impl output_impl = {
-	.transform = output_transform,
 	.set_custom_mode = output_set_custom_mode,
 	.destroy = output_destroy,
 	.attach_render = output_attach_render,

--- a/backend/rdp/output.c
+++ b/backend/rdp/output.c
@@ -62,13 +62,6 @@ static bool output_set_custom_mode(struct wlr_output *wlr_output, int32_t width,
 	return true;
 }
 
-static void output_transform(struct wlr_output *wlr_output,
-		enum wl_output_transform transform) {
-	struct wlr_rdp_output *output =
-		rdp_output_from_output(wlr_output);
-	output->wlr_output.transform = transform;
-}
-
 static bool output_attach_render(struct wlr_output *wlr_output,
 		int *buffer_age) {
 	struct wlr_rdp_output *output =
@@ -242,7 +235,6 @@ static void output_destroy(struct wlr_output *wlr_output) {
 
 static const struct wlr_output_impl output_impl = {
 	.set_custom_mode = output_set_custom_mode,
-	.transform = output_transform,
 	.destroy = output_destroy,
 	.attach_render = output_attach_render,
 	.commit = output_commit,

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -86,12 +86,6 @@ static bool output_commit(struct wlr_output *wlr_output) {
 	return true;
 }
 
-static void output_transform(struct wlr_output *wlr_output,
-		enum wl_output_transform transform) {
-	struct wlr_wl_output *output = get_wl_output_from_output(wlr_output);
-	output->wlr_output.transform = transform;
-}
-
 static bool output_set_cursor(struct wlr_output *wlr_output,
 		struct wlr_texture *texture, int32_t scale,
 		enum wl_output_transform transform,
@@ -226,7 +220,6 @@ static bool output_schedule_frame(struct wlr_output *wlr_output) {
 
 static const struct wlr_output_impl output_impl = {
 	.set_custom_mode = output_set_custom_mode,
-	.transform = output_transform,
 	.destroy = output_destroy,
 	.attach_render = output_attach_render,
 	.commit = output_commit,

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -75,12 +75,6 @@ static bool output_set_custom_mode(struct wlr_output *wlr_output,
 	return true;
 }
 
-static void output_transform(struct wlr_output *wlr_output,
-		enum wl_output_transform transform) {
-	struct wlr_x11_output *output = get_x11_output_from_output(wlr_output);
-	output->wlr_output.transform = transform;
-}
-
 static void output_destroy(struct wlr_output *wlr_output) {
 	struct wlr_x11_output *output = get_x11_output_from_output(wlr_output);
 	struct wlr_x11_backend *x11 = output->x11;
@@ -122,7 +116,6 @@ static bool output_commit(struct wlr_output *wlr_output) {
 
 static const struct wlr_output_impl output_impl = {
 	.set_custom_mode = output_set_custom_mode,
-	.transform = output_transform,
 	.destroy = output_destroy,
 	.attach_render = output_attach_render,
 	.commit = output_commit,

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -19,8 +19,6 @@ struct wlr_output_impl {
 	bool (*set_mode)(struct wlr_output *output, struct wlr_output_mode *mode);
 	bool (*set_custom_mode)(struct wlr_output *output, int32_t width,
 		int32_t height, int32_t refresh);
-	void (*transform)(struct wlr_output *output,
-		enum wl_output_transform transform);
 	bool (*set_cursor)(struct wlr_output *output, struct wlr_texture *texture,
 		int32_t scale, enum wl_output_transform transform,
 		int32_t hotspot_x, int32_t hotspot_y, bool update_texture);

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -217,7 +217,11 @@ void wlr_output_update_custom_mode(struct wlr_output *output, int32_t width,
 
 void wlr_output_set_transform(struct wlr_output *output,
 		enum wl_output_transform transform) {
-	output->impl->transform(output, transform);
+	if (output->transform == transform) {
+		return;
+	}
+
+	output->transform = transform;
 	output_update_matrix(output);
 
 	struct wl_resource *resource;
@@ -291,7 +295,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 
 void wlr_output_init(struct wlr_output *output, struct wlr_backend *backend,
 		const struct wlr_output_impl *impl, struct wl_display *display) {
-	assert(impl->attach_render && impl->commit && impl->transform);
+	assert(impl->attach_render && impl->commit);
 	if (impl->set_cursor || impl->move_cursor) {
 		assert(impl->set_cursor && impl->move_cursor);
 	}

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -472,6 +472,7 @@ bool wlr_output_commit(struct wlr_output *output) {
 	wlr_signal_emit_safe(&output->events.precommit, &event);
 
 	if (!output->impl->commit(output)) {
+		output_state_clear(&output->pending);
 		return false;
 	}
 


### PR DESCRIPTION
See the individual commits.

Breaking change: `wlr_output_impl.transform` has been removed.