### PR TITLE
Remove all wayland-server.h includes

### DIFF
--- a/backend/backend.c
+++ b/backend/backend.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend/drm.h>
 #include <wlr/backend/headless.h>
 #include <wlr/backend/interface.h>

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend/interface.h>
 #include <wlr/backend/session.h>
 #include <wlr/interfaces/wlr_output.h>

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include <strings.h>
 #include <time.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wayland-util.h>
 #include <wlr/backend/interface.h>
 #include <wlr/interfaces/wlr_output.h>

--- a/backend/rdp/keyboard.c
+++ b/backend/rdp/keyboard.c
@@ -1,5 +1,5 @@
 #include <stdlib.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_keyboard.h>
 #include <wlr/interfaces/wlr_keyboard.h>

--- a/backend/rdp/output.c
+++ b/backend/rdp/output.c
@@ -2,7 +2,7 @@
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #include <stdlib.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/interfaces/wlr_output.h>
 #include <wlr/util/log.h>

--- a/backend/rdp/pointer.c
+++ b/backend/rdp/pointer.c
@@ -1,7 +1,7 @@
 #define _POSIX_C_SOURCE 200809L
 #include <stdlib.h>
 #include <string.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_pointer.h>
 #include <wlr/interfaces/wlr_pointer.h>

--- a/backend/session/direct-freebsd.c
+++ b/backend/session/direct-freebsd.c
@@ -13,7 +13,7 @@
 #include <sys/types.h>
 #include <termios.h>
 #include <unistd.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend/session/interface.h>
 #include <wlr/util/log.h>
 #include <xf86drm.h>

--- a/backend/session/direct.c
+++ b/backend/session/direct.c
@@ -14,7 +14,7 @@
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
 #include <unistd.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend/session/interface.h>
 #include <wlr/util/log.h>
 #include "backend/session/direct-ipc.h"

--- a/backend/session/logind.c
+++ b/backend/session/logind.c
@@ -9,7 +9,7 @@
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
 #include <unistd.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend/session/interface.h>
 #include <wlr/config.h>
 #include <wlr/util/log.h>

--- a/backend/session/noop.c
+++ b/backend/session/noop.c
@@ -3,7 +3,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend/session/interface.h>
 #include <wlr/util/log.h>
 #include "util/signal.h"

--- a/backend/session/session.c
+++ b/backend/session/session.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend/session.h>
 #include <wlr/backend/session/interface.h>
 #include <wlr/config.h>

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -5,7 +5,7 @@
 
 #include <wlr/config.h>
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 
 #include <wlr/backend/interface.h>
 #include <wlr/interfaces/wlr_input_device.h>

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -10,7 +10,7 @@
 #include <wlr/config.h>
 
 #include <X11/Xlib-xcb.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <xcb/xcb.h>
 #include <xcb/xfixes.h>
 #include <xcb/xinput.h>

--- a/examples/fullscreen-shell.c
+++ b/examples/fullscreen-shell.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include <unistd.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_compositor.h>

--- a/examples/multi-pointer.c
+++ b/examples/multi-pointer.c
@@ -7,8 +7,7 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
-#include <wayland-server-protocol.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
 #include <wlr/render/gles2.h>

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -8,8 +8,7 @@
 #include <strings.h>
 #include <time.h>
 #include <unistd.h>
-#include <wayland-server-protocol.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
 #include <wlr/render/wlr_renderer.h>

--- a/examples/pointer.c
+++ b/examples/pointer.c
@@ -6,8 +6,7 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
-#include <wayland-server-protocol.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
 #include <wlr/render/gles2.h>

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -8,8 +8,7 @@
 #include <strings.h>
 #include <time.h>
 #include <unistd.h>
-#include <wayland-server-protocol.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
 #include <wlr/render/wlr_renderer.h>

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
 #include <wlr/types/wlr_output.h>

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -6,8 +6,7 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
-#include <wayland-server-protocol.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
 #include <wlr/render/wlr_renderer.h>

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -7,8 +7,7 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
-#include <wayland-server-protocol.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
 #include <wlr/types/wlr_output.h>

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -7,7 +7,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <time.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wayland-util.h>
 #include <wlr/backend/drm.h>
 #include <wlr/backend/session.h>

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -5,7 +5,7 @@
 
 #include <wayland-client.h>
 #include <wayland-egl.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wayland-util.h>
 
 #include <wlr/backend/wayland.h>

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 
 #include <X11/Xlib-xcb.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <xcb/xcb.h>
 
 #include <wlr/backend/x11.h>

