### PR TITLE
wlr_seat_touch: Don't destroy touch point with surface

### DIFF
--- a/types/seat/wlr_seat_touch.c
+++ b/types/seat/wlr_seat_touch.c
@@ -109,7 +109,10 @@ static void touch_point_handle_surface_destroy(struct wl_listener *listener,
 		void *data) {
 	struct wlr_touch_point *point =
 		wl_container_of(listener, point, surface_destroy);
-	touch_point_destroy(point);
+	// Touch point itself is destroyed on up event
+	point->surface = NULL;
+	wl_list_remove(&point->surface_destroy.link);
+	wl_list_init(&point->surface_destroy.link);
 }
 
 static struct wlr_touch_point *touch_point_create(


### PR DESCRIPTION
When the surface is destroyed clear it's reference but wait for the up
event to destroy the touch point via wlr_seat_touch_notify_up().

If the surface is destroyed before the up event we end up with
incomplete sequences sent to the client like

```
[915821.276] wl_touch@3.down(146, 2475027, wl_surface@38, 0, 236.000000, 515.000000)
[915821.608] wl_touch@3.frame()
[915821.637] wl_touch@3.motion(2475027, 0, 236.000000, 515.000000)
[915821.779] wl_touch@3.frame()
```

so there's never an up event. While it should be something like

```
[2461229.051] wl_touch@3.down(81, 3236959, wl_surface@34, 0, 218.000000, 478.000000)
[2461229.435] wl_touch@3.frame()
[2461229.484] wl_touch@3.motion(3236959, 0, 218.000000, 478.000000)
[2461229.636] wl_touch@3.frame()
[2461277.520] wl_touch@3.up(82, 3237007, 0)
[2461277.681] wl_touch@3.frame()
```

this confuses tookits intepreting the next down event incorrectly. So
don't destroy the touch point too early.