### PR TITLE
wlr_xdg_toplevel: reparent on parent unmap

### DIFF
--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -117,8 +117,10 @@ struct wlr_xdg_toplevel_state {
 struct wlr_xdg_toplevel {
 	struct wl_resource *resource;
 	struct wlr_xdg_surface *base;
-	struct wlr_xdg_surface *parent;
 	bool added;
+
+	struct wlr_xdg_surface *parent;
+	struct wl_listener parent_unmap;
 
 	struct wlr_xdg_toplevel_state client_pending;
 	struct wlr_xdg_toplevel_state server_pending;

--- a/types/xdg_shell/wlr_xdg_surface.c
+++ b/types/xdg_shell/wlr_xdg_surface.c
@@ -41,6 +41,10 @@ void unmap_xdg_surface(struct wlr_xdg_surface *surface) {
 
 	switch (surface->role) {
 	case WLR_XDG_SURFACE_ROLE_TOPLEVEL:
+		if (surface->toplevel->parent) {
+			wl_list_remove(&surface->toplevel->parent_unmap.link);
+			surface->toplevel->parent = NULL;
+		}
 		free(surface->toplevel->title);
 		surface->toplevel->title = NULL;
 		free(surface->toplevel->app_id);


### PR DESCRIPTION
Fixes  swaywm/sway#4421

[From the xdg-shell specification:](https://github.com/wayland-project/wayland-protocols/blob/630fb089103a1d0eab1a684b853ab5c4d2b252aa/stable/xdg-shell/xdg-shell.xml#L555)

	If the parent is unmapped then its children are managed as
	though the parent of the now-unmapped parent has become the
	parent of this surface. If no parent exists for the now-unmapped
	parent then the children are managed as though they have no
	parent surface.