### PR TITLE
meson: Fix protocol includes for compositor examples

### DIFF
--- a/backend/wayland/meson.build
+++ b/backend/wayland/meson.build
@@ -16,5 +16,5 @@ client_protos = [
 ]
 
 foreach proto : client_protos
-	wlr_files += get_variable(proto.underscorify() + '_h')
+	wlr_files += get_variable(proto.underscorify() + '_client_h')
 endforeach

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -42,6 +42,7 @@ compositors = {
 	},
 	'fullscreen-shell': {
 		'src': 'fullscreen-shell.c',
+		'proto': ['fullscreen-shell-unstable-v1'],
 	},
 }
 
@@ -151,9 +152,14 @@ clients = {
 }
 
 foreach name, info : compositors
+	extra_src = []
+	foreach p : info.get('proto', [])
+		extra_src += get_variable(p.underscorify() + '_server_h')
+	endforeach
+
 	executable(
 		name,
-		info.get('src'),
+		[info.get('src'), extra_src],
 		dependencies: wlroots,
 		include_directories: [wlr_inc, proto_inc],
 		build_by_default: get_option('examples'),
@@ -164,7 +170,7 @@ foreach name, info : clients
 	extra_src = []
 	foreach p : info.get('proto')
 		extra_src += get_variable(p.underscorify() + '_c')
-		extra_src += get_variable(p.underscorify() + '_h')
+		extra_src += get_variable(p.underscorify() + '_client_h')
 	endforeach
 
 	executable(

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -53,14 +53,15 @@ foreach name, path : protocols
 	)
 	wlr_files += code
 
-	wlr_files += custom_target(
+	server_header = custom_target(
 		name.underscorify() + '_server_h',
 		input: path,
 		output: '@BASENAME@-protocol.h',
 		command: [wayland_scanner, 'server-header', '@INPUT@', '@OUTPUT@'],
 	)
+	wlr_files += server_header
 
-	header = custom_target(
+	client_header = custom_target(
 		name.underscorify() + '_client_h',
 		input: path,
 		output: '@BASENAME@-client-protocol.h',
@@ -69,5 +70,6 @@ foreach name, path : protocols
 	)
 
 	set_variable(name.underscorify() + '_c', code)
-	set_variable(name.underscorify() + '_h', header)
+	set_variable(name.underscorify() + '_server_h', server_header)
+	set_variable(name.underscorify() + '_client_h', client_header)
 endforeach


### PR DESCRIPTION
This should fix the alpine build, due to underspecifying the example dependencies.