### PR TITLE
backend/wayland: fix frame callback not registered

### DIFF
--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -200,6 +200,14 @@ static bool output_commit(struct wlr_output *wlr_output) {
 			damage = &wlr_output->pending.damage;
 		}
 
+		if (output->frame_callback != NULL) {
+			wlr_log(WLR_ERROR, "Skipping buffer swap");
+			return false;
+		}
+
+		output->frame_callback = wl_surface_frame(output->surface);
+		wl_callback_add_listener(output->frame_callback, &frame_listener, output);
+
 		switch (wlr_output->pending.buffer_type) {
 		case WLR_OUTPUT_STATE_BUFFER_RENDER:
 			if (!wlr_egl_swap_buffers(&output->backend->egl,


### PR DESCRIPTION
This got removed in [1]. I probably messed up the rebase.

[1]: https://github.com/swaywm/wlroots/pull/1797/files#diff-3065f86e6de87d143d4a7673a8ee3a2d

Fixes: 5d1ba0f44687 ("output: re-introduce atomic mode, enabled, scale and transform")