### PR TITLE
Unbreak examples/screencopy on FreeBSD

### DIFF
--- a/examples/screencopy.c
+++ b/examples/screencopy.c
@@ -32,6 +32,7 @@
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/param.h>
+#include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #include <wayland-client-protocol.h>
@@ -69,7 +70,7 @@ static struct wl_buffer *create_shm_buffer(enum wl_shm_format fmt,
 	int size = stride * height;
 
 	const char shm_name[] = "/wlroots-screencopy";
-	int fd = shm_open(shm_name, O_RDWR | O_CREAT | O_EXCL, 0);
+	int fd = shm_open(shm_name, O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
 	if (fd < 0) {
 		fprintf(stderr, "shm_open failed\n");
 		return NULL;


### PR DESCRIPTION
Similar to https://github.com/cyclopsian/wdisplays/pull/6
wlroots already uses `shm_open` correctly elsewhere:
https://github.com/swaywm/wlroots/blob/16e5e9541b3de49e397a3d2caa3212db25487648/util/shm.c#L29

