### PR TITLE
Revert "output: atomic mode"

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -328,9 +328,12 @@ static bool drm_connector_attach_render(struct wlr_output *output,
 	return make_drm_surface_current(&conn->crtc->primary->surf, buffer_age);
 }
 
-static bool drm_connector_commit_buffer(struct wlr_output *output) {
+static bool drm_connector_commit(struct wlr_output *output) {
 	struct wlr_drm_connector *conn = get_drm_connector_from_output(output);
 	struct wlr_drm_backend *drm = get_drm_backend_from_backend(output->backend);
+	if (!drm->session->active) {
+		return false;
+	}
 
 	struct wlr_drm_crtc *crtc = conn->crtc;
 	if (!crtc) {
@@ -398,37 +401,6 @@ static bool drm_connector_commit_buffer(struct wlr_output *output) {
 	}
 
 	wlr_output_update_enabled(output, true);
-	return true;
-}
-
-static bool drm_connector_commit(struct wlr_output *output) {
-	struct wlr_drm_backend *drm = get_drm_backend_from_backend(output->backend);
-
-	if (!drm->session->active) {
-		return false;
-	}
-
-	if (output->pending.committed & WLR_OUTPUT_STATE_ENABLED) {
-		if (!enable_drm_connector(output, output->pending.enabled)) {
-			return false;
-		}
-	}
-
-	if (output->pending.committed & WLR_OUTPUT_STATE_MODE) {
-		if (output->pending.mode_type != WLR_OUTPUT_STATE_MODE_FIXED) {
-			return false;
-		}
-		if (!drm_connector_set_mode(output, output->pending.mode)) {
-			return false;
-		}
-	}
-
-	if (output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
-		if (!drm_connector_commit_buffer(output)) {
-			return false;
-		}
-	}
-
 	return true;
 }
 
@@ -950,6 +922,8 @@ static void drm_connector_destroy(struct wlr_output *output) {
 }
 
 static const struct wlr_output_impl output_impl = {
+	.enable = enable_drm_connector,
+	.set_mode = drm_connector_set_mode,
 	.set_cursor = drm_connector_set_cursor,
 	.move_cursor = drm_connector_move_cursor,
 	.destroy = drm_connector_destroy,

--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -58,26 +58,8 @@ static bool output_attach_render(struct wlr_output *wlr_output,
 }
 
 static bool output_commit(struct wlr_output *wlr_output) {
-	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_ENABLED) {
-		wlr_log(WLR_DEBUG, "Cannot disable a headless output");
-		return false;
-	}
-
-	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_MODE) {
-		assert(wlr_output->pending.mode_type == WLR_OUTPUT_STATE_MODE_CUSTOM);
-		if (!output_set_custom_mode(wlr_output,
-				wlr_output->pending.custom_mode.width,
-				wlr_output->pending.custom_mode.height,
-				wlr_output->pending.custom_mode.refresh)) {
-			return false;
-		}
-	}
-
-	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
-		// Nothing needs to be done for pbuffers
-		wlr_output_send_present(wlr_output, NULL);
-	}
-
+	// Nothing needs to be done for pbuffers
+	wlr_output_send_present(wlr_output, NULL);
 	return true;
 }
 
