### PR TITLE
Patches

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -7,6 +7,7 @@
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 #include <inttypes.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1427,7 +1428,7 @@ int handle_drm_event(int fd, uint32_t mask, void *data) {
 }
 
 void restore_drm_outputs(struct wlr_drm_backend *drm) {
-	uint64_t to_close = (1L << wl_list_length(&drm->outputs)) - 1;
+	uint64_t to_close = (UINT64_C(1) << wl_list_length(&drm->outputs)) - 1;
 
 	struct wlr_drm_connector *conn;
 	wl_list_for_each(conn, &drm->outputs, link) {
@@ -1444,7 +1445,7 @@ void restore_drm_outputs(struct wlr_drm_backend *drm) {
 		struct wlr_drm_connector *conn;
 		wl_list_for_each(conn, &drm->outputs, link) {
 			if (conn->state != WLR_DRM_CONN_CLEANUP || !conn->pageflip_pending) {
-				to_close &= ~(1 << i);
+				to_close &= ~(UINT64_C(1) << i);
 			}
 			i++;
 		}

--- a/backend/session/logind.c
+++ b/backend/session/logind.c
@@ -258,6 +258,7 @@ static struct wlr_device *find_device(struct wlr_session *session,
 	wlr_log(WLR_ERROR, "Tried to use dev_t %lu not opened by session",
 		(unsigned long)devnum);
 	assert(0);
+	return NULL;
 }
 
 static int pause_device(sd_bus_message *msg, void *userdata,

--- a/backend/session/session.c
+++ b/backend/session/session.c
@@ -197,6 +197,7 @@ static struct wlr_device *find_device(struct wlr_session *session, int fd) {
 
 	wlr_log(WLR_ERROR, "Tried to use fd %d not opened by session", fd);
 	assert(0);
+	return NULL;
 }
 
 void wlr_session_close_file(struct wlr_session *session, int fd) {

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -319,7 +319,7 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *wlr_backend) {
 		output->zxdg_toplevel_decoration_v1 =
 			zxdg_decoration_manager_v1_get_toplevel_decoration(
 			backend->zxdg_decoration_manager_v1, output->xdg_toplevel);
-		if (!output->xdg_toplevel) {
+		if (!output->zxdg_toplevel_decoration_v1) {
 			wlr_log_errno(WLR_ERROR, "Could not get xdg toplevel decoration");
 			goto error;
 		}

--- a/examples/text-input.c
+++ b/examples/text-input.c
@@ -137,8 +137,7 @@ static void show_status(void) {
 		goto end;
 	}
 
-	if ((unsigned)current.preedit.cursor_begin > strlen(preedit_text)
-			|| (unsigned)current.preedit.cursor_begin > strlen(preedit_text)) {
+	if ((unsigned)current.preedit.cursor_begin > strlen(preedit_text)) {
 		printf("Cursor out of bounds\n");
 		goto end;
 	}

--- a/render/drm_format_set.c
+++ b/render/drm_format_set.c
@@ -60,7 +60,7 @@ bool wlr_drm_format_set_add(struct wlr_drm_format_set *set, uint32_t format,
 	struct wlr_drm_format **ptr = format_set_get_ref(set, format);
 
 	if (ptr) {
-		struct wlr_drm_format *fmt = *ptr;
+		struct wlr_drm_format *fmt = *ptr, *newfmt = NULL;
 
 		if (modifier == DRM_FORMAT_MOD_INVALID) {
 			return true;
@@ -75,17 +75,17 @@ bool wlr_drm_format_set_add(struct wlr_drm_format_set *set, uint32_t format,
 		if (fmt->len == fmt->cap) {
 			size_t cap = fmt->cap ? fmt->cap * 2 : 4;
 
-			fmt = realloc(fmt, sizeof(*fmt) + sizeof(fmt->modifiers[0]) * cap);
-			if (!fmt) {
+			newfmt = realloc(fmt, sizeof(*fmt) + sizeof(fmt->modifiers[0]) * cap);
+			if (!newfmt) {
 				wlr_log_errno(WLR_ERROR, "Allocation failed");
 				return false;
 			}
 
-			fmt->cap = cap;
-			*ptr = fmt;
+			newfmt->cap = cap;
+			*ptr = newfmt;
 		}
 
-		fmt->modifiers[fmt->len++] = modifier;
+		newfmt->modifiers[newfmt->len++] = modifier;
 		return true;
 	}
 

--- a/types/wlr_data_control_v1.c
+++ b/types/wlr_data_control_v1.c
@@ -300,6 +300,7 @@ static struct wl_resource *create_offer(struct wlr_data_control_device_v1 *devic
 	struct wl_resource *resource = wl_resource_create(client,
 		&zwlr_data_control_offer_v1_interface, version, 0);
 	if (resource == NULL) {
+		free(offer);
 		return NULL;
 	}
 

--- a/types/wlr_output_layout.c
+++ b/types/wlr_output_layout.c
@@ -437,8 +437,8 @@ struct wlr_output *wlr_output_layout_get_center_output(
 	}
 
 	struct wlr_box *extents = wlr_output_layout_get_box(layout, NULL);
-	double center_x = extents->width / 2 + extents->x;
-	double center_y = extents->height / 2 + extents->y;
+	double center_x = extents->width / 2. + extents->x;
+	double center_y = extents->height / 2. + extents->y;
 
 	double dest_x = 0, dest_y = 0;
 	wlr_output_layout_closest_point(layout, NULL, center_x, center_y,

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -828,10 +828,6 @@ static void subsurface_consider_map(struct wlr_subsurface *subsurface,
 	}
 
 	// Now we can map the subsurface
-	if (subsurface->mapped) {
-		return;
-	}
-
 	wlr_signal_emit_safe(&subsurface->events.map, subsurface);
 	subsurface->mapped = true;
 

--- a/types/xdg_shell/wlr_xdg_positioner.c
+++ b/types/xdg_shell/wlr_xdg_positioner.c
@@ -222,20 +222,16 @@ struct wlr_box wlr_xdg_positioner_get_geometry(
 	if (positioner_gravity_has_edge(positioner->gravity,
 			XDG_POSITIONER_GRAVITY_TOP)) {
 		geometry.y -= geometry.height;
-	} else if (positioner_gravity_has_edge(positioner->gravity,
+	} else if (!positioner_gravity_has_edge(positioner->gravity,
 			XDG_POSITIONER_GRAVITY_BOTTOM)) {
-		geometry.y = geometry.y;
-	} else {
 		geometry.y -= geometry.height / 2;
 	}
 
 	if (positioner_gravity_has_edge(positioner->gravity,
 			XDG_POSITIONER_GRAVITY_LEFT)) {
 		geometry.x -= geometry.width;
-	} else if (positioner_gravity_has_edge(positioner->gravity,
+	} else if (!positioner_gravity_has_edge(positioner->gravity,
 			XDG_POSITIONER_GRAVITY_RIGHT)) {
-		geometry.x = geometry.x;
-	} else {
 		geometry.x -= geometry.width / 2;
 	}
 

--- a/types/xdg_shell_v6/wlr_xdg_positioner_v6.c
+++ b/types/xdg_shell_v6/wlr_xdg_positioner_v6.c
@@ -154,17 +154,13 @@ struct wlr_box wlr_xdg_positioner_v6_get_geometry(
 
 	if (positioner->gravity & ZXDG_POSITIONER_V6_GRAVITY_TOP) {
 		geometry.y -= geometry.height;
-	} else if (positioner->gravity & ZXDG_POSITIONER_V6_GRAVITY_BOTTOM) {
-		geometry.y = geometry.y;
-	} else {
+	} else if (!(positioner->gravity & ZXDG_POSITIONER_V6_GRAVITY_BOTTOM)) {
 		geometry.y -= geometry.height / 2;
 	}
 
 	if (positioner->gravity & ZXDG_POSITIONER_V6_GRAVITY_LEFT) {
 		geometry.x -= geometry.width;
-	} else if (positioner->gravity & ZXDG_POSITIONER_V6_GRAVITY_RIGHT) {
-		geometry.x = geometry.x;
-	} else {
+	} else if (!(positioner->gravity & ZXDG_POSITIONER_V6_GRAVITY_RIGHT)) {
 		geometry.x -= geometry.width / 2;
 	}
 

--- a/util/region.c
+++ b/util/region.c
@@ -218,7 +218,7 @@ static void region_confine(pixman_region32_t *region, double x1, double y1, doub
 		bool bordering_x = x == box.x1 || x == box.x2 - 1;
 		bool bordering_y = y == box.y1 || y == box.y2 - 1;
 
-		if ((bordering_x && bordering_y) || (!bordering_x && !bordering_y)) {
+		if (bordering_x == bordering_y) {
 			double x2_potential, y2_potential;
 			double tmp1, tmp2;
 			region_confine(region, x, y, x, y2, &tmp1, &y2_potential, box);

--- a/xcursor/wlr_xcursor.c
+++ b/xcursor/wlr_xcursor.c
@@ -196,15 +196,17 @@ static void load_callback(XcursorImages *images, void *data) {
 	cursor = xcursor_create_from_xcursor_images(images, theme);
 
 	if (cursor) {
+		struct wlr_xcursor **cursors;
 		theme->cursor_count++;
-		theme->cursors =
+		cursors =
 			realloc(theme->cursors,
 				theme->cursor_count * sizeof(theme->cursors[0]));
 
-		if (theme->cursors == NULL) {
+		if (cursors == NULL) {
 			theme->cursor_count--;
 			free(cursor);
 		} else {
+			theme->cursors = cursors;
 			theme->cursors[theme->cursor_count - 1] = cursor;
 		}
 	}

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -291,7 +291,7 @@ static void xwm_surface_activate(struct wlr_xwm *xwm,
 
 static void xsurface_set_net_wm_state(struct wlr_xwayland_surface *xsurface) {
 	struct wlr_xwm *xwm = xsurface->xwm;
-	uint32_t property[3];
+	uint32_t property[4];
 	int i;
 
 	i = 0;


### PR DESCRIPTION
Hello,
This is a bunch of patches for bugs reported by [PVS-Studio](https://www.viva64.com/en/pvs-studio/).

If realloc fails, the whole array is lost.
cd1e96e8: xcursor: avoid leak and loss of all cursors if cursors realloc fails
b894c55c: render/drm: keep old drm_format if realloc fails

Remove dead code and trivial fixes.
cd91349c: backend/session: non-void function should return a value
364c7913: xdg_shell: remove variable self-assignment
af02f97a: wlr_surface: condition is always false
a1c2bc22: Simplify check
96fa3c2e: Fix memory leak

There are also around 20 reports for `calloc`, `strdup` calls that are not checked for possible null returns. I don’t know how serious you are about enforcing this kind of checks, so I did not make a patch for it.

See inline for comments on the other commits.

PVS-Studio also reports two errors that I'm not sure how to fix:
- There are identical sub-expressions  `(unsigned) current.preedit.cursor_begin > strlen(preedit_text)` to  the left and to the right of the `||` operator.
  https://github.com/swaywm/wlroots/blob/58b2584863201f32d1a4770a1d5cde5e57b300c6/examples/text-input.c#L140-L141
  *Edit: fixed in baffb90: examples: remove duplicated condition*
 
- The `surface` pointer was utilized before it was verified against nullptr. Check lines: 272, 280.
  https://github.com/swaywm/wlroots/blob/58b2584863201f32d1a4770a1d5cde5e57b300c6/types/seat/wlr_seat_keyboard.c#L272

Thanks for the great work!