### PR TITLE
Fix issues with multi-monitors and screencopy/export-dmabuf 

### DIFF
--- a/include/wlr/types/wlr_screencopy_v1.h
+++ b/include/wlr/types/wlr_screencopy_v1.h
@@ -43,6 +43,8 @@ struct wlr_screencopy_frame_v1 {
 
 	struct wlr_output *output;
 	struct wl_listener output_precommit;
+	struct wl_listener output_destroy;
+	struct wl_listener output_enable;
 
 	void *data;
 };

--- a/types/wlr_export_dmabuf_v1.c
+++ b/types/wlr_export_dmabuf_v1.c
@@ -34,9 +34,11 @@ static void frame_destroy(struct wlr_export_dmabuf_frame_v1 *frame) {
 	if (frame == NULL) {
 		return;
 	}
-	wlr_output_lock_attach_render(frame->output, false);
-	if (frame->cursor_locked) {
-		wlr_output_lock_software_cursors(frame->output, false);
+	if (frame->output != NULL) {
+		wlr_output_lock_attach_render(frame->output, false);
+		if (frame->cursor_locked) {
+			wlr_output_lock_software_cursors(frame->output, false);
+		}
 	}
 	wl_list_remove(&frame->link);
 	wl_list_remove(&frame->output_precommit.link);
@@ -112,7 +114,7 @@ static void manager_handle_capture_output(struct wl_client *client,
 
 	wl_list_insert(&manager->frames, &frame->link);
 
-	if (!output->impl->export_dmabuf) {
+	if (output == NULL || !output->enabled || !output->impl->export_dmabuf) {
 		zwlr_export_dmabuf_frame_v1_send_cancel(frame->resource,
 			ZWLR_EXPORT_DMABUF_FRAME_V1_CANCEL_REASON_PERMANENT);
 		frame_destroy(frame);


### PR DESCRIPTION
This fixes 3 crashes and hangs I encountered in sway when testing the screencopy and export-dmabuf protocols with multi-monitor setups. These all require at least two monitors.

1. Run [grim](https://github.com/emersion/grim) with `WAYLAND_DEBUG=1` on an output that is disabled
    - Application hangs after `zwlr_screencopy_frame_v1_copy()`, no `failed()` or `ready()` event is sent
    - Expected: `failed()` event

2. Run `examples/dmabuf-capture` on an output
    - Run `swaymsg "output <name> disable"` on that output
    - Get a segfault in sway
    - Expected: permanent `cancel()` event

3. Run my [test application](https://gist.github.com/cyclopsian/57435c6fd0f34ec4a5b98bdcc2beb310) that copies the screen as fast as possible
    - Repeatedly disable and enable some outputs with swaymsg either manually or with [this script](https://gist.githubusercontent.com/cyclopsian/57435c6fd0f34ec4a5b98bdcc2beb310/raw/b62e5f375c635725817cf26c11967a8ea2db224b/toggle-output.sh) (requires jq)
    - After a few attempts at this, get a segfault in sway
    - Expected: `failed()` events to be sent for the disabled outputs