### PR TITLE
Revert "output: add block_idle_frame"

### DIFF
--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -148,8 +148,6 @@ struct wlr_output {
 	struct wl_listener display_destroy;
 
 	void *data;
-
-	bool block_idle_frame;
 };
 
 struct wlr_output_event_precommit {

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -544,8 +544,7 @@ void wlr_output_send_frame(struct wlr_output *output) {
 static void schedule_frame_handle_idle_timer(void *data) {
 	struct wlr_output *output = data;
 	output->idle_frame = NULL;
-	if (!output->frame_pending && output->impl->schedule_frame
-			&& !output->block_idle_frame) {
+	if (!output->frame_pending && output->impl->schedule_frame) {
 		// Ask the backend to send a frame event when appropriate
 		if (output->impl->schedule_frame(output)) {
 			output->frame_pending = true;


### PR DESCRIPTION
This reverts commit cbb2781fed7944dae680a66a35443f5b1a678ec7.

In [1], we found issues with block_idle_frame and replaced it with
frame_pending. block_idle_frame is now unused.

[1]: https://github.com/swaywm/sway/pull/4772