### PR TITLE
Use -fmacro-prefix-map to strip build path, when available

### DIFF
--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -98,7 +98,7 @@ struct wlr_gles2_texture *gles2_get_texture(
 
 void push_gles2_marker(const char *file, const char *func);
 void pop_gles2_marker(void);
-#define PUSH_GLES2_DEBUG push_gles2_marker(_wlr_strip_path(__FILE__), __func__)
+#define PUSH_GLES2_DEBUG push_gles2_marker(_WLR_FILENAME, __func__)
 #define POP_GLES2_DEBUG pop_gles2_marker()
 
 #endif

--- a/include/wlr/util/log.h
+++ b/include/wlr/util/log.h
@@ -50,13 +50,19 @@ enum wlr_log_importance wlr_log_get_verbosity(void);
 
 void _wlr_log(enum wlr_log_importance verbosity, const char *format, ...) _WLR_ATTRIB_PRINTF(2, 3);
 void _wlr_vlog(enum wlr_log_importance verbosity, const char *format, va_list args) _WLR_ATTRIB_PRINTF(2, 0);
-const char *_wlr_strip_path(const char *filepath);
+
+#ifdef WLR_REL_SRC_DIR
+// strip prefix from __FILE__, leaving the path relative to the project root
+#define _WLR_FILENAME ((const char *)__FILE__ + sizeof(WLR_REL_SRC_DIR) - 1)
+#else
+#define _WLR_FILENAME __FILE__
+#endif
 
 #define wlr_log(verb, fmt, ...) \
-	_wlr_log(verb, "[%s:%d] " fmt, _wlr_strip_path(__FILE__), __LINE__, ##__VA_ARGS__)
+	_wlr_log(verb, "[%s:%d] " fmt, _WLR_FILENAME, __LINE__, ##__VA_ARGS__)
 
 #define wlr_vlog(verb, fmt, args) \
-	_wlr_vlog(verb, "[%s:%d] " fmt, _wlr_strip_path(__FILE__), __LINE__, args)
+	_wlr_vlog(verb, "[%s:%d] " fmt, _WLR_FILENAME, __LINE__, args)
 
 #define wlr_log_errno(verb, fmt, ...) \
 	wlr_log(verb, fmt ": %s", ##__VA_ARGS__, strerror(errno))

--- a/meson.build
+++ b/meson.build
@@ -17,7 +17,6 @@ project(
 so_version = ['3', '4', '1']
 
 add_project_arguments([
-	'-DWLR_SRC_DIR="@0@"'.format(meson.current_source_dir()),
 	'-DWLR_USE_UNSTABLE',
 ], language: 'c')
 
@@ -40,6 +39,43 @@ add_project_arguments(cc.get_supported_arguments([
 	'-Wno-missing-field-initializers',
 	'-Wno-unused-parameter',
 ]), language: 'c')
+
+# Compute the relative path used by compiler invocations.
+source_root = meson.current_source_dir().split('/')
+build_root = meson.build_root().split('/')
+relative_dir_parts = []
+i = 0
+in_prefix = true
+foreach p : build_root
+	if i >= source_root.length() or not in_prefix or p != source_root[i]
+		in_prefix = false
+		relative_dir_parts += '..'
+	endif
+	i += 1
+endforeach
+i = 0
+in_prefix = true
+foreach p : source_root
+	if i >= build_root.length() or not in_prefix or build_root[i] != p
+		in_prefix = false
+		relative_dir_parts += p
+	endif
+	i += 1
+endforeach
+relative_dir = join_paths(relative_dir_parts) + '/'
+
+# Strip relative path prefixes from the code if possible, otherwise hide them.
+if cc.has_argument('-fmacro-prefix-map=/prefix/to/hide=')
+	add_project_arguments(
+		'-fmacro-prefix-map=@0@='.format(relative_dir),
+		language: 'c',
+	)
+else
+	add_project_arguments(
+		'-DWLR_REL_SRC_DIR="@0@"'.format(relative_dir),
+		language: 'c',
+	)
+endif
 
 conf_data = configuration_data()
 conf_data.set10('WLR_HAS_LIBCAP', false)

--- a/util/log.c
+++ b/util/log.c
@@ -81,23 +81,6 @@ void _wlr_log(enum wlr_log_importance verbosity, const char *fmt, ...) {
 	va_end(args);
 }
 
-// strips the path prefix from filepath
-// will try to strip WLR_SRC_DIR as well as a relative src dir
-// e.g. '/src/build/wlroots/backend/wayland/backend.c' and
-// '../backend/wayland/backend.c' will both be stripped to
-// 'backend/wayland/backend.c'
-const char *_wlr_strip_path(const char *filepath) {
-	static int srclen = sizeof(WLR_SRC_DIR);
-	if (strstr(filepath, WLR_SRC_DIR) == filepath) {
-		filepath += srclen;
-	} else if (*filepath == '.') {
-		while (*filepath == '.' || *filepath == '/') {
-			++filepath;
-		}
-	}
-	return filepath;
-}
-
 enum wlr_log_importance wlr_log_get_verbosity(void) {
 	return log_importance;
 }


### PR DESCRIPTION
This PR applies the same change as https://github.com/swaywm/sway/pull/4282.

I have tested this change with Clang (8.0.0) and GCC (9.1.0, has `-fmacro-prefix-map`), with `--buildtype release`, and with wlroots built both standalone and as a subproject of sway.

To check that `-fmacro-prefix-map` actually strips paths correctly, run `strings libwlroots.so | grep wlroots`.