### PR TITLE
xwm: allow applications to change focus between their own surfaces

### DIFF
--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -1234,8 +1234,17 @@ static void xwm_handle_focus_in(struct wlr_xwm *xwm,
 
 	// Do not let X clients change the focus behind the compositor's
 	// back. Reset the focus to the old one if it changed.
-	if (!xwm->focus_surface || ev->event != xwm->focus_surface->window_id) {
+	//
+	// Note: Some applications rely on being able to change focus, for ex. Steam:
+	// https://github.com/swaywm/sway/issues/1865
+	// Because of that, we allow changing focus between surfaces belonging to the
+	// same application.
+	struct wlr_xwayland_surface *requested_focus = lookup_surface(xwm, ev->event);
+	if (!xwm->focus_surface || !requested_focus ||
+			requested_focus->pid != xwm->focus_surface->pid) {
 		xwm_send_focus_window(xwm, xwm->focus_surface);
+	} else {
+		xwm->focus_surface = requested_focus;
 	}
 }
 


### PR DESCRIPTION
Although currently this problem is present in only Steam, and it is actually a client bug.

Relevant discussion:  https://github.com/swaywm/sway/issues/1865 and #1645 

What I am not sure: should we update `xwm->focus_surface` ?