### PR TITLE
output: add description

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1348,6 +1348,12 @@ void scan_drm_connectors(struct wlr_drm_backend *drm) {
 			parse_edid(&wlr_conn->output, edid_len, edid);
 			free(edid);
 
+			struct wlr_output *output = &wlr_conn->output;
+			char description[128];
+			snprintf(description, sizeof(description), "%s %s %s (%s)",
+				output->make, output->model, output->serial, output->name);
+			wlr_output_set_description(output, description);
+
 			wlr_log(WLR_INFO, "Detected modes:");
 
 			for (int i = 0; i < drm_conn->count_modes; ++i) {

--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -121,6 +121,11 @@ struct wlr_output *wlr_headless_add_output(struct wlr_backend *wlr_backend,
 	snprintf(wlr_output->name, sizeof(wlr_output->name), "HEADLESS-%zd",
 		++backend->last_output_num);
 
+	char description[128];
+	snprintf(description, sizeof(description),
+		"Headless output %zd", backend->last_output_num);
+	wlr_output_set_description(wlr_output, description);
+
 	if (!wlr_egl_make_current(&output->backend->egl, output->egl_surface,
 			NULL)) {
 		goto error;

--- a/backend/rdp/output.c
+++ b/backend/rdp/output.c
@@ -278,6 +278,11 @@ struct wlr_rdp_output *wlr_rdp_output_create(struct wlr_rdp_backend *backend,
 	snprintf(wlr_output->name, sizeof(wlr_output->name), "RDP-%d",
 		wl_list_length(&backend->clients));
 
+	char description[128];
+	snprintf(description, sizeof(description),
+		"RDP output %d", wl_list_length(&backend->clients));
+	wlr_output_set_description(wlr_output, description);
+
 	if (!wlr_egl_make_current(&output->backend->egl, output->egl_surface,
 			NULL)) {
 		goto error;

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -458,6 +458,11 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *wlr_backend) {
 	snprintf(wlr_output->name, sizeof(wlr_output->name), "WL-%zd",
 		++backend->last_output_num);
 
+	char description[128];
+	snprintf(description, sizeof(description),
+		"Wayland output %zd", backend->last_output_num);
+	wlr_output_set_description(wlr_output, description);
+
 	output->backend = backend;
 	wl_list_init(&output->presentation_feedbacks);
 

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -149,6 +149,11 @@ struct wlr_output *wlr_x11_output_create(struct wlr_backend *backend) {
 		++x11->last_output_num);
 	parse_xcb_setup(wlr_output, x11->xcb);
 
+	char description[128];
+	snprintf(description, sizeof(description),
+		"X11 output %zd", x11->last_output_num);
+	wlr_output_set_description(wlr_output, description);
+
 	uint32_t mask = XCB_CW_EVENT_MASK;
 	uint32_t values[] = {
 		XCB_EVENT_MASK_EXPOSURE | XCB_EVENT_MASK_STRUCTURE_NOTIFY

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -90,6 +90,7 @@ struct wlr_output {
 	struct wl_list resources;
 
 	char name[24];
+	char *description; // may be NULL
 	char make[56];
 	char model[16];
 	char serial[16];
@@ -133,6 +134,7 @@ struct wlr_output {
 		struct wl_signal mode;
 		struct wl_signal scale;
 		struct wl_signal transform;
+		struct wl_signal description;
 		struct wl_signal destroy;
 	} events;
 
@@ -214,6 +216,7 @@ void wlr_output_set_transform(struct wlr_output *output,
 void wlr_output_set_scale(struct wlr_output *output, float scale);
 void wlr_output_set_subpixel(struct wlr_output *output,
 	enum wl_output_subpixel subpixel);
+void wlr_output_set_description(struct wlr_output *output, const char *desc);
 /**
  * Schedule a done event.
  *

--- a/include/wlr/types/wlr_xdg_output_v1.h
+++ b/include/wlr/types/wlr_xdg_output_v1.h
@@ -22,6 +22,7 @@ struct wlr_xdg_output_v1 {
 	int32_t width, height;
 
 	struct wl_listener destroy;
+	struct wl_listener description;
 };
 
 struct wlr_xdg_output_manager_v1 {

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -270,6 +270,22 @@ void wlr_output_set_subpixel(struct wlr_output *output,
 	wlr_output_schedule_done(output);
 }
 
+void wlr_output_set_description(struct wlr_output *output, const char *desc) {
+	if (output->description != NULL && desc != NULL &&
+			strcmp(output->description, desc) == 0) {
+		return;
+	}
+
+	free(output->description);
+	if (desc != NULL) {
+		output->description = strdup(desc);
+	} else {
+		output->description = NULL;
+	}
+
+	wlr_signal_emit_safe(&output->events.description, output);
+}
+
 static void schedule_done_handle_idle_timer(void *data) {
 	struct wlr_output *output = data;
 	output->idle_done = NULL;
@@ -323,6 +339,7 @@ void wlr_output_init(struct wlr_output *output, struct wlr_backend *backend,
 	wl_signal_init(&output->events.mode);
 	wl_signal_init(&output->events.scale);
 	wl_signal_init(&output->events.transform);
+	wl_signal_init(&output->events.description);
 	wl_signal_init(&output->events.destroy);
 	pixman_region32_init(&output->damage);
 	pixman_region32_init(&output->pending.damage);
@@ -364,6 +381,8 @@ void wlr_output_destroy(struct wlr_output *output) {
 	if (output->idle_done != NULL) {
 		wl_event_source_remove(output->idle_done);
 	}
+
+	free(output->description);
 
 	pixman_region32_fini(&output->pending.damage);
 	pixman_region32_fini(&output->damage);

--- a/types/wlr_output_management_v1.c
+++ b/types/wlr_output_management_v1.c
@@ -752,11 +752,8 @@ static void manager_send_head(struct wlr_output_manager_v1 *manager,
 	zwlr_output_manager_v1_send_head(manager_resource, head_resource);
 
 	zwlr_output_head_v1_send_name(head_resource, output->name);
-
-	char description[128];
-	snprintf(description, sizeof(description), "%s %s %s (%s)",
-		output->make, output->model, output->serial, output->name);
-	zwlr_output_head_v1_send_description(head_resource, description);
+	zwlr_output_head_v1_send_description(head_resource,
+		output->description ? output->description : "Unknown");
 
 	if (output->phys_width > 0 && output->phys_height > 0) {
 		zwlr_output_head_v1_send_physical_size(head_resource,


### PR DESCRIPTION
wlr_output.description is a string containing a human-readable string
identifying the output. Compositors can customise it via
wlr_output_set_description, for instance to make the name more
user-friendly.
    
References: https://github.com/swaywm/wlroots/issues/1623

cc @agx