### PR TITLE
render/gles2: do not set GL_TEXTURE_MAG_FILTER

### DIFF
--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -152,7 +152,6 @@ static bool gles2_render_texture_with_matrix(struct wlr_renderer *wlr_renderer,
 	glBindTexture(texture->target, texture->tex);
 
 	glTexParameteri(texture->target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri(texture->target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
 	glUseProgram(shader->program);
 


### PR DESCRIPTION
My take on #1770 
As @emersion says [this comment](https://github.com/swaywm/wlroots/pull/1898#pullrequestreview-311603780)

> Hmm, I'm really not a fan of adding get_scale/set_scale to the renderer. I'd rather manually call glTexParameteri in the compositor before rendering a texture.

I found in [the reference](https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glTexParameter.xml):

> GL_TEXTURE_MAG_FILTER
    The texture magnification function is used when the pixel being textured maps to an area less than or equal to one texture element. [...] The initial value of GL_TEXTURE_MAG_FILTER is GL_LINEAR.

Since it just so happens that GL_LINEAR is the default value, my idea is to just not set MAG_FILTER at all in wlroots, and let it remain the default value. It shouldn't cause any change in behavior, but will allow compositors to set the value before rendering if they like.

I'll go ahead and post a POC sway patch that does just this. I'm not sure if the implementation is the best approach for sway, but it does appear to work for me. What do you think?