### PR TITLE
backend: drm: switch to pageflip_handler_2

### DIFF
--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -45,18 +45,20 @@ static bool atomic_end(int drm_fd, struct atomic *atom) {
 
 static bool atomic_commit(int drm_fd, struct atomic *atom,
 		struct wlr_drm_connector *conn, uint32_t flags, bool modeset) {
+	struct wlr_drm_backend *drm =
+		get_drm_backend_from_backend(conn->output.backend);
 	if (atom->failed) {
 		return false;
 	}
 
-	int ret = drmModeAtomicCommit(drm_fd, atom->req, flags, conn);
+	int ret = drmModeAtomicCommit(drm_fd, atom->req, flags, drm);
 	if (ret) {
 		wlr_log_errno(WLR_ERROR, "%s: Atomic commit failed (%s)",
 			conn->output.name, modeset ? "modeset" : "pageflip");
 
 		// Try to commit without new changes
 		drmModeAtomicSetCursor(atom->req, atom->cursor);
-		if (drmModeAtomicCommit(drm_fd, atom->req, flags, conn)) {
+		if (drmModeAtomicCommit(drm_fd, atom->req, flags, drm)) {
 			wlr_log_errno(WLR_ERROR,
 				"%s: Atomic commit without new changes failed (%s)",
 				conn->output.name, modeset ? "modeset" : "pageflip");

--- a/backend/drm/legacy.c
+++ b/backend/drm/legacy.c
@@ -17,7 +17,7 @@ static bool legacy_crtc_pageflip(struct wlr_drm_backend *drm,
 		}
 	}
 
-	if (drmModePageFlip(drm->fd, crtc->id, fb_id, DRM_MODE_PAGE_FLIP_EVENT, conn)) {
+	if (drmModePageFlip(drm->fd, crtc->id, fb_id, DRM_MODE_PAGE_FLIP_EVENT, drm)) {
 		wlr_log_errno(WLR_ERROR, "%s: Failed to page flip", conn->output.name);
 		return false;
 	}


### PR DESCRIPTION
atomic and legacy now both pass the backend as the user data for the
pageflip event. We than retrieve the correct connector by matching on
the crtc_id passed to the page_flip_handler2.

Fixes #1297