### PR TITLE
output: fix cursor wl_surface.{enter,leave} tracking

### DIFF
--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -791,6 +791,9 @@ static void output_cursor_reset(struct wlr_output_cursor *cursor) {
 	if (cursor->surface != NULL) {
 		wl_list_remove(&cursor->surface_commit.link);
 		wl_list_remove(&cursor->surface_destroy.link);
+		if (cursor->visible) {
+			wlr_surface_send_leave(cursor->surface, cursor->output);
+		}
 		cursor->surface = NULL;
 	}
 }


### PR DESCRIPTION
> This change ensures that `wl_surface::leave` is sent when a surface associated with the cursor is disassociated, e.g. when the cursor is reset or its image is changed.

One way to test this fix is to run a program linked to a beta version Qt 5.14, and move the cursor onto and off of a window (so that the cursor surface changes); before this change, the program will print a warning. Alternatively, apply [0001-surface-warn.patch.txt](https://github.com/swaywm/wlroots/files/3935514/0001-surface-Warn-on-redundant-wl_surface.-enter-leave.patch.txt), which modifies wlroots to detect and log an error when `wlr_surface_send_leave` and `wlr_surface_send_enter` are incorrectly invoked a second time.


