### PR TITLE
virtual-pointer: Actually use the value passed to axis_discrete

### DIFF
--- a/types/wlr_virtual_pointer_v1.c
+++ b/types/wlr_virtual_pointer_v1.c
@@ -195,6 +195,7 @@ static void virtual_pointer_axis_discrete(struct wl_client *client,
 	pointer->axis_event[pointer->axis].device = wlr_dev;
 	pointer->axis_event[pointer->axis].time_msec = time;
 	pointer->axis_event[pointer->axis].orientation = axis;
+	pointer->axis_event[pointer->axis].delta = wl_fixed_to_double(value);
 	pointer->axis_event[pointer->axis].delta_discrete = discrete;
 }
 


### PR DESCRIPTION
It turns out that scrolling doesn't work unless this value is set somewhere.