### PR TITLE
backend/drm: don't modeset with a NULL mode after TTY switch

### DIFF
--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -93,7 +93,7 @@ static void session_signal(struct wl_listener *listener, void *data) {
 
 		struct wlr_drm_connector *conn;
 		wl_list_for_each(conn, &drm->outputs, link){
-			if (conn->output.enabled) {
+			if (conn->output.enabled && conn->output.current_mode != NULL) {
 				drm_connector_set_mode(&conn->output,
 						conn->output.current_mode);
 			} else {

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1394,6 +1394,8 @@ void scan_drm_connectors(struct wlr_drm_backend *drm) {
 					wlr_conn->output.name);
 			}
 
+			// TODO: this results in connectors being enabled without a mode
+			// set
 			wlr_output_update_enabled(&wlr_conn->output, wlr_conn->crtc != NULL);
 			wlr_conn->desired_enabled = true;
 


### PR DESCRIPTION
This fixes a segfault in drm_connector_set_mode (mode = NULL).

This happens because we set wlr_output.enabled to true if the connector
is attached to the CRTC. When the user disables an output in the
wlroots-based compositor, switches to another VT (enabling the output),
then switches back, wlroots sets wlr_output.enabled to true but
wlr_output.current_mode is NULL.

We should consider not reading properties from KMS after a TTY switch,
disabling all connectors. However this may result in flickering (outputs
being disabled then re-enabled).

Closes: https://github.com/swaywm/wlroots/issues/1874