### PR TITLE
backend/drm: Exit-early if 0 crtcs

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1140,6 +1140,14 @@ static uint32_t get_possible_crtcs(int fd, drmModeRes *res,
 }
 
 void scan_drm_connectors(struct wlr_drm_backend *drm) {
+	/*
+	 * This GPU is not really a modesetting device.
+	 * It's just being used as a renderer.
+	 */
+	if (drm->num_crtcs == 0) {
+		return;
+	}
+
 	wlr_log(WLR_INFO, "Scanning DRM connectors");
 
 	drmModeRes *res = drmModeGetResources(drm->fd);


### PR DESCRIPTION
This fixes an assertion failure if we're using a device that has 0 crtcs
as a renderer.
This would happen on some laptops with discrete GPUs.