### PR TITLE
Implement input-method keyboard grab

### DIFF
--- a/examples/input-method-keyboard-grab.c
+++ b/examples/input-method-keyboard-grab.c
@@ -1,0 +1,217 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <wayland-client.h>
+#include <xkbcommon/xkbcommon.h>
+#include "input-method-unstable-v2-client-protocol.h"
+
+static struct wl_display *display = NULL;
+static struct wl_seat *seat = NULL;
+static struct zwp_input_method_manager_v2 *input_method_manager = NULL;
+static struct zwp_input_method_v2 *input_method = NULL;
+static struct zwp_input_method_keyboard_grab_v2 *kb_grab = NULL;
+
+static bool active = false;
+static bool pending_active = false;
+
+static struct xkb_context *xkb_context = NULL;
+static struct xkb_keymap *keymap = NULL;
+static struct xkb_state *xkb_state = NULL;
+
+static void handle_key(void *data,
+		struct zwp_input_method_keyboard_grab_v2 *im_keyboard_grab,
+		uint32_t serial, uint32_t time, uint32_t key, uint32_t state) {
+	printf("handle_key %u %u %u %u\n", serial, time, key, state);
+	xkb_keysym_t keysym = xkb_state_key_get_one_sym(xkb_state, key + 8);
+	char keysym_name[64];
+	xkb_keysym_get_name(keysym, keysym_name, sizeof(keysym_name));
+	printf("xkb translated to %s\n", keysym_name);
+	if (state == WL_KEYBOARD_KEY_STATE_PRESSED) {
+		if (keysym == XKB_KEY_KP_Enter || keysym == XKB_KEY_Return) {
+			printf("Stopping grab\n");
+			zwp_input_method_keyboard_grab_v2_release(kb_grab);
+			kb_grab = NULL;
+		}
+	}
+
+}
+
+static void handle_modifiers(void *data,
+		struct zwp_input_method_keyboard_grab_v2 *im_keyboard_grab,
+		uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched,
+		uint32_t mods_locked, uint32_t group) {
+	printf("handle_modifiers %u %u %u %u %u\n", serial, mods_depressed,
+		mods_latched, mods_locked, group);
+	xkb_state_update_mask(xkb_state, mods_depressed, mods_latched,
+		mods_locked, 0, 0, group);
+}
+
+static void handle_keymap(void *data,
+		struct zwp_input_method_keyboard_grab_v2 *im_keyboard_grab,
+		uint32_t format, int32_t fd, uint32_t size) {
+	printf("handle_keymap\n");
+	char *keymap_string = mmap(NULL, size, PROT_READ, MAP_SHARED, fd, 0);
+	xkb_keymap_unref(keymap);
+	keymap = xkb_keymap_new_from_string(xkb_context, keymap_string,
+		XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS);
+	munmap(keymap_string, size);
+	close(fd);
+	xkb_state_unref(xkb_state);
+	xkb_state = xkb_state_new(keymap);
+}
+
+static void handle_repeat_info(void *data,
+		struct zwp_input_method_keyboard_grab_v2 *im_keyboard_grab,
+		int32_t rate, int32_t delay) {
+	printf("handle_repeat_info %d %d", rate, delay);
+}
+
+
+static const struct zwp_input_method_keyboard_grab_v2_listener grab_listener = {
+	.key = handle_key,
+	.modifiers = handle_modifiers,
+	.keymap = handle_keymap,
+	.repeat_info = handle_repeat_info,
+};
+
+static void handle_activate(void *data,
+		struct zwp_input_method_v2 *zwp_input_method_v2) {
+	pending_active = true;
+}
+
+static void handle_deactivate(void *data,
+		struct zwp_input_method_v2 *zwp_input_method_v2) {
+	pending_active = false;
+}
+
+static void handle_unavailable(void *data,
+		struct zwp_input_method_v2 *zwp_input_method_v2) {
+	printf("IM unavailable\n");
+	zwp_input_method_v2_destroy(zwp_input_method_v2);
+	input_method = NULL;
+}
+
+static void im_activate(void *data,
+		struct zwp_input_method_v2 *id) {
+	kb_grab = zwp_input_method_v2_grab_keyboard(input_method);
+	if (kb_grab == NULL) {
+		fprintf(stderr, "Failed to grab\n");
+		exit(EXIT_FAILURE);
+	}
+	zwp_input_method_keyboard_grab_v2_add_listener(kb_grab, &grab_listener,
+		NULL);
+	printf("Started grab, press enter to stop grab\n");
+}
+
+static void im_deactivate(void *data,
+		struct zwp_input_method_v2 *context) {
+	if (kb_grab != NULL) {
+		zwp_input_method_keyboard_grab_v2_release(kb_grab);
+		kb_grab = NULL;
+	}
+}
+
+static void handle_done(void *data,
+		struct zwp_input_method_v2 *zwp_input_method_v2) {
+	bool prev_active = active;
+	if (active != pending_active) {
+		printf("Now %s\n", pending_active ? "active" : "inactive");
+	}
+	active = pending_active;
+	if (active && !prev_active) {
+		im_activate(data, zwp_input_method_v2);
+	} else if (!active && prev_active) {
+		im_deactivate(data, zwp_input_method_v2);
+	}
+}
+
+static void handle_surrounding_text(void *data,
+		struct zwp_input_method_v2 *zwp_input_method_v2,
+		const char *text, uint32_t cursor, uint32_t anchor) {
+	// not for this test
+}
+
+static void handle_text_change_cause(void *data,
+		struct zwp_input_method_v2 *zwp_input_method_v2,
+		uint32_t cause) {
+	// not for this test
+}
+
+static void handle_content_type(void *data,
+		struct zwp_input_method_v2 *zwp_input_method_v2,
+		uint32_t hint, uint32_t purpose) {
+	// not for this test
+}
+
+static const struct zwp_input_method_v2_listener im_listener = {
+	.activate = handle_activate,
+	.deactivate = handle_deactivate,
+	.surrounding_text = handle_surrounding_text,
+	.text_change_cause = handle_text_change_cause,
+	.content_type = handle_content_type,
+	.done = handle_done,
+	.unavailable = handle_unavailable,
+};
+
+static void handle_global(void *data, struct wl_registry *registry,
+		uint32_t name, const char *interface, uint32_t version) {
+	if (strcmp(interface, zwp_input_method_manager_v2_interface.name) == 0) {
+		input_method_manager = wl_registry_bind(registry, name,
+			&zwp_input_method_manager_v2_interface, 1);
+	} else if (strcmp(interface, wl_seat_interface.name) == 0) {
+		seat = wl_registry_bind(registry, name, &wl_seat_interface, version);
+	}
+}
+
+static void handle_global_remove(void *data, struct wl_registry *registry,
+		uint32_t name) {
+	// who cares
+}
+
+static const struct wl_registry_listener registry_listener = {
+	.global = handle_global,
+	.global_remove = handle_global_remove,
+};
+
+int main(int argc, char **argv) {
+	xkb_context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+	if (xkb_context == NULL) {
+		fprintf(stderr, "Failed to create xkb context\n");
+		return EXIT_FAILURE;
+	}
+
+	display = wl_display_connect(NULL);
+	if (display == NULL) {
+		fprintf(stderr, "Failed to create display\n");
+		return EXIT_FAILURE;
+	}
+
+	struct wl_registry *registry = wl_display_get_registry(display);
+	wl_registry_add_listener(registry, &registry_listener, NULL);
+	wl_display_dispatch(display);
+	wl_display_roundtrip(display);
+
+	if (input_method_manager == NULL) {
+		fprintf(stderr, "input-method not available\n");
+		return EXIT_FAILURE;
+	}
+	if (seat == NULL) {
+		fprintf(stderr, "seat not available\n");
+		return EXIT_FAILURE;
+	}
+
+	input_method = zwp_input_method_manager_v2_get_input_method(
+		input_method_manager, seat);
+	zwp_input_method_v2_add_listener(input_method, &im_listener, NULL);
+
+	wl_display_roundtrip(display);
+
+	while (wl_display_dispatch(display) != -1) {
+		// This space is intentionally left blank
+	};
+
+	return EXIT_SUCCESS;
+}

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -170,6 +170,13 @@ clients = {
 		'dep': wlroots,
 		'proto': ['wlr-virtual-pointer-unstable-v1'],
 	},
