### PR TITLE
ci: add xorgproto dep to Arch build

### DIFF
--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -14,6 +14,7 @@ packages:
   - xcb-util-errors
   - xcb-util-image
   - xcb-util-wm
+  - xorgproto
 sources:
   - https://github.com/swaywm/wlroots
 tasks:


### PR DESCRIPTION
Arch Linux maintainers are still figuring out whether they should ask
people to explicitely install it or make it a dependency of xcb again.
In the meantime, add it as an explicit dependency. I'll revert this
patch if they decide otherwise.

[1]: https://bugs.archlinux.org/task/64914