### PR TITLE
wlr_keyboard_group: reference count destruction

### DIFF
--- a/include/wlr/types/wlr_keyboard_group.h
+++ b/include/wlr/types/wlr_keyboard_group.h
@@ -18,6 +18,8 @@ struct wlr_keyboard_group {
 	struct wlr_input_device *input_device;
 	struct wl_list devices; // keyboard_group_device::link
 	struct wl_list keys; // keyboard_group_key::link
+	bool destroying;
+	uint32_t nrefs;
 	void *data;
 };
 


### PR DESCRIPTION
Fixes swaywm/sway#4744

This introduces a simple reference counter for destruction of
`wlr_keyboard_group` objects. This allows for the current operation to
complete (ex. `wlr_keyboard_notify_key` for the group's keyboard), before
the `wlr_keyboard_group`, and thus it's keyboard, are completely
destroyed.