### PR TITLE
xdg-foreign: add implementation

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -8,6 +8,7 @@ packages:
   - mesa-dev
   - meson
   - pixman-dev
+  - util-linux-dev
   - wayland-dev
   - wayland-protocols
   - xcb-util-image-dev

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -10,6 +10,7 @@ packages:
 - graphics/png
 - graphics/wayland
 - graphics/wayland-protocols
+- misc/e2fsprogs-libuuid
 - multimedia/ffmpeg
 - x11/libX11
 - x11/libinput

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Install dependencies:
 * systemd (optional, for logind support)
 * elogind (optional, for logind support on systems without systemd)
 * libcap (optional, for capability support)
+* libuuid (optional, for xdg-foreign support)
 
 If you choose to enable X11 support:
 

--- a/include/meson.build
+++ b/include/meson.build
@@ -7,6 +7,12 @@ endif
 if conf_data.get('WLR_HAS_XWAYLAND', 0) != 1
 	exclude_files += 'xwayland.h'
 endif
+if conf_data.get('WLR_HAS_XDG_FOREIGN', 0) != 1
+	exclude_files += [
+    'types/wlr_xdg_foreign_v1.h',
+    'types/wlr_xdg_foreign_v2.h',
+	]
+endif
 
 install_subdir('wlr',
 	install_dir: get_option('includedir'),

--- a/include/util/uuid.h
+++ b/include/util/uuid.h
@@ -1,0 +1,6 @@
+#ifndef UTIL_UUID_H
+#define UTIL_UUID_H
+
+int generate_uuid(char out[static 37]);
+
+#endif

--- a/include/wlr/config.h.in
+++ b/include/wlr/config.h.in
@@ -13,4 +13,6 @@
 #mesondefine WLR_HAS_XCB_ERRORS
 #mesondefine WLR_HAS_XCB_ICCCM
 
+#mesondefine WLR_HAS_XDG_FOREIGN
+
 #endif

--- a/include/wlr/types/wlr_xdg_foreign_v1.h
+++ b/include/wlr/types/wlr_xdg_foreign_v1.h
@@ -1,0 +1,86 @@
+/*
+ * This an unstable interface of wlroots. No guarantees are made regarding the
+ * future consistency of this API.
+ */
+#ifndef WLR_USE_UNSTABLE
+#error "Add -DWLR_USE_UNSTABLE to enable unstable wlroots features"
+#endif
+
+#ifndef WLR_TYPES_WLR_XDG_FOREIGN_V1_H
+#define WLR_TYPES_WLR_XDG_FOREIGN_V1_H
+
+#include <wayland-server-core.h>
+
+#define WLR_XDG_FOREIGN_V1_HANDLE_SIZE 37
+
+struct wlr_xdg_foreign_v1 {
+	struct {
+		struct wl_global *global;
+		struct wl_list resources;
+		struct wl_list clients;
+	} exporter, importer;
+
+	struct wl_listener display_destroy;
+
+	struct {
+		struct wl_signal destroy;
+	} events;
+
+	void *data;
+};
+
+struct wlr_xdg_exporter_v1 {
+	struct wlr_xdg_foreign_v1 *foreign;
+	struct wl_resource *resource;
+
+	struct wl_list link; // wlr_xdg_foreign_v1::exporter::clients
+
+	struct wl_list exports;
+};
+
+struct wlr_xdg_importer_v1 {
+	struct wlr_xdg_foreign_v1 *foreign;
+	struct wl_resource *resource;
+
+	struct wl_list link; // wlr_xdg_foreign_v1::importer::clients
+
+	struct wl_list imports;
+};
+
+struct wlr_xdg_exported_v1 {
+	struct wlr_surface *surface;
+	struct wl_resource *resource;
+
+	struct wl_list link; // wlr_xdg_exporter_v1::exports
+
+	struct wl_listener xdg_surface_unmap;
+
+	struct wl_list imports;
+	char handle[WLR_XDG_FOREIGN_V1_HANDLE_SIZE];
+};
+
+struct wlr_xdg_imported_v1 {
+	struct wlr_xdg_exported_v1 *exported;
+	struct wl_resource *resource;
+
+	struct wl_list export_link; // wlr_xdg_exported_v1::imports
+	struct wl_list link; // wlr_xdg_importer_v1::imports
+
+	struct wl_list children;
+};
+
+struct wlr_xdg_imported_child_v1 {
+	struct wlr_xdg_imported_v1 *imported;
+	struct wlr_surface *surface;
+
+	struct wl_list link; // wlr_xdg_imported_v1::children
+
+	struct wl_listener xdg_surface_unmap;
+	struct wl_listener xdg_toplevel_set_parent;
+};
+
+struct wlr_xdg_foreign_v1 *wlr_xdg_foreign_v1_create(
+		struct wl_display *display);
+void wlr_xdg_foreign_v1_destroy(struct wlr_xdg_foreign_v1 *foreign);
+
+#endif

--- a/include/wlr/types/wlr_xdg_foreign_v2.h
+++ b/include/wlr/types/wlr_xdg_foreign_v2.h
@@ -1,0 +1,86 @@
+/*
+ * This an unstable interface of wlroots. No guarantees are made regarding the
+ * future consistency of this API.
+ */
+#ifndef WLR_USE_UNSTABLE
+#error "Add -DWLR_USE_UNSTABLE to enable unstable wlroots features"
+#endif
+
+#ifndef WLR_TYPES_WLR_XDG_FOREIGN_V2_H
+#define WLR_TYPES_WLR_XDG_FOREIGN_V2_H
+
+#include <wayland-server-core.h>
+
+#define WLR_XDG_FOREIGN_V2_HANDLE_SIZE 37
+
+struct wlr_xdg_foreign_v2 {
+	struct {
+		struct wl_global *global;
+		struct wl_list resources;
+		struct wl_list clients;
+	} exporter, importer;
+
+	struct wl_listener display_destroy;
+
+	struct {
+		struct wl_signal destroy;
+	} events;
+
+	void *data;
+};
+
+struct wlr_xdg_exporter_v2 {
+	struct wlr_xdg_foreign_v2 *foreign;
+	struct wl_resource *resource;
+
+	struct wl_list link; // wlr_xdg_foreign_v2::exporter::clients
+
+	struct wl_list exports;
+};
+
+struct wlr_xdg_importer_v2 {
+	struct wlr_xdg_foreign_v2 *foreign;
+	struct wl_resource *resource;
+
+	struct wl_list link; // wlr_xdg_foreign_v2::importer::clients
+
+	struct wl_list imports;
+};
+
+struct wlr_xdg_exported_v2 {
+	struct wlr_surface *surface;
+	struct wl_resource *resource;
+
+	struct wl_list link; // wlr_xdg_exporter_v2::exports
+
+	struct wl_listener xdg_surface_unmap;
+
+	struct wl_list imports;
+	char handle[WLR_XDG_FOREIGN_V2_HANDLE_SIZE];
+};
+
+struct wlr_xdg_imported_v2 {
+	struct wlr_xdg_exported_v2 *exported;
+	struct wl_resource *resource;
+
+	struct wl_list export_link; // wlr_xdg_exported_v2::imports
+	struct wl_list link; // wlr_xdg_importer_v2::imports
+
+	struct wl_list children;
+};
+
+struct wlr_xdg_imported_child_v2 {
+	struct wlr_xdg_imported_v2 *imported;
+	struct wlr_surface *surface;
+
+	struct wl_list link; // wlr_xdg_imported_v2::children
+
+	struct wl_listener xdg_surface_unmap;
+	struct wl_listener xdg_toplevel_set_parent;
+};
+
+struct wlr_xdg_foreign_v2 *wlr_xdg_foreign_v2_create(
+		struct wl_display *display);
+void wlr_xdg_foreign_v2_destroy(struct wlr_xdg_foreign_v2 *foreign);
+
+#endif

--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -311,6 +311,12 @@ uint32_t wlr_xdg_toplevel_set_tiled(struct wlr_xdg_surface *surface,
 void wlr_xdg_toplevel_send_close(struct wlr_xdg_surface *surface);
 
 /**
+ * Sets the parent of this toplevel. Parent can be NULL.
+ */
+void wlr_xdg_toplevel_set_parent(struct wlr_xdg_surface *surface,
+		struct wlr_xdg_surface *parent);
+
+/**
  * Request that this xdg popup closes.
  **/
 void wlr_xdg_popup_destroy(struct wlr_xdg_surface *surface);

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -291,6 +291,12 @@ uint32_t wlr_xdg_toplevel_v6_set_resizing(struct wlr_xdg_surface_v6 *surface,
 void wlr_xdg_surface_v6_send_close(struct wlr_xdg_surface_v6 *surface);
 
 /**
+ * Sets the parent of this toplevel. Parent can be NULL.
+ */
+void wlr_xdg_toplevel_v6_set_parent(struct wlr_xdg_surface_v6 *surface,
+		struct wlr_xdg_surface_v6 *parent);
+
+/**
  * Find a surface within this xdg-surface tree at the given surface-local
  * coordinates. Returns the surface and coordinates in the leaf surface
  * coordinate system or NULL if no surface is found at that location.

--- a/meson.build
+++ b/meson.build
@@ -87,6 +87,7 @@ conf_data.set10('WLR_HAS_X11_BACKEND', false)
 conf_data.set10('WLR_HAS_XWAYLAND', false)
 conf_data.set10('WLR_HAS_XCB_ERRORS', false)
 conf_data.set10('WLR_HAS_XCB_ICCCM', false)
+conf_data.set10('WLR_HAS_XDG_FOREIGN', false)
 
 # Clang complains about some zeroed initializer lists (= {0}), even though they
 # are valid
@@ -107,6 +108,8 @@ libinput = dependency('libinput', version: '>=1.9.0')
 xkbcommon = dependency('xkbcommon')
 udev = dependency('libudev')
 pixman = dependency('pixman-1')
+uuid = dependency('uuid', required: false)
+uuid_create = cc.has_function('uuid_create')
 math = cc.find_library('m')
 rt = cc.find_library('rt')
 
@@ -179,6 +182,7 @@ summary = [
 	' x11_backend: @0@'.format(conf_data.get('WLR_HAS_X11_BACKEND', false)),
 	'   xcb-icccm: @0@'.format(conf_data.get('WLR_HAS_XCB_ICCCM', false)),
 	'  xcb-errors: @0@'.format(conf_data.get('WLR_HAS_XCB_ERRORS', false)),
+	' xdg-foreign: @0@'.format(conf_data.get('WLR_HAS_XDG_FOREIGN', false)),
 	'----------------',
 	''
 ]

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -25,6 +25,8 @@ protocols = {
 	'tablet-unstable-v2': wl_protocol_dir / 'unstable/tablet/tablet-unstable-v2.xml',
 	'text-input-unstable-v3': wl_protocol_dir / 'unstable/text-input/text-input-unstable-v3.xml',
 	'xdg-decoration-unstable-v1': wl_protocol_dir / 'unstable/xdg-decoration/xdg-decoration-unstable-v1.xml',
+	'xdg-foreign-unstable-v1': wl_protocol_dir / 'unstable/xdg-foreign/xdg-foreign-unstable-v1.xml',
+	'xdg-foreign-unstable-v2': wl_protocol_dir / 'unstable/xdg-foreign/xdg-foreign-unstable-v2.xml',
 	'xdg-output-unstable-v1': wl_protocol_dir / 'unstable/xdg-output/xdg-output-unstable-v1.xml',
 	'xdg-shell-unstable-v6': wl_protocol_dir / 'unstable/xdg-shell/xdg-shell-unstable-v6.xml',
 	# Other protocols

--- a/types/meson.build
+++ b/types/meson.build
@@ -68,3 +68,10 @@ wlr_files += files(
 	'wlr_xdg_decoration_v1.c',
 	'wlr_xdg_output_v1.c',
 )
+if uuid.found() or uuid_create
+	conf_data.set10('WLR_HAS_XDG_FOREIGN', true)
+	wlr_files += files(
+		'wlr_xdg_foreign_v1.c',
+		'wlr_xdg_foreign_v2.c',
+	)
+endif

--- a/types/wlr_xdg_foreign_v1.c
+++ b/types/wlr_xdg_foreign_v1.c
@@ -1,0 +1,491 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <wlr/types/wlr_xdg_foreign_v1.h>
+#include <wlr/types/wlr_xdg_shell.h>
+#include <wlr/types/wlr_xdg_shell_v6.h>
+#include <wlr/util/log.h>
+#include "util/signal.h"
+#include "util/uuid.h"
+#include "xdg-foreign-unstable-v1-protocol.h"
+
+#define FOREIGN_V1_VERSION 1
+
+static const struct zxdg_exported_v1_interface xdg_exported_impl;
+static const struct zxdg_imported_v1_interface xdg_imported_impl;
+static const struct zxdg_exporter_v1_interface xdg_exporter_impl;
+static const struct zxdg_importer_v1_interface xdg_importer_impl;
+
+static struct wlr_xdg_imported_v1 *xdg_imported_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &zxdg_imported_v1_interface,
+		&xdg_imported_impl));
+	return wl_resource_get_user_data(resource);
+}
+
+static void xdg_imported_handle_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+
+static bool verify_is_toplevel(struct wl_resource *client_resource,
+		struct wlr_surface *surface) {
+	if (wlr_surface_is_xdg_surface(surface)) {
+		struct wlr_xdg_surface *xdg_surface =
+			wlr_xdg_surface_from_wlr_surface(surface);
+		if (xdg_surface->role != WLR_XDG_SURFACE_ROLE_TOPLEVEL) {
+			wl_resource_post_error(client_resource, -1,
+					"surface must be an xdg_toplevel");
+			return false;
+		}
+	} else if (wlr_surface_is_xdg_surface_v6(surface)) {
+		struct wlr_xdg_surface_v6 *xdg_surface_v6 =
+			wlr_xdg_surface_v6_from_wlr_surface(surface);
+		if (xdg_surface_v6->role != WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL) {
+			wl_resource_post_error(client_resource, -1,
+					"surface must be an xdg_toplevel_v6");
+			return false;
+		}
+	} else {
+		wl_resource_post_error(client_resource, -1,
+				"surface must be an xdg_surface");
+		return false;
+	}
+	return true;
+}
+
+static void destroy_imported_child(struct wlr_xdg_imported_child_v1 *child) {
+	wl_list_remove(&child->xdg_toplevel_set_parent.link);
+	wl_list_remove(&child->xdg_surface_unmap.link);
+	wl_list_remove(&child->link);
+	free(child);
+}
+
+static void handle_child_xdg_surface_unmap(
+		struct wl_listener *listener, void *data) {
+	struct wlr_xdg_imported_child_v1 *child =
+		wl_container_of(listener, child, xdg_surface_unmap);
+	destroy_imported_child(child);
+}
+
+static void handle_xdg_toplevel_set_parent(
+		struct wl_listener *listener, void *data) {
+	struct wlr_xdg_imported_child_v1 *child =
+		wl_container_of(listener, child, xdg_toplevel_set_parent);
+	destroy_imported_child(child);
+}
+
+static void xdg_imported_handle_set_parent_of(struct wl_client *client,
+		struct wl_resource *resource,
+		struct wl_resource *child_resource) {
+	struct wlr_xdg_imported_v1 *imported =
+		xdg_imported_from_resource(resource);
+	if (imported->exported == NULL) {
+		return;
+	}
+	struct wlr_surface *wlr_surface = imported->exported->surface;
+	struct wlr_surface *wlr_surface_child =
+		wlr_surface_from_resource(child_resource);
+
+	if (!verify_is_toplevel(resource, wlr_surface_child)) {
+		return;
+	}
+	if (wlr_surface_is_xdg_surface(wlr_surface)
+			!= wlr_surface_is_xdg_surface(wlr_surface_child)) {
+		wl_resource_post_error(resource, -1,
+				"surfaces must have the same role");
+		return;
+	}
+	struct wlr_xdg_imported_child_v1 *child;
+	wl_list_for_each(child, &imported->children, link) {
+		if (child->surface == wlr_surface_child) {
+			return;
+		}
+	}
+
+	child = calloc(1, sizeof(struct wlr_xdg_imported_child_v1));
+	if (child == NULL) {
+		wl_client_post_no_memory(client);
+		return;
+	}
+	child->surface = wlr_surface_child;
+	child->xdg_surface_unmap.notify = handle_child_xdg_surface_unmap;
+	child->xdg_toplevel_set_parent.notify = handle_xdg_toplevel_set_parent;
+
+	if (wlr_surface_is_xdg_surface(wlr_surface)) {
+		struct wlr_xdg_surface *surface =
+			wlr_xdg_surface_from_wlr_surface(wlr_surface);
+		struct wlr_xdg_surface *surface_child =
+			wlr_xdg_surface_from_wlr_surface(wlr_surface_child);
+
+		wlr_xdg_toplevel_set_parent(surface_child, surface);
+		wl_signal_add(&surface_child->events.unmap,
+				&child->xdg_surface_unmap);
+		wl_signal_add(&surface_child->toplevel->events.set_parent,
+				&child->xdg_toplevel_set_parent);
+	} else if (wlr_surface_is_xdg_surface_v6(wlr_surface)) {
+		struct wlr_xdg_surface_v6 *surface =
+			wlr_xdg_surface_v6_from_wlr_surface(wlr_surface);
+		struct wlr_xdg_surface_v6 *surface_child =
+			wlr_xdg_surface_v6_from_wlr_surface(wlr_surface_child);
+
+		wlr_xdg_toplevel_v6_set_parent(surface_child, surface);
+		wl_signal_add(&surface_child->events.unmap,
+				&child->xdg_surface_unmap);
+		wl_signal_add(&surface_child->toplevel->events.set_parent,
+				&child->xdg_toplevel_set_parent);
+	}
+
+	wl_list_insert(&imported->children, &child->link);
+}
+
+static const struct zxdg_imported_v1_interface xdg_imported_impl = {
+	.destroy = xdg_imported_handle_destroy,
+	.set_parent_of = xdg_imported_handle_set_parent_of
+};
+
+static struct wlr_xdg_exported_v1 *xdg_exported_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &zxdg_exported_v1_interface,
+		&xdg_exported_impl));
+	return wl_resource_get_user_data(resource);
+}
+
+static void xdg_exported_handle_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+
+static const struct zxdg_exported_v1_interface xdg_exported_impl = {
+	.destroy = xdg_exported_handle_destroy
+};
+
+static void xdg_exporter_handle_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+
+static struct wlr_xdg_exporter_v1 *xdg_exporter_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &zxdg_exporter_v1_interface,
+		&xdg_exporter_impl));
+	return wl_resource_get_user_data(resource);
+}
+
+static void disconnect_imported(struct wlr_xdg_imported_v1 *imported) {
+	if (imported->exported != NULL) {
+		imported->exported = NULL;
+		zxdg_imported_v1_send_destroyed(imported->resource);
+		wl_list_remove(&imported->export_link);
+	}
+}
+
+static void xdg_exported_handle_resource_destroy(
+		struct wl_resource *resource) {
+	struct wlr_xdg_exported_v1 *exported =
+		xdg_exported_from_resource(resource);
+	struct wlr_xdg_imported_v1 *imported, *imported_tmp;
+	wl_list_for_each_safe(imported, imported_tmp,
+			&exported->imports, export_link) {
+		disconnect_imported(imported);
+	}
+	wl_list_remove(&exported->xdg_surface_unmap.link);
+	wl_list_remove(&exported->link);
+	free(exported);
+}
+
+static void handle_xdg_surface_unmap(
+		struct wl_listener *listener, void *data) {
+	struct wlr_xdg_exported_v1 *exported =
+		wl_container_of(listener, exported, xdg_surface_unmap);
+	wl_resource_destroy(exported->resource);
+}
+
+static struct wlr_xdg_exported_v1 *find_exported(
+		struct wlr_xdg_foreign_v1 *foreign, const char *handle) {
+	if (handle == NULL) {
+		return NULL;
+	}
+	struct wlr_xdg_exporter_v1 *exporter;
+	wl_list_for_each(exporter, &foreign->exporter.clients, link) {
+		struct wlr_xdg_exported_v1 *exported;
+		wl_list_for_each(exported, &exporter->exports, link) {
+			if (strcmp(handle, exported->handle) == 0) {
+				return exported;
+			}
+		}
+	}
+	return NULL;
+}
+
+static void xdg_exporter_handle_export_toplevel(struct wl_client *wl_client,
+		struct wl_resource *client_resource,
+		uint32_t id,
+		struct wl_resource *surface_resource) {
+	struct wlr_xdg_exporter_v1 *exporter =
+		xdg_exporter_from_resource(client_resource);
+	struct wlr_surface *surface = wlr_surface_from_resource(surface_resource);
+
+	if (!verify_is_toplevel(client_resource, surface)) {
+		return;
+	}
+
+	struct wlr_xdg_exported_v1 *exported =
+		calloc(1, sizeof(struct wlr_xdg_exported_v1));
+	if (exported == NULL) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+
+	exported->surface = surface;
+	do {
+		if (generate_uuid(exported->handle)) {
+			wl_client_post_no_memory(wl_client);
+			free(exported);
+			return;
+		}
+	} while (find_exported(exporter->foreign, exported->handle) != NULL);
+	exported->resource = wl_resource_create(wl_client,
+		&zxdg_exported_v1_interface,
+		wl_resource_get_version(exporter->resource),
+		id);
+
+	wl_resource_set_implementation(exported->resource, &xdg_exported_impl,
+			exported, xdg_exported_handle_resource_destroy);
+
+	wl_list_insert(&exporter->exports, &exported->link);
+	wl_list_init(&exported->imports);
+
+	zxdg_exported_v1_send_handle(exported->resource, exported->handle);
+
+	exported->xdg_surface_unmap.notify = handle_xdg_surface_unmap;
+	if (wlr_surface_is_xdg_surface(surface)) {
+		struct wlr_xdg_surface *xdg_surface =
+			wlr_xdg_surface_from_wlr_surface(surface);
+		wl_signal_add(&xdg_surface->events.unmap, &exported->xdg_surface_unmap);
+	} else if (wlr_surface_is_xdg_surface_v6(surface)) {
+		struct wlr_xdg_surface_v6 *xdg_surface_v6 =
+			wlr_xdg_surface_v6_from_wlr_surface(surface);
+		wl_signal_add(&xdg_surface_v6->events.unmap, &exported->xdg_surface_unmap);
+	}
+}
+
+static const struct zxdg_exporter_v1_interface xdg_exporter_impl = {
+	.destroy = xdg_exporter_handle_destroy,
+	.export = xdg_exporter_handle_export_toplevel
+};
+
+static void xdg_exporter_handle_resource_destroy(
+		struct wl_resource *resource) {
+	struct wlr_xdg_exporter_v1 *exporter = xdg_exporter_from_resource(resource);
+	struct wlr_xdg_exported_v1 *exported, *exported_tmp;
+	wl_list_for_each_safe(exported, exported_tmp, &exporter->exports, link) {
+		wl_resource_destroy(exported->resource);
+	}
+	wl_list_remove(&exporter->link);
+	free(exporter);
+}
+
+static void xdg_exporter_bind(struct wl_client *wl_client, void *data,
+		uint32_t version, uint32_t id) {
+	struct wlr_xdg_foreign_v1 *foreign = data;
+
+	struct wlr_xdg_exporter_v1 *exporter =
+		calloc(1, sizeof(struct wlr_xdg_exporter_v1));
+	if (exporter == NULL) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+
+	exporter->foreign = foreign;
+	exporter->resource =
+		wl_resource_create(wl_client, &zxdg_exporter_v1_interface, version, id);
+	if (exporter->resource == NULL) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+	wl_list_init(&exporter->exports);
+
+	wl_resource_set_implementation(exporter->resource, &xdg_exporter_impl,
+			exporter, xdg_exporter_handle_resource_destroy);
+
+	wl_list_insert(&foreign->exporter.clients, &exporter->link);
+}
+
+static struct wlr_xdg_importer_v1 *xdg_importer_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &zxdg_importer_v1_interface,
+		&xdg_importer_impl));
+	return wl_resource_get_user_data(resource);
+}
+
+static void xdg_importer_handle_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+
+static void xdg_imported_handle_resource_destroy(
+		struct wl_resource *resource) {
+	struct wlr_xdg_imported_v1 *imported = xdg_imported_from_resource(resource);
+
+	struct wlr_xdg_imported_child_v1 *child, *child_tmp;
+	wl_list_for_each_safe(child, child_tmp, &imported->children, link) {
+		struct wlr_xdg_surface *xdg_child =
+			wlr_xdg_surface_from_wlr_surface(child->surface);
+		wlr_xdg_toplevel_set_parent(xdg_child, NULL);
+	}
+	if (imported->export_link.prev != NULL) {
+		wl_list_remove(&imported->export_link);
+	}
+	if (imported->link.prev != NULL) {
+		wl_list_remove(&imported->link);
+	}
+	free(imported);
+}
+
+static void xdg_importer_handle_import_toplevel(struct wl_client *wl_client,
+				struct wl_resource *client_resource,
+				uint32_t id,
+				const char *handle) {
+	struct wlr_xdg_importer_v1 *importer =
+		xdg_importer_from_resource(client_resource);
+
+	struct wlr_xdg_imported_v1 *imported =
+		calloc(1, sizeof(struct wlr_xdg_imported_v1));
+	if (imported == NULL) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+
+	imported->exported = find_exported(importer->foreign, handle);
+	imported->resource = wl_resource_create(wl_client,
+		&zxdg_imported_v1_interface,
+		wl_resource_get_version(importer->resource),
+		id);
+	wl_resource_set_implementation(imported->resource, &xdg_imported_impl,
+			imported, xdg_imported_handle_resource_destroy);
+
+	wl_list_init(&imported->children);
+	wl_list_insert(&importer->imports, &imported->link);
+
+	if (imported->exported == NULL) {
+		zxdg_imported_v1_send_destroyed(imported->resource);
+	} else {
+		wl_list_insert(&imported->exported->imports, &imported->export_link);
+	}
+}
+
+static const struct zxdg_importer_v1_interface xdg_importer_impl = {
+	.destroy = xdg_importer_handle_destroy,
+	.import = xdg_importer_handle_import_toplevel
+};
+
+static void xdg_importer_handle_resource_destroy(
+		struct wl_resource *resource) {
+	struct wlr_xdg_importer_v1 *importer =
+		xdg_importer_from_resource(resource);
+	struct wlr_xdg_imported_v1 *imported, *imported_tmp;
+	wl_list_for_each_safe(imported, imported_tmp, &importer->imports, link) {
+		disconnect_imported(imported);
+		wl_list_remove(&imported->link);
+	}
+	wl_list_remove(&importer->link);
+	free(importer);
+}
+
+static void xdg_importer_bind(struct wl_client *wl_client, void *data,
+		uint32_t version, uint32_t id) {
+	struct wlr_xdg_foreign_v1 *foreign = data;
+
+	struct wlr_xdg_importer_v1 *importer =
+		calloc(1, sizeof(struct wlr_xdg_importer_v1));
+	if (importer == NULL) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+
+	importer->foreign = foreign;
+	importer->resource =
+		wl_resource_create(wl_client, &zxdg_importer_v1_interface, version, id);
+	if (importer->resource == NULL) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+	wl_list_init(&importer->imports);
+
+	wl_resource_set_implementation(importer->resource, &xdg_importer_impl,
+			importer, xdg_importer_handle_resource_destroy);
+
+	wl_list_insert(&foreign->importer.clients, &importer->link);
+}
+
+void wlr_xdg_foreign_v1_destroy(
+		struct wlr_xdg_foreign_v1 *foreign) {
+	if (!foreign) {
+		return;
+	}
+
+	struct wl_resource *resource, *tmp_resource;
+	wl_resource_for_each_safe(resource, tmp_resource,
+			&foreign->importer.resources) {
+		wl_resource_destroy(resource);
+	}
+	wl_resource_for_each_safe(resource, tmp_resource,
+			&foreign->exporter.resources) {
+		wl_resource_destroy(resource);
+	}
+
+	wlr_signal_emit_safe(&foreign->events.destroy, foreign);
+	wl_list_remove(&foreign->display_destroy.link);
+
+	wl_global_destroy(foreign->exporter.global);
+	wl_global_destroy(foreign->importer.global);
+	free(foreign);
+}
+
+static void handle_display_destroy(struct wl_listener *listener, void *data) {
+	struct wlr_xdg_foreign_v1 *foreign =
+		wl_container_of(listener, foreign, display_destroy);
+	wlr_xdg_foreign_v1_destroy(foreign);
+}
+
+struct wlr_xdg_foreign_v1 *wlr_xdg_foreign_v1_create(
+		struct wl_display *display) {
+	struct wlr_xdg_foreign_v1 *foreign = calloc(1,
+			sizeof(struct wlr_xdg_foreign_v1));
+	if (!foreign) {
+		return NULL;
+	}
+
+	foreign->exporter.global = wl_global_create(display,
+			&zxdg_exporter_v1_interface,
+			FOREIGN_V1_VERSION, foreign,
+			xdg_exporter_bind);
+	if (!foreign->exporter.global) {
+		free(foreign);
+		return NULL;
+	}
+
+	foreign->importer.global = wl_global_create(display,
+			&zxdg_importer_v1_interface,
+			FOREIGN_V1_VERSION, foreign,
+			xdg_importer_bind);
+	if (!foreign->importer.global) {
+		wl_global_destroy(foreign->exporter.global);
+		free(foreign);
+		return NULL;
+	}
+
+	wl_signal_init(&foreign->events.destroy);
+	wl_list_init(&foreign->exporter.resources);
+	wl_list_init(&foreign->exporter.clients);
+	wl_list_init(&foreign->importer.resources);
+	wl_list_init(&foreign->importer.clients);
+
+	foreign->display_destroy.notify = handle_display_destroy;
+	wl_display_add_destroy_listener(display, &foreign->display_destroy);
+
+	return foreign;
+}

--- a/types/wlr_xdg_foreign_v2.c
+++ b/types/wlr_xdg_foreign_v2.c
@@ -1,0 +1,491 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <wlr/types/wlr_xdg_foreign_v2.h>
+#include <wlr/types/wlr_xdg_shell.h>
+#include <wlr/types/wlr_xdg_shell_v6.h>
+#include <wlr/util/log.h>
+#include "util/signal.h"
+#include "util/uuid.h"
+#include "xdg-foreign-unstable-v2-protocol.h"
+
+#define FOREIGN_V2_VERSION 1
+
+static const struct zxdg_exported_v2_interface xdg_exported_impl;
+static const struct zxdg_imported_v2_interface xdg_imported_impl;
+static const struct zxdg_exporter_v2_interface xdg_exporter_impl;
+static const struct zxdg_importer_v2_interface xdg_importer_impl;
+
+static struct wlr_xdg_imported_v2 *xdg_imported_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &zxdg_imported_v2_interface,
+		&xdg_imported_impl));
+	return wl_resource_get_user_data(resource);
+}
+
+static void xdg_imported_handle_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+
+static bool verify_is_toplevel(struct wl_resource *client_resource,
+		struct wlr_surface *surface) {
+	if (wlr_surface_is_xdg_surface(surface)) {
+		struct wlr_xdg_surface *xdg_surface =
+			wlr_xdg_surface_from_wlr_surface(surface);
+		if (xdg_surface->role != WLR_XDG_SURFACE_ROLE_TOPLEVEL) {
+			wl_resource_post_error(client_resource, -1,
+					"surface must be an xdg_toplevel");
+			return false;
+		}
+	} else if (wlr_surface_is_xdg_surface_v6(surface)) {
+		struct wlr_xdg_surface_v6 *xdg_surface_v6 =
+			wlr_xdg_surface_v6_from_wlr_surface(surface);
+		if (xdg_surface_v6->role != WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL) {
+			wl_resource_post_error(client_resource, -1,
+					"surface must be an xdg_toplevel_v6");
+			return false;
+		}
+	} else {
+		wl_resource_post_error(client_resource, -1,
+				"surface must be an xdg_surface");
+		return false;
+	}
+	return true;
+}
+
+static void destroy_imported_child(struct wlr_xdg_imported_child_v2 *child) {
+	wl_list_remove(&child->xdg_toplevel_set_parent.link);
+	wl_list_remove(&child->xdg_surface_unmap.link);
+	wl_list_remove(&child->link);
+	free(child);
+}
+
+static void handle_child_xdg_surface_unmap(
+		struct wl_listener *listener, void *data) {
+	struct wlr_xdg_imported_child_v2 *child =
+		wl_container_of(listener, child, xdg_surface_unmap);
+	destroy_imported_child(child);
+}
+
+static void handle_xdg_toplevel_set_parent(
+		struct wl_listener *listener, void *data) {
+	struct wlr_xdg_imported_child_v2 *child =
+		wl_container_of(listener, child, xdg_toplevel_set_parent);
+	destroy_imported_child(child);
+}
+
+static void xdg_imported_handle_set_parent_of(struct wl_client *client,
+		struct wl_resource *resource,
+		struct wl_resource *child_resource) {
+	struct wlr_xdg_imported_v2 *imported =
+		xdg_imported_from_resource(resource);
+	if (imported->exported == NULL) {
+		return;
+	}
+	struct wlr_surface *wlr_surface = imported->exported->surface;
+	struct wlr_surface *wlr_surface_child =
+		wlr_surface_from_resource(child_resource);
+
+	if (!verify_is_toplevel(resource, wlr_surface_child)) {
+		return;
+	}
+	if (wlr_surface_is_xdg_surface(wlr_surface)
+			!= wlr_surface_is_xdg_surface(wlr_surface_child)) {
+		wl_resource_post_error(resource, -1,
+				"surfaces must have the same role");
+		return;
+	}
+	struct wlr_xdg_imported_child_v2 *child;
+	wl_list_for_each(child, &imported->children, link) {
+		if (child->surface == wlr_surface_child) {
+			return;
+		}
+	}
+
+	child = calloc(1, sizeof(struct wlr_xdg_imported_child_v2));
+	if (child == NULL) {
+		wl_client_post_no_memory(client);
+		return;
+	}
+	child->surface = wlr_surface_child;
+	child->xdg_surface_unmap.notify = handle_child_xdg_surface_unmap;
+	child->xdg_toplevel_set_parent.notify = handle_xdg_toplevel_set_parent;
+
+	if (wlr_surface_is_xdg_surface(wlr_surface)) {
+		struct wlr_xdg_surface *surface =
+			wlr_xdg_surface_from_wlr_surface(wlr_surface);
+		struct wlr_xdg_surface *surface_child =
+			wlr_xdg_surface_from_wlr_surface(wlr_surface_child);
+
+		wlr_xdg_toplevel_set_parent(surface_child, surface);
+		wl_signal_add(&surface_child->events.unmap,
+				&child->xdg_surface_unmap);
+		wl_signal_add(&surface_child->toplevel->events.set_parent,
+				&child->xdg_toplevel_set_parent);
+	} else if (wlr_surface_is_xdg_surface_v6(wlr_surface)) {
+		struct wlr_xdg_surface_v6 *surface =
+			wlr_xdg_surface_v6_from_wlr_surface(wlr_surface);
+		struct wlr_xdg_surface_v6 *surface_child =
+			wlr_xdg_surface_v6_from_wlr_surface(wlr_surface_child);
+
+		wlr_xdg_toplevel_v6_set_parent(surface_child, surface);
+		wl_signal_add(&surface_child->events.unmap,
+				&child->xdg_surface_unmap);
+		wl_signal_add(&surface_child->toplevel->events.set_parent,
+				&child->xdg_toplevel_set_parent);
+	}
+
+	wl_list_insert(&imported->children, &child->link);
+}
+
+static const struct zxdg_imported_v2_interface xdg_imported_impl = {
+	.destroy = xdg_imported_handle_destroy,
+	.set_parent_of = xdg_imported_handle_set_parent_of
+};
+
+static struct wlr_xdg_exported_v2 *xdg_exported_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &zxdg_exported_v2_interface,
+		&xdg_exported_impl));
+	return wl_resource_get_user_data(resource);
+}
+
+static void xdg_exported_handle_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+
+static const struct zxdg_exported_v2_interface xdg_exported_impl = {
+	.destroy = xdg_exported_handle_destroy
+};
+
+static void xdg_exporter_handle_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+
+static struct wlr_xdg_exporter_v2 *xdg_exporter_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &zxdg_exporter_v2_interface,
+		&xdg_exporter_impl));
+	return wl_resource_get_user_data(resource);
+}
+
+static void disconnect_imported(struct wlr_xdg_imported_v2 *imported) {
+	if (imported->exported != NULL) {
+		imported->exported = NULL;
+		zxdg_imported_v2_send_destroyed(imported->resource);
+		wl_list_remove(&imported->export_link);
+	}
+}
+
+static void xdg_exported_handle_resource_destroy(
+		struct wl_resource *resource) {
+	struct wlr_xdg_exported_v2 *exported =
+		xdg_exported_from_resource(resource);
+	struct wlr_xdg_imported_v2 *imported, *imported_tmp;
+	wl_list_for_each_safe(imported, imported_tmp,
+			&exported->imports, export_link) {
+		disconnect_imported(imported);
+	}
+	wl_list_remove(&exported->xdg_surface_unmap.link);
+	wl_list_remove(&exported->link);
+	free(exported);
+}
+
+static void handle_xdg_surface_unmap(
+		struct wl_listener *listener, void *data) {
+	struct wlr_xdg_exported_v2 *exported =
+		wl_container_of(listener, exported, xdg_surface_unmap);
+	wl_resource_destroy(exported->resource);
+}
+
+static struct wlr_xdg_exported_v2 *find_exported(
+		struct wlr_xdg_foreign_v2 *foreign, const char *handle) {
+	if (handle == NULL) {
+		return NULL;
+	}
+	struct wlr_xdg_exporter_v2 *exporter;
+	wl_list_for_each(exporter, &foreign->exporter.clients, link) {
+		struct wlr_xdg_exported_v2 *exported;
+		wl_list_for_each(exported, &exporter->exports, link) {
+			if (strcmp(handle, exported->handle) == 0) {
+				return exported;
+			}
+		}
+	}
+	return NULL;
+}
+
+static void xdg_exporter_handle_export_toplevel(struct wl_client *wl_client,
+		struct wl_resource *client_resource,
+		uint32_t id,
+		struct wl_resource *surface_resource) {
+	struct wlr_xdg_exporter_v2 *exporter =
+		xdg_exporter_from_resource(client_resource);
+	struct wlr_surface *surface = wlr_surface_from_resource(surface_resource);
+
+	if (!verify_is_toplevel(client_resource, surface)) {
+		return;
+	}
+
+	struct wlr_xdg_exported_v2 *exported =
+		calloc(1, sizeof(struct wlr_xdg_exported_v2));
+	if (exported == NULL) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+
+	exported->surface = surface;
+	do {
+		if (generate_uuid(exported->handle)) {
+			wl_client_post_no_memory(wl_client);
+			free(exported);
+			return;
+		}
+	} while (find_exported(exporter->foreign, exported->handle) != NULL);
+	exported->resource = wl_resource_create(wl_client,
+		&zxdg_exported_v2_interface,
+		wl_resource_get_version(exporter->resource),
+		id);
+
+	wl_resource_set_implementation(exported->resource, &xdg_exported_impl,
+			exported, xdg_exported_handle_resource_destroy);
+
+	wl_list_insert(&exporter->exports, &exported->link);
+	wl_list_init(&exported->imports);
+
+	zxdg_exported_v2_send_handle(exported->resource, exported->handle);
+
+	exported->xdg_surface_unmap.notify = handle_xdg_surface_unmap;
+	if (wlr_surface_is_xdg_surface(surface)) {
+		struct wlr_xdg_surface *xdg_surface =
+			wlr_xdg_surface_from_wlr_surface(surface);
+		wl_signal_add(&xdg_surface->events.unmap, &exported->xdg_surface_unmap);
+	} else if (wlr_surface_is_xdg_surface_v6(surface)) {
+		struct wlr_xdg_surface_v6 *xdg_surface_v6 =
+			wlr_xdg_surface_v6_from_wlr_surface(surface);
+		wl_signal_add(&xdg_surface_v6->events.unmap, &exported->xdg_surface_unmap);
+	}
+}
+
+static const struct zxdg_exporter_v2_interface xdg_exporter_impl = {
+	.destroy = xdg_exporter_handle_destroy,
+	.export_toplevel = xdg_exporter_handle_export_toplevel
+};
+
+static void xdg_exporter_handle_resource_destroy(
+		struct wl_resource *resource) {
+	struct wlr_xdg_exporter_v2 *exporter = xdg_exporter_from_resource(resource);
+	struct wlr_xdg_exported_v2 *exported, *exported_tmp;
+	wl_list_for_each_safe(exported, exported_tmp, &exporter->exports, link) {
+		wl_resource_destroy(exported->resource);
+	}
+	wl_list_remove(&exporter->link);
+	free(exporter);
+}
+
+static void xdg_exporter_bind(struct wl_client *wl_client, void *data,
+		uint32_t version, uint32_t id) {
+	struct wlr_xdg_foreign_v2 *foreign = data;
+
+	struct wlr_xdg_exporter_v2 *exporter =
+		calloc(1, sizeof(struct wlr_xdg_exporter_v2));
+	if (exporter == NULL) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+
+	exporter->foreign = foreign;
+	exporter->resource =
+		wl_resource_create(wl_client, &zxdg_exporter_v2_interface, version, id);
+	if (exporter->resource == NULL) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+	wl_list_init(&exporter->exports);
+
+	wl_resource_set_implementation(exporter->resource, &xdg_exporter_impl,
+			exporter, xdg_exporter_handle_resource_destroy);
+
+	wl_list_insert(&foreign->exporter.clients, &exporter->link);
+}
+
+static struct wlr_xdg_importer_v2 *xdg_importer_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &zxdg_importer_v2_interface,
+		&xdg_importer_impl));
+	return wl_resource_get_user_data(resource);
+}
+
+static void xdg_importer_handle_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+
+static void xdg_imported_handle_resource_destroy(
+		struct wl_resource *resource) {
+	struct wlr_xdg_imported_v2 *imported = xdg_imported_from_resource(resource);
+
+	struct wlr_xdg_imported_child_v2 *child, *child_tmp;
+	wl_list_for_each_safe(child, child_tmp, &imported->children, link) {
+		struct wlr_xdg_surface *xdg_child =
+			wlr_xdg_surface_from_wlr_surface(child->surface);
+		wlr_xdg_toplevel_set_parent(xdg_child, NULL);
+	}
+	if (imported->export_link.prev != NULL) {
+		wl_list_remove(&imported->export_link);
+	}
+	if (imported->link.prev != NULL) {
+		wl_list_remove(&imported->link);
+	}
+	free(imported);
+}
+
+static void xdg_importer_handle_import_toplevel(struct wl_client *wl_client,
+				struct wl_resource *client_resource,
+				uint32_t id,
+				const char *handle) {
+	struct wlr_xdg_importer_v2 *importer =
+		xdg_importer_from_resource(client_resource);
+
+	struct wlr_xdg_imported_v2 *imported =
+		calloc(1, sizeof(struct wlr_xdg_imported_v2));
+	if (imported == NULL) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+
+	imported->exported = find_exported(importer->foreign, handle);
+	imported->resource = wl_resource_create(wl_client,
+		&zxdg_imported_v2_interface,
+		wl_resource_get_version(importer->resource),
+		id);
+	wl_resource_set_implementation(imported->resource, &xdg_imported_impl,
+			imported, xdg_imported_handle_resource_destroy);
+
+	wl_list_init(&imported->children);
+	wl_list_insert(&importer->imports, &imported->link);
+
+	if (imported->exported == NULL) {
+		zxdg_imported_v2_send_destroyed(imported->resource);
+	} else {
+		wl_list_insert(&imported->exported->imports, &imported->export_link);
+	}
+}
+
+static const struct zxdg_importer_v2_interface xdg_importer_impl = {
+	.destroy = xdg_importer_handle_destroy,
+	.import_toplevel = xdg_importer_handle_import_toplevel
+};
+
+static void xdg_importer_handle_resource_destroy(
+		struct wl_resource *resource) {
+	struct wlr_xdg_importer_v2 *importer =
+		xdg_importer_from_resource(resource);
+	struct wlr_xdg_imported_v2 *imported, *imported_tmp;
+	wl_list_for_each_safe(imported, imported_tmp, &importer->imports, link) {
+		disconnect_imported(imported);
+		wl_list_remove(&imported->link);
+	}
+	wl_list_remove(&importer->link);
+	free(importer);
+}
+
+static void xdg_importer_bind(struct wl_client *wl_client, void *data,
+		uint32_t version, uint32_t id) {
+	struct wlr_xdg_foreign_v2 *foreign = data;
+
+	struct wlr_xdg_importer_v2 *importer =
+		calloc(1, sizeof(struct wlr_xdg_importer_v2));
+	if (importer == NULL) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+
+	importer->foreign = foreign;
+	importer->resource =
+		wl_resource_create(wl_client, &zxdg_importer_v2_interface, version, id);
+	if (importer->resource == NULL) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+	wl_list_init(&importer->imports);
+
+	wl_resource_set_implementation(importer->resource, &xdg_importer_impl,
+			importer, xdg_importer_handle_resource_destroy);
+
+	wl_list_insert(&foreign->importer.clients, &importer->link);
+}
+
+void wlr_xdg_foreign_v2_destroy(
+		struct wlr_xdg_foreign_v2 *foreign) {
+	if (!foreign) {
+		return;
+	}
+
+	struct wl_resource *resource, *tmp_resource;
+	wl_resource_for_each_safe(resource, tmp_resource,
+			&foreign->importer.resources) {
+		wl_resource_destroy(resource);
+	}
+	wl_resource_for_each_safe(resource, tmp_resource,
+			&foreign->exporter.resources) {
+		wl_resource_destroy(resource);
+	}
+
+	wlr_signal_emit_safe(&foreign->events.destroy, foreign);
+	wl_list_remove(&foreign->display_destroy.link);
+
+	wl_global_destroy(foreign->exporter.global);
+	wl_global_destroy(foreign->importer.global);
+	free(foreign);
+}
+
+static void handle_display_destroy(struct wl_listener *listener, void *data) {
+	struct wlr_xdg_foreign_v2 *foreign =
+		wl_container_of(listener, foreign, display_destroy);
+	wlr_xdg_foreign_v2_destroy(foreign);
+}
+
+struct wlr_xdg_foreign_v2 *wlr_xdg_foreign_v2_create(
+		struct wl_display *display) {
+	struct wlr_xdg_foreign_v2 *foreign = calloc(1,
+			sizeof(struct wlr_xdg_foreign_v2));
+	if (!foreign) {
+		return NULL;
+	}
+
+	foreign->exporter.global = wl_global_create(display,
+			&zxdg_exporter_v2_interface,
+			FOREIGN_V2_VERSION, foreign,
+			xdg_exporter_bind);
+	if (!foreign->exporter.global) {
+		free(foreign);
+		return NULL;
+	}
+
+	foreign->importer.global = wl_global_create(display,
+			&zxdg_importer_v2_interface,
+			FOREIGN_V2_VERSION, foreign,
+			xdg_importer_bind);
+	if (!foreign->importer.global) {
+		wl_global_destroy(foreign->exporter.global);
+		free(foreign);
+		return NULL;
+	}
+
+	wl_signal_init(&foreign->events.destroy);
+	wl_list_init(&foreign->exporter.resources);
+	wl_list_init(&foreign->exporter.clients);
+	wl_list_init(&foreign->importer.resources);
+	wl_list_init(&foreign->importer.clients);
+
+	foreign->display_destroy.notify = handle_display_destroy;
+	wl_display_add_destroy_listener(display, &foreign->display_destroy);
+
+	return foreign;
+}

--- a/types/xdg_shell/wlr_xdg_toplevel.c
+++ b/types/xdg_shell/wlr_xdg_toplevel.c
@@ -207,16 +207,14 @@ struct wlr_xdg_surface *wlr_xdg_surface_from_toplevel_resource(
 	return wl_resource_get_user_data(resource);
 }
 
-static void set_parent(struct wlr_xdg_surface *surface,
-		struct wlr_xdg_surface *parent);
-
 static void handle_parent_unmap(struct wl_listener *listener, void *data) {
 	struct wlr_xdg_toplevel *toplevel =
 		wl_container_of(listener, toplevel, parent_unmap);
-	set_parent(toplevel->base, toplevel->parent->toplevel->parent);
+	wlr_xdg_toplevel_set_parent(toplevel->base,
+			toplevel->parent->toplevel->parent);
 }
 
-static void set_parent(struct wlr_xdg_surface *surface,
+void wlr_xdg_toplevel_set_parent(struct wlr_xdg_surface *surface,
 		struct wlr_xdg_surface *parent) {
 	assert(surface->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL);
 	assert(!parent || parent->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL);
@@ -245,7 +243,7 @@ static void xdg_toplevel_handle_set_parent(struct wl_client *client,
 		parent = wlr_xdg_surface_from_toplevel_resource(parent_resource);
 	}
 
-	set_parent(surface, parent);
+	wlr_xdg_toplevel_set_parent(surface, parent);
 }
 
 static void xdg_toplevel_handle_set_title(struct wl_client *client,

--- a/types/xdg_shell_v6/wlr_xdg_toplevel_v6.c
+++ b/types/xdg_shell_v6/wlr_xdg_toplevel_v6.c
@@ -36,6 +36,15 @@ static void xdg_toplevel_handle_destroy(struct wl_client *client,
 	wl_resource_destroy(resource);
 }
 
+void wlr_xdg_toplevel_v6_set_parent(struct wlr_xdg_surface_v6 *surface,
+		struct wlr_xdg_surface_v6 *parent) {
+	assert(surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL);
+	assert(!parent || parent->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL);
+
+	surface->toplevel->parent = parent;
+	wlr_signal_emit_safe(&surface->toplevel->events.set_parent, surface);
+}
+
 static void xdg_toplevel_handle_set_parent(struct wl_client *client,
 		struct wl_resource *resource, struct wl_resource *parent_resource) {
 	struct wlr_xdg_surface_v6 *surface =
@@ -45,9 +54,7 @@ static void xdg_toplevel_handle_set_parent(struct wl_client *client,
 	if (parent_resource != NULL) {
 		parent = xdg_surface_from_xdg_toplevel_resource(parent_resource);
 	}
-
-	surface->toplevel->parent = parent;
-	wlr_signal_emit_safe(&surface->toplevel->events.set_parent, surface);
+	wlr_xdg_toplevel_v6_set_parent(surface, parent);
 }
 
 static void xdg_toplevel_handle_set_title(struct wl_client *client,

--- a/util/meson.build
+++ b/util/meson.build
@@ -5,3 +5,14 @@ wlr_files += files(
 	'shm.c',
 	'signal.c',
 )
+
+if uuid.found()
+	wlr_deps += uuid
+	add_project_arguments('-DHAS_LIBUUID', language: 'c')
+endif
+
+if conf_data.get('WLR_HAS_XDG_FOREIGN', 0) == 1
+	wlr_files += files(
+			'uuid.c',
+		)
+endif

--- a/util/uuid.c
+++ b/util/uuid.c
@@ -1,0 +1,32 @@
+#include "util/uuid.h"
+
+#include <uuid.h>
+
+#ifdef HAS_LIBUUID
+int generate_uuid(char out[static 37]) {
+	uuid_t uuid;
+	uuid_generate_random(uuid);
+	uuid_unparse(uuid, out);
+	return 0;
+}
+#else
+#include <string.h>
+#include <stdlib.h>
+
+int generate_uuid(char out[static 37]) {
+	uuid_t uuid;
+	uint32_t status;
+	uuid_create(&uuid, &status);
+	if (status != uuid_s_ok) {
+		return 1;
+	}
+	char *str;
+	uuid_to_string(&uuid, &str, &status);
+	if (status != uuid_s_ok) {
+		return 1;
+	}
+	strcpy(out, str);
+	free(str);
+	return 0;
+}
+#endif


### PR DESCRIPTION
Closes #1702

Sway branch for testing is here: [cyclopsian/sway:xdg-foreign](https://github.com/cyclopsian/sway/tree/xdg-foreign)

To test, run [portal-test](https://github.com/matthiasclasen/portal-test) or some other flatpak application that uses the desktop portal. Make the application fullscreen in sway and open a file dialog. Before these patches, the file dialogs would appear behind the fullscreen surface since toplevel->parent was not being set.

Both versions are supported because Mutter/GTK uses v1 and KWayland uses v2.

Possible changes that should be made (feedback requested):

- Combine the v1 and v2 implementations instead of copying the file? Both implementations are exactly the same. 
- Use an actually secure way of generating handles, maybe use libuuid?
- Store the handles in a hash table?
