### PR TITLE
Simplify globals implementation by removing destructors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -242,14 +242,12 @@ at least one struct for each interface in the protocol. For instance,
 ### Globals
 
 Global interfaces generally have public constructors and destructors. Their
-struct has a field holding the `wl_global` itself, a list of resources clients
-created by binding to the global, a destroy signal and a `wl_display` destroy
-listener. Example:
+struct has a field holding the `wl_global` itself, a destroy signal and a
+`wl_display` destroy listener. Example:
 
 ```c
 struct wlr_compositor {
 	struct wl_global *global;
-	struct wl_list resources;
 	…
 
 	struct wl_listener display_destroy;
@@ -262,8 +260,9 @@ struct wlr_compositor {
 ```
 
 When the destructor is called, it should emit the destroy signal, remove the
-display destroy listener, destroy the `wl_global`, destroy all bound resources
-and then destroy the struct.
+display destroy listener, destroy the `wl_global` and then destroy the struct.
+The destructor can assume all clients and resources have been already
+destroyed.
 
 ### Resources
 

--- a/include/wlr/types/wlr_compositor.h
+++ b/include/wlr/types/wlr_compositor.h
@@ -16,16 +16,11 @@ struct wlr_surface;
 
 struct wlr_subcompositor {
 	struct wl_global *global;
-	struct wl_list resources;
-	struct wl_list subsurface_resources;
 };
 
 struct wlr_compositor {
 	struct wl_global *global;
-	struct wl_list resources;
 	struct wlr_renderer *renderer;
-	struct wl_list surface_resources;
-	struct wl_list region_resources;
 
 	struct wlr_subcompositor subcompositor;
 
@@ -37,7 +32,6 @@ struct wlr_compositor {
 	} events;
 };
 
-void wlr_compositor_destroy(struct wlr_compositor *wlr_compositor);
 struct wlr_compositor *wlr_compositor_create(struct wl_display *display,
 	struct wlr_renderer *renderer);
 

