### PR TITLE
Add new define EGL_NO_X11 for newer mesa library

### DIFF
--- a/glgen.sh
+++ b/glgen.sh
@@ -64,8 +64,13 @@ cat > "$OUTDIR/$BASE.h" << EOF
 #include <stdbool.h>
 #include <wlr/config.h>
 
-#if !WLR_HAS_X11_BACKEND && !WLR_HAS_XWAYLAND && !defined MESA_EGL_NO_X11_HEADERS
+#if !WLR_HAS_X11_BACKEND && !WLR_HAS_XWAYLAND
+#ifndef MESA_EGL_NO_X11_HEADERS
 #define MESA_EGL_NO_X11_HEADERS
+#endif
+#ifndef EGL_NO_X11
+#define EGL_NO_X11
+#endif
 #endif
 
 #include <EGL/egl.h>

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -11,8 +11,13 @@
 
 #include <wlr/config.h>
 
-#if !WLR_HAS_X11_BACKEND && !WLR_HAS_XWAYLAND && !defined MESA_EGL_NO_X11_HEADERS
+#if !WLR_HAS_X11_BACKEND && !WLR_HAS_XWAYLAND
+#ifndef MESA_EGL_NO_X11_HEADERS
 #define MESA_EGL_NO_X11_HEADERS
+#endif
+#ifndef EGL_NO_X11
+#define EGL_NO_X11
+#endif
 #endif
 
 #include <EGL/egl.h>

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -11,8 +11,13 @@
 
 #include <wlr/config.h>
 
-#if !WLR_HAS_X11_BACKEND && !WLR_HAS_XWAYLAND && !defined MESA_EGL_NO_X11_HEADERS
+#if !WLR_HAS_X11_BACKEND && !WLR_HAS_XWAYLAND
+#ifndef MESA_EGL_NO_X11_HEADERS
 #define MESA_EGL_NO_X11_HEADERS
+#endif
+#ifndef EGL_NO_X11
+#define EGL_NO_X11
+#endif
 #endif
 
 #include <EGL/egl.h>


### PR DESCRIPTION
Define both MESA_EGL_NO_X11_HEADERS and EGL_NO_X11 for
backward combatibility.

Newer versions of mesa now define -DEGL_NO_X11 instead of -DMESA_EGL_NO_X11_HEADERS.