### PR TITLE
Fix heap-use-after-free in wlr_send_tablet_v2_tablet_pad_leave

### DIFF
--- a/types/tablet_v2/wlr_tablet_v2_pad.c
+++ b/types/tablet_v2/wlr_tablet_v2_pad.c
@@ -171,6 +171,9 @@ void destroy_tablet_pad_v2(struct wl_resource *resource) {
 	}
 	free(pad->strips);
 
+	if (pad->pad->current_client == pad) {
+		pad->pad->current_client = NULL;
+	}
 	free(pad);
 	wl_resource_set_user_data(resource, NULL);
 }


### PR DESCRIPTION
See swaywm/sway#4660

This change does fix the crash, but I am not sure if this is the proper way to do it, so I want someone with knowledge about wlroots memory management to review this.

cc @emersion @Ongy 