### PR TITLE
backend: touch: Assign good ids to single touch devices

### DIFF
--- a/backend/libinput/touch.c
+++ b/backend/libinput/touch.c
@@ -34,7 +34,7 @@ void handle_touch_down(struct libinput_event *event,
 	wlr_event.device = wlr_dev;
 	wlr_event.time_msec =
 		usec_to_msec(libinput_event_touch_get_time_usec(tevent));
-	wlr_event.touch_id = libinput_event_touch_get_slot(tevent);
+	wlr_event.touch_id = libinput_event_touch_get_seat_slot(tevent);
 	wlr_event.x = libinput_event_touch_get_x_transformed(tevent, 1);
 	wlr_event.y = libinput_event_touch_get_y_transformed(tevent, 1);
 	wlr_signal_emit_safe(&wlr_dev->touch->events.down, &wlr_event);


### PR DESCRIPTION
libinput_event_touch_get_slot always returns -1 for single touch devices. Using
libinput_event_touch_get_seat_slot instead ensures that they are assigned actual
slot ids.

Also, this is what Weston does, so this change yields a more consistent
behaviour between different compositors.