### PR TITLE
rootston: cursor: call pointer_notify_enter before pointer_notify_button

### DIFF
--- a/rootston/cursor.c
+++ b/rootston/cursor.c
@@ -300,6 +300,7 @@ static void roots_cursor_press_button(struct roots_cursor *cursor,
 	}
 
 	if (!is_touch) {
+		wlr_seat_pointer_notify_enter(seat->seat, surface, sx, sy);
 		wlr_seat_pointer_notify_button(seat->seat, time, button, state);
 	}
 }


### PR DESCRIPTION
This fixes issues with pointer hover not being registered after exiting xdg_popup grab - without this, the window underneath doesn't notice the pointer (and button clicks) until it gets slightly moved.