### PR TITLE
wlr-layer-shell-v1: destroy xdg popups on unmap

### DIFF
--- a/types/wlr_layer_shell_v1.c
+++ b/types/wlr_layer_shell_v1.c
@@ -188,6 +188,11 @@ static void layer_surface_unmap(struct wlr_layer_surface_v1 *surface) {
 	// TODO: probably need to ungrab before this event
 	wlr_signal_emit_safe(&surface->events.unmap, surface);
 
+	struct wlr_xdg_popup *popup, *popup_tmp;
+	wl_list_for_each_safe(popup, popup_tmp, &surface->popups, link) {
+		wlr_xdg_popup_destroy(popup->base);
+	}
+
 	struct wlr_layer_surface_v1_configure *configure, *tmp;
 	wl_list_for_each_safe(configure, tmp, &surface->configure_list, link) {
 		layer_surface_configure_destroy(configure);


### PR DESCRIPTION
Mirrors #1530 (xdg-shell) for wlr-layer-shell-v1
Supersedes/Closes #1418 (#1530 + this is basically #1418)
Fixes swaywm/sway#4477

This destroys the xdg popups associated with a layer surface when the
layer surface is unmapped. It does not make sense to keep the popups
open when unmapped.