### PR TITLE
add destroy listener for textures

### DIFF
--- a/backend/headless/backend.c
+++ b/backend/headless/backend.c
@@ -3,7 +3,7 @@
 #include <wlr/interfaces/wlr_input_device.h>
 #include <wlr/interfaces/wlr_output.h>
 #include <wlr/render/egl.h>
-#include <wlr/render/gles2.h>
+#include <wlr/render/wlr_renderer.h>
 #include <wlr/util/log.h>
 #include "backend/headless.h"
 #include "util/signal.h"

--- a/examples/multi-pointer.c
+++ b/examples/multi-pointer.c
@@ -10,7 +10,6 @@
 #include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
-#include <wlr/render/gles2.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_keyboard.h>

--- a/examples/pointer.c
+++ b/examples/pointer.c
@@ -9,7 +9,6 @@
 #include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
-#include <wlr/render/gles2.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_keyboard.h>

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -97,6 +97,8 @@ const enum wl_shm_format *get_gles2_wl_formats(size_t *len);
 
 struct wlr_gles2_texture *gles2_get_texture(
 	struct wlr_texture *wlr_texture);
+struct wlr_gles2_renderer *gles2_get_renderer(
+		struct wlr_renderer *wlr_renderer);
 
 void push_gles2_marker(const char *file, const char *func);
 void pop_gles2_marker(void);

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -100,6 +100,14 @@ struct wlr_gles2_texture *gles2_get_texture(
 struct wlr_gles2_renderer *gles2_get_renderer(
 		struct wlr_renderer *wlr_renderer);
 
+struct wlr_texture *gles2_texture_from_pixels(struct wlr_renderer *renderer,
+	enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width, uint32_t height,
+	const void *data);
+struct wlr_texture *gles2_texture_from_wl_drm(struct wlr_renderer *renderer,
+	struct wl_resource *data);
+struct wlr_texture *gles2_texture_from_dmabuf(struct wlr_renderer *renderer,
+	struct wlr_dmabuf_attributes *attribs);
+
 void push_gles2_marker(const char *file, const char *func);
 void pop_gles2_marker(void);
 #define PUSH_GLES2_DEBUG push_gles2_marker(_WLR_FILENAME, __func__)

--- a/include/wlr/render/gles2.h
+++ b/include/wlr/render/gles2.h
@@ -19,14 +19,6 @@ struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_egl *egl);
 
 struct wlr_egl *wlr_gles2_renderer_get_egl(struct wlr_renderer *renderer);
 
-struct wlr_texture *wlr_gles2_texture_from_pixels(struct wlr_renderer *renderer,
-	enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width, uint32_t height,
-	const void *data);
-struct wlr_texture *wlr_gles2_texture_from_wl_drm(struct wlr_renderer *renderer,
-	struct wl_resource *data);
-struct wlr_texture *wlr_gles2_texture_from_dmabuf(struct wlr_renderer *renderer,
-	struct wlr_dmabuf_attributes *attribs);
-
 struct wlr_gles2_texture_attribs {
 	GLenum target; /* either GL_TEXTURE_2D or GL_TEXTURE_EXTERNAL_OES */
 	GLuint tex;

--- a/include/wlr/render/gles2.h
+++ b/include/wlr/render/gles2.h
@@ -19,12 +19,12 @@ struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_egl *egl);
 
 struct wlr_egl *wlr_gles2_renderer_get_egl(struct wlr_renderer *renderer);
 
