### PR TITLE
Implement serial validation for selection requests

### DIFF
--- a/include/types/wlr_tablet_v2.h
+++ b/include/types/wlr_tablet_v2.h
@@ -48,6 +48,7 @@ struct wlr_tablet_pad_client_v2 {
 	struct wl_client *client;
 	struct wl_resource *resource;
 	struct wlr_tablet_v2_tablet_pad *pad;
+	struct wlr_tablet_seat_client_v2 *seat;
 
 	size_t button_count;
 

--- a/include/wlr/types/wlr_data_device.h
+++ b/include/wlr/types/wlr_data_device.h
@@ -168,10 +168,14 @@ struct wlr_data_device_manager *wlr_data_device_manager_create(
 void wlr_data_device_manager_destroy(struct wlr_data_device_manager *manager);
 
 /**
- * Requests a selection to be set for the seat.
+ * Requests a selection to be set for the seat. If the request comes from
+ * a client, then set `client` to be the matching seat client so that this
+ * function can verify that the serial provided was once sent to the client
+ * on this seat.
  */
 void wlr_seat_request_set_selection(struct wlr_seat *seat,
-	struct wlr_data_source *source, uint32_t serial);
+	struct wlr_seat_client *client, struct wlr_data_source *source,
+	uint32_t serial);
 
 /**
  * Sets the current selection for the seat. NULL can be provided to clear it.

--- a/include/wlr/types/wlr_primary_selection.h
+++ b/include/wlr/types/wlr_primary_selection.h
@@ -48,7 +48,13 @@ void wlr_primary_selection_source_send(
 	struct wlr_primary_selection_source *source, const char *mime_type,
 	int fd);
 
+/**
+ * Request setting the primary selection. If `client` is not null, then the
+ * serial will be checked against the set of serials sent to the client on that
+ * seat.
+ */
 void wlr_seat_request_set_primary_selection(struct wlr_seat *seat,
+	struct wlr_seat_client *client,
 	struct wlr_primary_selection_source *source, uint32_t serial);
 /**
  * Sets the current primary selection for the seat. NULL can be provided to

--- a/types/data_device/wlr_data_device.c
+++ b/types/data_device/wlr_data_device.c
@@ -144,7 +144,7 @@ void seat_client_send_selection(struct wlr_seat_client *seat_client) {
 void wlr_seat_request_set_selection(struct wlr_seat *seat,
 		struct wlr_seat_client *client,
 		struct wlr_data_source *source, uint32_t serial) {
-	if (client && !wlr_serial_maybe_valid(&client->serials, serial)) {
+	if (client && !wlr_seat_client_validate_event_serial(client, serial)) {
 		wlr_log(WLR_DEBUG, "Rejecting set_selection request, "
 			"serial %"PRIu32" was never given to client", serial);
 		return;

--- a/types/seat/wlr_seat_keyboard.c
+++ b/types/seat/wlr_seat_keyboard.c
@@ -72,7 +72,7 @@ void wlr_seat_keyboard_send_key(struct wlr_seat *wlr_seat, uint32_t time,
 		return;
 	}
 
-	uint32_t serial = wl_display_next_serial(wlr_seat->display);
+	uint32_t serial = wlr_seat_client_next_serial(client);
 	struct wl_resource *resource;
 	wl_resource_for_each(resource, &client->keyboards) {
 		if (seat_client_from_keyboard_resource(resource) == NULL) {
@@ -201,7 +201,7 @@ void wlr_seat_keyboard_send_modifiers(struct wlr_seat *seat,
 		return;
 	}
 
-	uint32_t serial = wl_display_next_serial(seat->display);
+	uint32_t serial = wlr_seat_client_next_serial(client);
 	struct wl_resource *resource;
 	wl_resource_for_each(resource, &client->keyboards) {
 		if (seat_client_from_keyboard_resource(resource) == NULL) {
@@ -240,7 +240,7 @@ void wlr_seat_keyboard_enter(struct wlr_seat *seat,
 
 	// leave the previously entered surface
 	if (focused_client != NULL && focused_surface != NULL) {
-		uint32_t serial = wl_display_next_serial(seat->display);
+		uint32_t serial = wlr_seat_client_next_serial(focused_client);
 		struct wl_resource *resource;
 		wl_resource_for_each(resource, &focused_client->keyboards) {
 			if (seat_client_from_keyboard_resource(resource) == NULL) {
@@ -263,7 +263,7 @@ void wlr_seat_keyboard_enter(struct wlr_seat *seat,
 			}
 			*p = keycodes[i];
 		}
-		uint32_t serial = wl_display_next_serial(seat->display);
+		uint32_t serial = wlr_seat_client_next_serial(client);
 		struct wl_resource *resource;
 		wl_resource_for_each(resource, &client->keyboards) {
 			if (seat_client_from_keyboard_resource(resource) == NULL) {

--- a/types/seat/wlr_seat_pointer.c
+++ b/types/seat/wlr_seat_pointer.c
@@ -149,7 +149,7 @@ void wlr_seat_pointer_enter(struct wlr_seat *wlr_seat,
 
 	// leave the previously entered surface
 	if (focused_client != NULL && focused_surface != NULL) {
-		uint32_t serial = wl_display_next_serial(wlr_seat->display);
+		uint32_t serial = wlr_seat_client_next_serial(focused_client);
 		struct wl_resource *resource;
 		wl_resource_for_each(resource, &focused_client->pointers) {
 			if (wlr_seat_client_from_pointer_resource(resource) == NULL) {
@@ -163,7 +163,7 @@ void wlr_seat_pointer_enter(struct wlr_seat *wlr_seat,
 
 	// enter the current surface
 	if (client != NULL && surface != NULL) {
-		uint32_t serial = wl_display_next_serial(wlr_seat->display);
+		uint32_t serial = wlr_seat_client_next_serial(client);
 		struct wl_resource *resource;
 		wl_resource_for_each(resource, &client->pointers) {
 			if (wlr_seat_client_from_pointer_resource(resource) == NULL) {
@@ -242,7 +242,7 @@ uint32_t wlr_seat_pointer_send_button(struct wlr_seat *wlr_seat, uint32_t time,
 		return 0;
 	}
 
-	uint32_t serial = wl_display_next_serial(wlr_seat->display);
+	uint32_t serial = wlr_seat_client_next_serial(client);
 	struct wl_resource *resource;
 	wl_resource_for_each(resource, &client->pointers) {
 		if (wlr_seat_client_from_pointer_resource(resource) == NULL) {

--- a/types/seat/wlr_seat_touch.c
+++ b/types/seat/wlr_seat_touch.c
@@ -278,7 +278,7 @@ uint32_t wlr_seat_touch_send_down(struct wlr_seat *seat,
 		return 0;
 	}
 
-	uint32_t serial = wl_display_next_serial(seat->display);
+	uint32_t serial = wlr_seat_client_next_serial(point->client);
 	struct wl_resource *resource;
 	wl_resource_for_each(resource, &point->client->touches) {
 		if (seat_client_from_touch_resource(resource) == NULL) {
@@ -299,7 +299,7 @@ void wlr_seat_touch_send_up(struct wlr_seat *seat, uint32_t time, int32_t touch_
 		return;
 	}
 
-	uint32_t serial = wl_display_next_serial(seat->display);
+	uint32_t serial = wlr_seat_client_next_serial(point->client);
 	struct wl_resource *resource;
 	wl_resource_for_each(resource, &point->client->touches) {
 		if (seat_client_from_touch_resource(resource) == NULL) {

--- a/types/tablet_v2/wlr_tablet_v2_pad.c
+++ b/types/tablet_v2/wlr_tablet_v2_pad.c
@@ -276,6 +276,7 @@ void add_tablet_pad_client(struct wlr_tablet_seat_client_v2 *seat,
 		return;
 	}
 	client->pad = pad;
+	client->seat = seat;
 
 	client->groups = calloc(wl_list_length(&pad->wlr_pad->groups), sizeof(struct wl_resource*));
 	if (!client->groups) {
@@ -450,7 +451,8 @@ uint32_t wlr_send_tablet_v2_tablet_pad_enter(
 
 	pad->current_client = pad_client;
 
-	uint32_t serial = wl_display_next_serial(wl_client_get_display(client));
+	uint32_t serial = wlr_seat_client_next_serial(
+		pad_client->seat->seat_client);
 
 	zwp_tablet_pad_v2_send_enter(pad_client->resource, serial,
 		tablet_client->resource, surface->resource);
@@ -526,7 +528,9 @@ uint32_t wlr_send_tablet_v2_tablet_pad_leave(struct wlr_tablet_v2_tablet_pad *pa
 		return 0;
 	}
 
-	uint32_t serial = wl_display_next_serial(wl_client_get_display(client));
+
+	uint32_t serial = wlr_seat_client_next_serial(
+		pad->current_client->seat->seat_client);
 
 	zwp_tablet_pad_v2_send_leave(pad->current_client->resource, serial, surface->resource);
 	return serial;
@@ -546,8 +550,8 @@ uint32_t wlr_send_tablet_v2_tablet_pad_mode(struct wlr_tablet_v2_tablet_pad *pad
 
 	pad->groups[group] = mode;
 
-	struct wl_client *client = wl_resource_get_client(pad->current_client->resource);
-	uint32_t serial = wl_display_next_serial(wl_client_get_display(client));
+	uint32_t serial = wlr_seat_client_next_serial(
+		pad->current_client->seat->seat_client);
 
 	zwp_tablet_pad_group_v2_send_mode_switch(
 		pad->current_client->groups[group], time, serial, mode);

--- a/types/tablet_v2/wlr_tablet_v2_tool.c
+++ b/types/tablet_v2/wlr_tablet_v2_tool.c
@@ -350,7 +350,7 @@ void wlr_send_tablet_v2_tablet_tool_proximity_in(
 
 	tool->current_client = tool_client;
 
-	uint32_t serial = wl_display_next_serial(wl_client_get_display(client));
+	uint32_t serial = wlr_seat_client_next_serial(tool_client->seat->seat_client);
 	tool->focused_surface = surface;
 	tool->proximity_serial = serial;
 
@@ -466,9 +466,8 @@ void wlr_send_tablet_v2_tablet_tool_button(
 	ssize_t index = tablet_tool_button_update(tool, button, state);
 
 	if (tool->current_client) {
-		struct wl_client *client =
-			wl_resource_get_client(tool->current_client->resource);
-		uint32_t serial = wl_display_next_serial(wl_client_get_display(client));
+		uint32_t serial = wlr_seat_client_next_serial(
+			tool->current_client->seat->seat_client);
 		if (index >= 0) {
 			tool->pressed_serials[index] = serial;
 		}
@@ -496,9 +495,8 @@ void wlr_send_tablet_v2_tablet_tool_down(struct wlr_tablet_v2_tablet_tool *tool)
 
 	tool->is_down = true;
 	if (tool->current_client) {
-		struct wl_client *client =
-			wl_resource_get_client(tool->current_client->resource);
-		uint32_t serial = wl_display_next_serial(wl_client_get_display(client));
+		uint32_t serial = wlr_seat_client_next_serial(
+			tool->current_client->seat->seat_client);
 
 		zwp_tablet_tool_v2_send_down(tool->current_client->resource,
 			serial);

--- a/types/wlr_data_control_v1.c
+++ b/types/wlr_data_control_v1.c
@@ -343,7 +343,7 @@ static void control_handle_set_selection(struct wl_client *client,
 	}
 
 	if (source == NULL) {
-		wlr_seat_request_set_selection(device->seat, NULL,
+		wlr_seat_request_set_selection(device->seat, NULL, NULL,
 			wl_display_next_serial(device->seat->display));
 
 		return;
@@ -377,7 +377,7 @@ static void control_handle_set_selection(struct wl_client *client,
 
 	source->finalized = true;
 
-	wlr_seat_request_set_selection(device->seat, wlr_source,
+	wlr_seat_request_set_selection(device->seat, NULL, wlr_source,
 		wl_display_next_serial(device->seat->display));
 }
 
@@ -396,7 +396,7 @@ static void control_handle_set_primary_selection(struct wl_client *client,
 	}
 
 	if (source == NULL) {
-		wlr_seat_request_set_primary_selection(device->seat, NULL,
+		wlr_seat_request_set_primary_selection(device->seat, NULL, NULL,
 			wl_display_next_serial(device->seat->display));
 
 		return;
@@ -430,7 +430,7 @@ static void control_handle_set_primary_selection(struct wl_client *client,
 
 	source->finalized = true;
 
-	wlr_seat_request_set_primary_selection(device->seat, wlr_source,
+	wlr_seat_request_set_primary_selection(device->seat, NULL, wlr_source,
 		wl_display_next_serial(device->seat->display));
 }
 

--- a/types/wlr_gtk_primary_selection.c
+++ b/types/wlr_gtk_primary_selection.c
@@ -217,7 +217,10 @@ static void device_handle_set_selection(struct wl_client *client,
 		source = &client_source->source;
 	}
 
-	wlr_seat_request_set_primary_selection(device->seat, source, serial);
+	struct wlr_seat_client *seat_client =
+		wlr_seat_client_for_wl_client(device->seat, client);
+
+	wlr_seat_request_set_primary_selection(device->seat, seat_client, source, serial);
 }
 
 static void device_handle_destroy(struct wl_client *client,

--- a/types/wlr_pointer_gestures_v1.c
+++ b/types/wlr_pointer_gestures_v1.c
@@ -53,8 +53,8 @@ void wlr_pointer_gestures_v1_send_swipe_begin(
 	}
 
 	struct wl_client *focus_client = wl_resource_get_client(focus->resource);
-	uint32_t serial = wl_display_next_serial(
-			wl_client_get_display(focus_client));
+	uint32_t serial = wlr_seat_client_next_serial(
+		seat->pointer_state.focused_client);
 
 	struct wl_resource *gesture;
 	wl_resource_for_each(gesture, &gestures->swipes) {
@@ -104,8 +104,8 @@ void wlr_pointer_gestures_v1_send_swipe_end(
 	}
 
 	struct wl_client *focus_client = wl_resource_get_client(focus->resource);
-	uint32_t serial = wl_display_next_serial(
-			wl_client_get_display(focus_client));
+	uint32_t serial = wlr_seat_client_next_serial(
+		seat->pointer_state.focused_client);
 
 	struct wl_resource *gesture;
 	wl_resource_for_each(gesture, &gestures->swipes) {
@@ -165,8 +165,8 @@ void wlr_pointer_gestures_v1_send_pinch_begin(
 	}
 
 	struct wl_client *focus_client = wl_resource_get_client(focus->resource);
-	uint32_t serial = wl_display_next_serial(
-			wl_client_get_display(focus_client));
+	uint32_t serial = wlr_seat_client_next_serial(
+		seat->pointer_state.focused_client);
 
 	struct wl_resource *gesture;
 	wl_resource_for_each(gesture, &gestures->pinches) {
@@ -220,8 +220,8 @@ void wlr_pointer_gestures_v1_send_pinch_end(
 	}
 
 	struct wl_client *focus_client = wl_resource_get_client(focus->resource);
-	uint32_t serial = wl_display_next_serial(
-			wl_client_get_display(focus_client));
+	uint32_t serial = wlr_seat_client_next_serial(
+		seat->pointer_state.focused_client);
 
 	struct wl_resource *gesture;
 	wl_resource_for_each(gesture, &gestures->pinches) {

--- a/types/wlr_primary_selection.c
+++ b/types/wlr_primary_selection.c
@@ -44,7 +44,7 @@ void wlr_primary_selection_source_send(
 void wlr_seat_request_set_primary_selection(struct wlr_seat *seat,
 		struct wlr_seat_client *client,
 		struct wlr_primary_selection_source *source, uint32_t serial) {
-	if (client && !wlr_serial_maybe_valid(&client->serials, serial)) {
+	if (client && !wlr_seat_client_validate_event_serial(client, serial)) {
 		wlr_log(WLR_DEBUG, "Rejecting set_primary_selection request, "
 			"serial %"PRIu32" was never given to client", serial);
 		return;

--- a/types/wlr_primary_selection_v1.c
+++ b/types/wlr_primary_selection_v1.c
@@ -217,7 +217,10 @@ static void device_handle_set_selection(struct wl_client *client,
 		source = &client_source->source;
 	}
 
-	wlr_seat_request_set_primary_selection(device->seat, source, serial);
+	struct wlr_seat_client *seat_client =
+		wlr_seat_client_for_wl_client(device->seat, client);
+
+	wlr_seat_request_set_primary_selection(device->seat, seat_client, source, serial);
 }
 
 static void device_handle_destroy(struct wl_client *client,

--- a/xwayland/selection/incoming.c
+++ b/xwayland/selection/incoming.c
@@ -349,7 +349,7 @@ static void xwm_selection_get_targets(struct wlr_xwm_selection *selection) {
 		bool ok = source_get_targets(selection, &source->base.mime_types,
 			&source->mime_types_atoms);
 		if (ok) {
-			wlr_seat_request_set_selection(xwm->seat, &source->base,
+			wlr_seat_request_set_selection(xwm->seat, NULL, &source->base,
 				wl_display_next_serial(xwm->xwayland->wl_display));
 		} else {
 			wlr_data_source_destroy(&source->base);
@@ -424,10 +424,10 @@ int xwm_handle_xfixes_selection_notify(struct wlr_xwm *xwm,
 			// A real X client selection went away, not our
 			// proxy selection
 			if (selection == &xwm->clipboard_selection) {
-				wlr_seat_request_set_selection(xwm->seat, NULL,
+				wlr_seat_request_set_selection(xwm->seat, NULL, NULL,
 					wl_display_next_serial(xwm->xwayland->wl_display));
 			} else if (selection == &xwm->primary_selection) {
-				wlr_seat_request_set_primary_selection(xwm->seat, NULL,
+				wlr_seat_request_set_primary_selection(xwm->seat, NULL, NULL,
 					wl_display_next_serial(xwm->xwayland->wl_display));
 			} else if (selection == &xwm->dnd_selection) {
 				// TODO: DND


### PR DESCRIPTION
See also commit message, and #755. In short, this change verifies, for copy selection requests, that the serial numbers used to determine which request corresponds to the most recent user input were actually sent to the client.

Right now the code registers serial numbers for the keyboard, pointer, and touch events; serial numbers produced by any other input source will fail validation when provided by a client. (Serial numbers generated by e.g. xwayland code have no associated seat or client, and are not checked.) I'm not familiar with all of wlroots' protocols, so I don't know if e.g. tablet events are associated with a seat and should be allowed to trigger copy requests. 

This change alters the size of `struct wlr_seat_client`, silently breaking ABI for compositors which use that struct inline.

To test this PR, you'll need a misbehaving client; either modify some small program that does copy+paste to send in bad serial values, or try e.g. this work-in-progress test program: mstoeckl/wleird@01920741bb8e19bbd5af2e9ce53d957122d37847 .

Edit: Please remind me to rebase once the changes are acceptable.