### PR TITLE
add WLR_USE_XDG_DIR option

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -62,3 +62,4 @@ done like so:
 * *WAYLAND_DISPLAY*, *_WAYLAND_DISPLAY*, *WAYLAND_SOCKET*: if set probe Wayland
   backend in *wlr_backend_autocreate*
 * *XCURSOR_PATH*: directory where xcursors are located
+* *XDG_RUNTIME_DIR*: used to store non persistent temporary files

--- a/include/util/os-compatibility.h
+++ b/include/util/os-compatibility.h
@@ -1,0 +1,9 @@
+#ifndef UTIL_OS_COMPATIBILITY_H
+#define UTIL_OS_COMPATIBILITY_H
+
+int os_fd_set_cloexec(int fd);
+int set_cloexec_or_close(int fd);
+int create_tmpfile_cloexec(char *tmpname);
+int os_create_anonymous_file(off_t size);
+
+#endif

--- a/include/wlr/config.h.in
+++ b/include/wlr/config.h.in
@@ -14,4 +14,6 @@
 #mesondefine WLR_HAS_XCB_ERRORS
 #mesondefine WLR_HAS_XCB_ICCCM
 
+#mesondefine WLR_HAS_POSIX_FALLOCATE
+
 #endif

--- a/meson.build
+++ b/meson.build
@@ -83,6 +83,7 @@ conf_data.set10('WLR_HAS_LIBCAP', false)
 conf_data.set10('WLR_HAS_SYSTEMD', false)
 conf_data.set10('WLR_HAS_ELOGIND', false)
 conf_data.set10('WLR_HAS_RDP_BACKEND', false)
+conf_data.set10('WLR_USE_XDG_DIR', get_option('xdg-dir'))
 conf_data.set10('WLR_HAS_X11_BACKEND', false)
 conf_data.set10('WLR_HAS_XWAYLAND', false)
 conf_data.set10('WLR_HAS_XCB_ERRORS', false)
@@ -127,6 +128,10 @@ endif
 if logind.found()
 	conf_data.set10('WLR_HAS_' + get_option('logind-provider').to_upper(), true)
 	wlr_deps += logind
+endif
+
+if cc.has_header_symbol('fcntl.h', 'posix_fallocate', prefix: '#define _POSIX_C_SOURCE 200112L')
+       conf_data.set('WLR_HAS_POSIX_FALLOCATE', true)
 endif
 
 if libinput.found()
