### PR TITLE
build: replace version with soversion

### DIFF
--- a/contrib/_incr_version
+++ b/contrib/_incr_version
@@ -3,31 +3,26 @@ old_version="$1"
 new_version="$2"
 sed -i meson.build -e "s/version: '$old_version'/version: '$new_version'/g"
 
-printf "Backwards-incompatible ABI changes? (y/n) "
-read inc_age
-if [ "$inc_age" = 'n' ]
+bugfix='n'
+printf "Breaking API changes? (y/n) "
+read breaking
+if [ "$breaking" = 'n' ]
 then
-	printf "Interface(s) added, removed, or changed? (y/n) "
-	read inc_current
+	printf "Bugfix release (no backwards-incompatible ABI changes)? (y/n) "
+	read bugfix
 fi
 
-so_version=$(egrep '^so_version =' meson.build | cut -d'[' -f2- | cut -d']' -f1)
-current=$(echo "$so_version" | cut -d',' -f1 | sed -e "s/'//g" -e "s/ //g")
-revision=$(echo "$so_version" | cut -d',' -f2 | sed -e "s/'//g" -e "s/ //g")
-age=$(echo "$so_version" | cut -d',' -f3 | sed -e "s/'//g" -e "s/ //g")
+soversion=$(egrep '^soversion =' meson.build | cut -d'=' -f2-)
+soversion=$((soversion))
 
-if [ "$inc_age" = 'y' ]
+if [ "$bugfix" != 'y' ]
 then
-	age=$((age+1))
-	current=$((current+1))
-elif [ "$inc_current" = 'y' ]
-then
-	current=$((current+1))
+	soversion=$((soversion+1))
 fi
-revision=$((revision+1))
 
 sed -i meson.build \
-	-e "s/so_version = .*/so_version = ['$current', '$revision', '$age']/g"
+	-e "s/soversion = .*/soversion = $soversion/g"
 
+exit 1
 git add meson.build
 git commit -m "Update version to $new_version"

--- a/include/wlr/meson.build
+++ b/include/wlr/meson.build
@@ -1,12 +1,9 @@
 version_array = meson.project_version().split('.')
 version_data = configuration_data()
-version_data.set_quoted('WLR_VERSION_STR',   meson.project_version())
-version_data.set('WLR_VERSION_MAJOR',        version_array[0])
-version_data.set('WLR_VERSION_MINOR',        version_array[1])
-version_data.set('WLR_VERSION_MICRO',        version_array[2])
-version_data.set('WLR_VERSION_API_CURRENT',  so_version[0])
-version_data.set('WLR_VERSION_API_REVISION', so_version[1])
-version_data.set('WLR_VERSION_API_AGE',      so_version[2])
+version_data.set_quoted('WLR_VERSION_STR', meson.project_version())
+version_data.set('WLR_VERSION_MAJOR', version_array[0])
+version_data.set('WLR_VERSION_MINOR', version_array[1])
+version_data.set('WLR_VERSION_MICRO', version_array[2])
 
 conf_h = configure_file(
 	input: 'config.h.in',

--- a/meson.build
+++ b/meson.build
@@ -11,10 +11,11 @@ project(
 	],
 )
 
-# Format of so_version is CURRENT, REVISION, AGE.
-# See: https://autotools.io/libtool/version.html
-# for a reference about clean library versioning.
-so_version = ['5', '9', '1']
+# When doing a major or minor release, *always* increase soversion. This isn't
+# necessary for bugfix releases. Increasing soversion is required because
+# wlroots never guarantees ABI stability -- only API stability is guaranteed
+# between minor releases.
+soversion = 5
 
 add_project_arguments([
 	'-DWLR_USE_UNSTABLE',
@@ -152,7 +153,7 @@ symbols_file = 'wlroots.syms'
 symbols_flag = '-Wl,--version-script,@0@/@1@'.format(meson.current_source_dir(), symbols_file)
 lib_wlr = library(
 	meson.project_name(), wlr_files,
-	version: '.'.join(so_version),
+	soversion: soversion,
 	dependencies: wlr_deps,
 	include_directories: [wlr_inc, proto_inc],
 	install: true,


### PR DESCRIPTION
This allows us to have a single number to update when doing a release.

* * *

Breaking change: `WLR_VERSION_API_*` definitions are dropped.