### PR TITLE
Add missing include required by mesa and libglvnd change

### DIFF
--- a/glgen.sh
+++ b/glgen.sh
@@ -70,6 +70,7 @@ cat > "$OUTDIR/$BASE.h" << EOF
 
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
+#include <EGL/eglmesaext.h>
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 


### PR DESCRIPTION
eglext.h no longer inludes eglmesaext.h, include it within wlroots
explicitly.

Fixes #1862