### PR TITLE
Backend fixes

### DIFF
--- a/backend/backend.c
+++ b/backend/backend.c
@@ -297,10 +297,12 @@ struct wlr_backend *wlr_backend_autocreate(struct wl_display *display,
 			getenv("WAYLAND_SOCKET")) {
 		struct wlr_backend *wl_backend = attempt_wl_backend(display,
 			create_renderer_func);
-		if (wl_backend) {
-			wlr_multi_backend_add(backend, wl_backend);
-			return backend;
+		if (!wl_backend) {
+			goto error;
 		}
+
+		wlr_multi_backend_add(backend, wl_backend);
+		return backend;
 	}
 
 #if WLR_HAS_X11_BACKEND
@@ -308,10 +310,12 @@ struct wlr_backend *wlr_backend_autocreate(struct wl_display *display,
 	if (x11_display) {
 		struct wlr_backend *x11_backend =
 			attempt_x11_backend(display, x11_display, create_renderer_func);
-		if (x11_backend) {
-			wlr_multi_backend_add(backend, x11_backend);
-			return backend;
+		if (!x11_backend) {
+			goto error;
 		}
+
+		wlr_multi_backend_add(backend, x11_backend);
+		return backend;
 	}
 #endif
 
@@ -344,4 +348,8 @@ struct wlr_backend *wlr_backend_autocreate(struct wl_display *display,
 	}
 
 	return backend;
+
+error:
+	wlr_backend_destroy(backend);
+	return NULL;
 }

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -228,12 +228,11 @@ struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
 	x11->present_opcode = ext->major_opcode;
 
 	xcb_present_query_version_cookie_t present_cookie =
-		xcb_present_query_version(x11->xcb, 1, 2);
+		xcb_present_query_version(x11->xcb, 1, 0);
 	xcb_present_query_version_reply_t *present_reply =
 		xcb_present_query_version_reply(x11->xcb, present_cookie, NULL);
 
-	if (!present_reply || (present_reply->major_version <= 1 &&
-			present_reply->minor_version < 2)) {
+	if (!present_reply) {
 		wlr_log(WLR_ERROR, "X11 does not support required Present version");
 		free(present_reply);
 		goto error_display;


### PR DESCRIPTION
### backend: Do not attempt DRM on X11/WL failure

This can really mess with the session if logind is not being used, and it's going to always fail anyway.

---

### backend/x11: Drop required present version

We say 1.2, but I don't think we actually use anything that was
introduced past 1.0.