### PR TITLE
Layer shell crash

### DIFF
--- a/include/wlr/types/wlr_layer_shell_v1.h
+++ b/include/wlr/types/wlr_layer_shell_v1.h
@@ -75,7 +75,6 @@ struct wlr_layer_surface_v1 {
 
 	bool added, configured, mapped, closed;
 	uint32_t configure_serial;
-	struct wl_event_source *configure_idle;
 	uint32_t configure_next_serial;
 	struct wl_list configure_list;
 

--- a/types/wlr_layer_shell_v1.c
+++ b/types/wlr_layer_shell_v1.c
@@ -60,6 +60,10 @@ static void layer_surface_handle_ack_configure(struct wl_client *client,
 
 	bool found = false;
 	struct wlr_layer_surface_v1_configure *configure, *tmp;
+
+	if (!surface) {
+		return;
+	}
 	wl_list_for_each_safe(configure, tmp, &surface->configure_list, link) {
 		if (configure->serial < serial) {
 			layer_surface_configure_destroy(configure);
@@ -88,6 +92,10 @@ static void layer_surface_handle_ack_configure(struct wl_client *client,
 static void layer_surface_handle_set_size(struct wl_client *client,
 		struct wl_resource *resource, uint32_t width, uint32_t height) {
 	struct wlr_layer_surface_v1 *surface = layer_surface_from_resource(resource);
+
+	if (!surface) {
+		return;
+	}
 	surface->client_pending.desired_width = width;
 	surface->client_pending.desired_height = height;
 }
@@ -105,12 +113,20 @@ static void layer_surface_handle_set_anchor(struct wl_client *client,
 			"invalid anchor %d", anchor);
 	}
 	struct wlr_layer_surface_v1 *surface = layer_surface_from_resource(resource);
+
+	if (!surface) {
+		return;
+	}
 	surface->client_pending.anchor = anchor;
 }
 
 static void layer_surface_handle_set_exclusive_zone(struct wl_client *client,
 		struct wl_resource *resource, int32_t zone) {
 	struct wlr_layer_surface_v1 *surface = layer_surface_from_resource(resource);
+
+	if (!surface) {
+		return;
+	}
 	surface->client_pending.exclusive_zone = zone;
 }
 
@@ -118,6 +134,10 @@ static void layer_surface_handle_set_margin(
 		struct wl_client *client, struct wl_resource *resource,
 		int32_t top, int32_t right, int32_t bottom, int32_t left) {
 	struct wlr_layer_surface_v1 *surface = layer_surface_from_resource(resource);
+
+	if (!surface) {
+		return;
+	}
 	surface->client_pending.margin.top = top;
 	surface->client_pending.margin.right = right;
 	surface->client_pending.margin.bottom = bottom;
@@ -128,6 +148,10 @@ static void layer_surface_handle_set_keyboard_interactivity(
 		struct wl_client *client, struct wl_resource *resource,
 		uint32_t interactive) {
 	struct wlr_layer_surface_v1 *surface = layer_surface_from_resource(resource);
+
+	if (!surface) {
+		return;
+	}
 	surface->client_pending.keyboard_interactive = !!interactive;
 }
 
@@ -139,6 +163,9 @@ static void layer_surface_handle_get_popup(struct wl_client *client,
 	struct wlr_xdg_surface *popup_surface =
 		wlr_xdg_surface_from_popup_resource(popup_resource);
 
+	if (!parent) {
+		return;
+	}
 	assert(popup_surface->role == WLR_XDG_SURFACE_ROLE_POPUP);
 	struct wlr_xdg_popup *popup = popup_surface->popup;
 	popup->parent = parent->surface;

--- a/types/wlr_layer_shell_v1.c
+++ b/types/wlr_layer_shell_v1.c
@@ -168,10 +168,6 @@ static void layer_surface_unmap(struct wlr_layer_surface_v1 *surface) {
 
 	surface->configured = surface->mapped = false;
 	surface->configure_serial = 0;
-	if (surface->configure_idle) {
-		wl_event_source_remove(surface->configure_idle);
-		surface->configure_idle = NULL;
-	}
 	surface->configure_next_serial = 0;
 }
 


### PR DESCRIPTION
This fixes a crash where the compositor tries to access `surface->configure_list` after the surface was destroyed via `handle_surface_destroy()->layer_surface_destroy()` but the resource is still around.

```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==22322==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000070 (pc 0x55f4117f8d96 bp 0x7ffdadca6040 sp 0x7ffdadca6000 T0)
==22322==The signal is caused by a READ memory access.
==22322==Hint: address points to the zero page.
    #0 0x55f4117f8d95 in layer_surface_handle_ack_configure ../subprojects/wlroots/types/wlr_layer_shell_v1.c:65
    #1 0x7f65158a58ed in ffi_call_unix64 (/usr/lib/x86_64-linux-gnu/libffi.so.6+0x68ed)
    #2 0x7f65158a52be in ffi_call (/usr/lib/x86_64-linux-gnu/libffi.so.6+0x62be)
    #3 0x7f651666fb2c  (/usr/lib/x86_64-linux-gnu/libwayland-server.so.0+0xcb2c)
    #4 0x7f651666c5a8  (/usr/lib/x86_64-linux-gnu/libwayland-server.so.0+0x95a8)
    #5 0x7f651666db71 in wl_event_loop_dispatch (/usr/lib/x86_64-linux-gnu/libwayland-server.so.0+0xab71)
    #6 0x55f41174ba9a in wayland_event_source_dispatch ../src/main.c:49
    #7 0x7f65168f0f2d in g_main_dispatch ../../../glib/gmain.c:3182
    #8 0x7f65168f0f2d in g_main_context_dispatch ../../../glib/gmain.c:3847
    #9 0x7f65168f11c7 in g_main_context_iterate ../../../glib/gmain.c:3920
    #10 0x7f65168f14c1 in g_main_loop_run ../../../glib/gmain.c:4116
    #11 0x55f41173619f in main ../src/main.c:207
    #12 0x7f651618909a in __libc_start_main ../csu/libc-start.c:308
    #13 0x55f411737769 in _start (/var/scratch/librem5/phoc/_build/src/phoc+0x5f769)
```
(line numbers might be slightly off due to some printf debugging.