--- a/include/wlr/types/wlr_data_control_v1.h
+++ b/include/wlr/types/wlr_data_control_v1.h
@@ -14,7 +14,6 @@
 
 struct wlr_data_control_manager_v1 {
 	struct wl_global *global;
-	struct wl_list resources; // wl_resource_get_link
 	struct wl_list devices; // wlr_data_control_device_v1::link
 
 	struct {
@@ -41,8 +40,6 @@ struct wlr_data_control_device_v1 {
 
 struct wlr_data_control_manager_v1 *wlr_data_control_manager_v1_create(
 	struct wl_display *display);
-void wlr_data_control_manager_v1_destroy(
-	struct wlr_data_control_manager_v1 *manager);
 
 void wlr_data_control_device_v1_destroy(
 	struct wlr_data_control_device_v1 *device);

--- a/include/wlr/types/wlr_data_device.h
+++ b/include/wlr/types/wlr_data_device.h
@@ -23,7 +23,6 @@ extern const struct wlr_touch_grab_interface
 
 struct wlr_data_device_manager {
 	struct wl_global *global;
-	struct wl_list resources;
 	struct wl_list data_sources;
 
 	struct wl_listener display_destroy;
@@ -161,11 +160,6 @@ struct wlr_drag_drop_event {
  */
 struct wlr_data_device_manager *wlr_data_device_manager_create(
 	struct wl_display *display);
-
-/**
- * Destroys a wlr_data_device_manager and removes its wl_data_device_manager global.
- */
-void wlr_data_device_manager_destroy(struct wlr_data_device_manager *manager);
 
 /**
  * Requests a selection to be set for the seat. If the request comes from

--- a/include/wlr/types/wlr_export_dmabuf_v1.h
+++ b/include/wlr/types/wlr_export_dmabuf_v1.h
@@ -15,7 +15,6 @@
 
 struct wlr_export_dmabuf_manager_v1 {
 	struct wl_global *global;
-	struct wl_list resources; // wl_resource_get_link
 	struct wl_list frames; // wlr_export_dmabuf_frame_v1::link
 
 	struct wl_listener display_destroy;
@@ -40,7 +39,5 @@ struct wlr_export_dmabuf_frame_v1 {
 
 struct wlr_export_dmabuf_manager_v1 *wlr_export_dmabuf_manager_v1_create(
 	struct wl_display *display);
-void wlr_export_dmabuf_manager_v1_destroy(
-	struct wlr_export_dmabuf_manager_v1 *manager);
 
 #endif

--- a/include/wlr/types/wlr_foreign_toplevel_management_v1.h
+++ b/include/wlr/types/wlr_foreign_toplevel_management_v1.h
@@ -15,7 +15,7 @@
 struct wlr_foreign_toplevel_manager_v1 {
 	struct wl_event_loop *event_loop;
 	struct wl_global *global;
-	struct wl_list resources;
+	struct wl_list resources; // wl_resource_get_link
 	struct wl_list toplevels; // wlr_foreign_toplevel_handle_v1::link
 
 	struct wl_listener display_destroy;
@@ -101,8 +101,6 @@ struct wlr_foreign_toplevel_handle_v1_set_rectangle_event {
 
 struct wlr_foreign_toplevel_manager_v1 *wlr_foreign_toplevel_manager_v1_create(
 	struct wl_display *display);
-void wlr_foreign_toplevel_manager_v1_destroy(
-	struct wlr_foreign_toplevel_manager_v1 *manager);
 
 struct wlr_foreign_toplevel_handle_v1 *wlr_foreign_toplevel_handle_v1_create(
 	struct wlr_foreign_toplevel_manager_v1 *manager);

--- a/include/wlr/types/wlr_fullscreen_shell_v1.h
+++ b/include/wlr/types/wlr_fullscreen_shell_v1.h
@@ -14,7 +14,6 @@
 
 struct wlr_fullscreen_shell_v1 {
 	struct wl_global *global;
-	struct wl_list resources;
 
 	struct {
 		struct wl_signal destroy;
@@ -36,6 +35,5 @@ struct wlr_fullscreen_shell_v1_present_surface_event {
 
 struct wlr_fullscreen_shell_v1 *wlr_fullscreen_shell_v1_create(
 	struct wl_display *display);
-void wlr_fullscreen_shell_v1_destroy(struct wlr_fullscreen_shell_v1 *shell);
 
 #endif

--- a/include/wlr/types/wlr_gamma_control_v1.h
+++ b/include/wlr/types/wlr_gamma_control_v1.h
@@ -5,7 +5,6 @@
 
 struct wlr_gamma_control_manager_v1 {
 	struct wl_global *global;
-	struct wl_list resources;
 	struct wl_list controls; // wlr_gamma_control_v1::link
 
 	struct wl_listener display_destroy;
@@ -29,7 +28,5 @@ struct wlr_gamma_control_v1 {
 
 struct wlr_gamma_control_manager_v1 *wlr_gamma_control_manager_v1_create(
 	struct wl_display *display);
-void wlr_gamma_control_manager_v1_destroy(
-	struct wlr_gamma_control_manager_v1 *manager);
 
 #endif

--- a/include/wlr/types/wlr_gtk_primary_selection.h
+++ b/include/wlr/types/wlr_gtk_primary_selection.h
@@ -22,7 +22,6 @@
  */
 struct wlr_gtk_primary_selection_device_manager {
 	struct wl_global *global;
-	struct wl_list resources; // wl_resource_get_link
 	struct wl_list devices; // wlr_gtk_primary_selection_device::link
 
 	struct wl_listener display_destroy;
@@ -54,7 +53,5 @@ struct wlr_gtk_primary_selection_device {
 
 struct wlr_gtk_primary_selection_device_manager *
 	wlr_gtk_primary_selection_device_manager_create(struct wl_display *display);
-void wlr_gtk_primary_selection_device_manager_destroy(
-	struct wlr_gtk_primary_selection_device_manager *manager);
 
 #endif

--- a/include/wlr/types/wlr_idle.h
+++ b/include/wlr/types/wlr_idle.h
@@ -60,8 +60,6 @@ struct wlr_idle_timeout {
 
 struct wlr_idle *wlr_idle_create(struct wl_display *display);
 
-void wlr_idle_destroy(struct wlr_idle *idle);
-
 /**
  * Send notification to restart all timers for the given seat. Called by
  * compositor when there is an user activity event on that seat.

--- a/include/wlr/types/wlr_idle_inhibit_v1.h
+++ b/include/wlr/types/wlr_idle_inhibit_v1.h
@@ -24,7 +24,6 @@
  */
 
 struct wlr_idle_inhibit_manager_v1 {
-	struct wl_list resources; // wl_resource_get_link
 	struct wl_list inhibitors; // wlr_idle_inhibit_inhibitor_v1::link
 	struct wl_global *global;
 
@@ -53,6 +52,5 @@ struct wlr_idle_inhibitor_v1 {
 };
 
 struct wlr_idle_inhibit_manager_v1 *wlr_idle_inhibit_v1_create(struct wl_display *display);
-void wlr_idle_inhibit_v1_destroy(struct wlr_idle_inhibit_manager_v1 *idle_inhibit);
 
 #endif

--- a/include/wlr/types/wlr_input_inhibitor.h
+++ b/include/wlr/types/wlr_input_inhibitor.h
@@ -28,7 +28,5 @@ struct wlr_input_inhibit_manager {
 
 struct wlr_input_inhibit_manager *wlr_input_inhibit_manager_create(
 		struct wl_display *display);
-void wlr_input_inhibit_manager_destroy(
-		struct wlr_input_inhibit_manager *manager);
 
 #endif

--- a/include/wlr/types/wlr_input_method_v2.h
+++ b/include/wlr/types/wlr_input_method_v2.h
@@ -53,7 +53,6 @@ struct wlr_input_method_v2 {
 
 struct wlr_input_method_manager_v2 {
 	struct wl_global *global;
-	struct wl_list bound_resources; // struct wl_resource*::link
 	struct wl_list input_methods; // struct wlr_input_method_v2*::link
 
 	struct wl_listener display_destroy;
@@ -66,8 +65,6 @@ struct wlr_input_method_manager_v2 {
 
 struct wlr_input_method_manager_v2 *wlr_input_method_manager_v2_create(
 	struct wl_display *display);
-void wlr_input_method_manager_v2_destroy(
-	struct wlr_input_method_manager_v2 *manager);
 
 void wlr_input_method_v2_send_activate(
 	struct wlr_input_method_v2 *input_method);
@@ -84,4 +81,5 @@ void wlr_input_method_v2_send_text_change_cause(
 void wlr_input_method_v2_send_done(struct wlr_input_method_v2 *input_method);
 void wlr_input_method_v2_send_unavailable(
 	struct wlr_input_method_v2 *input_method);
+
 #endif

--- a/include/wlr/types/wlr_layer_shell_v1.h
+++ b/include/wlr/types/wlr_layer_shell_v1.h
@@ -29,7 +29,6 @@
  */
 struct wlr_layer_shell_v1 {
 	struct wl_global *global;
-	struct wl_list resources; // wl_resource
 	struct wl_list surfaces; // wl_layer_surface
 
 	struct wl_listener display_destroy;
@@ -97,7 +96,6 @@ struct wlr_layer_surface_v1 {
 };
 
 struct wlr_layer_shell_v1 *wlr_layer_shell_v1_create(struct wl_display *display);
-void wlr_layer_shell_v1_destroy(struct wlr_layer_shell_v1 *layer_shell);
 
 /**
  * Notifies the layer surface to configure itself with this width/height. The

--- a/include/wlr/types/wlr_linux_dmabuf_v1.h
+++ b/include/wlr/types/wlr_linux_dmabuf_v1.h
@@ -45,7 +45,6 @@ struct wlr_dmabuf_v1_buffer *wlr_dmabuf_v1_buffer_from_params_resource(
 struct wlr_linux_dmabuf_v1 {
 	struct wl_global *global;
 	struct wlr_renderer *renderer;
-	struct wl_list resources;
 
 	struct {
 		struct wl_signal destroy;
@@ -60,10 +59,6 @@ struct wlr_linux_dmabuf_v1 {
  */
 struct wlr_linux_dmabuf_v1 *wlr_linux_dmabuf_v1_create(struct wl_display *display,
 	struct wlr_renderer *renderer);
-/**
- * Destroy the linux-dmabuf interface
- */
-void wlr_linux_dmabuf_v1_destroy(struct wlr_linux_dmabuf_v1 *linux_dmabuf);
 
 /**
  * Returns the wlr_linux_dmabuf if the given resource was created

--- a/include/wlr/types/wlr_pointer_constraints_v1.h
+++ b/include/wlr/types/wlr_pointer_constraints_v1.h
@@ -64,8 +64,8 @@ struct wlr_pointer_constraint_v1 {
 };
 
 struct wlr_pointer_constraints_v1 {
-	struct wl_list resources; // wl_resource_get_link
 	struct wl_global *global;
+	struct wl_list constraints; // wlr_pointer_constraint_v1::link
 
 	struct {
 		/**
@@ -76,15 +76,13 @@ struct wlr_pointer_constraints_v1 {
 		struct wl_signal new_constraint;
 	} events;
 
-	struct wl_list constraints; // wlr_pointer_constraint_v1::link
+	struct wl_listener display_destroy;
 
 	void *data;
 };
 
 struct wlr_pointer_constraints_v1 *wlr_pointer_constraints_v1_create(
 	struct wl_display *display);
-void wlr_pointer_constraints_v1_destroy(
-	struct wlr_pointer_constraints_v1 *pointer_constraints);
 
 struct wlr_pointer_constraint_v1 *
 	wlr_pointer_constraints_v1_constraint_for_surface(

--- a/include/wlr/types/wlr_pointer_gestures_v1.h
+++ b/include/wlr/types/wlr_pointer_gestures_v1.h
@@ -15,9 +15,8 @@
 
 struct wlr_pointer_gestures_v1 {
 	struct wl_global *global;
-	struct wl_list resources; // wl_resource_get_link
-	struct wl_list swipes;    // wl_resource_get_link
-	struct wl_list pinches;   // wl_resource_get_link
+	struct wl_list swipes; // wl_resource_get_link
+	struct wl_list pinches; // wl_resource_get_link
 
 	struct wl_listener display_destroy;
 
@@ -66,8 +65,5 @@ void wlr_pointer_gestures_v1_send_pinch_end(
 	struct wlr_seat *seat,
 	uint32_t time_msec,
 	bool cancelled);
-
-void wlr_pointer_gestures_v1_destroy(
-	struct wlr_pointer_gestures_v1 *pointer_gestures_v1);
 
 #endif

--- a/include/wlr/types/wlr_presentation_time.h
+++ b/include/wlr/types/wlr_presentation_time.h
@@ -19,7 +19,6 @@ struct wlr_output_event_present;
 
 struct wlr_presentation {
 	struct wl_global *global;
-	struct wl_list resources; // wl_resource_get_link
 	struct wl_list feedbacks; // wlr_presentation_feedback::link
 	clockid_t clock;
 
@@ -71,7 +70,6 @@ struct wlr_backend;
 
 struct wlr_presentation *wlr_presentation_create(struct wl_display *display,
 	struct wlr_backend *backend);
-void wlr_presentation_destroy(struct wlr_presentation *presentation);
 /**
  * Mark the current surface's buffer as sampled.
  *

--- a/include/wlr/types/wlr_primary_selection_v1.h
+++ b/include/wlr/types/wlr_primary_selection_v1.h
@@ -14,7 +14,6 @@
 
 struct wlr_primary_selection_v1_device_manager {
 	struct wl_global *global;
-	struct wl_list resources; // wl_resource_get_link
 	struct wl_list devices; // wlr_primary_selection_v1_device::link
 
 	struct wl_listener display_destroy;
@@ -46,7 +45,5 @@ struct wlr_primary_selection_v1_device {
 
 struct wlr_primary_selection_v1_device_manager *
 	wlr_primary_selection_v1_device_manager_create(struct wl_display *display);
-void wlr_primary_selection_v1_device_manager_destroy(
-	struct wlr_primary_selection_v1_device_manager *manager);
 
 #endif

--- a/include/wlr/types/wlr_relative_pointer_v1.h
+++ b/include/wlr/types/wlr_relative_pointer_v1.h
@@ -23,7 +23,6 @@
  */
 struct wlr_relative_pointer_manager_v1 {
 	struct wl_global *global;
-	struct wl_list resources; // wl_resource_get_link()
 	struct wl_list relative_pointers; // wlr_relative_pointer_v1::link
 
 	struct {
@@ -60,8 +59,6 @@ struct wlr_relative_pointer_v1 {
 
 struct wlr_relative_pointer_manager_v1 *wlr_relative_pointer_manager_v1_create(
 	struct wl_display *display);
-void wlr_relative_pointer_manager_v1_destroy(
-	struct wlr_relative_pointer_manager_v1 *manager);
 
 /**
  * Send a relative motion event to the seat. Time is given in microseconds

--- a/include/wlr/types/wlr_screencopy_v1.h
+++ b/include/wlr/types/wlr_screencopy_v1.h
@@ -15,7 +15,6 @@
 
 struct wlr_screencopy_manager_v1 {
 	struct wl_global *global;
-	struct wl_list resources; // wl_resource
 	struct wl_list frames; // wlr_screencopy_frame_v1::link
 
 	struct wl_listener display_destroy;
@@ -59,7 +58,5 @@ struct wlr_screencopy_frame_v1 {
 
 struct wlr_screencopy_manager_v1 *wlr_screencopy_manager_v1_create(
 	struct wl_display *display);
-void wlr_screencopy_manager_v1_destroy(
-	struct wlr_screencopy_manager_v1 *screencopy);
 
 #endif

--- a/include/wlr/types/wlr_server_decoration.h
+++ b/include/wlr/types/wlr_server_decoration.h
@@ -44,7 +44,7 @@ enum wlr_server_decoration_manager_mode {
  */
 struct wlr_server_decoration_manager {
 	struct wl_global *global;
-	struct wl_list resources;
+	struct wl_list resources; // wl_resource_get_link
 	struct wl_list decorations; // wlr_server_decoration::link
 
 	uint32_t default_mode; // enum wlr_server_decoration_manager_mode
@@ -80,7 +80,5 @@ struct wlr_server_decoration_manager *wlr_server_decoration_manager_create(
 	struct wl_display *display);
 void wlr_server_decoration_manager_set_default_mode(
 	struct wlr_server_decoration_manager *manager, uint32_t default_mode);
-void wlr_server_decoration_manager_destroy(
-	struct wlr_server_decoration_manager *manager);
 
 #endif

--- a/include/wlr/types/wlr_tablet_v2.h
+++ b/include/wlr/types/wlr_tablet_v2.h
@@ -141,7 +141,6 @@ struct wlr_tablet_v2_tablet_tool *wlr_tablet_tool_create(
 	struct wlr_tablet_tool *wlr_tool);
 
 struct wlr_tablet_manager_v2 *wlr_tablet_v2_create(struct wl_display *display);
-void wlr_tablet_v2_destroy(struct wlr_tablet_manager_v2 *manager);
 
 void wlr_send_tablet_v2_tablet_tool_proximity_in(
 	struct wlr_tablet_v2_tablet_tool *tool,

--- a/include/wlr/types/wlr_text_input_v3.h
+++ b/include/wlr/types/wlr_text_input_v3.h
@@ -60,8 +60,6 @@ struct wlr_text_input_v3 {
 
 struct wlr_text_input_manager_v3 {
 	struct wl_global *global;
-
-	struct wl_list bound_resources; // struct wl_resource*::link
 	struct wl_list text_inputs; // struct wlr_text_input_v3::resource::link
 
 	struct wl_listener display_destroy;
@@ -74,8 +72,6 @@ struct wlr_text_input_manager_v3 {
 
 struct wlr_text_input_manager_v3 *wlr_text_input_manager_v3_create(
 	struct wl_display *wl_display);
-void wlr_text_input_manager_v3_destroy(
-	struct wlr_text_input_manager_v3 *manager);
 
 // Sends enter to the surface and saves it
 void wlr_text_input_v3_send_enter(struct wlr_text_input_v3 *text_input,
@@ -90,4 +86,5 @@ void wlr_text_input_v3_send_delete_surrounding_text(
 	struct wlr_text_input_v3 *text_input, uint32_t before_length,
 	uint32_t after_length);
 void wlr_text_input_v3_send_done(struct wlr_text_input_v3 *text_input);
+
 #endif

--- a/include/wlr/types/wlr_virtual_keyboard_v1.h
+++ b/include/wlr/types/wlr_virtual_keyboard_v1.h
@@ -15,7 +15,6 @@
 
 struct wlr_virtual_keyboard_manager_v1 {
 	struct wl_global *global;
-	struct wl_list resources; // struct wl_resource*
 	struct wl_list virtual_keyboards; // struct wlr_virtual_keyboard_v1*
 
 	struct wl_listener display_destroy;
@@ -41,7 +40,5 @@ struct wlr_virtual_keyboard_v1 {
 
 struct wlr_virtual_keyboard_manager_v1* wlr_virtual_keyboard_manager_v1_create(
 	struct wl_display *display);
-void wlr_virtual_keyboard_manager_v1_destroy(
-	struct wlr_virtual_keyboard_manager_v1 *manager);
 
 #endif

--- a/include/wlr/types/wlr_xdg_decoration_v1.h
+++ b/include/wlr/types/wlr_xdg_decoration_v1.h
@@ -12,7 +12,6 @@ enum wlr_xdg_toplevel_decoration_v1_mode {
 
 struct wlr_xdg_decoration_manager_v1 {
 	struct wl_global *global;
-	struct wl_list resources;
 	struct wl_list decorations; // wlr_xdg_toplevel_decoration::link
 
 	struct wl_listener display_destroy;
@@ -59,8 +58,6 @@ struct wlr_xdg_toplevel_decoration_v1 {
 
 struct wlr_xdg_decoration_manager_v1 *
 	wlr_xdg_decoration_manager_v1_create(struct wl_display *display);
-void wlr_xdg_decoration_manager_v1_destroy(
-	struct wlr_xdg_decoration_manager_v1 *manager);
 
 uint32_t wlr_xdg_toplevel_decoration_v1_set_mode(
 	struct wlr_xdg_toplevel_decoration_v1 *decoration,

--- a/include/wlr/types/wlr_xdg_output_v1.h
+++ b/include/wlr/types/wlr_xdg_output_v1.h
@@ -26,22 +26,21 @@ struct wlr_xdg_output_v1 {
 
 struct wlr_xdg_output_manager_v1 {
 	struct wl_global *global;
-	struct wl_list resources;
 	struct wlr_output_layout *layout;
 
 	struct wl_list outputs;
 
-	struct wl_listener layout_add;
-	struct wl_listener layout_change;
-	struct wl_listener layout_destroy;
-
 	struct {
 		struct wl_signal destroy;
 	} events;
+
+	struct wl_listener display_destroy;
+	struct wl_listener layout_add;
+	struct wl_listener layout_change;
+	struct wl_listener layout_destroy;
 };
 
 struct wlr_xdg_output_manager_v1 *wlr_xdg_output_manager_v1_create(
-		struct wl_display *display, struct wlr_output_layout *layout);
-void wlr_xdg_output_manager_v1_destroy(struct wlr_xdg_output_manager_v1 *manager);
+	struct wl_display *display, struct wlr_output_layout *layout);
 
 #endif

--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -243,7 +243,6 @@ struct wlr_xdg_toplevel_show_window_menu_event {
 };
 
 struct wlr_xdg_shell *wlr_xdg_shell_create(struct wl_display *display);
-void wlr_xdg_shell_destroy(struct wlr_xdg_shell *xdg_shell);
 
 struct wlr_xdg_surface *wlr_xdg_surface_from_resource(
 		struct wl_resource *resource);

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -243,7 +243,6 @@ struct wlr_xdg_toplevel_v6_show_window_menu_event {
 };
 
 struct wlr_xdg_shell_v6 *wlr_xdg_shell_v6_create(struct wl_display *display);
-void wlr_xdg_shell_v6_destroy(struct wlr_xdg_shell_v6 *xdg_shell);
 
 /**
  * Send a ping to the surface. If the surface does not respond in a reasonable

--- a/types/tablet_v2/wlr_tablet_v2.c
+++ b/types/tablet_v2/wlr_tablet_v2.c
@@ -273,22 +273,8 @@ static void tablet_v2_bind(struct wl_client *wl_client, void *data,
 }
 
 static void handle_display_destroy(struct wl_listener *listener, void *data) {
-	struct wlr_tablet_manager_v2 *tablet =
-		wl_container_of(listener, tablet, display_destroy);
-	wlr_tablet_v2_destroy(tablet);
-}
-
-void wlr_tablet_v2_destroy(struct wlr_tablet_manager_v2 *manager) {
-	struct wlr_tablet_manager_client_v2 *client, *client_tmp;
-	wl_list_for_each_safe(client, client_tmp, &manager->clients, link) {
-		wlr_tablet_manager_v2_destroy(client->resource);
-	}
-
-	struct wlr_tablet_seat_v2 *seat, *seat_tmp;
-	wl_list_for_each_safe(seat, seat_tmp, &manager->seats, link) {
-		tablet_seat_destroy(seat);
-	}
-
+	struct wlr_tablet_manager_v2 *manager =
+		wl_container_of(listener, manager, display_destroy);
 	wlr_signal_emit_safe(&manager->events.destroy, manager);
 	wl_list_remove(&manager->display_destroy.link);
 	wl_global_destroy(manager->wl_global);

--- a/types/wlr_compositor.c
+++ b/types/wlr_compositor.c
@@ -22,15 +22,6 @@ struct wlr_subsurface *wlr_subsurface_from_wlr_surface(
 	return (struct wlr_subsurface *)surface->role_data;
 }
 
-static const struct wl_subcompositor_interface subcompositor_impl;
-
-static struct wlr_subcompositor *subcompositor_from_resource(
-		struct wl_resource *resource) {
-	assert(wl_resource_instance_of(resource, &wl_subcompositor_interface,
-		&subcompositor_impl));
-	return wl_resource_get_user_data(resource);
-}
-
 static void subcompositor_handle_destroy(struct wl_client *client,
 		struct wl_resource *resource) {
 	wl_resource_destroy(resource);
@@ -40,8 +31,6 @@ static void subcompositor_handle_get_subsurface(struct wl_client *client,
 		struct wl_resource *resource, uint32_t id,
 		struct wl_resource *surface_resource,
 		struct wl_resource *parent_resource) {
-	struct wlr_subcompositor *subcompositor =
-		subcompositor_from_resource(resource);
 	struct wlr_surface *surface = wlr_surface_from_resource(surface_resource);
 	struct wlr_surface *parent = wlr_surface_from_resource(parent_resource);
 
@@ -78,17 +67,13 @@ static void subcompositor_handle_get_subsurface(struct wl_client *client,
 	}
 
 	wlr_subsurface_create(surface, parent, wl_resource_get_version(resource),
-		id, &subcompositor->subsurface_resources);
+		id, NULL);
 }
 
 static const struct wl_subcompositor_interface subcompositor_impl = {
 	.destroy = subcompositor_handle_destroy,
 	.get_subsurface = subcompositor_handle_get_subsurface,
 };
-
-static void subcompositor_resource_destroy(struct wl_resource *resource) {
-	wl_list_remove(wl_resource_get_link(resource));
-}
 
 static void subcompositor_bind(struct wl_client *client, void *data,
 		uint32_t version, uint32_t id) {
@@ -100,33 +85,24 @@ static void subcompositor_bind(struct wl_client *client, void *data,
 		return;
 	}
 	wl_resource_set_implementation(resource, &subcompositor_impl,
-		subcompositor, subcompositor_resource_destroy);
-	wl_list_insert(&subcompositor->resources, wl_resource_get_link(resource));
+		subcompositor, NULL);
 }
 
-static void subcompositor_init(struct wlr_subcompositor *subcompositor,
+static bool subcompositor_init(struct wlr_subcompositor *subcompositor,
 		struct wl_display *display) {
 	subcompositor->global = wl_global_create(display,
 		&wl_subcompositor_interface, SUBCOMPOSITOR_VERSION, subcompositor,
 		subcompositor_bind);
 	if (subcompositor->global == NULL) {
 		wlr_log_errno(WLR_ERROR, "Could not allocate subcompositor global");
-		return;
+		return false;
 	}
-	wl_list_init(&subcompositor->resources);
-	wl_list_init(&subcompositor->subsurface_resources);
+
+	return true;
 }
 
 static void subcompositor_finish(struct wlr_subcompositor *subcompositor) {
 	wl_global_destroy(subcompositor->global);
-	struct wl_resource *resource, *tmp;
-	wl_resource_for_each_safe(resource, tmp,
-			&subcompositor->subsurface_resources) {
-		wl_resource_destroy(resource);
-	}
-	wl_resource_for_each_safe(resource, tmp, &subcompositor->resources) {
-		wl_resource_destroy(resource);
-	}
 }
 
 
@@ -144,8 +120,7 @@ static void compositor_create_surface(struct wl_client *client,
 	struct wlr_compositor *compositor = compositor_from_resource(resource);
 
 	struct wlr_surface *surface = wlr_surface_create(client,
-		wl_resource_get_version(resource), id, compositor->renderer,
-		&compositor->surface_resources);
+		wl_resource_get_version(resource), id, compositor->renderer, NULL);
 	if (surface == NULL) {
 		wl_client_post_no_memory(client);
 		return;
@@ -156,9 +131,7 @@ static void compositor_create_surface(struct wl_client *client,
 
 static void compositor_create_region(struct wl_client *client,
 		struct wl_resource *resource, uint32_t id) {
-	struct wlr_compositor *compositor = compositor_from_resource(resource);
-
-	wlr_region_create(client, 1, id, &compositor->region_resources);
+	wlr_region_create(client, wl_resource_get_version(resource), id, NULL);
 }
 
 static const struct wl_compositor_interface compositor_impl = {
@@ -166,14 +139,9 @@ static const struct wl_compositor_interface compositor_impl = {
 	.create_region = compositor_create_region,
 };
 
-static void compositor_resource_destroy(struct wl_resource *resource) {
-	wl_list_remove(wl_resource_get_link(resource));
-}
-
 static void compositor_bind(struct wl_client *wl_client, void *data,
 		uint32_t version, uint32_t id) {
 	struct wlr_compositor *compositor = data;
-	assert(wl_client && compositor);
 
 	struct wl_resource *resource =
 		wl_resource_create(wl_client, &wl_compositor_interface, version, id);
@@ -181,36 +149,17 @@ static void compositor_bind(struct wl_client *wl_client, void *data,
 		wl_client_post_no_memory(wl_client);
 		return;
 	}
-	wl_resource_set_implementation(resource, &compositor_impl,
-		compositor, compositor_resource_destroy);
-	wl_list_insert(&compositor->resources, wl_resource_get_link(resource));
-}
-
-void wlr_compositor_destroy(struct wlr_compositor *compositor) {
-	if (compositor == NULL) {
-		return;
-	}
-	wlr_signal_emit_safe(&compositor->events.destroy, compositor);
-	subcompositor_finish(&compositor->subcompositor);
-	wl_list_remove(&compositor->display_destroy.link);
-	wl_global_destroy(compositor->global);
-	struct wl_resource *resource, *tmp;
-	wl_resource_for_each_safe(resource, tmp, &compositor->surface_resources) {
-		wl_resource_destroy(resource);
-	}
-	wl_resource_for_each_safe(resource, tmp, &compositor->region_resources) {
-		wl_resource_destroy(resource);
-	}
-	wl_resource_for_each_safe(resource, tmp, &compositor->resources) {
-		wl_resource_destroy(resource);
-	}
-	free(compositor);
+	wl_resource_set_implementation(resource, &compositor_impl, compositor, NULL);
 }
 
 static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	struct wlr_compositor *compositor =
 		wl_container_of(listener, compositor, display_destroy);
-	wlr_compositor_destroy(compositor);
+	wlr_signal_emit_safe(&compositor->events.destroy, compositor);
+	subcompositor_finish(&compositor->subcompositor);
+	wl_list_remove(&compositor->display_destroy.link);
+	wl_global_destroy(compositor->global);
+	free(compositor);
 }
 
 struct wlr_compositor *wlr_compositor_create(struct wl_display *display,
@@ -231,9 +180,6 @@ struct wlr_compositor *wlr_compositor_create(struct wl_display *display,
 	}
 	compositor->renderer = renderer;
 
-	wl_list_init(&compositor->resources);
-	wl_list_init(&compositor->surface_resources);
-	wl_list_init(&compositor->region_resources);
 	wl_signal_init(&compositor->events.new_surface);
 	wl_signal_init(&compositor->events.destroy);
 

--- a/types/wlr_data_control_v1.c
+++ b/types/wlr_data_control_v1.c
@@ -650,10 +650,6 @@ static const struct zwlr_data_control_manager_v1_interface manager_impl = {
 	.destroy = manager_handle_destroy,
 };
 
-static void manager_handle_resource_destroy(struct wl_resource *resource) {
-	wl_list_remove(wl_resource_get_link(resource));
-}
-
 static void manager_bind(struct wl_client *client, void *data, uint32_t version,
 		uint32_t id) {
 	struct wlr_data_control_manager_v1 *manager = data;
@@ -664,16 +660,16 @@ static void manager_bind(struct wl_client *client, void *data, uint32_t version,
 		wl_client_post_no_memory(client);
 		return;
 	}
-	wl_resource_set_implementation(resource, &manager_impl, manager,
-		manager_handle_resource_destroy);
-
-	wl_list_insert(&manager->resources, wl_resource_get_link(resource));
+	wl_resource_set_implementation(resource, &manager_impl, manager, NULL);
 }
 
 static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	struct wlr_data_control_manager_v1 *manager =
 		wl_container_of(listener, manager, display_destroy);
-	wlr_data_control_manager_v1_destroy(manager);
+	wlr_signal_emit_safe(&manager->events.destroy, manager);
+	wl_list_remove(&manager->display_destroy.link);
+	wl_global_destroy(manager->global);
+	free(manager);
 }
 
 struct wlr_data_control_manager_v1 *wlr_data_control_manager_v1_create(
@@ -683,7 +679,6 @@ struct wlr_data_control_manager_v1 *wlr_data_control_manager_v1_create(
 	if (manager == NULL) {
 		return NULL;
 	}
-	wl_list_init(&manager->resources);
 	wl_list_init(&manager->devices);
 	wl_signal_init(&manager->events.destroy);
 	wl_signal_init(&manager->events.new_device);
@@ -700,26 +695,4 @@ struct wlr_data_control_manager_v1 *wlr_data_control_manager_v1_create(
 	wl_display_add_destroy_listener(display, &manager->display_destroy);
 
 	return manager;
-}
-
-void wlr_data_control_manager_v1_destroy(
-		struct wlr_data_control_manager_v1 *manager) {
-	if (manager == NULL) {
-		return;
-	}
-
-	wlr_signal_emit_safe(&manager->events.destroy, manager);
-
-	struct wlr_data_control_device_v1 *device, *control_tmp;
-	wl_list_for_each_safe(device, control_tmp, &manager->devices, link) {
-		wl_resource_destroy(device->resource);
-	}
-
-	struct wl_resource *resource, *resource_tmp;
-	wl_resource_for_each_safe(resource, resource_tmp, &manager->resources) {
-		wl_resource_destroy(resource);
-	}
-
-	wl_list_remove(&manager->display_destroy.link);
-	free(manager);
 }

--- a/types/wlr_foreign_toplevel_management_v1.c
+++ b/types/wlr_foreign_toplevel_management_v1.c
@@ -568,33 +568,13 @@ static void foreign_toplevel_manager_bind(struct wl_client *client, void *data,
 	}
 }
 
-void wlr_foreign_toplevel_manager_v1_destroy(
-		struct wlr_foreign_toplevel_manager_v1 *manager) {
-	if (!manager) {
-		return;
-	}
-
-	struct wlr_foreign_toplevel_handle_v1 *toplevel, *tmp_toplevel;
-	wl_list_for_each_safe(toplevel, tmp_toplevel, &manager->toplevels, link) {
-		wlr_foreign_toplevel_handle_v1_destroy(toplevel);
-	}
-
-	struct wl_resource *resource, *tmp_resource;
-	wl_resource_for_each_safe(resource, tmp_resource, &manager->resources) {
-		wl_resource_destroy(resource);
-	}
-
-	wlr_signal_emit_safe(&manager->events.destroy, manager);
-	wl_list_remove(&manager->display_destroy.link);
-
-	wl_global_destroy(manager->global);
-	free(manager);
-}
-
 static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	struct wlr_foreign_toplevel_manager_v1 *manager =
 		wl_container_of(listener, manager, display_destroy);
-	wlr_foreign_toplevel_manager_v1_destroy(manager);
+	wlr_signal_emit_safe(&manager->events.destroy, manager);
+	wl_list_remove(&manager->display_destroy.link);
+	wl_global_destroy(manager->global);
+	free(manager);
 }
 
 struct wlr_foreign_toplevel_manager_v1 *wlr_foreign_toplevel_manager_v1_create(

--- a/types/wlr_gamma_control_v1.c
+++ b/types/wlr_gamma_control_v1.c
@@ -200,11 +200,6 @@ static const struct zwlr_gamma_control_manager_v1_interface
 	.destroy = gamma_control_manager_destroy,
 };
 
-static void gamma_control_manager_handle_resource_destroy(
-		struct wl_resource *resource) {
-	wl_list_remove(wl_resource_get_link(resource));
-}
-
 static void gamma_control_manager_bind(struct wl_client *client, void *data,
 		uint32_t version, uint32_t id) {
 	struct wlr_gamma_control_manager_v1 *manager = data;
@@ -216,33 +211,16 @@ static void gamma_control_manager_bind(struct wl_client *client, void *data,
 		return;
 	}
 	wl_resource_set_implementation(resource, &gamma_control_manager_impl,
-		manager, gamma_control_manager_handle_resource_destroy);
-	wl_list_insert(&manager->resources, wl_resource_get_link(resource));
-}
-
-void wlr_gamma_control_manager_v1_destroy(
-		struct wlr_gamma_control_manager_v1 *manager) {
-	if (!manager) {
-		return;
-	}
-	struct wlr_gamma_control_v1 *gamma_control, *tmp;
-	wl_list_for_each_safe(gamma_control, tmp, &manager->controls, link) {
-		wl_resource_destroy(gamma_control->resource);
-	}
-	wlr_signal_emit_safe(&manager->events.destroy, manager);
-	wl_list_remove(&manager->display_destroy.link);
-	struct wl_resource *resource, *resource_tmp;
-	wl_resource_for_each_safe(resource, resource_tmp, &manager->resources) {
-		wl_resource_destroy(resource);
-	}
-	wl_global_destroy(manager->global);
-	free(manager);
+		manager, NULL);
 }
 
 static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	struct wlr_gamma_control_manager_v1 *manager =
 		wl_container_of(listener, manager, display_destroy);
-	wlr_gamma_control_manager_v1_destroy(manager);
+	wlr_signal_emit_safe(&manager->events.destroy, manager);
+	wl_list_remove(&manager->display_destroy.link);
+	wl_global_destroy(manager->global);
+	free(manager);
 }
 
 struct wlr_gamma_control_manager_v1 *wlr_gamma_control_manager_v1_create(
@@ -262,7 +240,6 @@ struct wlr_gamma_control_manager_v1 *wlr_gamma_control_manager_v1_create(
 	}
 
 	wl_signal_init(&manager->events.destroy);
-	wl_list_init(&manager->resources);
 	wl_list_init(&manager->controls);
 
 	manager->display_destroy.notify = handle_display_destroy;

--- a/types/wlr_gtk_primary_selection.c
+++ b/types/wlr_gtk_primary_selection.c
@@ -434,11 +434,6 @@ static const struct gtk_primary_selection_device_manager_interface
 	.destroy = device_manager_handle_destroy,
 };
 
-static void device_manager_handle_resource_destroy(
-		struct wl_resource *resource) {
-	wl_list_remove(wl_resource_get_link(resource));
-}
-
 
 static void primary_selection_device_manager_bind(struct wl_client *client,
 		void *data, uint32_t version, uint32_t id) {
@@ -451,15 +446,16 @@ static void primary_selection_device_manager_bind(struct wl_client *client,
 		return;
 	}
 	wl_resource_set_implementation(resource, &device_manager_impl, manager,
-		device_manager_handle_resource_destroy);
-
-	wl_list_insert(&manager->resources, wl_resource_get_link(resource));
+		NULL);
 }
 
 static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	struct wlr_gtk_primary_selection_device_manager *manager =
 		wl_container_of(listener, manager, display_destroy);
-	wlr_gtk_primary_selection_device_manager_destroy(manager);
+	wlr_signal_emit_safe(&manager->events.destroy, manager);
+	wl_list_remove(&manager->display_destroy.link);
+	wl_global_destroy(manager->global);
+	free(manager);
 }
 
 struct wlr_gtk_primary_selection_device_manager *
@@ -478,7 +474,6 @@ struct wlr_gtk_primary_selection_device_manager *
 		return NULL;
 	}
 
-	wl_list_init(&manager->resources);
 	wl_list_init(&manager->devices);
 	wl_signal_init(&manager->events.destroy);
 
@@ -486,19 +481,4 @@ struct wlr_gtk_primary_selection_device_manager *
 	wl_display_add_destroy_listener(display, &manager->display_destroy);
 
 	return manager;
-}
-
-void wlr_gtk_primary_selection_device_manager_destroy(
-		struct wlr_gtk_primary_selection_device_manager *manager) {
-	if (manager == NULL) {
-		return;
-	}
-	wlr_signal_emit_safe(&manager->events.destroy, manager);
-	wl_list_remove(&manager->display_destroy.link);
-	struct wl_resource *resource, *resource_tmp;
-	wl_resource_for_each_safe(resource, resource_tmp, &manager->resources) {
-		wl_resource_destroy(resource);
-	}
-	wl_global_destroy(manager->global);
-	free(manager);
 }

--- a/types/wlr_idle_inhibit_v1.c
+++ b/types/wlr_idle_inhibit_v1.c
@@ -98,11 +98,6 @@ static void manager_handle_create_inhibitor(struct wl_client *client,
 	wlr_signal_emit_safe(&manager->events.new_inhibitor, inhibitor);
 }
 
-static void idle_inhibit_manager_v1_handle_resource_destroy(
-		struct wl_resource *resource) {
-	wl_list_remove(wl_resource_get_link(resource));
-}
-
 static void manager_handle_destroy(struct wl_client *client,
 		struct wl_resource *manager_resource) {
 	wl_resource_destroy(manager_resource);
@@ -116,8 +111,10 @@ static const struct zwp_idle_inhibit_manager_v1_interface idle_inhibit_impl = {
 static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	struct wlr_idle_inhibit_manager_v1 *idle_inhibit =
 		wl_container_of(listener, idle_inhibit, display_destroy);
-
-	wlr_idle_inhibit_v1_destroy(idle_inhibit);
+	wlr_signal_emit_safe(&idle_inhibit->events.destroy, idle_inhibit);
+	wl_list_remove(&idle_inhibit->display_destroy.link);
+	wl_global_destroy(idle_inhibit->global);
+	free(idle_inhibit);
 }
 
 static void idle_inhibit_bind(struct wl_client *wl_client, void *data,
@@ -126,69 +123,36 @@ static void idle_inhibit_bind(struct wl_client *wl_client, void *data,
 
 	struct wl_resource *wl_resource  = wl_resource_create(wl_client,
 		&zwp_idle_inhibit_manager_v1_interface, version, id);
-
 	if (!wl_resource) {
 		wl_client_post_no_memory(wl_client);
 		return;
 	}
 
-	wl_list_insert(&idle_inhibit->resources, wl_resource_get_link(wl_resource));
-
 	wl_resource_set_implementation(wl_resource, &idle_inhibit_impl,
-		idle_inhibit, idle_inhibit_manager_v1_handle_resource_destroy);
-	wlr_log(WLR_DEBUG, "idle_inhibit bound");
-}
-
-void wlr_idle_inhibit_v1_destroy(struct wlr_idle_inhibit_manager_v1 *idle_inhibit) {
-	if (!idle_inhibit) {
-		return;
-	}
-
-	struct wlr_idle_inhibitor_v1 *inhibitor;
-	struct wlr_idle_inhibitor_v1 *tmp;
-	wl_list_for_each_safe(inhibitor, tmp, &idle_inhibit->inhibitors, link) {
-		idle_inhibitor_v1_destroy(inhibitor);
-	}
-
-	wlr_signal_emit_safe(&idle_inhibit->events.destroy, idle_inhibit);
-	wl_list_remove(&idle_inhibit->display_destroy.link);
-
-	struct wl_resource *resource;
-	struct wl_resource *tmp_resource;
-	wl_resource_for_each_safe(resource, tmp_resource, &idle_inhibit->resources) {
-		wl_resource_destroy(resource);
-	}
-
-	wl_global_destroy(idle_inhibit->global);
-	free(idle_inhibit);
+		idle_inhibit, NULL);
 }
 
 struct wlr_idle_inhibit_manager_v1 *wlr_idle_inhibit_v1_create(struct wl_display *display) {
 	struct wlr_idle_inhibit_manager_v1 *idle_inhibit =
 		calloc(1, sizeof(struct wlr_idle_inhibit_manager_v1));
-
 	if (!idle_inhibit) {
 		return NULL;
 	}
 
-	wl_list_init(&idle_inhibit->resources);
 	wl_list_init(&idle_inhibit->inhibitors);
-	idle_inhibit->display_destroy.notify = handle_display_destroy;
-	wl_display_add_destroy_listener(display, &idle_inhibit->display_destroy);
 	wl_signal_init(&idle_inhibit->events.new_inhibitor);
 	wl_signal_init(&idle_inhibit->events.destroy);
 
 	idle_inhibit->global = wl_global_create(display,
 		&zwp_idle_inhibit_manager_v1_interface, 1,
 		idle_inhibit, idle_inhibit_bind);
-
 	if (!idle_inhibit->global) {
-		wl_list_remove(&idle_inhibit->display_destroy.link);
 		free(idle_inhibit);
 		return NULL;
 	}
 
-	wlr_log(WLR_DEBUG, "idle_inhibit manager created");
+	idle_inhibit->display_destroy.notify = handle_display_destroy;
+	wl_display_add_destroy_listener(display, &idle_inhibit->display_destroy);
 
 	return idle_inhibit;
 }

--- a/types/wlr_input_inhibitor.c
+++ b/types/wlr_input_inhibitor.c
@@ -103,25 +103,13 @@ static void inhibit_manager_bind(struct wl_client *wl_client, void *data,
 			input_manager_resource_destroy);
 }
 
-void wlr_input_inhibit_manager_destroy(
-		struct wlr_input_inhibit_manager *manager) {
-	if (!manager) {
-		return;
-	}
-	if (manager->active_client) {
-		input_inhibitor_destroy(manager->active_client,
-				manager->active_inhibitor);
-	}
+static void handle_display_destroy(struct wl_listener *listener, void *data) {
+	struct wlr_input_inhibit_manager *manager =
+		wl_container_of(listener, manager, display_destroy);
 	wlr_signal_emit_safe(&manager->events.destroy, manager);
 	wl_list_remove(&manager->display_destroy.link);
 	wl_global_destroy(manager->global);
 	free(manager);
-}
-
-static void handle_display_destroy(struct wl_listener *listener, void *data) {
-	struct wlr_input_inhibit_manager *manager =
-		wl_container_of(listener, manager, display_destroy);
-	wlr_input_inhibit_manager_destroy(manager);
 }
 
 struct wlr_input_inhibit_manager *wlr_input_inhibit_manager_create(
@@ -137,7 +125,6 @@ struct wlr_input_inhibit_manager *wlr_input_inhibit_manager_create(
 			&zwlr_input_inhibit_manager_v1_interface,
 			1, manager, inhibit_manager_bind);
 	if (manager->global == NULL){
-		wl_list_remove(&manager->display_destroy.link);
 		free(manager);
 		return NULL;
 	}

--- a/types/wlr_pointer_gestures_v1.c
+++ b/types/wlr_pointer_gestures_v1.c
@@ -287,27 +287,13 @@ static void pointer_gestures_v1_bind(struct wl_client *wl_client, void *data,
 	}
 
 	wl_resource_set_implementation(resource,
-			&gestures_impl, gestures, resource_remove_from_list);
-	wl_list_insert(&gestures->resources, wl_resource_get_link(resource));
+			&gestures_impl, gestures, NULL);
 }
 
 static void handle_display_destroy(struct wl_listener *listener, void *data) {
-	struct wlr_pointer_gestures_v1 *tablet =
-		wl_container_of(listener, tablet, display_destroy);
-	wlr_pointer_gestures_v1_destroy(tablet);
-}
-
-void wlr_pointer_gestures_v1_destroy(struct wlr_pointer_gestures_v1 *gestures) {
-	struct wl_resource *resource, *tmp;
-	wl_resource_for_each_safe(resource, tmp, &gestures->resources) {
-		wl_resource_destroy(resource);
-	}
-	wl_resource_for_each_safe(resource, tmp, &gestures->swipes) {
-		wl_resource_destroy(resource);
-	}
-	wl_resource_for_each_safe(resource, tmp, &gestures->pinches) {
-		wl_resource_destroy(resource);
-	}
+	struct wlr_pointer_gestures_v1 *gestures =
+		wl_container_of(listener, gestures, display_destroy);
+	wl_list_remove(&gestures->display_destroy.link);
 	wl_global_destroy(gestures->global);
 	free(gestures);
 }
@@ -320,7 +306,6 @@ struct wlr_pointer_gestures_v1 *wlr_pointer_gestures_v1_create(
 		return NULL;
 	}
 
-	wl_list_init(&gestures->resources);
 	wl_list_init(&gestures->swipes);
 	wl_list_init(&gestures->pinches);
 

--- a/types/wlr_server_decoration.c
+++ b/types/wlr_server_decoration.c
@@ -163,30 +163,13 @@ static void server_decoration_manager_bind(struct wl_client *client, void *data,
 		manager->default_mode);
 }
 
-void wlr_server_decoration_manager_destroy(
-		struct wlr_server_decoration_manager *manager) {
-	if (manager == NULL) {
-		return;
-	}
-	struct wlr_server_decoration *decoration, *tmp_decoration;
-	wl_list_for_each_safe(decoration, tmp_decoration, &manager->decorations,
-			link) {
-		server_decoration_destroy(decoration);
-	}
-	wlr_signal_emit_safe(&manager->events.destroy, manager);
-	wl_list_remove(&manager->display_destroy.link);
-	struct wl_resource *resource, *tmp_resource;
-	wl_resource_for_each_safe(resource, tmp_resource, &manager->resources) {
-		server_decoration_manager_destroy_resource(resource);
-	}
-	wl_global_destroy(manager->global);
-	free(manager);
-}
-
 static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	struct wlr_server_decoration_manager *manager =
 		wl_container_of(listener, manager, display_destroy);
-	wlr_server_decoration_manager_destroy(manager);
+	wlr_signal_emit_safe(&manager->events.destroy, manager);
+	wl_list_remove(&manager->display_destroy.link);
+	wl_global_destroy(manager->global);
+	free(manager);
 }
 
 struct wlr_server_decoration_manager *wlr_server_decoration_manager_create(

--- a/types/wlr_xdg_output_v1.c
+++ b/types/wlr_xdg_output_v1.c
@@ -142,11 +142,6 @@ static const struct zxdg_output_manager_v1_interface
 	.get_xdg_output = output_manager_handle_get_xdg_output,
 };
 
-static void output_manager_handle_resource_destroy(
-		struct wl_resource *resource) {
-	wl_list_remove(wl_resource_get_link(resource));
-}
-
 static void output_manager_bind(struct wl_client *wl_client, void *data,
 		uint32_t version, uint32_t id) {
 	struct wlr_xdg_output_manager_v1 *manager = data;
@@ -158,8 +153,7 @@ static void output_manager_bind(struct wl_client *wl_client, void *data,
 		return;
 	}
 	wl_resource_set_implementation(resource, &output_manager_implementation,
-		manager, output_manager_handle_resource_destroy);
-	wl_list_insert(&manager->resources, wl_resource_get_link(resource));
+		manager, NULL);
 }
 
 static void handle_output_destroy(struct wl_listener *listener, void *data) {
@@ -203,16 +197,29 @@ static void handle_layout_change(struct wl_listener *listener, void *data) {
 	output_manager_send_details(manager);
 }
 
+static void manager_destroy(struct wlr_xdg_output_manager_v1 *manager) {
+	wlr_signal_emit_safe(&manager->events.destroy, manager);
+	wl_list_remove(&manager->display_destroy.link);
+	wl_list_remove(&manager->layout_add.link);
+	wl_list_remove(&manager->layout_change.link);
+	wl_list_remove(&manager->layout_destroy.link);
+	free(manager);
+}
+
 static void handle_layout_destroy(struct wl_listener *listener, void *data) {
 	struct wlr_xdg_output_manager_v1 *manager =
 		wl_container_of(listener, manager, layout_destroy);
-	wlr_xdg_output_manager_v1_destroy(manager);
+	manager_destroy(manager);
+}
+
+static void handle_display_destroy(struct wl_listener *listener, void *data) {
+	struct wlr_xdg_output_manager_v1 *manager =
+		wl_container_of(listener, manager, display_destroy);
+	manager_destroy(manager);
 }
 
 struct wlr_xdg_output_manager_v1 *wlr_xdg_output_manager_v1_create(
 		struct wl_display *display, struct wlr_output_layout *layout) {
-	assert(display && layout);
-
 	// TODO: require wayland-protocols 1.18 and remove this condition
 	int version = OUTPUT_MANAGER_VERSION;
 	if (version > zxdg_output_manager_v1_interface.version) {
@@ -233,7 +240,6 @@ struct wlr_xdg_output_manager_v1 *wlr_xdg_output_manager_v1_create(
 		return NULL;
 	}
 
-	wl_list_init(&manager->resources);
 	wl_list_init(&manager->outputs);
 	struct wlr_output_layout_output *layout_output;
 	wl_list_for_each(layout_output, &layout->outputs, link) {
@@ -248,21 +254,9 @@ struct wlr_xdg_output_manager_v1 *wlr_xdg_output_manager_v1_create(
 	wl_signal_add(&layout->events.change, &manager->layout_change);
 	manager->layout_destroy.notify = handle_layout_destroy;
 	wl_signal_add(&layout->events.destroy, &manager->layout_destroy);
-	return manager;
-}
 
-void wlr_xdg_output_manager_v1_destroy(struct wlr_xdg_output_manager_v1 *manager) {
-	struct wlr_xdg_output_v1 *output, *output_tmp;
-	wl_list_for_each_safe(output, output_tmp, &manager->outputs, link) {
-		output_destroy(output);
-	}
-	struct wl_resource *resource, *resource_tmp;
-	wl_resource_for_each_safe(resource, resource_tmp, &manager->resources) {
-		wl_resource_destroy(resource);
-	}
-	wlr_signal_emit_safe(&manager->events.destroy, manager);
-	wl_list_remove(&manager->layout_add.link);
-	wl_list_remove(&manager->layout_change.link);
-	wl_list_remove(&manager->layout_destroy.link);
-	free(manager);
+	manager->display_destroy.notify = handle_display_destroy;
+	wl_display_add_destroy_listener(display, &manager->display_destroy);
+
+	return manager;
 }

--- a/types/xdg_shell/wlr_xdg_shell.c
+++ b/types/xdg_shell/wlr_xdg_shell.c
@@ -131,7 +131,10 @@ static void xdg_shell_bind(struct wl_client *wl_client, void *data,
 static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	struct wlr_xdg_shell *xdg_shell =
 		wl_container_of(listener, xdg_shell, display_destroy);
-	wlr_xdg_shell_destroy(xdg_shell);
+	wlr_signal_emit_safe(&xdg_shell->events.destroy, xdg_shell);
+	wl_list_remove(&xdg_shell->display_destroy.link);
+	wl_global_destroy(xdg_shell->global);
+	free(xdg_shell);
 }
 
 struct wlr_xdg_shell *wlr_xdg_shell_create(struct wl_display *display) {
@@ -161,14 +164,4 @@ struct wlr_xdg_shell *wlr_xdg_shell_create(struct wl_display *display) {
 	wl_display_add_destroy_listener(display, &xdg_shell->display_destroy);
 
 	return xdg_shell;
-}
-
-void wlr_xdg_shell_destroy(struct wlr_xdg_shell *xdg_shell) {
-	if (!xdg_shell) {
-		return;
-	}
-	wlr_signal_emit_safe(&xdg_shell->events.destroy, xdg_shell);
-	wl_list_remove(&xdg_shell->display_destroy.link);
-	wl_global_destroy(xdg_shell->global);
-	free(xdg_shell);
 }

--- a/types/xdg_shell_v6/wlr_xdg_shell_v6.c
+++ b/types/xdg_shell_v6/wlr_xdg_shell_v6.c
@@ -132,7 +132,10 @@ static void xdg_shell_bind(struct wl_client *wl_client, void *data,
 static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	struct wlr_xdg_shell_v6 *xdg_shell =
 		wl_container_of(listener, xdg_shell, display_destroy);
-	wlr_xdg_shell_v6_destroy(xdg_shell);
+	wlr_signal_emit_safe(&xdg_shell->events.destroy, xdg_shell);
+	wl_list_remove(&xdg_shell->display_destroy.link);
+	wl_global_destroy(xdg_shell->global);
+	free(xdg_shell);
 }
 
 struct wlr_xdg_shell_v6 *wlr_xdg_shell_v6_create(struct wl_display *display) {
@@ -162,14 +165,4 @@ struct wlr_xdg_shell_v6 *wlr_xdg_shell_v6_create(struct wl_display *display) {
 	wl_display_add_destroy_listener(display, &xdg_shell->display_destroy);
 
 	return xdg_shell;
-}
-
-void wlr_xdg_shell_v6_destroy(struct wlr_xdg_shell_v6 *xdg_shell) {
-	if (!xdg_shell) {
-		return;
-	}
-	wlr_signal_emit_safe(&xdg_shell->events.destroy, xdg_shell);
-	wl_list_remove(&xdg_shell->display_destroy.link);
-	wl_global_destroy(xdg_shell->global);
-	free(xdg_shell);
 }


### PR DESCRIPTION
Some globals are static and it doesn't make sense to destroy them before
the wl_display. For instance, wl_compositor should be created before the
display is started and shouldn't be destroyed.

For these globals, we can simplify the code by removing the destructor
and stop keeping track of wl_resources (these will be destroyed with the
wl_display by libwayland).

* * *

Breaking change: destructors and resource lists for static globals have been removed.