### PR TITLE
output: re-introduce atomic mode, enabled, scale and transform

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -422,12 +422,6 @@ static bool drm_connector_commit(struct wlr_output *output) {
 		return false;
 	}
 
-	if (output->pending.committed & WLR_OUTPUT_STATE_ENABLED) {
-		if (!enable_drm_connector(output, output->pending.enabled)) {
-			return false;
-		}
-	}
-
 	if (output->pending.committed & WLR_OUTPUT_STATE_MODE) {
 		switch (output->pending.mode_type) {
 		case WLR_OUTPUT_STATE_MODE_FIXED:
@@ -443,6 +437,12 @@ static bool drm_connector_commit(struct wlr_output *output) {
 				return false;
 			}
 			break;
+		}
+	}
+
+	if (output->pending.committed & WLR_OUTPUT_STATE_ENABLED) {
+		if (!enable_drm_connector(output, output->pending.enabled)) {
+			return false;
 		}
 	}
 

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -446,7 +446,9 @@ static bool drm_connector_commit(struct wlr_output *output) {
 		}
 	}
 
-	if (output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
+	// TODO: support modesetting with a buffer
+	if (output->pending.committed & WLR_OUTPUT_STATE_BUFFER &&
+			!(output->pending.committed & WLR_OUTPUT_STATE_MODE)) {
 		if (!drm_connector_commit_buffer(output)) {
 			return false;
 		}

--- a/backend/noop/output.c
+++ b/backend/noop/output.c
@@ -12,19 +12,30 @@ static struct wlr_noop_output *noop_output_from_output(
 	return (struct wlr_noop_output *)wlr_output;
 }
 
-static bool output_set_custom_mode(struct wlr_output *wlr_output,
-		int32_t width, int32_t height, int32_t refresh) {
-	wlr_output_update_custom_mode(wlr_output, width, height, refresh);
-	return true;
-}
-
 static bool output_attach_render(struct wlr_output *wlr_output,
 		int *buffer_age) {
 	return false;
 }
 
 static bool output_commit(struct wlr_output *wlr_output) {
-	return false;
+	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_ENABLED) {
+		wlr_log(WLR_DEBUG, "Cannot disable a noop output");
+		return false;
+	}
+
+	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_MODE) {
+		assert(wlr_output->pending.mode_type == WLR_OUTPUT_STATE_MODE_CUSTOM);
+		wlr_output_update_custom_mode(wlr_output,
+			wlr_output->pending.custom_mode.width,
+			wlr_output->pending.custom_mode.height,
+			wlr_output->pending.custom_mode.refresh);
+	}
+
+	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
+		return false;
+	}
+
+	return true;
 }
 
 static void output_destroy(struct wlr_output *wlr_output) {
@@ -37,7 +48,6 @@ static void output_destroy(struct wlr_output *wlr_output) {
 }
 
 static const struct wlr_output_impl output_impl = {
-	.set_custom_mode = output_set_custom_mode,
 	.destroy = output_destroy,
 	.attach_render = output_attach_render,
 	.commit = output_commit,

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -15,10 +15,6 @@
 #include <wlr/types/wlr_output.h>
 
 struct wlr_output_impl {
-	bool (*enable)(struct wlr_output *output, bool enable);
-	bool (*set_mode)(struct wlr_output *output, struct wlr_output_mode *mode);
-	bool (*set_custom_mode)(struct wlr_output *output, int32_t width,
-		int32_t height, int32_t refresh);
 	bool (*set_cursor)(struct wlr_output *output, struct wlr_texture *texture,
 		int32_t scale, enum wl_output_transform transform,
 		int32_t hotspot_x, int32_t hotspot_y, bool update_texture);

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -49,11 +49,20 @@ struct wlr_output_cursor {
 enum wlr_output_state_field {
 	WLR_OUTPUT_STATE_BUFFER = 1 << 0,
 	WLR_OUTPUT_STATE_DAMAGE = 1 << 1,
+	WLR_OUTPUT_STATE_MODE = 1 << 2,
+	WLR_OUTPUT_STATE_ENABLED = 1 << 3,
+	WLR_OUTPUT_STATE_SCALE = 1 << 4,
+	WLR_OUTPUT_STATE_TRANSFORM = 1 << 5,
 };
 
 enum wlr_output_state_buffer_type {
 	WLR_OUTPUT_STATE_BUFFER_RENDER,
 	WLR_OUTPUT_STATE_BUFFER_SCANOUT,
+};
+
+enum wlr_output_state_mode_type {
+	WLR_OUTPUT_STATE_MODE_FIXED,
+	WLR_OUTPUT_STATE_MODE_CUSTOM,
 };
 
 /**
@@ -62,10 +71,21 @@ enum wlr_output_state_buffer_type {
 struct wlr_output_state {
 	uint32_t committed; // enum wlr_output_state_field
 	pixman_region32_t damage; // output-buffer-local coordinates
+	bool enabled;
+	float scale;
+	enum wl_output_transform transform;
 
 	// only valid if WLR_OUTPUT_STATE_BUFFER
 	enum wlr_output_state_buffer_type buffer_type;
 	struct wlr_buffer *buffer; // if WLR_OUTPUT_STATE_BUFFER_SCANOUT
+
+	// only valid if WLR_OUTPUT_STATE_MODE
+	enum wlr_output_state_mode_type mode_type;
+	struct wlr_output_mode *mode;
+	struct {
+		int32_t width, height;
+		int32_t refresh; // mHz, may be zero
+	} custom_mode;
 };
 
 struct wlr_output_impl;
@@ -189,8 +209,11 @@ struct wlr_surface;
 /**
  * Enables or disables the output. A disabled output is turned off and doesn't
  * emit `frame` events.
+ *
+ * Whether an output is enabled is double-buffered state, see
+ * `wlr_output_commit`.
  */
-bool wlr_output_enable(struct wlr_output *output, bool enable);
+void wlr_output_enable(struct wlr_output *output, bool enable);
 void wlr_output_create_global(struct wlr_output *output);
 void wlr_output_destroy_global(struct wlr_output *output);
 /**
@@ -200,17 +223,31 @@ void wlr_output_destroy_global(struct wlr_output *output);
 struct wlr_output_mode *wlr_output_preferred_mode(struct wlr_output *output);
 /**
  * Sets the output mode. Enables the output if it's currently disabled.
+ *
+ * Mode is double-buffered state, see `wlr_output_commit`.
  */
-bool wlr_output_set_mode(struct wlr_output *output,
+void wlr_output_set_mode(struct wlr_output *output,
 	struct wlr_output_mode *mode);
 /**
  * Sets a custom mode on the output. If modes are available, they are preferred.
  * Setting `refresh` to zero lets the backend pick a preferred value.
+ *
+ * Custom mode is double-buffered state, see `wlr_output_commit`.
  */
-bool wlr_output_set_custom_mode(struct wlr_output *output, int32_t width,
+void wlr_output_set_custom_mode(struct wlr_output *output, int32_t width,
 	int32_t height, int32_t refresh);
+/**
+ * Sets a transform for the output.
+ *
+ * Transform is double-buffered state, see `wlr_output_commit`.
+ */
 void wlr_output_set_transform(struct wlr_output *output,
 	enum wl_output_transform transform);
+/**
+ * Sets a scale for the output.
+ *
+ * Scale is double-buffered state, see `wlr_output_commit`.
+ */
 void wlr_output_set_scale(struct wlr_output *output, float scale);
 void wlr_output_set_subpixel(struct wlr_output *output,
 	enum wl_output_subpixel subpixel);
@@ -268,9 +305,10 @@ void wlr_output_set_damage(struct wlr_output *output,
 	pixman_region32_t *damage);
 /**
  * Commit the pending output state. If `wlr_output_attach_render` has been
- * called, the pending frame will be submitted for display.
+ * called, the pending frame will be submitted for display and a `frame` event
+ * will be scheduled.
  *
- * This function schedules a `frame` event.
+ * On failure, the pending changes are rolled back.
  */
 bool wlr_output_commit(struct wlr_output *output);
 /**

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -222,7 +222,7 @@ void wlr_output_destroy_global(struct wlr_output *output);
  */
 struct wlr_output_mode *wlr_output_preferred_mode(struct wlr_output *output);
 /**
- * Sets the output mode. Enables the output if it's currently disabled.
+ * Sets the output mode. The output needs to be enabled.
  *
  * Mode is double-buffered state, see `wlr_output_commit`.
  */
@@ -230,7 +230,8 @@ void wlr_output_set_mode(struct wlr_output *output,
 	struct wlr_output_mode *mode);
 /**
  * Sets a custom mode on the output. If modes are available, they are preferred.
- * Setting `refresh` to zero lets the backend pick a preferred value.
+ * Setting `refresh` to zero lets the backend pick a preferred value. The
+ * output needs to be enabled.
  *
  * Custom mode is double-buffered state, see `wlr_output_commit`.
  */
@@ -271,15 +272,19 @@ void wlr_output_effective_resolution(struct wlr_output *output,
 /**
  * Attach the renderer's buffer to the output. Compositors must call this
  * function before rendering. After they are done rendering, they should call
- * `wlr_output_commit` to submit the new frame.
+ * `wlr_output_commit` to submit the new frame. The output needs to be
+ * enabled.
  *
  * If non-NULL, `buffer_age` is set to the drawing buffer age in number of
  * frames or -1 if unknown. This is useful for damage tracking.
+ *
+ * If the compositor decides not to render after calling this function, it
+ * must call wlr_output_rollback.
  */
 bool wlr_output_attach_render(struct wlr_output *output, int *buffer_age);
 /**
  * Attach a buffer to the output. Compositors should call `wlr_output_commit`
- * to submit the new frame.
+ * to submit the new frame. The output needs to be enabled.
  */
 bool wlr_output_attach_buffer(struct wlr_output *output,
 	struct wlr_buffer *buffer);
@@ -311,6 +316,10 @@ void wlr_output_set_damage(struct wlr_output *output,
  * On failure, the pending changes are rolled back.
  */
 bool wlr_output_commit(struct wlr_output *output);
+/**
+ * Discard the pending output state.
+ */
+void wlr_output_rollback(struct wlr_output *output);
 /**
  * Manually schedules a `frame` event. If a `frame` event is already pending,
  * it is a no-op.

--- a/tinywl/tinywl.c
+++ b/tinywl/tinywl.c
@@ -648,12 +648,15 @@ static void server_new_output(struct wl_listener *listener, void *data) {
 	/* Some backends don't have modes. DRM+KMS does, and we need to set a mode
 	 * before we can use the output. The mode is a tuple of (width, height,
 	 * refresh rate), and each monitor supports only a specific set of modes. We
-	 * just pick the first, a more sophisticated compositor would let the user
-	 * configure it or pick the mode the display advertises as preferred. */
+	 * just pick the monitor's preferred mode, a more sophisticated compositor
+	 * would let the user configure it. */
 	if (!wl_list_empty(&wlr_output->modes)) {
-		struct wlr_output_mode *mode =
-			wl_container_of(wlr_output->modes.prev, mode, link);
+		struct wlr_output_mode *mode = wlr_output_preferred_mode(wlr_output);
 		wlr_output_set_mode(wlr_output, mode);
+		wlr_output_enable(wlr_output, true);
+		if (!wlr_output_commit(wlr_output)) {
+			return;
+		}
 	}
 
 	/* Allocates and configures our state for this output */

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -156,6 +156,7 @@ static void output_update_matrix(struct wlr_output *output) {
 
 void wlr_output_enable(struct wlr_output *output, bool enable) {
 	if (output->enabled == enable) {
+		output->pending.committed &= ~WLR_OUTPUT_STATE_ENABLED;
 		return;
 	}
 
@@ -175,11 +176,12 @@ static void output_state_clear_mode(struct wlr_output_state *state) {
 
 void wlr_output_set_mode(struct wlr_output *output,
 		struct wlr_output_mode *mode) {
+	output_state_clear_mode(&output->pending);
+
 	if (output->current_mode == mode) {
 		return;
 	}
 
-	output_state_clear_mode(&output->pending);
 	output->pending.committed |= WLR_OUTPUT_STATE_MODE;
 	output->pending.mode_type = WLR_OUTPUT_STATE_MODE_FIXED;
 	output->pending.mode = mode;
@@ -187,12 +189,13 @@ void wlr_output_set_mode(struct wlr_output *output,
 
 void wlr_output_set_custom_mode(struct wlr_output *output, int32_t width,
 		int32_t height, int32_t refresh) {
+	output_state_clear_mode(&output->pending);
+
 	if (output->width == width && output->height == height &&
 			output->refresh == refresh) {
 		return;
 	}
 
-	output_state_clear_mode(&output->pending);
 	output->pending.committed |= WLR_OUTPUT_STATE_MODE;
 	output->pending.mode_type = WLR_OUTPUT_STATE_MODE_CUSTOM;
 	output->pending.custom_mode.width = width;
@@ -236,6 +239,7 @@ void wlr_output_update_custom_mode(struct wlr_output *output, int32_t width,
 void wlr_output_set_transform(struct wlr_output *output,
 		enum wl_output_transform transform) {
 	if (output->transform == transform) {
+		output->pending.committed &= ~WLR_OUTPUT_STATE_TRANSFORM;
 		return;
 	}
 
@@ -245,6 +249,7 @@ void wlr_output_set_transform(struct wlr_output *output,
 
 void wlr_output_set_scale(struct wlr_output *output, float scale) {
 	if (output->scale == scale) {
+		output->pending.committed &= ~WLR_OUTPUT_STATE_SCALE;
 		return;
 	}
 

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -464,12 +464,26 @@ bool wlr_output_commit(struct wlr_output *output) {
 	if (output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
 		if (output->frame_pending) {
 			wlr_log(WLR_ERROR, "Tried to commit a buffer while a frame is pending");
-			return false;
+			goto error;
 		}
 		if (output->idle_frame != NULL) {
 			wl_event_source_remove(output->idle_frame);
 			output->idle_frame = NULL;
 		}
+	}
+
+	bool enabled = output->enabled;
+	if (output->pending.committed & WLR_OUTPUT_STATE_ENABLED) {
+		enabled = output->pending.enabled;
+	}
+
+	if (!enabled && output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
+		wlr_log(WLR_ERROR, "Tried to commit a buffer on a disabled output");
+		goto error;
+	}
+	if (!enabled && output->pending.committed & WLR_OUTPUT_STATE_MODE) {
+		wlr_log(WLR_ERROR, "Tried to modeset a disabled output");
+		goto error;
 	}
 
 	struct timespec now;
@@ -535,6 +549,14 @@ bool wlr_output_commit(struct wlr_output *output) {
 
 	output_state_clear(&output->pending);
 	return true;
+
+error:
+	output_state_clear(&output->pending);
+	return false;
+}
+
+void wlr_output_rollback(struct wlr_output *output) {
+	output_state_clear(&output->pending);
 }
 
 bool wlr_output_attach_buffer(struct wlr_output *output,

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -154,38 +154,50 @@ static void output_update_matrix(struct wlr_output *output) {
 		output->height, output->transform);
 }
 
-bool wlr_output_enable(struct wlr_output *output, bool enable) {
+void wlr_output_enable(struct wlr_output *output, bool enable) {
 	if (output->enabled == enable) {
-		return true;
+		return;
 	}
 
-	if (output->impl->enable) {
-		return output->impl->enable(output, enable);
-	}
-	return false;
+	output->pending.committed |= WLR_OUTPUT_STATE_ENABLED;
+	output->pending.enabled = enable;
 }
 
-bool wlr_output_set_mode(struct wlr_output *output,
+static void output_state_clear_mode(struct wlr_output_state *state) {
+	if (!(state->committed & WLR_OUTPUT_STATE_MODE)) {
+		return;
+	}
+
+	state->mode = NULL;
+
+	state->committed &= ~WLR_OUTPUT_STATE_MODE;
+}
+
+void wlr_output_set_mode(struct wlr_output *output,
 		struct wlr_output_mode *mode) {
-	if (!output->impl || !output->impl->set_mode) {
-		return false;
-	}
 	if (output->current_mode == mode) {
-		return true;
+		return;
 	}
-	return output->impl->set_mode(output, mode);
+
+	output_state_clear_mode(&output->pending);
+	output->pending.committed |= WLR_OUTPUT_STATE_MODE;
+	output->pending.mode_type = WLR_OUTPUT_STATE_MODE_FIXED;
+	output->pending.mode = mode;
 }
 
-bool wlr_output_set_custom_mode(struct wlr_output *output, int32_t width,
+void wlr_output_set_custom_mode(struct wlr_output *output, int32_t width,
 		int32_t height, int32_t refresh) {
-	if (!output->impl || !output->impl->set_custom_mode) {
-		return false;
-	}
 	if (output->width == width && output->height == height &&
 			output->refresh == refresh) {
-		return true;
+		return;
 	}
-	return output->impl->set_custom_mode(output, width, height, refresh);
+
+	output_state_clear_mode(&output->pending);
+	output->pending.committed |= WLR_OUTPUT_STATE_MODE;
+	output->pending.mode_type = WLR_OUTPUT_STATE_MODE_CUSTOM;
+	output->pending.custom_mode.width = width;
+	output->pending.custom_mode.height = height;
+	output->pending.custom_mode.refresh = refresh;
 }
 
 void wlr_output_update_mode(struct wlr_output *output,
@@ -227,16 +239,8 @@ void wlr_output_set_transform(struct wlr_output *output,
 		return;
 	}
 
-	output->transform = transform;
-	output_update_matrix(output);
-
-	struct wl_resource *resource;
-	wl_resource_for_each(resource, &output->resources) {
-		send_geometry(resource);
-	}
-	wlr_output_schedule_done(output);
-
-	wlr_signal_emit_safe(&output->events.transform, output);
+	output->pending.committed |= WLR_OUTPUT_STATE_TRANSFORM;
+	output->pending.transform = transform;
 }
 
 void wlr_output_set_scale(struct wlr_output *output, float scale) {
@@ -244,15 +248,8 @@ void wlr_output_set_scale(struct wlr_output *output, float scale) {
 		return;
 	}
 
-	output->scale = scale;
-
-	struct wl_resource *resource;
-	wl_resource_for_each(resource, &output->resources) {
-		send_scale(resource);
-	}
-	wlr_output_schedule_done(output);
-
-	wlr_signal_emit_safe(&output->events.scale, output);
+	output->pending.committed |= WLR_OUTPUT_STATE_SCALE;
+	output->pending.scale = scale;
 }
 
 void wlr_output_set_subpixel(struct wlr_output *output,
@@ -459,18 +456,15 @@ static void output_state_clear(struct wlr_output_state *state) {
 }
 
 bool wlr_output_commit(struct wlr_output *output) {
-	if (output->frame_pending) {
-		wlr_log(WLR_ERROR, "Tried to commit when a frame is pending");
-		return false;
-	}
-	if (output->idle_frame != NULL) {
-		wl_event_source_remove(output->idle_frame);
-		output->idle_frame = NULL;
-	}
-
-	if (!(output->pending.committed & WLR_OUTPUT_STATE_BUFFER)) {
-		wlr_log(WLR_ERROR, "Tried to commit without attaching a buffer");
-		return false;
+	if (output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
+		if (output->frame_pending) {
+			wlr_log(WLR_ERROR, "Tried to commit a buffer while a frame is pending");
+			return false;
+		}
+		if (output->idle_frame != NULL) {
+			wl_event_source_remove(output->idle_frame);
+			output->idle_frame = NULL;
+		}
 	}
 
 	struct timespec now;
@@ -487,22 +481,54 @@ bool wlr_output_commit(struct wlr_output *output) {
 		return false;
 	}
 
-	struct wlr_output_cursor *cursor;
-	wl_list_for_each(cursor, &output->cursors, link) {
-		if (!cursor->enabled || !cursor->visible || cursor->surface == NULL) {
-			continue;
+	if (output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
+		struct wlr_output_cursor *cursor;
+		wl_list_for_each(cursor, &output->cursors, link) {
+			if (!cursor->enabled || !cursor->visible || cursor->surface == NULL) {
+				continue;
+			}
+			wlr_surface_send_frame_done(cursor->surface, &now);
 		}
-		wlr_surface_send_frame_done(cursor->surface, &now);
 	}
 
 	output->commit_seq++;
 
 	wlr_signal_emit_safe(&output->events.commit, output);
 
-	output->frame_pending = true;
-	output->needs_frame = false;
+	bool scale_updated = output->pending.committed & WLR_OUTPUT_STATE_SCALE;
+	if (scale_updated) {
+		output->scale = output->pending.scale;
+		wlr_signal_emit_safe(&output->events.scale, output);
+	}
+
+	if (output->pending.committed & WLR_OUTPUT_STATE_TRANSFORM) {
+		output->transform = output->pending.transform;
+		output_update_matrix(output);
+		wlr_signal_emit_safe(&output->events.transform, output);
+	}
+
+	bool geometry_updated = output->pending.committed &
+		(WLR_OUTPUT_STATE_MODE | WLR_OUTPUT_STATE_TRANSFORM);
+	if (geometry_updated || scale_updated) {
+		struct wl_resource *resource;
+		wl_resource_for_each(resource, &output->resources) {
+			if (geometry_updated) {
+				send_geometry(resource);
+			}
+			if (scale_updated) {
+				send_scale(resource);
+			}
+		}
+		wlr_output_schedule_done(output);
+	}
+
+	if (output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
+		output->frame_pending = true;
+		output->needs_frame = false;
+		pixman_region32_clear(&output->damage);
+	}
+
 	output_state_clear(&output->pending);
-	pixman_region32_clear(&output->damage);
 	return true;
 }
 


### PR DESCRIPTION
This reverts commit 01f903874b7e27539488fad7f31476d5bcbc6ac9 and re-applies
commit ee5f98ad49fed0439f3313ec685307831d1d1d05.

Updates: https://github.com/swaywm/wlroots/issues/1640 (Atomic output updates issue)
See also: https://github.com/swaywm/wlroots/pull/1762 (Atomic output updates original PR)
See also: https://github.com/swaywm/wlroots/issues/1780 (Issue caused by atomic output updates)
See also: https://github.com/swaywm/sway/issues/4419 (Issue caused by atomic output updates)
See also: https://github.com/swaywm/wlroots/pull/1781 (Revert PR)

Sway PR: https://github.com/swaywm/sway/pull/4845

* * *

Breaking changes:

* Compositors now need to call `wlr_output_commit` after `wlr_output_enable`, `wlr_output_set_mode`, `wlr_output_set_custom_mode`, `wlr_output_set_transform` or `wlr_output_set_scale`
* `wlr_output_set_mode` no longer implicitly enables the output, compositors need to call `wlr_output_enable` as well
* Compositors now need to call `wlr_output_rollback` after `wlr_output_attach_render` if they decide not to render