### PR TITLE
Skip assign when sub_x or sub_y is NULL in wlr_surface_surface_at

### DIFF
--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -1016,8 +1016,12 @@ struct wlr_surface *wlr_surface_surface_at(struct wlr_surface *surface,
 	}
 
 	if (wlr_surface_point_accepts_input(surface, sx, sy)) {
-		*sub_x = sx;
-		*sub_y = sy;
+		if (sub_x) {
+			*sub_x = sx;
+		}
+		if (sub_y) {
+			*sub_y = sy;
+		}
 		return surface;
 	}
 


### PR DESCRIPTION
Sometimes if one don't want to get sx or sy, they can pass NULL after this PR, and will not cause segfault.