### PR TITLE
build: Pass lib_wlr as first argument to pkgconfig.generate()

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -213,8 +213,7 @@ message('\n'.join(summary))
 subdir('examples')
 
 pkgconfig = import('pkgconfig')
-pkgconfig.generate(
-	libraries: lib_wlr,
+pkgconfig.generate(lib_wlr,
 	version: meson.project_version(),
 	filebase: meson.project_name(),
 	name: meson.project_name(),


### PR DESCRIPTION
Eliminates this warning when building wlroots as a subproject:

subprojects/wlroots/meson.build:216: DEPRECATION: Library wlroots
was passed to the libraries keyword argument of a previous call
to generate() method instead of first positional argument. Adding
wlroots to Requires field, but this is a deprecated behaviour
that will change in a future version of Meson. Please report the
issue if this warning cannot be avoided in your case.