### PR TITLE
Add wlr_buffer interface

### DIFF
--- a/include/wlr/interfaces/wlr_buffer.h
+++ b/include/wlr/interfaces/wlr_buffer.h
@@ -1,0 +1,75 @@
+/*
+ * This an unstable interface of wlroots. No guarantees are made regarding the
+ * future consistency of this API.
+ */
+#ifndef WLR_USE_UNSTABLE
+#error "Add -DWLR_USE_UNSTABLE to enable unstable wlroots features"
+#endif
+
+#ifndef WLR_IFACES_WLR_BUFFER_H
+#define WLR_IFACES_WLR_BUFFER_H
+#include <stdbool.h>
+#include <pixman.h>
+#include <wayland-server-core.h>
+#include <wlr/render/wlr_renderer.h>
+
+struct wlr_buffer;
+
+struct wlr_buffer_impl {
+	/**
+	 * Return true if this wl_resource is an instance of a wl_buffer using this
+	 * API.
+	 *
+	 * Note: downstream compositors should not call this. We have to
+	 * special-case some buffer types and it will not necessarily work the way
+	 * you expect.
+	 */
+	bool (*is_instance)(struct wl_resource *resource);
+
+	/**
+	 * Initializes the buffer from a resource. This generally involves
+	 * populating wlr_buffer.texture, which is required to render it with
+	 * wlr_renderer. However, users with custom renderers may choose to leave it
+	 * NULL and process the buffer data some other way.
+	 *
+	 * Return false if an error occured and the resulting buffer is invalid.
+	 */
+	bool (*initialize)(struct wlr_buffer *buffer,
+			struct wl_resource *resource, struct wlr_renderer *renderer);
+	/**
+	 * Gets the width and height of this buffer in pixels. This is used for
+	 * wl_surface lifecycle management, and possibly by downstream compositors.
+	 * Return false if size is unknown, true otherwise. Set to NULL if
+	 * unsupported for this buffer type.
+	 */
+	bool (*get_resource_size)(struct wl_resource *resource,
+		struct wlr_renderer *renderer, int *width, int *height);
+
+	/**
+	 * Apply damage to this buffer, if supported. This is used, for example, by
+	 * shm buffers to upload only damaged pixels to the GPU. The resource
+	 * parameter is the wl_resource of the buffer to source new data from, it
+	 * may be the same resource as the buffer was created with or another. It
+	 * will be the same buffer implementation as the buffer parameter. The
+	 * underlying buffer resource will be updated to the resource parameter if
+	 * successful.
+	 *
+	 * Returns true if successful. Leave NULL if unsupported for this buffer
+	 * type.
+	 *
+	 * This is not called if the buffer has more than one reference.
+	 */
+	bool (*apply_damage)(struct wlr_buffer *buffer,
+			struct wl_resource *resource, pixman_region32_t *damage);
+
+	/**
+	 * Called when there are no remaining references to this buffer. The texture
+	 * will be destroyed for you, you may leave this NULL unless you have any
+	 * other work to do.
+	 */
+	void (*destroy)(struct wlr_buffer *buffer);
+};
+
+void wlr_buffer_register_implementation(const struct wlr_buffer_impl *impl);
+
+#endif

--- a/include/wlr/types/wlr_buffer.h
+++ b/include/wlr/types/wlr_buffer.h
@@ -13,6 +13,9 @@
 #include <wayland-server-core.h>
 #include <wlr/render/dmabuf.h>
 
+struct wlr_buffer_impl;
+struct wlr_renderer;
+
 /**
  * A client buffer.
  */
