### PR TITLE
buffer: improve error handling

### DIFF
--- a/types/wlr_buffer.c
+++ b/types/wlr_buffer.c
@@ -96,12 +96,14 @@ struct wlr_buffer *wlr_buffer_create(struct wlr_renderer *renderer,
 
 	if (texture == NULL) {
 		wlr_log(WLR_ERROR, "Failed to upload texture");
+		wl_buffer_send_release(resource);
 		return NULL;
 	}
 
 	struct wlr_buffer *buffer = calloc(1, sizeof(struct wlr_buffer));
 	if (buffer == NULL) {
 		wlr_texture_destroy(texture);
+		wl_resource_post_no_memory(resource);
 		return NULL;
 	}
 	buffer->resource = resource;

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -296,15 +296,13 @@ static void surface_apply_damage(struct wlr_surface *surface) {
 		}
 	}
 
-	wlr_buffer_unref(surface->buffer);
-	surface->buffer = NULL;
-
 	struct wlr_buffer *buffer = wlr_buffer_create(surface->renderer, resource);
 	if (buffer == NULL) {
 		wlr_log(WLR_ERROR, "Failed to upload buffer");
 		return;
 	}
 
+	wlr_buffer_unref(surface->buffer);
 	surface->buffer = buffer;
 }
 


### PR DESCRIPTION
In case the texture can't be imported, release the buffer so that the
client can submit another one. In case the allocation fails, disconnect
the client.