### PR TITLE
renderer: use GL_NEAREST with integer scale factor

### DIFF
--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -58,6 +58,7 @@ struct wlr_gles2_renderer {
 	} shaders;
 
 	uint32_t viewport_width, viewport_height;
+	float scale;
 };
 
 enum wlr_gles2_texture_type {

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -35,6 +35,8 @@ struct wlr_renderer_impl {
 		uint32_t height);
 	void (*end)(struct wlr_renderer *renderer);
 	void (*clear)(struct wlr_renderer *renderer, const float color[static 4]);
+	float (*get_scale)(struct wlr_renderer *renderer);
+	void (*set_scale)(struct wlr_renderer *renderer, const float scale);
 	void (*scissor)(struct wlr_renderer *renderer, struct wlr_box *box);
 	bool (*render_texture_with_matrix)(struct wlr_renderer *renderer,
 		struct wlr_texture *texture, const float matrix[static 9],

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -36,6 +36,10 @@ struct wlr_renderer *wlr_renderer_autocreate(struct wlr_egl *egl, EGLenum platfo
 void wlr_renderer_begin(struct wlr_renderer *r, int width, int height);
 void wlr_renderer_end(struct wlr_renderer *r);
 void wlr_renderer_clear(struct wlr_renderer *r, const float color[static 4]);
+
+float wlr_renderer_get_scale(struct wlr_renderer *r);
+void wlr_renderer_set_scale(struct wlr_renderer *r, const float scale);
+
 /**
  * Defines a scissor box. Only pixels that lie within the scissor box can be
  * modified by drawing functions. Providing a NULL `box` disables the scissor

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -52,6 +52,15 @@ void wlr_renderer_clear(struct wlr_renderer *r, const float color[static 4]) {
 	r->impl->clear(r, color);
 }
 
+float wlr_renderer_get_scale(struct wlr_renderer *r) {
+	return r->impl->get_scale(r);
+}
+
+void wlr_renderer_set_scale(struct wlr_renderer *r, const float scale) {
+	r->impl->set_scale(r, scale);
+}
+
+
 void wlr_renderer_scissor(struct wlr_renderer *r, struct wlr_box *box) {
 	r->impl->scissor(r, box);
 }

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -425,6 +425,9 @@ bool wlr_output_attach_render(struct wlr_output *output, int *buffer_age) {
 		return false;
 	}
 
+	struct wlr_renderer *r = wlr_backend_get_renderer(output->backend);
+	wlr_renderer_set_scale(r, output->scale);
+
 	output_state_clear_buffer(&output->pending);
 	output->pending.committed |= WLR_OUTPUT_STATE_BUFFER;
 	output->pending.buffer_type = WLR_OUTPUT_STATE_BUFFER_RENDER;


### PR DESCRIPTION
Fixes: #1770

This was based on a suggestion offered in IRC regarding implementing this feature without breaking the existing API. In this case, I've added getters/setters to the renderer/renderer_impl so the output can stash the scale inside the renderer's state so the renderer knows whether to use GL_NEAREST or GL_LINEAR.