### PR TITLE
output: atomic mode, enabled, scale and transform

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -328,12 +328,9 @@ static bool drm_connector_attach_render(struct wlr_output *output,
 	return make_drm_surface_current(&conn->crtc->primary->surf, buffer_age);
 }
 
-static bool drm_connector_commit(struct wlr_output *output) {
+static bool drm_connector_commit_buffer(struct wlr_output *output) {
 	struct wlr_drm_connector *conn = get_drm_connector_from_output(output);
 	struct wlr_drm_backend *drm = get_drm_backend_from_backend(output->backend);
-	if (!drm->session->active) {
-		return false;
-	}
 
 	struct wlr_drm_crtc *crtc = conn->crtc;
 	if (!crtc) {
@@ -401,6 +398,37 @@ static bool drm_connector_commit(struct wlr_output *output) {
 	}
 
 	wlr_output_update_enabled(output, true);
+	return true;
+}
+
+static bool drm_connector_commit(struct wlr_output *output) {
+	struct wlr_drm_backend *drm = get_drm_backend_from_backend(output->backend);
+
+	if (!drm->session->active) {
+		return false;
+	}
+
+	if (output->pending.committed & WLR_OUTPUT_STATE_ENABLED) {
+		if (!enable_drm_connector(output, output->pending.enabled)) {
+			return false;
+		}
+	}
+
+	if (output->pending.committed & WLR_OUTPUT_STATE_MODE) {
+		if (output->pending.mode_type != WLR_OUTPUT_STATE_MODE_FIXED) {
+			return false;
+		}
+		if (!drm_connector_set_mode(output, output->pending.mode)) {
+			return false;
+		}
+	}
+
+	if (output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
+		if (!drm_connector_commit_buffer(output)) {
+			return false;
+		}
+	}
+
 	return true;
 }
 
@@ -922,8 +950,6 @@ static void drm_connector_destroy(struct wlr_output *output) {
 }
 
 static const struct wlr_output_impl output_impl = {
-	.enable = enable_drm_connector,
-	.set_mode = drm_connector_set_mode,
 	.set_cursor = drm_connector_set_cursor,
 	.move_cursor = drm_connector_move_cursor,
 	.destroy = drm_connector_destroy,

--- a/backend/noop/output.c
+++ b/backend/noop/output.c
@@ -12,19 +12,30 @@ static struct wlr_noop_output *noop_output_from_output(
 	return (struct wlr_noop_output *)wlr_output;
 }
 
-static bool output_set_custom_mode(struct wlr_output *wlr_output,
-		int32_t width, int32_t height, int32_t refresh) {
-	wlr_output_update_custom_mode(wlr_output, width, height, refresh);
-	return true;
-}
-
 static bool output_attach_render(struct wlr_output *wlr_output,
 		int *buffer_age) {
 	return false;
 }
 
 static bool output_commit(struct wlr_output *wlr_output) {
-	return false;
+	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_ENABLED) {
+		wlr_log(WLR_DEBUG, "Cannot disable a noop output");
+		return false;
+	}
+
+	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_MODE) {
+		assert(wlr_output->pending.mode_type == WLR_OUTPUT_STATE_MODE_CUSTOM);
+		wlr_output_update_custom_mode(wlr_output,
+			wlr_output->pending.custom_mode.width,
+			wlr_output->pending.custom_mode.height,
+			wlr_output->pending.custom_mode.refresh);
+	}
+
+	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
+		return false;
+	}
+
+	return true;
 }
 
 static void output_destroy(struct wlr_output *wlr_output) {
@@ -37,7 +48,6 @@ static void output_destroy(struct wlr_output *wlr_output) {
 }
 
 static const struct wlr_output_impl output_impl = {
-	.set_custom_mode = output_set_custom_mode,
 	.destroy = output_destroy,
 	.attach_render = output_attach_render,
 	.commit = output_commit,

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -63,26 +63,44 @@ static bool output_commit(struct wlr_output *wlr_output) {
 	struct wlr_wl_output *output =
 		get_wl_output_from_output(wlr_output);
 
-	if (output->frame_callback != NULL) {
-		wlr_log(WLR_ERROR, "Skipping buffer swap");
+	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_ENABLED) {
+		wlr_log(WLR_DEBUG, "Cannot disable a Wayland output");
 		return false;
 	}
 
-	output->frame_callback = wl_surface_frame(output->surface);
-	wl_callback_add_listener(output->frame_callback, &frame_listener, output);
-
-	pixman_region32_t *damage = NULL;
-	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_DAMAGE) {
-		damage = &wlr_output->pending.damage;
+	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_MODE) {
+		assert(wlr_output->pending.mode_type == WLR_OUTPUT_STATE_MODE_CUSTOM);
+		if (!output_set_custom_mode(wlr_output,
+				wlr_output->pending.custom_mode.width,
+				wlr_output->pending.custom_mode.height,
+				wlr_output->pending.custom_mode.refresh)) {
+			return false;
+		}
 	}
 
-	if (!wlr_egl_swap_buffers(&output->backend->egl,
-			output->egl_surface, damage)) {
-		return false;
+	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
+		if (output->frame_callback != NULL) {
+			wlr_log(WLR_ERROR, "Skipping buffer swap");
+			return false;
+		}
+
+		output->frame_callback = wl_surface_frame(output->surface);
+		wl_callback_add_listener(output->frame_callback, &frame_listener, output);
+
+		pixman_region32_t *damage = NULL;
+		if (wlr_output->pending.committed & WLR_OUTPUT_STATE_DAMAGE) {
+			damage = &wlr_output->pending.damage;
+		}
+
+		if (!wlr_egl_swap_buffers(&output->backend->egl,
+				output->egl_surface, damage)) {
+			return false;
+		}
+
+		// TODO: if available, use the presentation-time protocol
+		wlr_output_send_present(wlr_output, NULL);
 	}
 
-	// TODO: if available, use the presentation-time protocol
-	wlr_output_send_present(wlr_output, NULL);
 	return true;
 }
 
@@ -219,7 +237,6 @@ static bool output_schedule_frame(struct wlr_output *wlr_output) {
 }
 
 static const struct wlr_output_impl output_impl = {
-	.set_custom_mode = output_set_custom_mode,
 	.destroy = output_destroy,
 	.attach_render = output_attach_render,
 	.commit = output_commit,

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -15,10 +15,6 @@
 #include <wlr/types/wlr_output.h>
 
 struct wlr_output_impl {
-	bool (*enable)(struct wlr_output *output, bool enable);
-	bool (*set_mode)(struct wlr_output *output, struct wlr_output_mode *mode);
-	bool (*set_custom_mode)(struct wlr_output *output, int32_t width,
-		int32_t height, int32_t refresh);
 	bool (*set_cursor)(struct wlr_output *output, struct wlr_texture *texture,
 		int32_t scale, enum wl_output_transform transform,
 		int32_t hotspot_x, int32_t hotspot_y, bool update_texture);

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -50,11 +50,20 @@ struct wlr_output_cursor {
 enum wlr_output_state_field {
 	WLR_OUTPUT_STATE_BUFFER = 1 << 0,
 	WLR_OUTPUT_STATE_DAMAGE = 1 << 1,
+	WLR_OUTPUT_STATE_MODE = 1 << 2,
+	WLR_OUTPUT_STATE_ENABLED = 1 << 3,
+	WLR_OUTPUT_STATE_SCALE = 1 << 4,
+	WLR_OUTPUT_STATE_TRANSFORM = 1 << 5,
 };
 
 enum wlr_output_state_buffer_type {
 	WLR_OUTPUT_STATE_BUFFER_RENDER,
 	WLR_OUTPUT_STATE_BUFFER_SCANOUT,
+};
+
+enum wlr_output_state_mode_type {
+	WLR_OUTPUT_STATE_MODE_FIXED,
+	WLR_OUTPUT_STATE_MODE_CUSTOM,
 };
 
 /**
@@ -63,10 +72,21 @@ enum wlr_output_state_buffer_type {
 struct wlr_output_state {
 	uint32_t committed; // enum wlr_output_state_field
 	pixman_region32_t damage; // output-buffer-local coordinates
+	bool enabled;
+	float scale;
+	enum wl_output_transform transform;
 
 	// only valid if WLR_OUTPUT_STATE_BUFFER
 	enum wlr_output_state_buffer_type buffer_type;
 	struct wlr_buffer *buffer; // if WLR_OUTPUT_STATE_BUFFER_SCANOUT
+
+	// only valid if WLR_OUTPUT_STATE_MODE
+	enum wlr_output_state_mode_type mode_type;
+	struct wlr_output_mode *mode;
+	struct {
+		int32_t width, height;
+		int32_t refresh; // mHz, may be zero
+	} custom_mode;
 };
 
 struct wlr_output_impl;
@@ -184,8 +204,11 @@ struct wlr_surface;
 /**
  * Enables or disables the output. A disabled output is turned off and doesn't
  * emit `frame` events.
+ *
+ * Whether an output is enabled is double-buffered state, see
+ * `wlr_output_commit`.
  */
-bool wlr_output_enable(struct wlr_output *output, bool enable);
+void wlr_output_enable(struct wlr_output *output, bool enable);
 void wlr_output_create_global(struct wlr_output *output);
 void wlr_output_destroy_global(struct wlr_output *output);
 /**
@@ -195,17 +218,31 @@ void wlr_output_destroy_global(struct wlr_output *output);
 struct wlr_output_mode *wlr_output_preferred_mode(struct wlr_output *output);
 /**
  * Sets the output mode. Enables the output if it's currently disabled.
+ *
+ * Mode is double-buffered state, see `wlr_output_commit`.
  */
-bool wlr_output_set_mode(struct wlr_output *output,
+void wlr_output_set_mode(struct wlr_output *output,
 	struct wlr_output_mode *mode);
 /**
  * Sets a custom mode on the output. If modes are available, they are preferred.
  * Setting `refresh` to zero lets the backend pick a preferred value.
+ *
+ * Custom mode is double-buffered state, see `wlr_output_commit`.
  */
-bool wlr_output_set_custom_mode(struct wlr_output *output, int32_t width,
+void wlr_output_set_custom_mode(struct wlr_output *output, int32_t width,
 	int32_t height, int32_t refresh);
+/**
+ * Sets a transform for the output.
+ *
+ * Transform is double-buffered state, see `wlr_output_commit`.
+ */
 void wlr_output_set_transform(struct wlr_output *output,
 	enum wl_output_transform transform);
+/**
+ * Sets a scale for the output.
+ *
+ * Scale is double-buffered state, see `wlr_output_commit`.
+ */
 void wlr_output_set_scale(struct wlr_output *output, float scale);
 void wlr_output_set_subpixel(struct wlr_output *output,
 	enum wl_output_subpixel subpixel);
@@ -263,9 +300,8 @@ void wlr_output_set_damage(struct wlr_output *output,
 	pixman_region32_t *damage);
 /**
  * Commit the pending output state. If `wlr_output_attach_render` has been
- * called, the pending frame will be submitted for display.
- *
- * This function schedules a `frame` event.
+ * called, the pending frame will be submitted for display and a `frame` event
+ * will be scheduled.
  */
 bool wlr_output_commit(struct wlr_output *output);
 /**

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -470,8 +470,10 @@ void handle_output_manager_apply(struct wl_listener *listener, void *data) {
 	wl_list_for_each(config_head, &config->heads, link) {
 		struct wlr_output *wlr_output = config_head->state.output;
 		if (!config_head->state.enabled) {
-			ok &= wlr_output_enable(wlr_output, false);
+			wlr_output_enable(wlr_output, false);
 			wlr_output_layout_remove(desktop->layout, wlr_output);
+
+			ok &= wlr_output_commit(wlr_output);
 		}
 	}
 
@@ -481,11 +483,12 @@ void handle_output_manager_apply(struct wl_listener *listener, void *data) {
 		if (!config_head->state.enabled) {
 			continue;
 		}
-		ok &= wlr_output_enable(wlr_output, true);
+
+		wlr_output_enable(wlr_output, true);
 		if (config_head->state.mode != NULL) {
-			ok &= wlr_output_set_mode(wlr_output, config_head->state.mode);
+			wlr_output_set_mode(wlr_output, config_head->state.mode);
 		} else {
-			ok &= wlr_output_set_custom_mode(wlr_output,
+			wlr_output_set_custom_mode(wlr_output,
 				config_head->state.custom_mode.width,
 				config_head->state.custom_mode.height,
 				config_head->state.custom_mode.refresh);
@@ -494,6 +497,8 @@ void handle_output_manager_apply(struct wl_listener *listener, void *data) {
 			config_head->state.x, config_head->state.y);
 		wlr_output_set_transform(wlr_output, config_head->state.transform);
 		wlr_output_set_scale(wlr_output, config_head->state.scale);
+
+		ok &= wlr_output_commit(wlr_output);
 	}
 
 	if (ok) {
@@ -674,6 +679,7 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 		}
 		wlr_output_layout_add_auto(desktop->layout, wlr_output);
 	}
+	wlr_output_commit(wlr_output);
 
 	struct roots_seat *seat;
 	wl_list_for_each(seat, &input->seats, link) {

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -148,38 +148,50 @@ static void output_update_matrix(struct wlr_output *output) {
 		output->height, output->transform);
 }
 
-bool wlr_output_enable(struct wlr_output *output, bool enable) {
+void wlr_output_enable(struct wlr_output *output, bool enable) {
 	if (output->enabled == enable) {
-		return true;
+		return;
 	}
 
-	if (output->impl->enable) {
-		return output->impl->enable(output, enable);
-	}
-	return false;
+	output->pending.committed |= WLR_OUTPUT_STATE_ENABLED;
+	output->pending.enabled = enable;
 }
 
-bool wlr_output_set_mode(struct wlr_output *output,
+static void output_state_clear_mode(struct wlr_output_state *state) {
+	if (!(state->committed & WLR_OUTPUT_STATE_MODE)) {
+		return;
+	}
+
+	state->mode = NULL;
+
+	state->committed &= ~WLR_OUTPUT_STATE_MODE;
+}
+
+void wlr_output_set_mode(struct wlr_output *output,
 		struct wlr_output_mode *mode) {
-	if (!output->impl || !output->impl->set_mode) {
-		return false;
-	}
 	if (output->current_mode == mode) {
-		return true;
+		return;
 	}
-	return output->impl->set_mode(output, mode);
+
+	output_state_clear_mode(&output->pending);
+	output->pending.committed |= WLR_OUTPUT_STATE_MODE;
+	output->pending.mode_type = WLR_OUTPUT_STATE_MODE_FIXED;
+	output->pending.mode = mode;
 }
 
-bool wlr_output_set_custom_mode(struct wlr_output *output, int32_t width,
+void wlr_output_set_custom_mode(struct wlr_output *output, int32_t width,
 		int32_t height, int32_t refresh) {
-	if (!output->impl || !output->impl->set_custom_mode) {
-		return false;
-	}
 	if (output->width == width && output->height == height &&
 			output->refresh == refresh) {
-		return true;
+		return;
 	}
-	return output->impl->set_custom_mode(output, width, height, refresh);
+
+	output_state_clear_mode(&output->pending);
+	output->pending.committed |= WLR_OUTPUT_STATE_MODE;
+	output->pending.mode_type = WLR_OUTPUT_STATE_MODE_CUSTOM;
+	output->pending.custom_mode.width = width;
+	output->pending.custom_mode.height = height;
+	output->pending.custom_mode.refresh = refresh;
 }
 
 void wlr_output_update_mode(struct wlr_output *output,
@@ -221,16 +233,8 @@ void wlr_output_set_transform(struct wlr_output *output,
 		return;
 	}
 
-	output->transform = transform;
-	output_update_matrix(output);
-
-	struct wl_resource *resource;
-	wl_resource_for_each(resource, &output->resources) {
-		send_geometry(resource);
-	}
-	wlr_output_schedule_done(output);
-
-	wlr_signal_emit_safe(&output->events.transform, output);
+	output->pending.committed |= WLR_OUTPUT_STATE_TRANSFORM;
+	output->pending.transform = transform;
 }
 
 void wlr_output_set_scale(struct wlr_output *output, float scale) {
@@ -238,15 +242,8 @@ void wlr_output_set_scale(struct wlr_output *output, float scale) {
 		return;
 	}
 
-	output->scale = scale;
-
-	struct wl_resource *resource;
-	wl_resource_for_each(resource, &output->resources) {
-		send_scale(resource);
-	}
-	wlr_output_schedule_done(output);
-
-	wlr_signal_emit_safe(&output->events.scale, output);
+	output->pending.committed |= WLR_OUTPUT_STATE_SCALE;
+	output->pending.scale = scale;
 }
 
 void wlr_output_set_subpixel(struct wlr_output *output,
@@ -452,18 +449,15 @@ static void output_state_clear(struct wlr_output_state *state) {
 }
 
 bool wlr_output_commit(struct wlr_output *output) {
-	if (output->frame_pending) {
-		wlr_log(WLR_ERROR, "Tried to commit when a frame is pending");
-		return false;
-	}
-	if (output->idle_frame != NULL) {
-		wl_event_source_remove(output->idle_frame);
-		output->idle_frame = NULL;
-	}
-
-	if (!(output->pending.committed & WLR_OUTPUT_STATE_BUFFER)) {
-		wlr_log(WLR_ERROR, "Tried to commit without attaching a buffer");
-		return false;
+	if (output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
+		if (output->frame_pending) {
+			wlr_log(WLR_ERROR, "Tried to commit a buffer while a frame is pending");
+			return false;
+		}
+		if (output->idle_frame != NULL) {
+			wl_event_source_remove(output->idle_frame);
+			output->idle_frame = NULL;
+		}
 	}
 
 	struct timespec now;
@@ -480,20 +474,52 @@ bool wlr_output_commit(struct wlr_output *output) {
 		return false;
 	}
 
-	struct wlr_output_cursor *cursor;
-	wl_list_for_each(cursor, &output->cursors, link) {
-		if (!cursor->enabled || !cursor->visible || cursor->surface == NULL) {
-			continue;
+	if (output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
+		struct wlr_output_cursor *cursor;
+		wl_list_for_each(cursor, &output->cursors, link) {
+			if (!cursor->enabled || !cursor->visible || cursor->surface == NULL) {
+				continue;
+			}
+			wlr_surface_send_frame_done(cursor->surface, &now);
 		}
-		wlr_surface_send_frame_done(cursor->surface, &now);
 	}
 
 	wlr_signal_emit_safe(&output->events.commit, output);
 
-	output->frame_pending = true;
-	output->needs_frame = false;
+	bool scale_updated = output->pending.committed & WLR_OUTPUT_STATE_SCALE;
+	if (scale_updated) {
+		output->scale = output->pending.scale;
+		wlr_signal_emit_safe(&output->events.scale, output);
+	}
+
+	if (output->pending.committed & WLR_OUTPUT_STATE_TRANSFORM) {
+		output->transform = output->pending.transform;
+		output_update_matrix(output);
+		wlr_signal_emit_safe(&output->events.transform, output);
+	}
+
+	bool geometry_updated = output->pending.committed &
+		(WLR_OUTPUT_STATE_MODE | WLR_OUTPUT_STATE_TRANSFORM);
+	if (geometry_updated || scale_updated) {
+		struct wl_resource *resource;
+		wl_resource_for_each(resource, &output->resources) {
+			if (geometry_updated) {
+				send_geometry(resource);
+			}
+			if (scale_updated) {
+				send_scale(resource);
+			}
+		}
+		wlr_output_schedule_done(output);
+	}
+
+	if (output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
+		output->frame_pending = true;
+		output->needs_frame = false;
+		pixman_region32_clear(&output->damage);
+	}
+
 	output_state_clear(&output->pending);
-	pixman_region32_clear(&output->damage);
 	return true;
 }
 


### PR DESCRIPTION
This commit makes more output properties (mode, enabled, scale and transform)
atomic. This means that they are double-buffered and only applied on commit.

Compositors now need to call wlr_output_commit after setting any of those
properties.

Internally, backends still apply properties sequentially. The behaviour should
be exactly the same as before. Future commits will update some backends to take
advantage of the atomic interface. Some backends are non-atomic by design, e.g.
the X11 backend or the legacy DRM backend.

Updates: https://github.com/swaywm/wlroots/issues/1640