### PR TITLE
output-management-v1: add assertion as a safety net

### DIFF
--- a/types/wlr_output_management_v1.c
+++ b/types/wlr_output_management_v1.c
@@ -686,6 +686,9 @@ static void head_send_state(struct wlr_output_head_v1 *head,
 	}
 
 	if (state & HEAD_STATE_MODE) {
+		assert(head->state.mode != NULL ||
+			wl_list_empty(&head->state.output->modes));
+
 		bool found = false;
 		struct wl_resource *mode_resource;
 		wl_resource_for_each(mode_resource, &head->mode_resources) {


### PR DESCRIPTION
Makes it easier to figure out when the compositor submits an invalid
output state.

References: https://github.com/swaywm/sway/pull/4673