### PR TITLE
render: remove return in wlr_texture_get_size

### DIFF
--- a/render/wlr_texture.c
+++ b/render/wlr_texture.c
@@ -44,7 +44,7 @@ struct wlr_texture *wlr_texture_from_dmabuf(struct wlr_renderer *renderer,
 
 void wlr_texture_get_size(struct wlr_texture *texture, int *width,
 		int *height) {
-	return texture->impl->get_size(texture, width, height);
+	texture->impl->get_size(texture, width, height);
 }
 
 bool wlr_texture_is_opaque(struct wlr_texture *texture) {


### PR DESCRIPTION
Otherwise this error happens:

    ../subprojects/wlroots/render/wlr_texture.c: In function ‘wlr_texture_get_size’:
    ../subprojects/wlroots/render/wlr_texture.c:47:9: error: ISO C forbids ‘return’ with expression, in function returning void [-Werror=pedantic]
       47 |  return texture->impl->get_size(texture, width, height);
          |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ../subprojects/wlroots/render/wlr_texture.c:45:6: note: declared here
       45 | void wlr_texture_get_size(struct wlr_texture *texture, int *width,
          |      ^~~~~~~~~~~~~~~~~~~~