### PR TITLE
fix build errors when using -fno-common

### DIFF
--- a/include/types/wlr_seat.h
+++ b/include/types/wlr_seat.h
@@ -4,9 +4,9 @@
 #include <wayland-server-core.h>
 #include <wlr/types/wlr_seat.h>
 
-const struct wlr_pointer_grab_interface default_pointer_grab_impl;
-const struct wlr_keyboard_grab_interface default_keyboard_grab_impl;
-const struct wlr_touch_grab_interface default_touch_grab_impl;
+extern const struct wlr_pointer_grab_interface default_pointer_grab_impl;
+extern const struct wlr_keyboard_grab_interface default_keyboard_grab_impl;
+extern const struct wlr_touch_grab_interface default_touch_grab_impl;
 
 void seat_client_create_pointer(struct wlr_seat_client *seat_client,
 	uint32_t version, uint32_t id);


### PR DESCRIPTION
GCC 10 will enable -fno-common by default and wlroots currently fails to compile when using this flag.