### PR TITLE
Honor the `examples` meson setting

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -183,7 +183,9 @@ summary = [
 ]
 message('\n'.join(summary))
 
-subdir('examples')
+if get_option('examples')
+	subdir('examples')
+endif
 
 pkgconfig = import('pkgconfig')
 pkgconfig.generate(lib_wlr,


### PR DESCRIPTION
The `examples` options defined in `meson_options.txt` currently has no effect, which I assume is not intended. From cursory glance into `git blame`, it seems that the `if` statement that checked it was removed in commit fd3fa760d336312acafeb6812b5b0068f5851f27, but I was also not able to tell if that was intentional.

As we use this option to disable the examples when packaging wlroots for Fedora, this PR adds the check for the option back. Alternatively, the option could be removed from the options (and we will adjust our packaging accordingly).