### PR TITLE
output: fix wlr_output_preferred_mode fallback

### DIFF
--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -406,7 +406,7 @@ struct wlr_output_mode *wlr_output_preferred_mode(struct wlr_output *output) {
 	}
 
 	// No preferred mode, choose the last one
-	return mode;
+	return wl_container_of(output->modes.prev, mode, link);
 }
 
 static void output_state_clear_buffer(struct wlr_output_state *state) {


### PR DESCRIPTION
`mode` points to an invalid pointer (head of the list) when the loop
stops.

Closes: https://github.com/swaywm/sway/issues/4717