+	'input-method-keyboard-grab': {
+		'src': 'input-method-keyboard-grab.c',
+		'dep': xkbcommon,
+		'proto': [
+			'input-method-unstable-v2',
+		],
+	},
 }
 
 foreach name, info : compositors

--- a/include/wlr/types/wlr_input_method_v2.h
+++ b/include/wlr/types/wlr_input_method_v2.h
@@ -34,6 +34,7 @@ struct wlr_input_method_v2 {
 	struct wl_resource *resource;
 
 	struct wlr_seat *seat;
+	struct wlr_seat_client *seat_client;
 
 	struct wlr_input_method_v2_state pending;
 	struct wlr_input_method_v2_state current;
@@ -41,13 +42,30 @@ struct wlr_input_method_v2 {
 	bool client_active; // state known to the client
 	uint32_t current_serial; // received in last commit call
 
+	struct wlr_input_method_keyboard_grab_v2 *keyboard_grab;
+
 	struct wl_list link;
 
-	struct wl_listener seat_destroy;
+	struct wl_listener seat_client_destroy;
 
 	struct {
 		struct wl_signal commit; // (struct wlr_input_method_v2*)
+		struct wl_signal grab_keyboard; // (struct wlr_input_method_keyboard_grab_v2*)
 		struct wl_signal destroy; // (struct wlr_input_method_v2*)
+	} events;
+};
+
+struct wlr_input_method_keyboard_grab_v2 {
+	struct wl_resource *resource;
+	struct wlr_input_method_v2 *input_method;
+	struct wlr_keyboard *keyboard;
+
+	struct wl_listener keyboard_keymap;
+	struct wl_listener keyboard_repeat_info;
+	struct wl_listener keyboard_destroy;
+
+	struct {
+		struct wl_signal destroy; // (struct wlr_input_method_keyboard_grab_v2*)
 	} events;
 };
 
@@ -81,5 +99,17 @@ void wlr_input_method_v2_send_text_change_cause(
 void wlr_input_method_v2_send_done(struct wlr_input_method_v2 *input_method);
 void wlr_input_method_v2_send_unavailable(
 	struct wlr_input_method_v2 *input_method);
+
+void wlr_input_method_keyboard_grab_v2_send_key(
+	struct wlr_input_method_keyboard_grab_v2 *keyboard_grab,
+	uint32_t time, uint32_t key, uint32_t state);
+void wlr_input_method_keyboard_grab_v2_send_modifiers(
+	struct wlr_input_method_keyboard_grab_v2 *keyboard_grab,
+	struct wlr_keyboard_modifiers *modifiers);
+void wlr_input_method_keyboard_grab_v2_set_keyboard(
+	struct wlr_input_method_keyboard_grab_v2 *keyboard_grab,
+	struct wlr_keyboard *keyboard);
+void wlr_input_method_keyboard_grab_v2_destroy(
+	struct wlr_input_method_keyboard_grab_v2 *keyboard_grab);
 
 #endif

--- a/include/wlr/types/wlr_virtual_keyboard_v1.h
+++ b/include/wlr/types/wlr_virtual_keyboard_v1.h
@@ -26,8 +26,8 @@ struct wlr_virtual_keyboard_manager_v1 {
 };
 
 struct wlr_virtual_keyboard_v1 {
-	struct wl_resource *resource;
 	struct wlr_input_device input_device;
+	struct wl_resource *resource;
 	struct wlr_seat *seat;
 	bool has_keymap;
 
@@ -40,5 +40,8 @@ struct wlr_virtual_keyboard_v1 {
 
 struct wlr_virtual_keyboard_manager_v1* wlr_virtual_keyboard_manager_v1_create(
 	struct wl_display *display);
+
+struct wlr_virtual_keyboard_v1 *wlr_input_device_get_virtual_keyboard(
+	struct wlr_input_device *wlr_dev);
 
 #endif

--- a/types/wlr_virtual_keyboard_v1.c
+++ b/types/wlr_virtual_keyboard_v1.c
@@ -40,6 +40,14 @@ static struct wlr_virtual_keyboard_v1 *virtual_keyboard_from_resource(
 	return wl_resource_get_user_data(resource);
 }
 
+struct wlr_virtual_keyboard_v1 *wlr_input_device_get_virtual_keyboard(
+		struct wlr_input_device *wlr_dev) {
+	if (wlr_dev->impl != &input_device_impl) {
+		return NULL;
+	}
+	return (struct wlr_virtual_keyboard_v1 *)wlr_dev;
+}
+
 static void virtual_keyboard_keymap(struct wl_client *client,
 		struct wl_resource *resource, uint32_t format, int32_t fd,
 		uint32_t size) {


### PR DESCRIPTION
I'm interested in implementing CJK input method in wayland so I try to implement this.
I've tested with my local client code but it's not suitable for a test example.
Should I extend examples/input-method.c for this or write a new one