--- a/include/rootston/desktop.h
+++ b/include/rootston/desktop.h
@@ -1,7 +1,7 @@
 #ifndef ROOTSTON_DESKTOP_H
 #define ROOTSTON_DESKTOP_H
 #include <time.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/config.h>
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_foreign_toplevel_management_v1.h>

--- a/include/rootston/input.h
+++ b/include/rootston/input.h
@@ -1,7 +1,7 @@
 #ifndef ROOTSTON_INPUT_H
 #define ROOTSTON_INPUT_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_seat.h>

--- a/include/rootston/output.h
+++ b/include/rootston/output.h
@@ -2,7 +2,7 @@
 #define ROOTSTON_OUTPUT_H
 #include <pixman.h>
 #include <time.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_output_damage.h>
 

--- a/include/rootston/seat.h
+++ b/include/rootston/seat.h
@@ -1,7 +1,7 @@
 #ifndef ROOTSTON_SEAT_H
 #define ROOTSTON_SEAT_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include "rootston/input.h"
 #include "rootston/keyboard.h"
 #include "rootston/layers.h"

--- a/include/rootston/server.h
+++ b/include/rootston/server.h
@@ -1,7 +1,7 @@
 #ifndef _ROOTSTON_SERVER_H
 #define _ROOTSTON_SERVER_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
 #include <wlr/config.h>

--- a/include/types/wlr_data_device.h
+++ b/include/types/wlr_data_device.h
@@ -1,7 +1,7 @@
 #ifndef TYPES_WLR_DATA_DEVICE_H
 #define TYPES_WLR_DATA_DEVICE_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 
 #define DATA_DEVICE_ALL_ACTIONS (WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY | \
 	WL_DATA_DEVICE_MANAGER_DND_ACTION_MOVE | \

--- a/include/types/wlr_seat.h
+++ b/include/types/wlr_seat.h
@@ -1,7 +1,7 @@
 #ifndef TYPES_WLR_SEAT_H
 #define TYPES_WLR_SEAT_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_seat.h>
 
 const struct wlr_pointer_grab_interface default_pointer_grab_impl;

