### PR TITLE
Send tablet tool frame on proximity_out

### DIFF
--- a/types/tablet_v2/wlr_tablet_v2_tool.c
+++ b/types/tablet_v2/wlr_tablet_v2_tool.c
@@ -398,6 +398,7 @@ void wlr_send_tablet_v2_tablet_tool_proximity_out(
 			send_tool_frame(tool->current_client);
 		}
 		zwp_tablet_tool_v2_send_proximity_out(tool->current_client->resource);
+		send_tool_frame(tool->current_client);
 
 		tool->current_client = NULL;
 		tool->focused_surface = NULL;


### PR DESCRIPTION
Tablet events, including `proximity_out`, are supposed to be grouped into frames. GTK will only "forget" a tool on the frame event after `proximity_out`. Not sending a frame event can cause a crash:

- have GTK >= 3.24.9
- launch a GTK app that likes to change cursors, e.g. gnome-terminal or tilix, on a HiDPI monitor
- interact with the app using a tablet
- start moving the mouse over the app
- GTK tries to reference the destroyed tablet tool, boom, crash in `wl_proxy_marshal` under `gdk_window_set_cursor`

(btw, I'm not sure about the `send_tool_frame` *above*, maybe having only this one is better?)