### PR TITLE
backend/drm: use modifiers for our GBM buffers

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -680,22 +680,24 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 		ret = drmGetCap(drm->fd, DRM_CAP_CURSOR_HEIGHT, &h);
 		h = ret ? 64 : h;
 
-
 		if (!drm->parent) {
 			if (!init_drm_surface(&plane->surf, &drm->renderer, w, h,
-					drm->renderer.gbm_format, GBM_BO_USE_LINEAR | GBM_BO_USE_SCANOUT)) {
+					drm->renderer.gbm_format, NULL,
+					GBM_BO_USE_LINEAR | GBM_BO_USE_SCANOUT)) {
 				wlr_log(WLR_ERROR, "Cannot allocate cursor resources");
 				return false;
 			}
 		} else {
 			if (!init_drm_surface(&plane->surf, &drm->parent->renderer, w, h,
-					drm->parent->renderer.gbm_format, GBM_BO_USE_LINEAR)) {
+					drm->parent->renderer.gbm_format, NULL,
+					GBM_BO_USE_LINEAR)) {
 				wlr_log(WLR_ERROR, "Cannot allocate cursor resources");
 				return false;
 			}
 
 			if (!init_drm_surface(&plane->mgpu_surf, &drm->renderer, w, h,
-					drm->renderer.gbm_format, GBM_BO_USE_LINEAR | GBM_BO_USE_SCANOUT)) {
+					drm->renderer.gbm_format, NULL,
+					GBM_BO_USE_LINEAR | GBM_BO_USE_SCANOUT)) {
 				wlr_log(WLR_ERROR, "Cannot allocate cursor resources");
 				return false;
 			}

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -40,7 +40,7 @@ void finish_drm_renderer(struct wlr_drm_renderer *renderer);
 
 bool init_drm_surface(struct wlr_drm_surface *surf,
 	struct wlr_drm_renderer *renderer, uint32_t width, uint32_t height,
-	uint32_t format, uint32_t flags);
+	uint32_t format, struct wlr_drm_format_set *set, uint32_t flags);
 
 bool init_drm_plane_surfaces(struct wlr_drm_plane *plane,
 	struct wlr_drm_backend *drm, int32_t width, uint32_t height,


### PR DESCRIPTION
On my Intel GPU, the primary plane ends up using X_TILED instead of LINEAR.

Closes: https://github.com/swaywm/wlroots/issues/1840