@@ -203,6 +208,7 @@ summary = [
 	'     elogind: @0@'.format(conf_data.get('WLR_HAS_ELOGIND', false)),
 	'    xwayland: @0@'.format(conf_data.get('WLR_HAS_XWAYLAND', false)),
 	' rdp_backend: @0@'.format(conf_data.get('WLR_HAS_RDP_BACKEND', false)),
+	'     xdg_dir: @0@'.format(conf_data.get('WLR_USE_XDG_DIR', false)),
 	' x11_backend: @0@'.format(conf_data.get('WLR_HAS_X11_BACKEND', false)),
 	'   xcb-icccm: @0@'.format(conf_data.get('WLR_HAS_XCB_ICCCM', false)),
 	'  xcb-errors: @0@'.format(conf_data.get('WLR_HAS_XCB_ERRORS', false)),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,4 +6,5 @@ option('xcb-errors', type: 'feature', value: 'auto', description: 'Use xcb-error
 option('xcb-icccm', type: 'feature', value: 'auto', description: 'Use xcb-icccm util library')
 option('xwayland', type: 'feature', value: 'auto', yield: true, description: 'Enable support for X11 applications')
 option('x11-backend', type: 'feature', value: 'auto', description: 'Enable X11 backend')
+option('xdg-dir', type: 'boolean', value: false, description: 'Use XDG_RUNTIME_DIR instead of /dev/shm for temp files')
 option('examples', type: 'boolean', value: true, description: 'Build example applications')

--- a/types/seat/wlr_seat_keyboard.c
+++ b/types/seat/wlr_seat_keyboard.c
@@ -12,7 +12,11 @@
 #include <wlr/util/log.h>
 #include "types/wlr_data_device.h"
 #include "types/wlr_seat.h"
+#ifndef WLR_USE_XDG_DIR
 #include "util/shm.h"
+#else
+#include "util/os-compatibility.h"
+#endif
 #include "util/signal.h"
 
 static void default_keyboard_enter(struct wlr_seat_keyboard_grab *grab,
@@ -348,7 +352,11 @@ static void seat_client_send_keymap(struct wlr_seat_client *client,
 			continue;
 		}
 
+		#ifndef WLR_USE_XDG_DIR
 		int keymap_fd = allocate_shm_file(keyboard->keymap_size);
+		#else
+		int keymap_fd = os_create_anonymous_file(keyboard->keymap_size);
+		#endif
 		if (keymap_fd < 0) {
 			wlr_log(WLR_ERROR, "creating a keymap file for %zu bytes failed", keyboard->keymap_size);
 			continue;

--- a/util/meson.build
+++ b/util/meson.build
@@ -3,6 +3,7 @@ lib_wlr_util = static_library(
 	files(
 		'array.c',
 		'log.c',
+		'os-compatibility.c',
 		'region.c',
 		'shm.c',
 		'signal.c',

--- a/util/os-compatibility.c
+++ b/util/os-compatibility.c
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2012 Collabora, Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the
+ * next paragraph) shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#define _POSIX_C_SOURCE 200809L
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <wlr/config.h>
+#include "util/os-compatibility.h"
+
+int os_fd_set_cloexec(int fd) {
+	if (fd == -1) {
+		return -1;
+	}
+
+	long flags = fcntl(fd, F_GETFD);
+	if (flags == -1) {
+		return -1;
+	}
+
+	if (fcntl(fd, F_SETFD, flags | FD_CLOEXEC) == -1) {
+		return -1;
+	}
+
+	return 0;
+}
+
+int set_cloexec_or_close(int fd) {
+	if (os_fd_set_cloexec(fd) != 0) {
+		close(fd);
+		return -1;
+	}
+	return fd;
+}
+
+int create_tmpfile_cloexec(char *tmpname) {
+	int fd;
+	mode_t prev_umask = umask(0066);
+#ifdef HAVE_MKOSTEMP
+	fd = mkostemp(tmpname, O_CLOEXEC);
+	if (fd >= 0) {
+		unlink(tmpname);
+	}
+#else
+	fd = mkstemp(tmpname);
+	if (fd >= 0) {
+		fd = set_cloexec_or_close(fd);
+		unlink(tmpname);
+	}
+#endif
+	umask(prev_umask);
+
+	return fd;
+}
+
+/*
+ * Create a new, unique, anonymous file of the given size, and
+ * return the file descriptor for it. The file descriptor is set
+ * CLOEXEC. The file is immediately suitable for mmap()'ing
+ * the given size at offset zero.
+ *
+ * The file should not have a permanent backing store like a disk,
+ * but may have if XDG_RUNTIME_DIR is not properly implemented in OS.
+ *
+ * The file name is deleted from the file system.
+ *
+ * The file is suitable for buffer sharing between processes by
+ * transmitting the file descriptor over Unix sockets using the
+ * SCM_RIGHTS methods.
+ *
+ * If the C library implements posix_fallocate(), it is used to
+ * guarantee that disk space is available for the file at the
+ * given size. If disk space is insufficient, errno is set to ENOSPC.
+ * If posix_fallocate() is not supported, program may receive
+ * SIGBUS on accessing mmap()'ed file contents instead.
+ */
+int os_create_anonymous_file(off_t size) {
+	static const char template[] = "/wlroots-shared-XXXXXX";
+
+	const char *path = getenv("XDG_RUNTIME_DIR");
+	if (!path) {
+		errno = ENOENT;
+		return -1;
+	}
+
+	char *name = malloc(strlen(path) + sizeof(template));
+	if (!name) {
+		return -1;
+	}
+
+	strcpy(name, path);
+	strcat(name, template);
+
+	int fd = create_tmpfile_cloexec(name);
+	free(name);
+	if (fd < 0) {
+		return -1;
+	}
+
+#ifdef WLR_HAS_POSIX_FALLOCATE
+	int ret;
+	do {
+		ret = posix_fallocate(fd, 0, size);
+	} while (ret == EINTR);
+	if (ret != 0) {
+		close(fd);
+		errno = ret;
+		return -1;
+	}
+#else
+	int ret;
+	do {
+		ret = ftruncate(fd, size);
+	} while (ret < 0 && errno == EINTR);
+	if (ret < 0) {
+		close(fd);
+		return -1;
+	}
+#endif
+
+	return fd;
+}


### PR DESCRIPTION
This patch add a option to toggle between XDG_RUNTIME_DIR and "/dev/shm".

If wlroots run inside a strict snap, they didn't have access to "/dev/shm".