--- a/include/types/wlr_tablet_v2.h
+++ b/include/types/wlr_tablet_v2.h
@@ -2,7 +2,7 @@
 #define TYPES_WLR_TABLET_V2_H
 
 #include "tablet-unstable-v2-protocol.h"
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_tablet_v2.h>
 
 struct wlr_tablet_seat_v2 {

--- a/include/types/wlr_xdg_shell.h
+++ b/include/types/wlr_xdg_shell.h
@@ -1,7 +1,7 @@
 #ifndef TYPES_WLR_XDG_SHELL_H
 #define TYPES_WLR_XDG_SHELL_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_xdg_shell.h>
 #include "xdg-shell-protocol.h"
 

--- a/include/types/wlr_xdg_shell_v6.h
+++ b/include/types/wlr_xdg_shell_v6.h
@@ -1,7 +1,7 @@
 #ifndef TYPES_WLR_XDG_SHELL_V6_H
 #define TYPES_WLR_XDG_SHELL_V6_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_xdg_shell_v6.h>
 #include "xdg-shell-unstable-v6-protocol.h"
 

--- a/include/util/signal.h
+++ b/include/util/signal.h
@@ -1,7 +1,7 @@
 #ifndef UTIL_SIGNAL_H
 #define UTIL_SIGNAL_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 
 void wlr_signal_emit_safe(struct wl_signal *signal, void *data);
 

--- a/include/wlr/backend.h
+++ b/include/wlr/backend.h
@@ -9,7 +9,7 @@
 #ifndef WLR_BACKEND_H
 #define WLR_BACKEND_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend/session.h>
 #include <wlr/render/egl.h>
 

--- a/include/wlr/backend/drm.h
+++ b/include/wlr/backend/drm.h
@@ -9,7 +9,7 @@
 #ifndef WLR_BACKEND_DRM_H
 #define WLR_BACKEND_DRM_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
 #include <wlr/types/wlr_output.h>

--- a/include/wlr/backend/libinput.h
+++ b/include/wlr/backend/libinput.h
@@ -10,7 +10,7 @@
 #define WLR_BACKEND_LIBINPUT_H
 
 #include <libinput.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
 #include <wlr/types/wlr_input_device.h>

--- a/include/wlr/backend/session.h
+++ b/include/wlr/backend/session.h
@@ -4,7 +4,7 @@
 #include <libudev.h>
 #include <stdbool.h>
 #include <sys/types.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 
 struct session_impl;
 

--- a/include/wlr/backend/wayland.h
+++ b/include/wlr/backend/wayland.h
@@ -2,7 +2,7 @@
 #define WLR_BACKEND_WAYLAND_H
 #include <stdbool.h>
 #include <wayland-client.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_output.h>

--- a/include/wlr/backend/x11.h
+++ b/include/wlr/backend/x11.h
@@ -3,7 +3,7 @@
 
 #include <stdbool.h>
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 
 #include <wlr/backend.h>
 #include <wlr/types/wlr_input_device.h>

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -19,7 +19,7 @@
 #include <EGL/eglext.h>
 #include <pixman.h>
 #include <stdbool.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/render/dmabuf.h>
 #include <wlr/render/drm_format_set.h>
 

--- a/include/wlr/types/wlr_box.h
+++ b/include/wlr/types/wlr_box.h
@@ -11,7 +11,7 @@
 
 #include <pixman.h>
 #include <stdbool.h>
-#include <wayland-server.h>
+#include <wayland-server-protocol.h>
 
 struct wlr_box {
 	int x, y;

--- a/include/wlr/types/wlr_buffer.h
+++ b/include/wlr/types/wlr_buffer.h
@@ -10,7 +10,7 @@
 #define WLR_TYPES_WLR_BUFFER_H
 
 #include <pixman.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/render/dmabuf.h>
 
 /**

--- a/include/wlr/types/wlr_compositor.h
+++ b/include/wlr/types/wlr_compositor.h
@@ -9,7 +9,7 @@
 #ifndef WLR_TYPES_WLR_COMPOSITOR_H
 #define WLR_TYPES_WLR_COMPOSITOR_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/render/wlr_renderer.h>
 
 struct wlr_surface;

--- a/include/wlr/types/wlr_cursor.h
+++ b/include/wlr/types/wlr_cursor.h
@@ -9,7 +9,7 @@
 #ifndef WLR_TYPES_WLR_CURSOR_H
 #define WLR_TYPES_WLR_CURSOR_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_output_layout.h>

--- a/include/wlr/types/wlr_data_control_v1.h
+++ b/include/wlr/types/wlr_data_control_v1.h
@@ -9,7 +9,7 @@
 #ifndef WLR_TYPES_WLR_DATA_CONTROL_V1_H
 #define WLR_TYPES_WLR_DATA_CONTROL_V1_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_seat.h>
 
 struct wlr_data_control_manager_v1 {

--- a/include/wlr/types/wlr_data_device.h
+++ b/include/wlr/types/wlr_data_device.h
@@ -9,7 +9,7 @@
 #ifndef WLR_TYPES_WLR_DATA_DEVICE_H
 #define WLR_TYPES_WLR_DATA_DEVICE_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_seat.h>
 
 extern const struct wlr_pointer_grab_interface

--- a/include/wlr/types/wlr_export_dmabuf_v1.h
+++ b/include/wlr/types/wlr_export_dmabuf_v1.h
@@ -10,7 +10,7 @@
 #define WLR_TYPES_WLR_EXPORT_DMABUF_V1_H
 
 #include <stdbool.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/render/dmabuf.h>
 
 struct wlr_export_dmabuf_manager_v1 {

--- a/include/wlr/types/wlr_foreign_toplevel_management_v1.h
+++ b/include/wlr/types/wlr_foreign_toplevel_management_v1.h
@@ -9,7 +9,7 @@
 #ifndef WLR_TYPES_WLR_FOREIGN_TOPLEVEL_MANAGEMENT_V1_H
 #define WLR_TYPES_WLR_FOREIGN_TOPLEVEL_MANAGEMENT_V1_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_output.h>
 
 struct wlr_foreign_toplevel_manager_v1 {

--- a/include/wlr/types/wlr_fullscreen_shell_v1.h
+++ b/include/wlr/types/wlr_fullscreen_shell_v1.h
@@ -9,7 +9,7 @@
 #ifndef WLR_TYPES_WLR_FULLSCREEN_SHELL_V1_H
 #define WLR_TYPES_WLR_FULLSCREEN_SHELL_V1_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include "fullscreen-shell-unstable-v1-protocol.h"
 
 struct wlr_fullscreen_shell_v1 {

--- a/include/wlr/types/wlr_gamma_control_v1.h
+++ b/include/wlr/types/wlr_gamma_control_v1.h
@@ -1,7 +1,7 @@
 #ifndef WLR_TYPES_WLR_GAMMA_CONTROL_V1_H
 #define WLR_TYPES_WLR_GAMMA_CONTROL_V1_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 
 struct wlr_gamma_control_manager_v1 {
 	struct wl_global *global;

--- a/include/wlr/types/wlr_gtk_primary_selection.h
+++ b/include/wlr/types/wlr_gtk_primary_selection.h
@@ -14,7 +14,7 @@
 #ifndef WLR_TYPES_WLR_GTK_PRIMARY_SELECTION_H
 #define WLR_TYPES_WLR_GTK_PRIMARY_SELECTION_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_seat.h>
 
 /**

--- a/include/wlr/types/wlr_idle.h
+++ b/include/wlr/types/wlr_idle.h
@@ -9,7 +9,7 @@
 #ifndef WLR_TYPES_WLR_IDLE_H
 #define WLR_TYPES_WLR_IDLE_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_seat.h>
 
 /**

--- a/include/wlr/types/wlr_idle_inhibit_v1.h
+++ b/include/wlr/types/wlr_idle_inhibit_v1.h
@@ -9,7 +9,7 @@
 #ifndef WLR_TYPES_WLR_IDLE_INHIBIT_V1_H
 #define WLR_TYPES_WLR_IDLE_INHIBIT_V1_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 
 /* This interface permits clients to inhibit the idle behavior such as
  * screenblanking, locking, and screensaving.

--- a/include/wlr/types/wlr_input_inhibitor.h
+++ b/include/wlr/types/wlr_input_inhibitor.h
@@ -8,7 +8,7 @@
 
 #ifndef WLR_TYPES_INPUT_INHIBITOR_H
 #define WLR_TYPES_INPUT_INHIBITOR_H
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 
 struct wlr_input_inhibit_manager {
 	struct wl_global *global;

--- a/include/wlr/types/wlr_input_method_v2.h
+++ b/include/wlr/types/wlr_input_method_v2.h
@@ -10,7 +10,7 @@
 #define WLR_TYPES_WLR_INPUT_METHOD_V2_H
 #include <stdint.h>
 #include <stdlib.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_seat.h>
 
 struct wlr_input_method_v2_preedit_string {

--- a/include/wlr/types/wlr_keyboard.h
+++ b/include/wlr/types/wlr_keyboard.h
@@ -11,8 +11,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <wayland-server.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
+#include <wayland-server-core.h>
 #include <xkbcommon/xkbcommon.h>
 
 #define WLR_LED_COUNT 3

--- a/include/wlr/types/wlr_layer_shell_v1.h
+++ b/include/wlr/types/wlr_layer_shell_v1.h
@@ -10,7 +10,7 @@
 #define WLR_TYPES_WLR_LAYER_SHELL_V1_H
 #include <stdbool.h>
 #include <stdint.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_surface.h>
 #include "wlr-layer-shell-unstable-v1-protocol.h"

--- a/include/wlr/types/wlr_matrix.h
+++ b/include/wlr/types/wlr_matrix.h
@@ -17,7 +17,7 @@
 #ifndef WLR_TYPES_WLR_MATRIX_H
 #define WLR_TYPES_WLR_MATRIX_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_box.h>
 
 /** Writes the identity matrix into mat */

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -12,7 +12,7 @@
 #include <pixman.h>
 #include <stdbool.h>
 #include <time.h>
-#include <wayland-server.h>
+#include <wayland-server-protocol.h>
 #include <wayland-util.h>
 #include <wlr/render/dmabuf.h>
 #include <wlr/types/wlr_buffer.h>

--- a/include/wlr/types/wlr_output_management_v1.h
+++ b/include/wlr/types/wlr_output_management_v1.h
@@ -10,7 +10,7 @@
 #define WLR_TYPES_WLR_OUTPUT_MANAGEMENT_V1_H
 
 #include <stdbool.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_output.h>
 
 struct wlr_output_manager_v1 {

--- a/include/wlr/types/wlr_pointer.h
+++ b/include/wlr/types/wlr_pointer.h
@@ -10,7 +10,7 @@
 #define WLR_TYPES_WLR_POINTER_H
 
 #include <stdint.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_input_device.h>
 
 struct wlr_pointer_impl;

--- a/include/wlr/types/wlr_pointer_constraints_v1.h
+++ b/include/wlr/types/wlr_pointer_constraints_v1.h
@@ -10,7 +10,7 @@
 #define WLR_TYPES_WLR_POINTER_CONSTRAINTS_V1_H
 
 #include <stdint.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <pixman.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_seat.h>

--- a/include/wlr/types/wlr_pointer_gestures_v1.h
+++ b/include/wlr/types/wlr_pointer_gestures_v1.h
@@ -9,7 +9,7 @@
 #ifndef WLR_TYPES_WLR_POINTER_GESTURES_V1_H
 #define WLR_TYPES_WLR_POINTER_GESTURES_V1_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/types/wlr_surface.h>
 

--- a/include/wlr/types/wlr_presentation_time.h
+++ b/include/wlr/types/wlr_presentation_time.h
@@ -12,7 +12,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <time.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 
 struct wlr_presentation {
 	struct wl_global *global;

--- a/include/wlr/types/wlr_primary_selection.h
+++ b/include/wlr/types/wlr_primary_selection.h
@@ -9,7 +9,7 @@
 #ifndef WLR_TYPES_WLR_PRIMARY_SELECTION_H
 #define WLR_TYPES_WLR_PRIMARY_SELECTION_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_seat.h>
 
 struct wlr_primary_selection_source;

--- a/include/wlr/types/wlr_primary_selection_v1.h
+++ b/include/wlr/types/wlr_primary_selection_v1.h
@@ -9,7 +9,7 @@
 #ifndef WLR_TYPES_WLR_PRIMARY_SELECTION_V1_H
 #define WLR_TYPES_WLR_PRIMARY_SELECTION_V1_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_seat.h>
 
 struct wlr_primary_selection_v1_device_manager {

--- a/include/wlr/types/wlr_relative_pointer_v1.h
+++ b/include/wlr/types/wlr_relative_pointer_v1.h
@@ -9,7 +9,7 @@
 #ifndef WLR_TYPES_WLR_RELATIVE_POINTER_V1_H
 #define WLR_TYPES_WLR_RELATIVE_POINTER_V1_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 
 /**
  * This protocol specifies a set of interfaces used for making clients able to

--- a/include/wlr/types/wlr_screencopy_v1.h
+++ b/include/wlr/types/wlr_screencopy_v1.h
@@ -10,7 +10,7 @@
 #define WLR_TYPES_WLR_SCREENCOPY_V1_H
 
 #include <stdbool.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_box.h>
 
 struct wlr_screencopy_manager_v1 {

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -10,7 +10,7 @@
 #define WLR_TYPES_WLR_SEAT_H
 
 #include <time.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_keyboard.h>
 #include <wlr/types/wlr_surface.h>

--- a/include/wlr/types/wlr_server_decoration.h
+++ b/include/wlr/types/wlr_server_decoration.h
@@ -14,7 +14,7 @@
 #ifndef WLR_TYPES_WLR_SERVER_DECORATION_H
 #define WLR_TYPES_WLR_SERVER_DECORATION_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 
 /**
  * Possible values to use in request_mode and the event mode. Same as

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -13,7 +13,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <time.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_output.h>
 
 enum wlr_surface_state_field {

--- a/include/wlr/types/wlr_switch.h
+++ b/include/wlr/types/wlr_switch.h
@@ -10,7 +10,7 @@
 #define WLR_TYPES_WLR_SWITCH_H
 
 #include <stdint.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_list.h>
 

--- a/include/wlr/types/wlr_tablet_pad.h
+++ b/include/wlr/types/wlr_tablet_pad.h
@@ -10,7 +10,7 @@
 #define WLR_TYPES_WLR_TABLET_PAD_H
 
 #include <stdint.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_list.h>
 

--- a/include/wlr/types/wlr_tablet_tool.h
+++ b/include/wlr/types/wlr_tablet_tool.h
@@ -10,7 +10,7 @@
 #define WLR_TYPES_TABLET_TOOL_H
 
 #include <stdint.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_list.h>
 
@@ -45,7 +45,7 @@ struct wlr_tablet_tool {
 	struct {
 		struct wl_signal destroy;
 	} events;
-	
+
 	void *data;
 };
 

--- a/include/wlr/types/wlr_tablet_v2.h
+++ b/include/wlr/types/wlr_tablet_v2.h
@@ -9,7 +9,7 @@
 #ifndef WLR_TYPES_WLR_TABLET_V2_H
 #define WLR_TYPES_WLR_TABLET_V2_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/types/wlr_input_device.h>
 

--- a/include/wlr/types/wlr_text_input_v3.h
+++ b/include/wlr/types/wlr_text_input_v3.h
@@ -9,7 +9,7 @@
 #ifndef WLR_TYPES_WLR_TEXT_INPUT_V3_H
 #define WLR_TYPES_WLR_TEXT_INPUT_V3_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/types/wlr_surface.h>
 

--- a/include/wlr/types/wlr_touch.h
+++ b/include/wlr/types/wlr_touch.h
@@ -10,7 +10,7 @@
 #define WLR_TYPES_WLR_TOUCH_H
 
 #include <stdint.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 
 struct wlr_touch_impl;
 

--- a/include/wlr/types/wlr_virtual_keyboard_v1.h
+++ b/include/wlr/types/wlr_virtual_keyboard_v1.h
@@ -9,7 +9,7 @@
 #ifndef WLR_TYPES_WLR_VIRTUAL_KEYBOARD_V1_H
 #define WLR_TYPES_WLR_VIRTUAL_KEYBOARD_V1_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/interfaces/wlr_input_device.h>
 #include <wlr/interfaces/wlr_keyboard.h>
 

--- a/include/wlr/types/wlr_xcursor_manager.h
+++ b/include/wlr/types/wlr_xcursor_manager.h
@@ -9,7 +9,7 @@
 #ifndef WLR_TYPES_WLR_XCURSOR_MANAGER_H
 #define WLR_TYPES_WLR_XCURSOR_MANAGER_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/xcursor.h>
 

--- a/include/wlr/types/wlr_xdg_decoration_v1.h
+++ b/include/wlr/types/wlr_xdg_decoration_v1.h
@@ -1,7 +1,7 @@
 #ifndef WLR_TYPES_WLR_XDG_DECORATION_V1
 #define WLR_TYPES_WLR_XDG_DECORATION_V1
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_xdg_shell.h>
 
 enum wlr_xdg_toplevel_decoration_v1_mode {

--- a/include/wlr/types/wlr_xdg_output_v1.h
+++ b/include/wlr/types/wlr_xdg_output_v1.h
@@ -8,7 +8,7 @@
 
 #ifndef WLR_TYPES_WLR_XDG_OUTPUT_V1_H
 #define WLR_TYPES_WLR_XDG_OUTPUT_V1_H
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_output_layout.h>
 
 struct wlr_xdg_output_v1 {

--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -10,7 +10,7 @@
 #define WLR_TYPES_WLR_XDG_SHELL_H
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_seat.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include "xdg-shell-protocol.h"
 
 struct wlr_xdg_shell {

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -14,7 +14,7 @@
 #ifndef WLR_TYPES_WLR_XDG_SHELL_V6_H
 #define WLR_TYPES_WLR_XDG_SHELL_V6_H
 
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_seat.h>
 #include "xdg-shell-unstable-v6-protocol.h"

--- a/include/wlr/util/region.h
+++ b/include/wlr/util/region.h
@@ -19,7 +19,7 @@
 
 #include <stdbool.h>
 #include <pixman.h>
-#include <wayland-server.h>
+#include <wayland-server-protocol.h>
 
 /**
  * Scales a region, ie. multiplies all its coordinates by `scale`.

--- a/meson.build
+++ b/meson.build
@@ -96,9 +96,6 @@ if cc.get_id() == 'clang'
 	add_project_arguments('-Wno-missing-braces', language: 'c')
 endif
 
-# Avoid wl_buffer deprecation warnings
-add_project_arguments('-DWL_HIDE_DEPRECATED', language: 'c')
-
 wayland_server = dependency('wayland-server', version: '>=1.16')
 wayland_client = dependency('wayland-client')
 wayland_egl    = dependency('wayland-egl')

--- a/rootston/input.c
+++ b/rootston/input.c
@@ -2,7 +2,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <time.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend/libinput.h>
 #include <wlr/config.h>
 #include <wlr/types/wlr_cursor.h>

--- a/rootston/keyboard.c
+++ b/rootston/keyboard.c
@@ -2,7 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend/session.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_pointer_constraints_v1.h>

--- a/rootston/layer_shell.c
+++ b/rootston/layer_shell.c
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_surface.h>
 #include <wlr/types/wlr_layer_shell_v1.h>

--- a/rootston/main.c
+++ b/rootston/main.c
@@ -2,7 +2,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/backend/headless.h>
 #include <wlr/backend/multi.h>

--- a/rootston/seat.c
+++ b/rootston/seat.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend/libinput.h>
 #include <wlr/config.h>
 #include <wlr/types/wlr_data_device.h>

--- a/rootston/xdg_shell.c
+++ b/rootston/xdg_shell.c
@@ -1,7 +1,7 @@
 #include <assert.h>
 #include <stdbool.h>
 #include <stdlib.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_surface.h>
 #include <wlr/types/wlr_xdg_shell.h>

--- a/rootston/xdg_shell_v6.c
+++ b/rootston/xdg_shell_v6.c
@@ -1,7 +1,7 @@
 #include <assert.h>
 #include <stdbool.h>
 #include <stdlib.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_surface.h>
 #include <wlr/types/wlr_xdg_shell_v6.h>

--- a/rootston/xwayland.c
+++ b/rootston/xwayland.c
@@ -1,7 +1,7 @@
 #include <assert.h>
 #include <stdbool.h>
 #include <stdlib.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/config.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_surface.h>

--- a/tinywl/tinywl.c
+++ b/tinywl/tinywl.c
@@ -5,7 +5,7 @@
 #include <stdio.h>
 #include <time.h>
 #include <unistd.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_cursor.h>

--- a/types/data_device/wlr_data_device.c
+++ b/types/data_device/wlr_data_device.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include <strings.h>
 #include <unistd.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/util/log.h>

--- a/types/data_device/wlr_data_offer.c
+++ b/types/data_device/wlr_data_offer.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <strings.h>
 #include <unistd.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/util/log.h>

--- a/types/data_device/wlr_data_source.c
+++ b/types/data_device/wlr_data_source.c
@@ -4,7 +4,7 @@
 #include <string.h>
 #include <strings.h>
 #include <unistd.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/util/log.h>

--- a/types/data_device/wlr_drag.c
+++ b/types/data_device/wlr_drag.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include <strings.h>
 #include <unistd.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/util/log.h>

--- a/types/seat/wlr_seat.c
+++ b/types/seat/wlr_seat.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_primary_selection.h>

--- a/types/seat/wlr_seat_keyboard.c
+++ b/types/seat/wlr_seat_keyboard.c
@@ -5,7 +5,7 @@
 #include <sys/mman.h>
 #include <time.h>
 #include <unistd.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_gtk_primary_selection.h>
 #include <wlr/types/wlr_input_device.h>

--- a/types/seat/wlr_seat_pointer.c
+++ b/types/seat/wlr_seat_pointer.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/util/log.h>
 #include "types/wlr_seat.h"

--- a/types/seat/wlr_seat_touch.c
+++ b/types/seat/wlr_seat_touch.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/util/log.h>
 #include "types/wlr_seat.h"

--- a/types/tablet_v2/wlr_tablet_v2.c
+++ b/types/tablet_v2/wlr_tablet_v2.c
@@ -5,7 +5,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <types/wlr_tablet_v2.h>
 #include <wlr/config.h>
 #include <wlr/types/wlr_seat.h>

--- a/types/wlr_compositor.c
+++ b/types/wlr_compositor.c
@@ -1,6 +1,6 @@
 #include <assert.h>
 #include <stdlib.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_region.h>
 #include <wlr/types/wlr_surface.h>

--- a/types/wlr_cursor.c
+++ b/types/wlr_cursor.c
@@ -2,7 +2,7 @@
 #include <limits.h>
 #include <math.h>
 #include <stdlib.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_output_layout.h>

--- a/types/wlr_gamma_control_v1.c
+++ b/types/wlr_gamma_control_v1.c
@@ -2,7 +2,7 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/interfaces/wlr_output.h>
 #include <wlr/types/wlr_gamma_control_v1.h>
 #include <wlr/types/wlr_output.h>

--- a/types/wlr_idle.c
+++ b/types/wlr_idle.c
@@ -1,7 +1,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_idle.h>
 #include <wlr/util/log.h>
 #include "idle-protocol.h"

--- a/types/wlr_idle_inhibit_v1.c
+++ b/types/wlr_idle_inhibit_v1.c
@@ -1,11 +1,11 @@
 #include <assert.h>
 #include <stdlib.h>
-#include <wlr/util/log.h>
 #include <util/signal.h>
-#include <wlr/types/wlr_surface.h>
+#include <wayland-server-core.h>
+#include <wayland-util.h>
 #include <wlr/types/wlr_idle_inhibit_v1.h>
-#include "wayland-util.h"
-#include "wayland-server.h"
+#include <wlr/types/wlr_surface.h>
+#include <wlr/util/log.h>
 #include "idle-inhibit-unstable-v1-protocol.h"
 
 static const struct zwp_idle_inhibit_manager_v1_interface idle_inhibit_impl;

--- a/types/wlr_input_device.c
+++ b/types/wlr_input_device.c
@@ -1,7 +1,7 @@
 #define _POSIX_C_SOURCE 200809L
 #include <stdlib.h>
 #include <string.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/interfaces/wlr_input_device.h>
 #include <wlr/interfaces/wlr_keyboard.h>
 #include <wlr/interfaces/wlr_pointer.h>

--- a/types/wlr_input_inhibitor.c
+++ b/types/wlr_input_inhibitor.c
@@ -1,7 +1,7 @@
 #include <assert.h>
 #include <stdbool.h>
 #include <stdlib.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include "wlr/types/wlr_input_inhibitor.h"
 #include "wlr-input-inhibitor-unstable-v1-protocol.h"
 #include "util/signal.h"

--- a/types/wlr_keyboard.c
+++ b/types/wlr_keyboard.c
@@ -2,7 +2,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/interfaces/wlr_keyboard.h>
 #include <wlr/types/wlr_keyboard.h>
 #include <wlr/util/log.h>

--- a/types/wlr_layer_shell_v1.c
+++ b/types/wlr_layer_shell_v1.c
@@ -2,7 +2,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_surface.h>

--- a/types/wlr_linux_dmabuf_v1.c
+++ b/types/wlr_linux_dmabuf_v1.c
@@ -3,7 +3,7 @@
 #include <drm_fourcc.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/render/drm_format_set.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_linux_dmabuf_v1.h>

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -4,7 +4,7 @@
 #include <string.h>
 #include <tgmath.h>
 #include <time.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/interfaces/wlr_output.h>
 #include <wlr/render/interface.h>
 #include <wlr/render/wlr_renderer.h>

--- a/types/wlr_output_damage.c
+++ b/types/wlr_output_damage.c
@@ -1,7 +1,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <time.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_output_damage.h>
 #include <wlr/types/wlr_output.h>

--- a/types/wlr_pointer.c
+++ b/types/wlr_pointer.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 #include <string.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/interfaces/wlr_pointer.h>
 #include <wlr/types/wlr_pointer.h>
 

--- a/types/wlr_pointer_constraints_v1.c
+++ b/types/wlr_pointer_constraints_v1.c
@@ -3,7 +3,7 @@
 #include <pixman.h>
 #include <stdbool.h>
 #include <stdlib.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_pointer_constraints_v1.h>
 #include <wlr/types/wlr_region.h>

--- a/types/wlr_pointer_gestures_v1.c
+++ b/types/wlr_pointer_gestures_v1.c
@@ -4,7 +4,7 @@
 
 #include <assert.h>
 #include <stdlib.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_pointer.h>
 #include <wlr/types/wlr_pointer_gestures_v1.h>
 #include <wlr/util/log.h>

--- a/types/wlr_region.c
+++ b/types/wlr_region.c
@@ -2,7 +2,7 @@
 #include <pixman.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_region.h>
 
 static void region_add(struct wl_client *client, struct wl_resource *resource,

--- a/types/wlr_relative_pointer_v1.c
+++ b/types/wlr_relative_pointer_v1.c
@@ -1,12 +1,12 @@
-#include <stdlib.h>
 #include <assert.h>
 #include <inttypes.h>
-#include <wlr/util/log.h>
+#include <stdlib.h>
 #include <util/signal.h>
+#include <wayland-server-core.h>
+#include <wayland-util.h>
 #include <wlr/types/wlr_relative_pointer_v1.h>
 #include <wlr/types/wlr_seat.h>
-#include "wayland-util.h"
-#include "wayland-server.h"
+#include <wlr/util/log.h>
 #include "relative-pointer-unstable-v1-protocol.h"
 
 #define RELATIVE_POINTER_MANAGER_VERSION 1

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -1,6 +1,6 @@
 #include <assert.h>
 #include <stdlib.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/render/interface.h>
 #include <wlr/types/wlr_buffer.h>
 #include <wlr/types/wlr_compositor.h>

--- a/types/wlr_switch.c
+++ b/types/wlr_switch.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 #include <string.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/interfaces/wlr_switch.h>
 #include <wlr/types/wlr_switch.h>
 

--- a/types/wlr_tablet_pad.c
+++ b/types/wlr_tablet_pad.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 #include <string.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/interfaces/wlr_tablet_pad.h>
 #include <wlr/types/wlr_tablet_pad.h>
 

--- a/types/wlr_tablet_tool.c
+++ b/types/wlr_tablet_tool.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 #include <string.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/interfaces/wlr_tablet_tool.h>
 #include <wlr/types/wlr_tablet_tool.h>
 

--- a/types/wlr_touch.c
+++ b/types/wlr_touch.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 #include <string.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/interfaces/wlr_touch.h>
 #include <wlr/types/wlr_touch.h>
 

--- a/util/log.c
+++ b/util/log.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/util/log.h>
 
 static bool colored = true;

--- a/xwayland/xwayland.c
+++ b/xwayland/xwayland.c
@@ -10,7 +10,7 @@
 #include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/util/log.h>
 #include <wlr/xwayland.h>
 #include "sockets.h"


### PR DESCRIPTION
The documentation for wayland-server.h says:

> Use of this header file is discouraged. Prefer including
> wayland-server-core.h instead, which does not include the server protocol
> header and as such only defines the library PI, excluding the deprecated API
> below.

Replacing wayland-server.h with wayland-server-core.h allows us to drop the
WL_HIDE_DEPRECATED declaration.