### PR TITLE
x11: Send a frame event on the pointer after button events

### DIFF
--- a/backend/x11/input_device.c
+++ b/backend/x11/input_device.c
@@ -36,6 +36,7 @@ static void send_button_event(struct wlr_x11_output *output, uint32_t key,
 		.state = st,
 	};
 	wlr_signal_emit_safe(&output->pointer.events.button, &ev);
+	wlr_signal_emit_safe(&output->pointer.events.frame, &output->pointer);
 }
 
 static void send_axis_event(struct wlr_x11_output *output, int32_t delta,


### PR DESCRIPTION
Without the immediate frame event, the button event would not be processed in time: https://source.puri.sm/Librem5/phoc/issues/