### PR TITLE
backend/drm: add env variable to disable modifiers

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -17,6 +17,8 @@ wlroots reads these environment variables
   considered the primary DRM device.
 * *WLR_DRM_NO_ATOMIC*: set to 1 to use legacy DRM interface instead of atomic
   mode setting
+* *WLR_DRM_NO_MODIFIERS*: set to 1 to always allocate planes without modifiers,
+  this can fix certain modeset failures because of bandwidth restrictions.
 
 ## Headless backend
 


### PR DESCRIPTION
In some cases modesets fail if the planes are initialized with
modifiers. Since in this case possibly all planes need to reinitialized,
which is not possible in the current wlroots design, add an environment
variable for affected users.