### PR TITLE
presentation_feedback: add the sampled state

### DIFF
--- a/include/wlr/types/wlr_presentation_time.h
+++ b/include/wlr/types/wlr_presentation_time.h
@@ -31,8 +31,14 @@ struct wlr_presentation_feedback {
 	struct wl_resource *resource;
 	struct wlr_presentation *presentation;
 	struct wlr_surface *surface;
-	bool committed;
 	struct wl_list link; // wlr_presentation::feedbacks
+
+	// The surface contents were committed.
+	bool committed;
+	// The surface contents were sampled by the compositor and are to be
+	// presented on the next flip. Can become true only after committed becomes
+	// true.
+	bool sampled;
 
 	struct wl_listener surface_commit;
 	struct wl_listener surface_destroy;
@@ -55,5 +61,7 @@ void wlr_presentation_destroy(struct wlr_presentation *presentation);
 void wlr_presentation_send_surface_presented(
 	struct wlr_presentation *presentation, struct wlr_surface *surface,
 	struct wlr_presentation_event *event);
+void wlr_presentation_surface_sampled(
+	struct wlr_presentation *presentation, struct wlr_surface *surface);
 
 #endif


### PR DESCRIPTION
cc https://github.com/swaywm/sway/issues/4451

The idea is that feedback goes from nothing to committed to either sampled (and subsequently presented) or discarded.

Sway patch: https://github.com/swaywm/sway/pull/4465

* * *

Compositor maintainers: call `wlr_presentation_surface_sampled` when rendering a surface.