### PR TITLE
Variable Refresh Rate

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -412,6 +412,43 @@ static bool drm_connector_commit_buffer(struct wlr_output *output) {
 	return true;
 }
 
+static void drm_connector_enable_adaptive_sync(struct wlr_output *output,
+		bool enabled) {
+	struct wlr_drm_connector *conn = get_drm_connector_from_output(output);
+	struct wlr_drm_backend *drm = get_drm_backend_from_backend(output->backend);
+
+	struct wlr_drm_crtc *crtc = conn->crtc;
+	if (!crtc) {
+		return;
+	}
+
+	uint64_t vrr_capable;
+	if (conn->props.vrr_capable == 0 ||
+			!get_drm_prop(drm->fd, conn->id, conn->props.vrr_capable,
+			&vrr_capable) || !vrr_capable) {
+		wlr_log(WLR_DEBUG, "Failed to enable adaptive sync: "
+			"connector '%s' doesn't support VRR", output->name);
+		return;
+	}
+
+	if (crtc->props.vrr_enabled == 0) {
+		wlr_log(WLR_DEBUG, "Failed to enable adaptive sync: "
+			"CRTC %"PRIu32" doesn't support VRR", crtc->id);
+		return;
+	}
+
+	if (drmModeObjectSetProperty(drm->fd, crtc->id, DRM_MODE_OBJECT_CRTC,
+			crtc->props.vrr_enabled, enabled) != 0) {
+		wlr_log_errno(WLR_ERROR, "drmModeObjectSetProperty(VRR_ENABLED) failed");
+		return;
+	}
+
+	output->adaptive_sync_status = enabled ? WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED :
+		WLR_OUTPUT_ADAPTIVE_SYNC_DISABLED;
+	wlr_log(WLR_DEBUG, "VRR %s on connector '%s'",
+		enabled ? "enabled" : "disabled", output->name);
+}
+
 static bool drm_connector_set_custom_mode(struct wlr_output *output,
 	int32_t width, int32_t height, int32_t refresh);
 
@@ -444,6 +481,11 @@ static bool drm_connector_commit(struct wlr_output *output) {
 		if (!enable_drm_connector(output, output->pending.enabled)) {
 			return false;
 		}
+	}
+
+	if (output->pending.committed & WLR_OUTPUT_STATE_ADAPTIVE_SYNC_ENABLED) {
+		drm_connector_enable_adaptive_sync(output,
+			output->pending.adaptive_sync_enabled);
 	}
 
 	// TODO: support modesetting with a buffer

--- a/backend/drm/properties.c
+++ b/backend/drm/properties.c
@@ -24,6 +24,7 @@ static const struct prop_info connector_info[] = {
 	{ "EDID", INDEX(edid) },
 	{ "PATH", INDEX(path) },
 	{ "link-status", INDEX(link_status) },
+	{ "vrr_capable", INDEX(vrr_capable) },
 #undef INDEX
 };
 
@@ -33,6 +34,7 @@ static const struct prop_info crtc_info[] = {
 	{ "GAMMA_LUT", INDEX(gamma_lut) },
 	{ "GAMMA_LUT_SIZE", INDEX(gamma_lut_size) },
 	{ "MODE_ID", INDEX(mode_id) },
+	{ "VRR_ENABLED", INDEX(vrr_enabled) },
 	{ "rotation", INDEX(rotation) },
 	{ "scaling mode", INDEX(scaling_mode) },
 #undef INDEX

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -203,6 +203,7 @@ struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
 		{ .name = "WM_DELETE_WINDOW", .atom = &x11->atoms.wm_delete_window },
 		{ .name = "_NET_WM_NAME", .atom = &x11->atoms.net_wm_name },
 		{ .name = "UTF8_STRING", .atom = &x11->atoms.utf8_string },
+		{ .name = "_VARIABLE_REFRESH", .atom = &x11->atoms.variable_refresh },
 	};
 
 	for (size_t i = 0; i < sizeof(atom) / sizeof(atom[0]); ++i) {

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -118,6 +118,21 @@ static bool output_commit(struct wlr_output *wlr_output) {
 		}
 	}
 
