### PR TITLE
Declare wlr_seat globals as extern

### DIFF
--- a/include/types/wlr_seat.h
+++ b/include/types/wlr_seat.h
@@ -4,9 +4,9 @@
 #include <wayland-server-core.h>
 #include <wlr/types/wlr_seat.h>
 
-const struct wlr_pointer_grab_interface default_pointer_grab_impl;
-const struct wlr_keyboard_grab_interface default_keyboard_grab_impl;
-const struct wlr_touch_grab_interface default_touch_grab_impl;
+extern const struct wlr_pointer_grab_interface default_pointer_grab_impl;
+extern const struct wlr_keyboard_grab_interface default_keyboard_grab_impl;
+extern const struct wlr_touch_grab_interface default_touch_grab_impl;
 
 void seat_client_create_pointer(struct wlr_seat_client *seat_client,
 	uint32_t version, uint32_t id);


### PR DESCRIPTION
When compiling wlroots with GCC 10, the linking fails with `multiple definition of 'default_pointer_grab_impl'` and similar errors for `default_keyboard_grab_impl` and `default_touch_grab_impl`. Full error: [gcc-10-ld.err.txt](https://github.com/swaywm/wlroots/files/4122843/gcc-10-ld.err.txt)

If I recall my C correctly, these should be marked `extern` – they just declare that the objects exist somewhere in the linked library, not necessarily in the current translation unit. Adding the `extern` qualifier causes the linking to pass successfully.