### PR TITLE
xdg_shell(_v6): Take maximize/fullscreen state into account on view init

### DIFF
--- a/rootston/xdg_shell.c
+++ b/rootston/xdg_shell.c
@@ -465,6 +465,10 @@ void handle_xdg_shell_surface(struct wl_listener *listener, void *data) {
 	roots_surface->xdg_surface = surface;
 	surface->data = roots_surface;
 
+	view_maximize(&roots_surface->view, surface->toplevel->client_pending.maximized);
+	view_set_fullscreen(&roots_surface->view, surface->toplevel->client_pending.fullscreen,
+		surface->toplevel->client_pending.fullscreen_output);
+
 	roots_surface->surface_commit.notify = handle_surface_commit;
 	wl_signal_add(&surface->surface->events.commit,
 		&roots_surface->surface_commit);

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -462,6 +462,10 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	view_init(&roots_surface->view, &view_impl, ROOTS_XDG_SHELL_V6_VIEW, desktop);
 	roots_surface->xdg_surface_v6 = surface;
 
+	view_maximize(&roots_surface->view, surface->toplevel->client_pending.maximized);
+	view_set_fullscreen(&roots_surface->view, surface->toplevel->client_pending.fullscreen,
+		surface->toplevel->client_pending.fullscreen_output);
+
 	roots_surface->surface_commit.notify = handle_surface_commit;
 	wl_signal_add(&surface->surface->events.commit,
 		&roots_surface->surface_commit);


### PR DESCRIPTION
set_maximized and set_fullscreen calls can come before the view is
constructed and before its signal handlers are registered.