-struct wlr_texture *wlr_gles2_texture_from_pixels(struct wlr_egl *egl,
+struct wlr_texture *wlr_gles2_texture_from_pixels(struct wlr_renderer *renderer,
 	enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width, uint32_t height,
 	const void *data);
-struct wlr_texture *wlr_gles2_texture_from_wl_drm(struct wlr_egl *egl,
+struct wlr_texture *wlr_gles2_texture_from_wl_drm(struct wlr_renderer *renderer,
 	struct wl_resource *data);
-struct wlr_texture *wlr_gles2_texture_from_dmabuf(struct wlr_egl *egl,
+struct wlr_texture *wlr_gles2_texture_from_dmabuf(struct wlr_renderer *renderer,
 	struct wlr_dmabuf_attributes *attribs);
 
 struct wlr_gles2_texture_attribs {

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -82,6 +82,6 @@ struct wlr_texture_impl {
 };
 
 void wlr_texture_init(struct wlr_texture *texture,
-	const struct wlr_texture_impl *impl);
+	struct wlr_renderer *renderer, const struct wlr_texture_impl *impl);
 
 #endif

--- a/include/wlr/render/wlr_texture.h
+++ b/include/wlr/render/wlr_texture.h
@@ -18,6 +18,8 @@ struct wlr_texture_impl;
 
 struct wlr_texture {
 	const struct wlr_texture_impl *impl;
+
+	struct wl_listener renderer_destroy;
 };
 
 /**

--- a/include/wlr/types/wlr_buffer.h
+++ b/include/wlr/types/wlr_buffer.h
@@ -89,12 +89,14 @@ struct wlr_client_buffer {
 	bool resource_released;
 	/**
 	 * The buffer's texture, if any. A buffer will not have a texture if the
-	 * client destroys the buffer before it has been released.
+	 * client destroys the buffer before it has been released. The texture will
+	 * be set to NULL if the renderer is destroyed.
 	 */
 	struct wlr_texture *texture;
 
 	struct wl_listener resource_destroy;
 	struct wl_listener release;
+	struct wl_listener renderer_destroy;
 };
 
 struct wlr_renderer;

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -35,6 +35,7 @@ struct wlr_output_cursor {
 
 	// only when using a software cursor without a surface
 	struct wlr_texture *texture;
+	struct wl_listener renderer_destroy;
 
 	// only when using a cursor surface
 	struct wlr_surface *surface;

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -18,7 +18,7 @@ struct wlr_gles2_procs gles2_procs = {0};
 
 static const struct wlr_renderer_impl renderer_impl;
 
-static struct wlr_gles2_renderer *gles2_get_renderer(
+struct wlr_gles2_renderer *gles2_get_renderer(
 		struct wlr_renderer *wlr_renderer) {
 	assert(wlr_renderer->impl == &renderer_impl);
 	return (struct wlr_gles2_renderer *)wlr_renderer;
@@ -334,22 +334,19 @@ static bool gles2_read_pixels(struct wlr_renderer *wlr_renderer,
 static struct wlr_texture *gles2_texture_from_pixels(
 		struct wlr_renderer *wlr_renderer, enum wl_shm_format wl_fmt,
 		uint32_t stride, uint32_t width, uint32_t height, const void *data) {
-	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
-	return wlr_gles2_texture_from_pixels(renderer->egl, wl_fmt, stride, width,
+	return wlr_gles2_texture_from_pixels(wlr_renderer, wl_fmt, stride, width,
 		height, data);
 }
 
 static struct wlr_texture *gles2_texture_from_wl_drm(
 		struct wlr_renderer *wlr_renderer, struct wl_resource *data) {
-	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
-	return wlr_gles2_texture_from_wl_drm(renderer->egl, data);
+	return wlr_gles2_texture_from_wl_drm(wlr_renderer, data);
 }
 
 static struct wlr_texture *gles2_texture_from_dmabuf(
 		struct wlr_renderer *wlr_renderer,
 		struct wlr_dmabuf_attributes *attribs) {
-	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
-	return wlr_gles2_texture_from_dmabuf(renderer->egl, attribs);
+	return wlr_gles2_texture_from_dmabuf(wlr_renderer, attribs);
 }
 
 static bool gles2_init_wl_display(struct wlr_renderer *wlr_renderer,

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -331,24 +331,6 @@ static bool gles2_read_pixels(struct wlr_renderer *wlr_renderer,
 	return glGetError() == GL_NO_ERROR;
 }
 
-static struct wlr_texture *gles2_texture_from_pixels(
-		struct wlr_renderer *wlr_renderer, enum wl_shm_format wl_fmt,
-		uint32_t stride, uint32_t width, uint32_t height, const void *data) {
-	return wlr_gles2_texture_from_pixels(wlr_renderer, wl_fmt, stride, width,
-		height, data);
-}
-
-static struct wlr_texture *gles2_texture_from_wl_drm(
-		struct wlr_renderer *wlr_renderer, struct wl_resource *data) {
-	return wlr_gles2_texture_from_wl_drm(wlr_renderer, data);
-}
-
-static struct wlr_texture *gles2_texture_from_dmabuf(
-		struct wlr_renderer *wlr_renderer,
-		struct wlr_dmabuf_attributes *attribs) {
-	return wlr_gles2_texture_from_dmabuf(wlr_renderer, attribs);
-}
-
 static bool gles2_init_wl_display(struct wlr_renderer *wlr_renderer,
 		struct wl_display *wl_display) {
 	struct wlr_gles2_renderer *renderer =

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -159,7 +159,7 @@ static struct wlr_gles2_texture *create_gles2_texture(
 	return texture;
 }
 
-struct wlr_texture *wlr_gles2_texture_from_pixels(struct wlr_renderer *renderer,
+struct wlr_texture *gles2_texture_from_pixels(struct wlr_renderer *renderer,
 		enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width,
 		uint32_t height, const void *data) {
 
@@ -203,7 +203,7 @@ struct wlr_texture *wlr_gles2_texture_from_pixels(struct wlr_renderer *renderer,
 	return &texture->wlr_texture;
 }
 
-struct wlr_texture *wlr_gles2_texture_from_wl_drm(struct wlr_renderer *renderer,
+struct wlr_texture *gles2_texture_from_wl_drm(struct wlr_renderer *renderer,
 		struct wl_resource *data) {
 	struct wlr_gles2_renderer *gles_renderer = gles2_get_renderer(renderer);
 	struct wlr_egl *egl = gles_renderer->egl;
@@ -259,7 +259,7 @@ struct wlr_texture *wlr_gles2_texture_from_wl_drm(struct wlr_renderer *renderer,
 	return &texture->wlr_texture;
 }
 
-struct wlr_texture *wlr_gles2_texture_from_dmabuf(struct wlr_renderer *renderer,
+struct wlr_texture *gles2_texture_from_dmabuf(struct wlr_renderer *renderer,
 		struct wlr_dmabuf_attributes *attribs) {
 	struct wlr_gles2_renderer *gles_renderer = gles2_get_renderer(renderer);
 	struct wlr_egl *egl = gles_renderer->egl;

--- a/render/wlr_texture.c
+++ b/render/wlr_texture.c
@@ -3,12 +3,24 @@
 #include <stdlib.h>
 #include <wlr/render/interface.h>
 #include <wlr/render/wlr_texture.h>
+#include <wlr/render/wlr_renderer.h>
+
+static void wlr_texture_handle_renderer_destroy(struct wl_listener *listener,
+		 void *data){
+	struct wlr_texture *wlr_texture;
+	wlr_texture = wl_container_of(listener, wlr_texture, renderer_destroy);
+	wlr_texture_destroy(wlr_texture);
+}
+
 
 void wlr_texture_init(struct wlr_texture *texture,
-		const struct wlr_texture_impl *impl) {
+		struct wlr_renderer *renderer, const struct wlr_texture_impl *impl) {
 	assert(impl->get_size);
 	assert(impl->write_pixels);
 	texture->impl = impl;
+
+	texture->renderer_destroy.notify = wlr_texture_handle_renderer_destroy;
+	wl_signal_add(&renderer->events.destroy, &texture->renderer_destroy);
 }
 
 void wlr_texture_destroy(struct wlr_texture *texture) {


### PR DESCRIPTION
Add a destroy listener for textures, which destroys the gles2 textures
when the renderer is destroyed.

Fixes #1949

----

I am not entirely sure about the API changes, since the `wlr_renderer` is now passed directly to the texture creation functions. I am all ears for possible improvements.