### PR TITLE
build: workaround for meson disabler object not working with if not

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -20,7 +20,8 @@ foreach dep : ['libpng', 'libavutil', 'libavcodec', 'libavformat']
 	endif
 endforeach
 
-if not cc.has_header('libavutil/hwcontext_drm.h', dependencies: libavutil)
+# Check if libavutil is found because of https://github.com/mesonbuild/meson/issues/6010
+if libavutil.found() and not cc.has_header('libavutil/hwcontext_drm.h', dependencies: libavutil)
 	libavutil = disabler()
 endif
 


### PR DESCRIPTION
Successful wlroots build in Sway CI: https://builds.sr.ht/~emersion/job/95358#task-wlroots

(The failure at the sway stage is fixed by https://github.com/swaywm/sway/pull/4615)