### PR TITLE
Call pthread_sigmask() as early as possible so Xwayland SIGUSR1 is not caught by GPU driver threads

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -114,6 +114,7 @@ libcap         = dependency('libcap', required: get_option('libcap'))
 logind         = dependency('lib' + get_option('logind-provider'), required: get_option('logind'), version: '>=237')
 math           = cc.find_library('m')
 rt             = cc.find_library('rt')
+threads        = dependency('threads')
 
 wlr_parts = []
 wlr_deps = []

--- a/xwayland/meson.build
+++ b/xwayland/meson.build
@@ -44,6 +44,7 @@ lib_wlr_xwayland = static_library(
 		xwayland_libs,
 		xkbcommon,
 		pixman,
+		threads,
 	],
 )
 


### PR DESCRIPTION
Supersedes/replaces https://github.com/swaywm/sway/pull/4537