### PR TITLE
virtual_keyboard: Require keymap before accepting keycodes

### DIFF
--- a/include/wlr/types/wlr_virtual_keyboard_v1.h
+++ b/include/wlr/types/wlr_virtual_keyboard_v1.h
@@ -30,6 +30,7 @@ struct wlr_virtual_keyboard_v1 {
 	struct wl_resource *resource;
 	struct wlr_input_device input_device;
 	struct wlr_seat *seat;
+	bool has_keymap;
 
 	struct wl_list link;
 


### PR DESCRIPTION
A simple check capturing the nonsensical case of sending keycodes without having defined a keymap before. Key presses would still go through in case of wlroots due to having a default keymap defined, but I can't see relying on this as anything but a source of mistakes. Therefore, the implementation matches the protocol now, and rejects key presses if there's no keymap.