### PR TITLE
backend/wayland: expose remote objects

### DIFF
--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -325,3 +325,8 @@ error_wl:
 	free(wl);
 	return NULL;
 }
+
+struct wl_display *wlr_wl_backend_get_remote_display(struct wlr_backend *backend) {
+	struct wlr_wl_backend *wl = get_wl_backend_from_backend(backend);
+	return wl->remote_display;
+}

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -478,3 +478,8 @@ void wlr_wl_output_set_title(struct wlr_output *output, const char *title) {
 
 	xdg_toplevel_set_title(wl_output->xdg_toplevel, title);
 }
+
+struct wl_surface *wlr_wl_output_get_surface(struct wlr_output *output) {
+	struct wlr_wl_output *wl_output = get_wl_output_from_output(output);
+	return wl_output->surface;
+}

--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -569,3 +569,9 @@ const struct wl_seat_listener seat_listener = {
 	.capabilities = seat_handle_capabilities,
 	.name = seat_handle_name,
 };
+
+struct wl_seat *wlr_wl_input_device_get_seat(struct wlr_input_device *wlr_dev) {
+	struct wlr_wl_input_device *dev =
+		get_wl_input_device_from_input_device(wlr_dev);
+	return dev->backend->seat;
+}

--- a/include/wlr/backend/wayland.h
+++ b/include/wlr/backend/wayland.h
@@ -19,6 +19,11 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display,
 		const char *remote, wlr_renderer_create_func_t create_renderer_func);
 
 /**
+ * Returns the remote wl_display used by the Wayland backend.
+ */
+struct wl_display *wlr_wl_backend_get_remote_display(struct wlr_backend *backend);
+
+/**
  * Adds a new output to this backend. You may remove outputs by destroying them.
  * Note that if called before initializing the backend, this will return NULL
  * and your outputs will be created during initialization (and given to you via
@@ -45,5 +50,15 @@ bool wlr_output_is_wl(struct wlr_output *output);
  * Sets the title of a wlr_output which is a Wayland window.
  */
 void wlr_wl_output_set_title(struct wlr_output *output, const char *title);
+
+/**
+ * Returns the remote wl_surface used by the Wayland output.
+ */
+struct wl_surface *wlr_wl_output_get_surface(struct wlr_output *output);
+
+/**
+ * Returns the remote wl_seat for a Wayland input device.
+ */
+struct wl_seat *wlr_wl_input_device_get_seat(struct wlr_input_device *dev);
 
 #endif


### PR DESCRIPTION
Expose the remote wl_display, wl_surface and wl_seat used by the Wayland
backend.

This allows compositors to customize the Wayland backend and to have
more freedom. For instance a compositor might want to handle clipboard
and drag-and-drop from the remote Wayland compositor. Another compositor
might want to setup pointer constraints.