+	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_ADAPTIVE_SYNC_ENABLED &&
+			x11->atoms.variable_refresh != XCB_ATOM_NONE) {
+		if (wlr_output->pending.adaptive_sync_enabled) {
+			uint32_t enabled = 1;
+			xcb_change_property(x11->xcb, XCB_PROP_MODE_REPLACE, output->win,
+				x11->atoms.variable_refresh, XCB_ATOM_CARDINAL, 32, 1,
+				&enabled);
+			wlr_output->adaptive_sync_status = WLR_OUTPUT_ADAPTIVE_SYNC_UNKNOWN;
+		} else {
+			xcb_delete_property(x11->xcb, output->win,
+				x11->atoms.variable_refresh);
+			wlr_output->adaptive_sync_status = WLR_OUTPUT_ADAPTIVE_SYNC_DISABLED;
+		}
+	}
+
 	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
 		pixman_region32_t *damage = NULL;
 		if (wlr_output->pending.committed & WLR_OUTPUT_STATE_DAMAGE) {

--- a/include/backend/drm/properties.h
+++ b/include/backend/drm/properties.h
@@ -16,6 +16,7 @@ union wlr_drm_connector_props {
 		uint32_t dpms;
 		uint32_t link_status; // not guaranteed to exist
 		uint32_t path;
+		uint32_t vrr_capable; // not guaranteed to exist
 
 		// atomic-modesetting only
 
@@ -29,6 +30,7 @@ union wlr_drm_crtc_props {
 		// Neither of these are guaranteed to exist
 		uint32_t rotation;
 		uint32_t scaling_mode;
+		uint32_t vrr_enabled;
 
 		// atomic-modesetting only
 

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -72,6 +72,7 @@ struct wlr_x11_backend {
 		xcb_atom_t wm_delete_window;
 		xcb_atom_t net_wm_name;
 		xcb_atom_t utf8_string;
+		xcb_atom_t variable_refresh;
 	} atoms;
 
 	// The time we last received an event

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -46,6 +46,12 @@ struct wlr_output_cursor {
 	} events;
 };
 
+enum wlr_output_adaptive_sync_status {
+	WLR_OUTPUT_ADAPTIVE_SYNC_DISABLED,
+	WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED,
+	WLR_OUTPUT_ADAPTIVE_SYNC_UNKNOWN, // requested, but maybe disabled
+};
+
 enum wlr_output_state_field {
 	WLR_OUTPUT_STATE_BUFFER = 1 << 0,
 	WLR_OUTPUT_STATE_DAMAGE = 1 << 1,
@@ -53,6 +59,7 @@ enum wlr_output_state_field {
 	WLR_OUTPUT_STATE_ENABLED = 1 << 3,
 	WLR_OUTPUT_STATE_SCALE = 1 << 4,
 	WLR_OUTPUT_STATE_TRANSFORM = 1 << 5,
+	WLR_OUTPUT_STATE_ADAPTIVE_SYNC_ENABLED = 1 << 6,
 };
 
 enum wlr_output_state_buffer_type {
@@ -74,6 +81,7 @@ struct wlr_output_state {
 	bool enabled;
 	float scale;
 	enum wl_output_transform transform;
+	bool adaptive_sync_enabled;
 
 	// only valid if WLR_OUTPUT_STATE_BUFFER
 	enum wlr_output_state_buffer_type buffer_type;
@@ -126,6 +134,7 @@ struct wlr_output {
 	float scale;
 	enum wl_output_subpixel subpixel;
 	enum wl_output_transform transform;
+	enum wlr_output_adaptive_sync_status adaptive_sync_status;
 
 	bool needs_frame;
 	// damage for cursors and fullscreen surface, in output-local coordinates
@@ -246,6 +255,16 @@ void wlr_output_set_custom_mode(struct wlr_output *output, int32_t width,
  */
 void wlr_output_set_transform(struct wlr_output *output,
 	enum wl_output_transform transform);
+/**
+ * Enables or disables adaptive sync (ie. variable refresh rate) on this
+ * output. This is just a hint, the backend is free to ignore this setting.
+ *
+ * When enabled, compositors can submit frames a little bit later than the
+ * deadline without dropping a frame.
+ *
+ * Adaptive sync is double-buffered state, see `wlr_output_commit`.
+ */
+void wlr_output_enable_adaptive_sync(struct wlr_output *output, bool enabled);
 /**
  * Sets a scale for the output.
  *


### PR DESCRIPTION
- [ ] Should we make the output commit fail if VRR can't be enabled? We don't know when VRR is indeed enabled, but in some cases we know when it fails. We still don't have support for test-only commits, so dealing with failures is going to be annoying for compositors.
- [x] Sway implementation

Fixes: https://github.com/swaywm/wlroots/issues/1406
~~Depends on: https://github.com/swaywm/wlroots/pull/2046~~

Future work: Wayland protocol to opt-in to VRR.