### PR TITLE
output: add wlr_output_event_present.commit_seq

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1497,6 +1497,9 @@ static void page_flip_handler(int fd, unsigned seq,
 		.tv_nsec = tv_usec * 1000,
 	};
 	struct wlr_output_event_present present_event = {
+		/* The DRM backend guarantees that the presentation event will be for
+		 * the last submitted frame. */
+		.commit_seq = conn->output.commit_seq,
 		.when = &present_time,
 		.seq = seq,
 		.refresh = mhz_to_nsec(conn->output.refresh),

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -173,6 +173,9 @@ enum wlr_output_present_flag {
 
 struct wlr_output_event_present {
 	struct wlr_output *output;
+	// Frame submission for which this presentation event is for (see
+	// wlr_output.commit_seq).
+	uint32_t commit_seq;
 	// Time when the content update turned into light the first time.
 	struct timespec *when;
 	// Vertical retrace counter. Zero if unavailable.

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -569,6 +569,7 @@ void wlr_output_send_present(struct wlr_output *output,
 	struct wlr_output_event_present _event = {0};
 	if (event == NULL) {
 		event = &_event;
+		event->commit_seq = output->commit_seq;
 	}
 
 	event->output = output;


### PR DESCRIPTION
This is set to the value of wlr_output.commit_seq when the frame has
been submitted. This allows to track presentation with more than 1 full
frame of latency.

References: https://github.com/swaywm/wlroots/issues/1917