### PR TITLE
virtual_keyboard: Accept keycode 0

### DIFF
--- a/types/wlr_virtual_keyboard_v1.c
+++ b/types/wlr_virtual_keyboard_v1.c
@@ -75,9 +75,6 @@ context_fail:
 static void virtual_keyboard_key(struct wl_client *client,
 		struct wl_resource *resource, uint32_t time, uint32_t key,
 		uint32_t state) {
-	if (key == 0) {
-		return;
-	}
 	struct wlr_virtual_keyboard_v1 *keyboard =
 		virtual_keyboard_from_resource(resource);
 	if (!keyboard->has_keymap) {

--- a/util/array.c
+++ b/util/array.c
@@ -24,7 +24,6 @@ bool set_add(uint32_t values[], size_t *len, size_t cap, uint32_t target) {
 	if (*len == cap) {
 		return false;
 	}
-	assert(target > 0);
 	for (uint32_t i = 0; i < *len; ++i) {
 		if (values[i] == target) {
 			return false;


### PR DESCRIPTION
This comes as a follow-up to https://github.com/swaywm/wlroots/issues/1821 and https://github.com/swaywm/wlroots/pull/1833

That merge resolved the crash when keycode 0 (8) was received, but it didn't allow the keycode to be accepted, causing some head scratching on squeekboard side.

It seems that keycode 0 (8 in xkb keymaps) is not an invalid one:

```
grep -r ' 8;' /usr/share/X11/xkb/keycodes/
/usr/share/X11/xkb/keycodes/sony:    <FK01> = 8;
/usr/share/X11/xkb/keycodes/sun:    <STOP> = 8;
/usr/share/X11/xkb/keycodes/amiga:    <TLDE> = 8;
/usr/share/X11/xkb/keycodes/amiga:    <TLDE> = 8;
/usr/share/X11/xkb/keycodes/xfree98:    <ESC>  =   8;
/usr/share/X11/xkb/keycodes/xfree86:    <MDSW> =     8;
/usr/share/X11/xkb/keycodes/macintosh:    <AC01> = 8;
/usr/share/X11/xkb/keycodes/digital_vndr/pc:    <ESC>   = 8;
/usr/share/X11/xkb/keycodes/digital_vndr/pc:    <AE00>      = 8;
```

so it should be accepted by the compositor.

This change removes the check in virtual keyboard, and removes the assert in `add_set` as well. `add_set` doesn't seem to be affected at all by the content of each cell, and 0s are not treated in any special way, except as the values outside of bounds. The callers also don't appear to care about 0s either, making me believe this won't cause any trouble.

With no more unneeded assertion, this change accepts keycode 0 as a rightful press.