### PR TITLE
text_input: Don't forget to send enter events

### DIFF
--- a/rootston/text_input.c
+++ b/rootston/text_input.c
@@ -297,7 +297,9 @@ void roots_input_method_relay_set_focus(struct roots_input_method_relay *relay,
 				relay_disable_text_input(relay, text_input);
 				wlr_text_input_v3_send_leave(text_input->input);
 			}
-		} else if (surface
+		}
+
+		if (surface
 				&& wl_resource_get_client(text_input->input->resource)
 				== wl_resource_get_client(surface->resource)) {
 			if (relay->input_method) {


### PR DESCRIPTION
When we move from one surface to another we ought to handle leave
for the old one but also send enter for the new one.

This fixes the case where an application with multiple windows gets the osk shown in the initial one but not subsequently opened ones.