### PR TITLE
Revert "ci: add xorgproto dep to Arch build"

### DIFF
--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -14,7 +14,6 @@ packages:
   - xcb-util-errors
   - xcb-util-image
   - xcb-util-wm
-  - xorgproto
 sources:
   - https://github.com/swaywm/wlroots
 tasks:


### PR DESCRIPTION
This reverts commit 35bc3e662a34fe92a3de4e3768dc976f8ac2c242.

Per [1], the dependency has been re-added and we shouldn't need to
explicitly install it anymore.

[1]: https://bugs.archlinux.org/task/64914