### PR TITLE
Improve presentation-time API

### DIFF
--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -495,13 +495,14 @@ bool wlr_output_commit(struct wlr_output *output) {
 		wlr_surface_send_frame_done(cursor->surface, &now);
 	}
 
+	output->commit_seq++;
+
 	wlr_signal_emit_safe(&output->events.commit, output);
 
 	output->frame_pending = true;
 	output->needs_frame = false;
 	output_state_clear(&output->pending);
 	pixman_region32_clear(&output->damage);
-	output->commit_seq++;
 	return true;
 }
 

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -570,7 +570,7 @@ void wlr_output_send_present(struct wlr_output *output,
 	struct wlr_output_event_present _event = {0};
 	if (event == NULL) {
 		event = &_event;
-		event->commit_seq = output->commit_seq;
+		event->commit_seq = output->commit_seq + 1;
 	}
 
 	event->output = output;


### PR DESCRIPTION
The wlr_presentation_feedback struct now tracks presentation feedback
for multiple resources (but still a single surface content update). This
allows the compositor to properly send presentation events even when
there is more than one frame of latency or when it references a
surface's buffer.

Most of the time, compositors just display the surface's current buffer
on an output. Add an helper to make it easy to support presentation-time
in this case.

References: https://github.com/swaywm/sway/issues/4572
Closes: https://github.com/swaywm/wlroots/issues/1917

cc @YaLTeR 

* * *

Breaking change: instead of calling `wlr_presentation_surface_sampled` at render time and `wlr_presentation_send_surface_presented` at presentation time, most compositors now just need to call `wlr_presentation_surface_sampled_on_output` at render time. Compositors that call `wlr_buffer_ref` need to call `wlr_presentation_surface_sampled` when they ref the buffer, `wlr_presentation_feedback_send_presented` when this buffer has been presented for the first time and then `wlr_presentation_feedback_destroy`.

Sway PR: https://github.com/swaywm/sway/pull/4731