### PR TITLE
Fix calculation for partial gles2 pixel read

### DIFF
--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -317,8 +317,8 @@ static bool gles2_read_pixels(struct wlr_renderer *wlr_renderer,
 	} else {
 		// Unfortunately GLES2 doesn't support GL_PACK_*, so we have to read
 		// the lines out row by row
-		for (size_t i = src_y; i < src_y + height; ++i) {
-			glReadPixels(src_x, src_y + height - i - 1, width, 1, fmt->gl_format,
+		for (size_t i = 0; i < height; ++i) {
+	        glReadPixels(src_x, renderer->viewport_height - src_y - i, width, 1, fmt->gl_format,
 				fmt->gl_type, p + i * stride + dst_x * fmt->bpp / 8);
 		}
 		if (flags != NULL) {

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -318,7 +318,7 @@ static bool gles2_read_pixels(struct wlr_renderer *wlr_renderer,
 		// Unfortunately GLES2 doesn't support GL_PACK_*, so we have to read
 		// the lines out row by row
 		for (size_t i = 0; i < height; ++i) {
-	        glReadPixels(src_x, renderer->viewport_height - src_y - i, width, 1, fmt->gl_format,
+			glReadPixels(src_x, renderer->viewport_height - src_y - i - 1, width, 1, fmt->gl_format,
 				fmt->gl_type, p + i * stride + dst_x * fmt->bpp / 8);
 		}
 		if (flags != NULL) {


### PR DESCRIPTION
I believe there is a calculation error in the gles2_read_pixels() function, causing issue #1699 .

The calculation is OK for the first readout of the entire viewport, but once a partial area roughly below the middle of the viewport is changed, the data offset will make the glReadPixels() overflow the buffer, causing the seg fault and strange display behaviour discussed in the bug report.