### PR TITLE
Bump meson version to 0.51.2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
 	'c',
 	version: '0.9.1',
 	license: 'MIT',
-	meson_version: '>=0.51.0',
+	meson_version: '>=0.51.2',
 	default_options: [
 		'c_std=c11',
 		'warning_level=2',


### PR DESCRIPTION
Closes #1994 

There was an issue in 0.51.0 and earlier, where lists of dependencies
and disablers weren't acting like they should. Instead of disabling a
build, it would error out instead.

Changing this logic to work around it is annoying, so just bump the
version instead.