### PR TITLE
backend/drm: fix segfault in init_drm_surface

### DIFF
--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -81,6 +81,7 @@ bool init_drm_surface(struct wlr_drm_surface *surf,
 			surf->back = NULL;
 		}
 		gbm_surface_destroy(surf->gbm);
+		surf->gbm = NULL;
 	}
 	wlr_egl_destroy_surface(&surf->renderer->egl, surf->egl);
 


### PR DESCRIPTION
When surf->gbm was previously set, we destroy it without setting it to
NULL. Later on, we only create the GBM surface if surf->gbm is NULL.
This result in a use-after-free when we start using surf->gbm.

Closes: https://github.com/swaywm/wlroots/issues/1868
Closes: https://github.com/swaywm/wlroots/issues/1874
Closes: https://github.com/swaywm/sway/issues/4785
Closes: https://github.com/swaywm/sway/issues/4717
Closes: https://github.com/swaywm/sway/issues/4730
Fixes: 2bdd1d0896cc ("backend/drm: use modifiers for our GBM buffers")