@@ -94,6 +76,7 @@ static void output_destroy(struct wlr_output *wlr_output) {
 }
 
 static const struct wlr_output_impl output_impl = {
+	.set_custom_mode = output_set_custom_mode,
 	.destroy = output_destroy,
 	.attach_render = output_attach_render,
 	.commit = output_commit,

--- a/backend/noop/output.c
+++ b/backend/noop/output.c
@@ -12,30 +12,19 @@ static struct wlr_noop_output *noop_output_from_output(
 	return (struct wlr_noop_output *)wlr_output;
 }
 
+static bool output_set_custom_mode(struct wlr_output *wlr_output,
+		int32_t width, int32_t height, int32_t refresh) {
+	wlr_output_update_custom_mode(wlr_output, width, height, refresh);
+	return true;
+}
+
 static bool output_attach_render(struct wlr_output *wlr_output,
 		int *buffer_age) {
 	return false;
 }
 
 static bool output_commit(struct wlr_output *wlr_output) {
-	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_ENABLED) {
-		wlr_log(WLR_DEBUG, "Cannot disable a noop output");
-		return false;
-	}
-
-	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_MODE) {
-		assert(wlr_output->pending.mode_type == WLR_OUTPUT_STATE_MODE_CUSTOM);
-		wlr_output_update_custom_mode(wlr_output,
-			wlr_output->pending.custom_mode.width,
-			wlr_output->pending.custom_mode.height,
-			wlr_output->pending.custom_mode.refresh);
-	}
-
-	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
-		return false;
-	}
-
-	return true;
+	return false;
 }
 
 static void output_destroy(struct wlr_output *wlr_output) {
@@ -48,6 +37,7 @@ static void output_destroy(struct wlr_output *wlr_output) {
 }
 
 static const struct wlr_output_impl output_impl = {
+	.set_custom_mode = output_set_custom_mode,
 	.destroy = output_destroy,
 	.attach_render = output_attach_render,
 	.commit = output_commit,

--- a/backend/rdp/output.c
+++ b/backend/rdp/output.c
@@ -166,9 +166,9 @@ static bool nsc_swap_buffers(
 	return true;
 }
 
-static bool output_commit_buffer(struct wlr_rdp_output *output) {
-	struct wlr_output *wlr_output = &output->wlr_output;
-
+static bool output_commit(struct wlr_output *wlr_output) {
+	struct wlr_rdp_output *output =
+		rdp_output_from_output(wlr_output);
 	bool ret = false;
 
 	pixman_region32_t output_region;
@@ -220,33 +220,6 @@ out:
 	return ret;
 }
 
-static bool output_commit(struct wlr_output *wlr_output) {
-	struct wlr_rdp_output *output = rdp_output_from_output(wlr_output);
-
-	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_ENABLED) {
-		wlr_log(WLR_DEBUG, "Cannot disable an RDP output");
-		return false;
-	}
-
-	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_MODE) {
-		assert(wlr_output->pending.mode_type == WLR_OUTPUT_STATE_MODE_CUSTOM);
-		if (!output_set_custom_mode(wlr_output,
-				wlr_output->pending.custom_mode.width,
-				wlr_output->pending.custom_mode.height,
-				wlr_output->pending.custom_mode.refresh)) {
-			return false;
-		}
-	}
-
-	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
-		if (!output_commit_buffer(output)) {
-			return false;
-		}
-	}
-
-	return true;
-}
-
 static void output_destroy(struct wlr_output *wlr_output) {
 	struct wlr_rdp_output *output =
 		rdp_output_from_output(wlr_output);
@@ -261,6 +234,7 @@ static void output_destroy(struct wlr_output *wlr_output) {
 }
 
 static const struct wlr_output_impl output_impl = {
+	.set_custom_mode = output_set_custom_mode,
 	.destroy = output_destroy,
 	.attach_render = output_attach_render,
 	.commit = output_commit,

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -103,38 +103,21 @@ static bool output_commit(struct wlr_output *wlr_output) {
 	struct wlr_x11_output *output = get_x11_output_from_output(wlr_output);
 	struct wlr_x11_backend *x11 = output->x11;
 
-	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_ENABLED) {
-		wlr_log(WLR_DEBUG, "Cannot disable an X11 output");
+	pixman_region32_t *damage = NULL;
+	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_DAMAGE) {
+		damage = &wlr_output->pending.damage;
+	}
+
+	if (!wlr_egl_swap_buffers(&x11->egl, output->surf, damage)) {
 		return false;
 	}
 
-	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_MODE) {
-		assert(wlr_output->pending.mode_type == WLR_OUTPUT_STATE_MODE_CUSTOM);
-		if (!output_set_custom_mode(wlr_output,
-				wlr_output->pending.custom_mode.width,
-				wlr_output->pending.custom_mode.height,
-				wlr_output->pending.custom_mode.refresh)) {
-			return false;
-		}
-	}
-
-	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
-		pixman_region32_t *damage = NULL;
-		if (wlr_output->pending.committed & WLR_OUTPUT_STATE_DAMAGE) {
-			damage = &wlr_output->pending.damage;
-		}
-
-		if (!wlr_egl_swap_buffers(&x11->egl, output->surf, damage)) {
-			return false;
-		}
-
-		wlr_output_send_present(wlr_output, NULL);
-	}
-
+	wlr_output_send_present(wlr_output, NULL);
 	return true;
 }
 
 static const struct wlr_output_impl output_impl = {
+	.set_custom_mode = output_set_custom_mode,
 	.destroy = output_destroy,
 	.attach_render = output_attach_render,
 	.commit = output_commit,

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -15,6 +15,10 @@
 #include <wlr/types/wlr_output.h>
 
 struct wlr_output_impl {
+	bool (*enable)(struct wlr_output *output, bool enable);
+	bool (*set_mode)(struct wlr_output *output, struct wlr_output_mode *mode);
+	bool (*set_custom_mode)(struct wlr_output *output, int32_t width,
+		int32_t height, int32_t refresh);
 	bool (*set_cursor)(struct wlr_output *output, struct wlr_texture *texture,
 		int32_t scale, enum wl_output_transform transform,
 		int32_t hotspot_x, int32_t hotspot_y, bool update_texture);

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -49,20 +49,11 @@ struct wlr_output_cursor {
 enum wlr_output_state_field {
 	WLR_OUTPUT_STATE_BUFFER = 1 << 0,
 	WLR_OUTPUT_STATE_DAMAGE = 1 << 1,
-	WLR_OUTPUT_STATE_MODE = 1 << 2,
-	WLR_OUTPUT_STATE_ENABLED = 1 << 3,
-	WLR_OUTPUT_STATE_SCALE = 1 << 4,
-	WLR_OUTPUT_STATE_TRANSFORM = 1 << 5,
 };
 
 enum wlr_output_state_buffer_type {
 	WLR_OUTPUT_STATE_BUFFER_RENDER,
 	WLR_OUTPUT_STATE_BUFFER_SCANOUT,
-};
-
-enum wlr_output_state_mode_type {
-	WLR_OUTPUT_STATE_MODE_FIXED,
-	WLR_OUTPUT_STATE_MODE_CUSTOM,
 };
 
 /**
@@ -71,21 +62,10 @@ enum wlr_output_state_mode_type {
 struct wlr_output_state {
 	uint32_t committed; // enum wlr_output_state_field
 	pixman_region32_t damage; // output-buffer-local coordinates
-	bool enabled;
-	float scale;
-	enum wl_output_transform transform;
 
 	// only valid if WLR_OUTPUT_STATE_BUFFER
 	enum wlr_output_state_buffer_type buffer_type;
 	struct wlr_buffer *buffer; // if WLR_OUTPUT_STATE_BUFFER_SCANOUT
-
-	// only valid if WLR_OUTPUT_STATE_MODE
-	enum wlr_output_state_mode_type mode_type;
-	struct wlr_output_mode *mode;
-	struct {
-		int32_t width, height;
-		int32_t refresh; // mHz, may be zero
-	} custom_mode;
 };
 
 struct wlr_output_impl;
@@ -203,11 +183,8 @@ struct wlr_surface;
 /**
  * Enables or disables the output. A disabled output is turned off and doesn't
  * emit `frame` events.
- *
- * Whether an output is enabled is double-buffered state, see
- * `wlr_output_commit`.
  */
-void wlr_output_enable(struct wlr_output *output, bool enable);
+bool wlr_output_enable(struct wlr_output *output, bool enable);
 void wlr_output_create_global(struct wlr_output *output);
 void wlr_output_destroy_global(struct wlr_output *output);
 /**
@@ -217,31 +194,17 @@ void wlr_output_destroy_global(struct wlr_output *output);
 struct wlr_output_mode *wlr_output_preferred_mode(struct wlr_output *output);
 /**
  * Sets the output mode. Enables the output if it's currently disabled.
- *
- * Mode is double-buffered state, see `wlr_output_commit`.
  */
-void wlr_output_set_mode(struct wlr_output *output,
+bool wlr_output_set_mode(struct wlr_output *output,
 	struct wlr_output_mode *mode);
 /**
  * Sets a custom mode on the output. If modes are available, they are preferred.
  * Setting `refresh` to zero lets the backend pick a preferred value.
- *
- * Custom mode is double-buffered state, see `wlr_output_commit`.
  */
-void wlr_output_set_custom_mode(struct wlr_output *output, int32_t width,
+bool wlr_output_set_custom_mode(struct wlr_output *output, int32_t width,
 	int32_t height, int32_t refresh);
-/**
- * Sets a transform for the output.
- *
- * Transform is double-buffered state, see `wlr_output_commit`.
- */
 void wlr_output_set_transform(struct wlr_output *output,
 	enum wl_output_transform transform);
-/**
- * Sets a scale for the output.
- *
- * Scale is double-buffered state, see `wlr_output_commit`.
- */
 void wlr_output_set_scale(struct wlr_output *output, float scale);
 void wlr_output_set_subpixel(struct wlr_output *output,
 	enum wl_output_subpixel subpixel);
@@ -299,8 +262,9 @@ void wlr_output_set_damage(struct wlr_output *output,
 	pixman_region32_t *damage);
 /**
  * Commit the pending output state. If `wlr_output_attach_render` has been
- * called, the pending frame will be submitted for display and a `frame` event
- * will be scheduled.
+ * called, the pending frame will be submitted for display.
+ *
+ * This function schedules a `frame` event.
  */
 bool wlr_output_commit(struct wlr_output *output);
 /**

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -470,10 +470,8 @@ void handle_output_manager_apply(struct wl_listener *listener, void *data) {
 	wl_list_for_each(config_head, &config->heads, link) {
 		struct wlr_output *wlr_output = config_head->state.output;
 		if (!config_head->state.enabled) {
-			wlr_output_enable(wlr_output, false);
+			ok &= wlr_output_enable(wlr_output, false);
 			wlr_output_layout_remove(desktop->layout, wlr_output);
-
-			ok &= wlr_output_commit(wlr_output);
 		}
 	}
 
@@ -483,12 +481,11 @@ void handle_output_manager_apply(struct wl_listener *listener, void *data) {
 		if (!config_head->state.enabled) {
 			continue;
 		}
-
-		wlr_output_enable(wlr_output, true);
+		ok &= wlr_output_enable(wlr_output, true);
 		if (config_head->state.mode != NULL) {
-			wlr_output_set_mode(wlr_output, config_head->state.mode);
+			ok &= wlr_output_set_mode(wlr_output, config_head->state.mode);
 		} else {
-			wlr_output_set_custom_mode(wlr_output,
+			ok &= wlr_output_set_custom_mode(wlr_output,
 				config_head->state.custom_mode.width,
 				config_head->state.custom_mode.height,
 				config_head->state.custom_mode.refresh);
@@ -497,8 +494,6 @@ void handle_output_manager_apply(struct wl_listener *listener, void *data) {
 			config_head->state.x, config_head->state.y);
 		wlr_output_set_transform(wlr_output, config_head->state.transform);
 		wlr_output_set_scale(wlr_output, config_head->state.scale);
-
-		ok &= wlr_output_commit(wlr_output);
 	}
 
 	if (ok) {
@@ -679,7 +674,6 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 		}
 		wlr_output_layout_add_auto(desktop->layout, wlr_output);
 	}
-	wlr_output_commit(wlr_output);
 
 	struct roots_seat *seat;
 	wl_list_for_each(seat, &input->seats, link) {


### PR DESCRIPTION
This reverts commit ee5f98ad49fed0439f3313ec685307831d1d1d05.

This intoduced problems where outputs could not be turned off because
they had flips pending.