### PR TITLE
xdg-output: send wl_output.done after xdg_output created

### DIFF
--- a/types/wlr_xdg_output_v1.c
+++ b/types/wlr_xdg_output_v1.c
@@ -132,6 +132,8 @@ static void output_manager_handle_get_xdg_output(struct wl_client *client,
 	}
 
 	output_send_details(xdg_output, xdg_output_resource);
+
+	wl_output_send_done(output_resource);
 }
 
 static const struct zxdg_output_manager_v1_interface


### PR DESCRIPTION
xdg-output version 3 requires to send wl_output.done
"after all xdg_output properties have been sent when the object is created"