### PR TITLE
Update environment variable documentation to include more backends

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -9,7 +9,7 @@ wlroots reads these environment variables
   mode setting
 * *WLR_LIBINPUT_NO_DEVICES*: set to 1 to not fail without any input devices
 * *WLR_BACKENDS*: comma-separated list of backends to use (available backends:
-  drm, wayland, x11, rdp, headless, noop)
+  libinput, drm, wayland, x11, rdp, headless, noop)
 * *WLR_NO_HARDWARE_CURSORS*: set to 1 to use software cursors instead of
   hardware cursors
 * *WLR_SESSION*: specifies the wlr\_session to be used (available sessions:

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -9,7 +9,7 @@ wlroots reads these environment variables
   mode setting
 * *WLR_LIBINPUT_NO_DEVICES*: set to 1 to not fail without any input devices
 * *WLR_BACKENDS*: comma-separated list of backends to use (available backends:
-  wayland, x11, headless, noop)
+  drm, wayland, x11, rdp, headless, noop)
 * *WLR_NO_HARDWARE_CURSORS*: set to 1 to use software cursors instead of
   hardware cursors
 * *WLR_SESSION*: specifies the wlr\_session to be used (available sessions:


### PR DESCRIPTION
Testing with exporting WLR_BACKENDS=drm worked, and it wasn't documented. Checking the backends folder, and it also mentions an RDP backend as well