@@ -21,9 +24,15 @@ struct wlr_buffer {
 	 * The buffer resource, if any. Will be NULL if the client destroys it.
 	 */
 	struct wl_resource *resource;
+
+	const struct wlr_buffer_impl *impl;
+
+	struct wlr_renderer *renderer;
+
 	/**
 	 * The buffer's texture, if any. A buffer will not have a texture if the
-	 * client destroys the buffer before it has been released.
+	 * client destroys the buffer before it has been released, or if the
+	 * underlying implementation does not support it.
 	 */
 	struct wlr_texture *texture;
 	bool released;
@@ -32,12 +41,11 @@ struct wlr_buffer {
 	struct wl_listener resource_destroy;
 };
 
-struct wlr_renderer;
-
 /**
  * Check if a resource is a wl_buffer resource.
  */
 bool wlr_resource_is_buffer(struct wl_resource *resource);
+
 /**
  * Get the size of a wl_buffer resource.
  */
@@ -49,15 +57,18 @@ bool wlr_buffer_get_resource_size(struct wl_resource *resource,
  */
 struct wlr_buffer *wlr_buffer_create(struct wlr_renderer *renderer,
 	struct wl_resource *resource);
+
 /**
  * Reference the buffer.
  */
 struct wlr_buffer *wlr_buffer_ref(struct wlr_buffer *buffer);
+
 /**
  * Unreference the buffer. After this call, `buffer` may not be accessed
  * anymore.
  */
 void wlr_buffer_unref(struct wlr_buffer *buffer);
+
 /**
  * Try to update the buffer's content. On success, returns the updated buffer
  * and destroys the provided `buffer`. On error, `buffer` is intact and NULL is
@@ -67,7 +78,8 @@ void wlr_buffer_unref(struct wlr_buffer *buffer);
  * isn't mutable.
  */
 struct wlr_buffer *wlr_buffer_apply_damage(struct wlr_buffer *buffer,
-	struct wl_resource *resource, pixman_region32_t *damage);
+		struct wl_resource *resource, pixman_region32_t *damage);
+
 /**
  * Reads the DMA-BUF attributes of the buffer. If this buffer isn't a DMA-BUF,
  * returns false.

--- a/render/meson.build
+++ b/render/meson.build
@@ -18,6 +18,7 @@ lib_wlr_render = static_library(
 		'gles2/shaders.c',
 		'gles2/texture.c',
 		'gles2/util.c',
+		'shm_buffer.c',
 		'wlr_renderer.c',
 		'wlr_texture.c',
 	),

--- a/render/shm_buffer.c
+++ b/render/shm_buffer.c
@@ -1,0 +1,101 @@
+#include <assert.h>
+#include <pixman.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <wayland-server.h>
+#include <wlr/interfaces/wlr_buffer.h>
+#include <wlr/types/wlr_buffer.h>
+
+static bool wl_shm_buf_is_instance(struct wl_resource *resource) {
+	return wl_shm_buffer_get(resource) != NULL;
+}
+
+static bool wl_shm_buf_initialize(struct wlr_buffer *buffer,
+			struct wl_resource *resource, struct wlr_renderer *renderer) {
+	struct wl_shm_buffer *shm_buf = wl_shm_buffer_get(resource);
+	assert(shm_buf);
+
+	enum wl_shm_format fmt = wl_shm_buffer_get_format(shm_buf);
+	int32_t stride = wl_shm_buffer_get_stride(shm_buf);
+	int32_t width = wl_shm_buffer_get_width(shm_buf);
+	int32_t height = wl_shm_buffer_get_height(shm_buf);
+
+	wl_shm_buffer_begin_access(shm_buf);
+	void *data = wl_shm_buffer_get_data(shm_buf);
+	buffer->texture = wlr_texture_from_pixels(renderer, fmt, stride,
+		width, height, data);
+	wl_shm_buffer_end_access(shm_buf);
+
+	// We have uploaded the data, we don't need to access the wl_buffer
+	// anymore
+	wl_buffer_send_release(resource);
+	buffer->released = true;
+
+	return true;
+}
+
+static bool wl_shm_buf_get_resource_size(struct wl_resource *resource,
+		struct wlr_renderer *renderer, int *width, int *height) {
+	struct wl_shm_buffer *shm_buf = wl_shm_buffer_get(resource);
+	assert(shm_buf);
+	*width = wl_shm_buffer_get_width(shm_buf);
+	*height = wl_shm_buffer_get_height(shm_buf);
+	return true;
+}
+
+static bool wl_shm_buf_apply_damage(struct wlr_buffer *buffer,
+		struct wl_resource *resource, pixman_region32_t *damage) {
+	struct wl_shm_buffer *shm_buf = wl_shm_buffer_get(resource);
+	struct wl_shm_buffer *old_shm_buf = wl_shm_buffer_get(buffer->resource);
+	if (!shm_buf || !old_shm_buf) {
+		return false;
+	}
+
+	enum wl_shm_format new_fmt = wl_shm_buffer_get_format(shm_buf);
+	enum wl_shm_format old_fmt = wl_shm_buffer_get_format(old_shm_buf);
+	if (new_fmt != old_fmt) {
+		// Uploading to textures can't change the format
+		return false;
+	}
+
+	int32_t stride = wl_shm_buffer_get_stride(shm_buf);
+	int32_t width = wl_shm_buffer_get_width(shm_buf);
+	int32_t height = wl_shm_buffer_get_height(shm_buf);
+
+	int32_t texture_width, texture_height;
+	wlr_texture_get_size(buffer->texture, &texture_width, &texture_height);
+	if (width != texture_width || height != texture_height) {
+		return false;
+	}
+
+	wl_shm_buffer_begin_access(shm_buf);
+	void *data = wl_shm_buffer_get_data(shm_buf);
+
+	int n;
+	pixman_box32_t *rects = pixman_region32_rectangles(damage, &n);
+	for (int i = 0; i < n; ++i) {
+		pixman_box32_t *r = &rects[i];
+		if (!wlr_texture_write_pixels(buffer->texture, stride,
+				r->x2 - r->x1, r->y2 - r->y1, r->x1, r->y1,
+				r->x1, r->y1, data)) {
+			wl_shm_buffer_end_access(shm_buf);
+			return false;
+		}
+	}
+
+	wl_shm_buffer_end_access(shm_buf);
+
+	// We have uploaded the data, we don't need to access the wl_buffer
+	// anymore
+	wl_buffer_send_release(resource);
+	buffer->released = true;
+
+	return true;
+}
+
+const struct wlr_buffer_impl wl_shm_buf_implementation = {
+	.is_instance = wl_shm_buf_is_instance,
+	.initialize = wl_shm_buf_initialize,
+	.get_resource_size = wl_shm_buf_get_resource_size,
+	.apply_damage = wl_shm_buf_apply_damage,
+};

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include <wlr/interfaces/wlr_buffer.h>
 #include <wlr/render/gles2.h>
 #include <wlr/render/interface.h>
 #include <wlr/render/wlr_renderer.h>
@@ -178,6 +179,8 @@ void wlr_renderer_init_wl_display(struct wlr_renderer *r,
 	}
 }
 
+extern const struct wlr_buffer_impl wl_shm_buf_implementation;
+
 struct wlr_renderer *wlr_renderer_autocreate(struct wlr_egl *egl,
 		EGLenum platform, void *remote_display, EGLint *config_attribs,
 		EGLint visual_id) {
@@ -208,6 +211,8 @@ struct wlr_renderer *wlr_renderer_autocreate(struct wlr_egl *egl,
 		wlr_log(WLR_ERROR, "Could not initialize EGL");
 		return NULL;
 	}
+
+	wlr_buffer_register_implementation(&wl_shm_buf_implementation);
 
 	struct wlr_renderer *renderer = wlr_gles2_renderer_create(egl);
 	if (!renderer) {


### PR DESCRIPTION
This allows downstream compositors to create their own wlr_buffer
implementations.

This is a little bit smelly because wl_drm throws a wrench into things.
In the future I would like to introduce wl_resource_get_implementation
to libwayland, which would allow us to add a proxy around mesa's wl_drm
implementation so we can track our own state alongside it. With this
change, we'd be able to swap out the wl_resource parameters given to
each wlr_buffer function with wlr_buffer references, and drop the
special-cased codepaths for wl_drm.