### PR TITLE
layer-shell: ignore ack_configure() on closed surfaces

### DIFF
--- a/types/wlr_layer_shell_v1.c
+++ b/types/wlr_layer_shell_v1.c
@@ -61,7 +61,7 @@ static void layer_surface_handle_ack_configure(struct wl_client *client,
 	bool found = false;
 	struct wlr_layer_surface_v1_configure *configure, *tmp;
 
-	if (!surface) {
+	if (!surface || surface->closed) {
 		return;
 	}
 	wl_list_for_each_safe(configure, tmp, &surface->configure_list, link) {


### PR DESCRIPTION
When the surface is closed, we destroy all pending serials waiting to be accepted. This means we need to ignore any future ack events, because we can have the following events:

1. -> configure()
2. -> close()
3. <- ack_configure()

At point 3, wlroots will error the client because of invalid serial,
however the client hasn't processed close() yet.