### PR TITLE
backend/wayland: add support for relative-pointer-unstable-v1

### DIFF
--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -22,6 +22,7 @@
 #include "xdg-decoration-unstable-v1-client-protocol.h"
 #include "xdg-shell-client-protocol.h"
 #include "tablet-unstable-v2-client-protocol.h"
+#include "relative-pointer-unstable-v1-client-protocol.h"
 
 struct wlr_wl_backend *get_wl_backend_from_backend(struct wlr_backend *backend) {
 	assert(wlr_backend_is_wl(backend));
@@ -116,6 +117,9 @@ static void registry_global(void *data, struct wl_registry *registry,
 			&zwp_linux_dmabuf_v1_interface, 3);
 		zwp_linux_dmabuf_v1_add_listener(wl->zwp_linux_dmabuf_v1,
 			&linux_dmabuf_v1_listener, wl);
+	} else if (strcmp(iface, zwp_relative_pointer_manager_v1_interface.name) == 0) {
+		wl->zwp_relative_pointer_manager_v1 = wl_registry_bind(registry, name,
+			&zwp_relative_pointer_manager_v1_interface, 1);
 	}
 }
 
@@ -200,6 +204,9 @@ static void backend_destroy(struct wlr_backend *backend) {
 	}
 	if (wl->zwp_linux_dmabuf_v1) {
 		zwp_linux_dmabuf_v1_destroy(wl->zwp_linux_dmabuf_v1);
+	}
+	if (wl->zwp_relative_pointer_manager_v1) {
+		zwp_relative_pointer_manager_v1_destroy(wl->zwp_relative_pointer_manager_v1);
 	}
 	xdg_wm_base_destroy(wl->xdg_wm_base);
 	wl_compositor_destroy(wl->compositor);

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -36,6 +36,7 @@ struct wlr_wl_backend {
 	struct zxdg_decoration_manager_v1 *zxdg_decoration_manager_v1;
 	struct zwp_pointer_gestures_v1 *zwp_pointer_gestures_v1;
 	struct zwp_linux_dmabuf_v1 *zwp_linux_dmabuf_v1;
+	struct zwp_relative_pointer_manager_v1 *zwp_relative_pointer_manager_v1;
 	struct wl_seat *seat;
 	struct wl_pointer *pointer;
 	struct wl_keyboard *keyboard;
@@ -86,6 +87,7 @@ struct wlr_wl_pointer {
 	struct wl_pointer *wl_pointer;
 	struct zwp_pointer_gesture_swipe_v1 *gesture_swipe;
 	struct zwp_pointer_gesture_pinch_v1 *gesture_pinch;
+	struct zwp_relative_pointer_v1 *relative_pointer;
 	enum wlr_axis_source axis_source;
 	int32_t axis_discrete;
 	struct wlr_wl_output *output;


### PR DESCRIPTION
We just send relative motion events alongside absolute motion events.
Compositors can figure out how absolute and relative events are related
(e.g. whether they have been triggered by the same logical event) with
the frame event.