### PR TITLE
backend/x11: Revert usage of present extension

### DIFF
--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -12,7 +12,6 @@
 #include <X11/Xlib-xcb.h>
 #include <wayland-server-core.h>
 #include <xcb/xcb.h>
-#include <xcb/present.h>
 #include <xcb/xfixes.h>
 #include <xcb/xinput.h>
 
@@ -51,6 +50,16 @@ static void handle_x11_event(struct wlr_x11_backend *x11,
 		}
 		break;
 	}
+	case XCB_CONFIGURE_NOTIFY: {
+		xcb_configure_notify_event_t *ev =
+			(xcb_configure_notify_event_t *)event;
+		struct wlr_x11_output *output =
+			get_x11_output_from_window_id(x11, ev->window);
+		if (output != NULL) {
+			handle_x11_configure_notify(output, ev);
+		}
+		break;
+	}
 	case XCB_CLIENT_MESSAGE: {
 		xcb_client_message_event_t *ev = (xcb_client_message_event_t *)event;
 		if (ev->data.data32[0] == x11->atoms.wm_delete_window) {
@@ -64,10 +73,7 @@ static void handle_x11_event(struct wlr_x11_backend *x11,
 	}
 	case XCB_GE_GENERIC: {
 		xcb_ge_generic_event_t *ev = (xcb_ge_generic_event_t *)event;
-		if (ev->extension == x11->present_opcode) {
-			handle_x11_present_event(x11,
-				(xcb_present_generic_event_t *)ev);
-		} else if (ev->extension == x11->xinput_opcode) {
+		if (ev->extension == x11->xinput_opcode) {
 			handle_x11_xinput_event(x11, ev);
 		}
 	}
@@ -218,29 +224,6 @@ struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
 
 	const xcb_query_extension_reply_t *ext;
 
-	/* Present extension */
-
-	ext = xcb_get_extension_data(x11->xcb, &xcb_present_id);
-	if (!ext || !ext->present) {
-		wlr_log(WLR_ERROR, "X11 does not support Present extension");
-		goto error_display;
-	}
-	x11->present_opcode = ext->major_opcode;
-
-	xcb_present_query_version_cookie_t present_cookie =
-		xcb_present_query_version(x11->xcb, 1, 0);
-	xcb_present_query_version_reply_t *present_reply =
-		xcb_present_query_version_reply(x11->xcb, present_cookie, NULL);
-
-	if (!present_reply) {
-		wlr_log(WLR_ERROR, "X11 does not support required Present version");
-		free(present_reply);
-		goto error_display;
-	}
-	free(present_reply);
-
-	/* Xfixes extension */
-
 	ext = xcb_get_extension_data(x11->xcb, &xcb_xfixes_id);
 	if (!ext || !ext->present) {
 		wlr_log(WLR_ERROR, "X11 does not support Xfixes extension");
@@ -258,8 +241,6 @@ struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
 		goto error_display;
 	}
 	free(fixes_reply);
-
-	/* Xinput extension */
 
 	ext = xcb_get_extension_data(x11->xcb, &xcb_input_id);
 	if (!ext || !ext->present) {

--- a/backend/x11/meson.build
+++ b/backend/x11/meson.build
@@ -2,9 +2,8 @@ x11_libs = []
 x11_required = [
 	'x11-xcb',
 	'xcb',
-	'xcb-present',
-	'xcb-xfixes',
 	'xcb-xinput',
+	'xcb-xfixes',
 ]
 
 foreach lib : x11_required

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -6,7 +6,6 @@
 #include <X11/Xlib-xcb.h>
 #include <wayland-server-core.h>
 #include <xcb/xcb.h>
-#include <xcb/present.h>
 
 #include <wlr/backend/x11.h>
 #include <wlr/config.h>
@@ -16,6 +15,8 @@
 #include <wlr/render/wlr_renderer.h>
 
 #define XCB_EVENT_RESPONSE_TYPE_MASK 0x7f
+
+#define X11_DEFAULT_REFRESH (60 * 1000) // 60 Hz
 
 struct wlr_x11_backend;
 
@@ -34,7 +35,8 @@ struct wlr_x11_output {
 	struct wlr_input_device touch_dev;
 	struct wl_list touchpoints; // wlr_x11_touchpoint::link
 
-	xcb_present_event_t present_context;
+	struct wl_event_source *frame_timer;
+	int frame_delay;
 
 	bool cursor_hidden;
 };
@@ -76,7 +78,6 @@ struct wlr_x11_backend {
 	xcb_timestamp_t time;
 
 	uint8_t xinput_opcode;
-	uint8_t present_opcode;
 
 	struct wl_listener display_destroy;
 };
@@ -96,7 +97,7 @@ void handle_x11_xinput_event(struct wlr_x11_backend *x11,
 void update_x11_pointer_position(struct wlr_x11_output *output,
 	xcb_timestamp_t time);
 
-void handle_x11_present_event(struct wlr_x11_backend *x11,
-		xcb_present_generic_event_t *ev);
+void handle_x11_configure_notify(struct wlr_x11_output *output,
+	xcb_configure_notify_event_t *event);
 
 #endif


### PR DESCRIPTION
This reverts commit 3317134adff0ed179e0ecaea6d778dbd0684f771.
This reverts commit a3c3b928a3814f1a44babf487b1508415958c721.

There are some serious issues when running this on a real X server, as
opposed to running this on Xwayland, where this was tested.

More investigation needs to be done into why these issues happen and if
our usage of the present extension is correct.