### PR TITLE
render/gles2: provide public API to access GL texture

### DIFF
--- a/include/wlr/render/gles2.h
+++ b/include/wlr/render/gles2.h
@@ -9,6 +9,7 @@
 #ifndef WLR_RENDER_GLES2_H
 #define WLR_RENDER_GLES2_H
 
+#include <GLES2/gl2.h>
 #include <wlr/backend.h>
 #include <wlr/render/wlr_renderer.h>
 
@@ -23,5 +24,17 @@ struct wlr_texture *wlr_gles2_texture_from_wl_drm(struct wlr_egl *egl,
 	struct wl_resource *data);
 struct wlr_texture *wlr_gles2_texture_from_dmabuf(struct wlr_egl *egl,
 	struct wlr_dmabuf_attributes *attribs);
+
+struct wlr_gles2_texture_attribs {
+	GLenum target; /* either GL_TEXTURE_2D or GL_TEXTURE_EXTERNAL_OES */
+	GLuint tex;
+
+	bool inverted_y;
+	bool has_alpha;
+};
+
+bool wlr_texture_is_gles2(struct wlr_texture *texture);
+void wlr_gles2_texture_get_attribs(struct wlr_texture *texture,
+	struct wlr_gles2_texture_attribs *attribs);
 
 #endif

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -17,9 +17,13 @@
 
 static const struct wlr_texture_impl texture_impl;
 
+bool wlr_texture_is_gles2(struct wlr_texture *wlr_texture) {
+	return wlr_texture->impl == &texture_impl;
+}
+
 struct wlr_gles2_texture *gles2_get_texture(
 		struct wlr_texture *wlr_texture) {
-	assert(wlr_texture->impl == &texture_impl);
+	assert(wlr_texture_is_gles2(wlr_texture));
 	return (struct wlr_gles2_texture *)wlr_texture;
 }
 
@@ -290,4 +294,14 @@ struct wlr_texture *wlr_gles2_texture_from_dmabuf(struct wlr_egl *egl,
 
 	POP_GLES2_DEBUG;
 	return &texture->wlr_texture;
+}
+
+void wlr_gles2_texture_get_attribs(struct wlr_texture *wlr_texture,
+		struct wlr_gles2_texture_attribs *attribs) {
+	struct wlr_gles2_texture *texture = gles2_get_texture(wlr_texture);
+	memset(attribs, 0, sizeof(*attribs));
+	attribs->target = texture->target;
+	attribs->tex = texture->tex;
+	attribs->inverted_y = texture->inverted_y;
+	attribs->has_alpha = texture->has_alpha;
 }


### PR DESCRIPTION
Prior to this commit, compositors needed to render the texture to an
intermediate off-screen buffer using wlr_renderer APIs if they wanted to
use a custom rendering path (e.g. render to a 3D scene).

A new wlr_gles2_texture_get_attribs exposes the GL texture target and ID
so that compositors can render wlr_textures with their own shaders. An
example of a compositor doing so is available at [1].

[1]: https://git.sr.ht/~sircmpwn/wxrc/tree/3db905b7842ac42cf1878876e647005b41f00a52/src/render.c#L227