### PR TITLE
xwayland: Expose configure mask

### DIFF
--- a/include/wlr/xwayland.h
+++ b/include/wlr/xwayland.h
@@ -179,6 +179,7 @@ struct wlr_xwayland_surface_configure_event {
 	struct wlr_xwayland_surface *surface;
 	int16_t x, y;
 	uint16_t width, height;
+	uint16_t mask; // xcb_config_window_t
 };
 
 // TODO: maybe add a seat to these

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -871,6 +871,7 @@ static void xwm_handle_configure_request(struct wlr_xwm *xwm,
 		.y = mask & XCB_CONFIG_WINDOW_Y ? ev->y : surface->y,
 		.width = mask & XCB_CONFIG_WINDOW_WIDTH ? ev->width : surface->width,
 		.height = mask & XCB_CONFIG_WINDOW_HEIGHT ? ev->height : surface->height,
+		.mask = mask,
 	};
 	wlr_log(WLR_DEBUG, "XCB_CONFIGURE_REQUEST (%u) [%ux%u+%d,%d]", ev->window,
 		wlr_event.width, wlr_event.height, wlr_event.x, wlr_event.y);


### PR DESCRIPTION
This allows compositors to know which elements are valid. Without this,
it is impossible to tell which are invalid. This means if only position or size
are valid for instance, the compositor can discard the values of the rest.