### PR TITLE
render/gles: Simplify textures a bit

### DIFF
--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -60,31 +60,24 @@ struct wlr_gles2_renderer {
 	uint32_t viewport_width, viewport_height;
 };
 
-enum wlr_gles2_texture_type {
-	WLR_GLES2_TEXTURE_GLTEX,
-	WLR_GLES2_TEXTURE_WL_DRM_GL,
-	WLR_GLES2_TEXTURE_WL_DRM_EXT,
-	WLR_GLES2_TEXTURE_DMABUF,
-};
-
 struct wlr_gles2_texture {
 	struct wlr_texture wlr_texture;
-
 	struct wlr_egl *egl;
-	enum wlr_gles2_texture_type type;
-	int width, height;
-	bool has_alpha;
-	enum wl_shm_format wl_format; // used to interpret upload data
-	bool inverted_y;
 
-	// Not set if WLR_GLES2_TEXTURE_GLTEX
+	// Basically:
+	//   GL_TEXTURE_2D == mutable
+	//   GL_TEXTURE_EXTERNAL_OES == immutable
+	GLenum target;
+	GLuint tex;
+
 	EGLImageKHR image;
-	GLuint image_tex;
 
-	union {
-		GLuint gl_tex;
-		struct wl_resource *wl_drm;
-	};
+	int width, height;
+	bool inverted_y;
+	bool has_alpha;
+
+	// Only affects target == GL_TEXTURE_2D
+	enum wl_shm_format wl_format; // used to interpret upload data
 };
 
 const struct wlr_gles2_pixel_format *get_gles2_format_from_wl(

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -51,7 +51,7 @@ static bool gles2_texture_write_pixels(struct wlr_texture *wlr_texture,
 	struct wlr_gles2_texture *texture =
 		get_gles2_texture_in_context(wlr_texture);
 
-	if (texture->type != WLR_GLES2_TEXTURE_GLTEX) {
+	if (texture->target != GL_TEXTURE_2D) {
 		wlr_log(WLR_ERROR, "Cannot write pixels to immutable texture");
 		return false;
 	}
@@ -63,7 +63,7 @@ static bool gles2_texture_write_pixels(struct wlr_texture *wlr_texture,
 	// TODO: what if the unpack subimage extension isn't supported?
 	PUSH_GLES2_DEBUG;
 
-	glBindTexture(GL_TEXTURE_2D, texture->gl_tex);
+	glBindTexture(GL_TEXTURE_2D, texture->tex);
 
 	glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, stride / (fmt->bpp / 8));
 	glPixelStorei(GL_UNPACK_SKIP_PIXELS_EXT, src_x);
@@ -85,7 +85,7 @@ static bool gles2_texture_to_dmabuf(struct wlr_texture *wlr_texture,
 	struct wlr_gles2_texture *texture = gles2_get_texture(wlr_texture);
 
 	if (!texture->image) {
-		assert(texture->type == WLR_GLES2_TEXTURE_GLTEX);
+		assert(texture->target == GL_TEXTURE_2D);
 
 		if (!eglCreateImageKHR) {
 			return false;
@@ -93,7 +93,7 @@ static bool gles2_texture_to_dmabuf(struct wlr_texture *wlr_texture,
 
 		texture->image = eglCreateImageKHR(texture->egl->display,
 			texture->egl->context, EGL_GL_TEXTURE_2D_KHR,
-			(EGLClientBuffer)(uintptr_t)texture->gl_tex, NULL);
+			(EGLClientBuffer)(uintptr_t)texture->tex, NULL);
 		if (texture->image == EGL_NO_IMAGE_KHR) {
 			return false;
 		}
@@ -121,14 +121,8 @@ static void gles2_texture_destroy(struct wlr_texture *wlr_texture) {
 
 	PUSH_GLES2_DEBUG;
 
-	if (texture->image_tex) {
-		glDeleteTextures(1, &texture->image_tex);
-	}
+	glDeleteTextures(1, &texture->tex);
 	wlr_egl_destroy_image(texture->egl, texture->image);
-
-	if (texture->type == WLR_GLES2_TEXTURE_GLTEX) {
-		glDeleteTextures(1, &texture->gl_tex);
-	}
 
 	POP_GLES2_DEBUG;
 
@@ -166,14 +160,14 @@ struct wlr_texture *wlr_gles2_texture_from_pixels(struct wlr_egl *egl,
 	texture->egl = egl;
 	texture->width = width;
 	texture->height = height;
-	texture->type = WLR_GLES2_TEXTURE_GLTEX;
+	texture->target = GL_TEXTURE_2D;
 	texture->has_alpha = fmt->has_alpha;
 	texture->wl_format = fmt->wl_format;
 
 	PUSH_GLES2_DEBUG;
 
-	glGenTextures(1, &texture->gl_tex);
-	glBindTexture(GL_TEXTURE_2D, texture->gl_tex);
+	glGenTextures(1, &texture->tex);
+	glBindTexture(GL_TEXTURE_2D, texture->tex);
 
 	glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, stride / (fmt->bpp / 8));
 	glTexImage2D(GL_TEXTURE_2D, 0, fmt->gl_format, width, height, 0,
@@ -202,7 +196,6 @@ struct wlr_texture *wlr_gles2_texture_from_wl_drm(struct wlr_egl *egl,
 	}
 	wlr_texture_init(&texture->wlr_texture, &texture_impl);
 	texture->egl = egl;
-	texture->wl_drm = data;
 
 	EGLint fmt;
 	texture->wl_format = 0xFFFFFFFF; // texture can't be written anyways
@@ -213,17 +206,12 @@ struct wlr_texture *wlr_gles2_texture_from_wl_drm(struct wlr_egl *egl,
 		return NULL;
 	}
 
-	GLenum target;
 	switch (fmt) {
 	case EGL_TEXTURE_RGB:
-	case EGL_TEXTURE_RGBA:
-		target = GL_TEXTURE_2D;
-		texture->type = WLR_GLES2_TEXTURE_WL_DRM_GL;
-		texture->has_alpha = fmt == EGL_TEXTURE_RGBA;
+		texture->has_alpha = false;
 		break;
+	case EGL_TEXTURE_RGBA:
 	case EGL_TEXTURE_EXTERNAL_WL:
-		target = GL_TEXTURE_EXTERNAL_OES;
-		texture->type = WLR_GLES2_TEXTURE_WL_DRM_EXT;
 		texture->has_alpha = true;
 		break;
 	default:
@@ -232,11 +220,13 @@ struct wlr_texture *wlr_gles2_texture_from_wl_drm(struct wlr_egl *egl,
 		return NULL;
 	}
 
+	texture->target = GL_TEXTURE_EXTERNAL_OES;
+
 	PUSH_GLES2_DEBUG;
 
-	glGenTextures(1, &texture->image_tex);
-	glBindTexture(target, texture->image_tex);
-	glEGLImageTargetTexture2DOES(target, texture->image);
+	glGenTextures(1, &texture->tex);
+	glBindTexture(GL_TEXTURE_EXTERNAL_OES, texture->tex);
+	glEGLImageTargetTexture2DOES(GL_TEXTURE_EXTERNAL_OES, texture->image);
 
 	POP_GLES2_DEBUG;
 	return &texture->wlr_texture;
@@ -280,7 +270,7 @@ struct wlr_texture *wlr_gles2_texture_from_dmabuf(struct wlr_egl *egl,
 	texture->egl = egl;
 	texture->width = attribs->width;
 	texture->height = attribs->height;
-	texture->type = WLR_GLES2_TEXTURE_DMABUF;
+	texture->target = GL_TEXTURE_EXTERNAL_OES;
 	texture->has_alpha = true;
 	texture->wl_format = 0xFFFFFFFF; // texture can't be written anyways
 	texture->inverted_y =
@@ -294,8 +284,8 @@ struct wlr_texture *wlr_gles2_texture_from_dmabuf(struct wlr_egl *egl,
 
 	PUSH_GLES2_DEBUG;
 
-	glGenTextures(1, &texture->image_tex);
-	glBindTexture(GL_TEXTURE_EXTERNAL_OES, texture->image_tex);
+	glGenTextures(1, &texture->tex);
+	glBindTexture(GL_TEXTURE_EXTERNAL_OES, texture->tex);
 	glEGLImageTargetTexture2DOES(GL_TEXTURE_EXTERNAL_OES, texture->image);
 
 	POP_GLES2_DEBUG;


### PR DESCRIPTION
While I was writing https://github.com/swaywm/wlroots/issues/1826#issuecomment-550171172 and looking through our code, I realised it's not as simple as it should be.

We don't need our own enum for types. Instead we just use GL_TEXTURE_{2D,EXTERNAL_OES}, which already describes usage.

Also fixes a situation where we were using GL_TEXTURE_2D in a situation we should not have. wl_drm buffers are always GL_TEXTURE_EXTERNAL_OES, no matter if they're RGB or any other format.