### PR TITLE
Revert "wlr_xdg_popup: don't treat all surfaces of grabbing client as grabbing surfaces"

### DIFF
--- a/types/xdg_shell/wlr_xdg_popup.c
+++ b/types/xdg_shell/wlr_xdg_popup.c
@@ -18,16 +18,7 @@ static void xdg_popup_grab_end(struct wlr_xdg_popup_grab *popup_grab) {
 static void xdg_pointer_grab_enter(struct wlr_seat_pointer_grab *grab,
 		struct wlr_surface *surface, double sx, double sy) {
 	struct wlr_xdg_popup_grab *popup_grab = grab->data;
-
-	bool grabbing = false;
-	struct wlr_xdg_popup *popup;
-	wl_list_for_each(popup, &popup_grab->popups, grab_link) {
-		if (surface == popup->base->surface) {
-			grabbing = true;
-		}
-	}
-
-	if (grabbing) {
+	if (wl_resource_get_client(surface->resource) == popup_grab->client) {
 		wlr_seat_pointer_enter(grab->seat, surface, sx, sy);
 	} else {
 		wlr_seat_pointer_clear_focus(grab->seat);
@@ -106,15 +97,7 @@ static uint32_t xdg_touch_grab_down(struct wlr_seat_touch_grab *grab,
 		uint32_t time, struct wlr_touch_point *point) {
 	struct wlr_xdg_popup_grab *popup_grab = grab->data;
 
-	bool grabbing = false;
-	struct wlr_xdg_popup *popup;
-	wl_list_for_each(popup, &popup_grab->popups, grab_link) {
-		if (point->surface == popup->base->surface) {
-			grabbing = true;
-		}
-	}
-
-	if (!grabbing) {
+	if (wl_resource_get_client(point->surface->resource) != popup_grab->client) {
 		xdg_popup_grab_end(grab->data);
 		return 0;
 	}

--- a/types/xdg_shell_v6/wlr_xdg_popup_v6.c
+++ b/types/xdg_shell_v6/wlr_xdg_popup_v6.c
@@ -28,16 +28,7 @@ static void xdg_popup_grab_end(struct wlr_xdg_popup_grab_v6 *popup_grab) {
 static void xdg_pointer_grab_enter(struct wlr_seat_pointer_grab *grab,
 		struct wlr_surface *surface, double sx, double sy) {
 	struct wlr_xdg_popup_grab_v6 *popup_grab = grab->data;
-
-	bool grabbing = false;
-	struct wlr_xdg_popup_v6 *popup;
-	wl_list_for_each(popup, &popup_grab->popups, grab_link) {
-		if (surface == popup->base->surface) {
-			grabbing = true;
-		}
-	}
-
-	if (grabbing) {
+	if (wl_resource_get_client(surface->resource) == popup_grab->client) {
 		wlr_seat_pointer_enter(grab->seat, surface, sx, sy);
 	} else {
 		wlr_seat_pointer_clear_focus(grab->seat);
@@ -116,15 +107,7 @@ static uint32_t xdg_touch_grab_down(struct wlr_seat_touch_grab *grab,
 		uint32_t time, struct wlr_touch_point *point) {
 	struct wlr_xdg_popup_grab_v6 *popup_grab = grab->data;
 
-	bool grabbing = false;
-	struct wlr_xdg_popup_v6 *popup;
-	wl_list_for_each(popup, &popup_grab->popups, grab_link) {
-		if (point->surface == popup->base->surface) {
-			grabbing = true;
-		}
-	}
-
-	if (!grabbing) {
+	if (wl_resource_get_client(point->surface->resource) != popup_grab->client) {
 		xdg_popup_grab_end(grab->data);
 		return 0;
 	}


### PR DESCRIPTION
This reverts commit 52037d13f7617bef8e0f2566cb4609646cf8cd8f.

Fixes #1801