### PR TITLE
Additions for repaint scheduling

### DIFF
--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -145,6 +145,8 @@ struct wlr_output {
 	struct wl_listener display_destroy;
 
 	void *data;
+
+	bool block_idle_frame;
 };
 
 struct wlr_output_event_precommit {

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -541,7 +541,8 @@ void wlr_output_send_frame(struct wlr_output *output) {
 static void schedule_frame_handle_idle_timer(void *data) {
 	struct wlr_output *output = data;
 	output->idle_frame = NULL;
-	if (!output->frame_pending && output->impl->schedule_frame) {
+	if (!output->frame_pending && output->impl->schedule_frame
+			&& !output->block_idle_frame) {
 		// Ask the backend to send a frame event when appropriate
 		if (output->impl->schedule_frame(output)) {
 			output->frame_pending = true;


### PR DESCRIPTION
For sway PR: https://github.com/swaywm/sway/pull/4588.

Idle frame block: when delaying the output render after a presentation, idle frames need to be blocked because they interfere (and a render is scheduled anyway).

Frame done timer: used for delayed frame callbacks.

cc #655 