### PR TITLE
backend/drm: track gbm_bo during direct scan-out

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -382,6 +382,11 @@ static bool drm_connector_commit(struct wlr_output *output) {
 			return false;
 		}
 
+		if (conn->pending_bo != NULL) {
+			gbm_bo_destroy(conn->pending_bo);
+		}
+		conn->pending_bo = bo;
+
 		fb_id = get_fb_for_bo(bo, gbm_bo_get_format(bo), drm->addfb2_modifiers);
 		if (fb_id == 0) {
 			wlr_log(WLR_ERROR, "get_fb_for_bo failed");
@@ -1403,6 +1408,12 @@ static void page_flip_handler(int fd, unsigned seq,
 	wlr_buffer_unref(conn->current_buffer);
 	conn->current_buffer = conn->pending_buffer;
 	conn->pending_buffer = NULL;
+
+	if (conn->current_bo != NULL) {
+		gbm_bo_destroy(conn->current_bo);
+	}
+	conn->current_bo = conn->pending_bo;
+	conn->pending_bo = NULL;
 
 	uint32_t present_flags = WLR_OUTPUT_PRESENT_VSYNC |
 		WLR_OUTPUT_PRESENT_HW_CLOCK | WLR_OUTPUT_PRESENT_HW_COMPLETION;

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -131,8 +131,10 @@ struct wlr_drm_connector {
 	struct wlr_dmabuf_attributes pending_dmabuf;
 	// Buffer submitted to the kernel but not yet displayed
 	struct wlr_buffer *pending_buffer;
+	struct gbm_bo *pending_bo;
 	// Buffer currently being displayed
 	struct wlr_buffer *current_buffer;
+	struct gbm_bo *current_bo;
 };
 
 struct wlr_drm_backend *get_drm_backend_from_backend(


### PR DESCRIPTION
We need to destroy the gbm_bo we imported and drmModeRmFb.

Closes: https://github.com/swaywm/sway/issues/4662