### PR TITLE
wlr_seat_touch: Destroy the touchpoint on client destroy

### DIFF
--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -64,6 +64,7 @@ struct wlr_touch_point {
 
 	struct wl_listener surface_destroy;
 	struct wl_listener focus_surface_destroy;
+	struct wl_listener client_destroy;
 
 	struct {
 		struct wl_signal destroy;


### PR DESCRIPTION
Since e26217c51e3a5e1d7dfc95a8a76299e056497981, touchpoints can outlive
surfaces. This works fine as long as the client stays around, but fails
horribly otherwise; therefore we have to make sure that touchpoints don't
outlive their clients.

Fixes #1788