### PR TITLE
wlr_keyboard_key_event: add group_update property

### DIFF
--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -215,6 +215,7 @@ static void keyboard_handle_enter(void *data, struct wl_keyboard *wl_keyboard,
 			.state = WLR_KEY_PRESSED,
 			.time_msec = time,
 			.update_state = false,
+			.group_update = false,
 		};
 		wlr_keyboard_notify_key(dev->keyboard, &event);
 	}
@@ -238,6 +239,7 @@ static void keyboard_handle_leave(void *data, struct wl_keyboard *wl_keyboard,
 			.state = WLR_KEY_RELEASED,
 			.time_msec = time,
 			.update_state = false,
+			.group_update = false,
 		};
 		wlr_keyboard_notify_key(dev->keyboard, &event);
 	}
@@ -253,6 +255,7 @@ static void keyboard_handle_key(void *data, struct wl_keyboard *wl_keyboard,
 		.state = state,
 		.time_msec = time,
 		.update_state = false,
+		.group_update = false,
 	};
 	wlr_keyboard_notify_key(dev->keyboard, &wlr_event);
 }

--- a/backend/x11/input_device.c
+++ b/backend/x11/input_device.c
@@ -24,6 +24,7 @@ static void send_key_event(struct wlr_x11_backend *x11, uint32_t key,
 		.keycode = key,
 		.state = st,
 		.update_state = true,
+		.group_update = false,
 	};
 	wlr_keyboard_notify_key(&x11->keyboard, &ev);
 }

--- a/include/wlr/types/wlr_keyboard.h
+++ b/include/wlr/types/wlr_keyboard.h
@@ -101,6 +101,12 @@ struct wlr_event_keyboard_key {
 	uint32_t keycode;
 	bool update_state; // if backend doesn't update modifiers on its own
 	enum wlr_key_state state;
+
+	// wlr_keyboard_group only: set when a keyboard is added to or removed from
+	// a group and it is the only keyboard that has/had the key pressed in the
+	// group. compositors should use this to update their internal state without
+	// triggering any associated bindings
+	bool group_update;
 };
 
 void wlr_keyboard_set_keymap(struct wlr_keyboard *kb,

--- a/types/wlr_keyboard_group.c
+++ b/types/wlr_keyboard_group.c
@@ -206,7 +206,8 @@ static void refresh_state(struct keyboard_group_device *device,
 			.time_msec = (int64_t)now.tv_sec * 1000 + now.tv_nsec / 1000000,
 			.keycode = device->keyboard->keycodes[i],
 			.update_state = true,
-			.state = state
+			.state = state,
+			.group_update = true,
 		};
 		handle_keyboard_key(&device->key, &event);
 	}

--- a/types/wlr_virtual_keyboard_v1.c
+++ b/types/wlr_virtual_keyboard_v1.c
@@ -88,6 +88,7 @@ static void virtual_keyboard_key(struct wl_client *client,
 		.keycode = key,
 		.update_state = false,
 		.state = state,
+		.group_update = false,
 	};
 	wlr_keyboard_notify_key(keyboard->input_device.keyboard, &event);
 }


### PR DESCRIPTION
When a keyboard is added to or removed from a wlr_keyboard_group, a key
event will be emitted for all keys that only pressed for that keyboard
in the group. This allows for compositors to update their internal
state. However because these keys were already down, only the state
should be updated. Compositors should not execute bindings and surfaces
should not receive the key event