### PR TITLE
Remove minor keyword incompatibilities with C++

### DIFF
--- a/backend/drm/util.c
+++ b/backend/drm/util.c
@@ -221,7 +221,7 @@ uint32_t get_fb_for_bo(struct gbm_bo *bo, uint32_t drm_format,
 	return id;
 }
 
-static inline bool is_taken(size_t n, const uint32_t arr[static n], uint32_t key) {
+static inline bool is_taken(size_t n, const uint32_t arr[n], uint32_t key) {
 	for (size_t i = 0; i < n; ++i) {
 		if (arr[i] == key) {
 			return true;
@@ -343,9 +343,9 @@ static bool match_obj_(struct match_state *st, size_t skips, size_t score, size_
 	return match_obj_(st, skips, score, replaced, i + 1);
 }
 
-size_t match_obj(size_t num_objs, const uint32_t objs[static restrict num_objs],
-		size_t num_res, const uint32_t res[static restrict num_res],
-		uint32_t out[static restrict num_res]) {
+size_t match_obj(size_t num_objs, const uint32_t objs[restrict num_objs],
+		size_t num_res, const uint32_t res[restrict num_res],
+		uint32_t out[restrict num_res]) {
 	uint32_t solution[num_res];
 	for (size_t i = 0; i < num_res; ++i) {
 		solution[i] = UNMATCHED;

--- a/backend/session/direct-freebsd.c
+++ b/backend/session/direct-freebsd.c
@@ -139,7 +139,7 @@ static int vt_handler(int signo, void *data) {
 	return 1;
 }
 
-static bool get_tty_path(int tty, char path[static 11], size_t len) {
+static bool get_tty_path(int tty, char path[11], size_t len) {
 	assert(tty > 0);
 
 	const char prefix[] = "/dev/ttyv";

--- a/backend/session/session.c
+++ b/backend/session/session.c
@@ -251,7 +251,7 @@ out_fd:
 }
 
 static size_t explicit_find_gpus(struct wlr_session *session,
-		size_t ret_len, int ret[static ret_len], const char *str) {
+		size_t ret_len, int ret[ret_len], const char *str) {
 	char *gpus = strdup(str);
 	if (!gpus) {
 		wlr_log_errno(WLR_ERROR, "Allocation failed");

--- a/include/backend/drm/util.h
+++ b/include/backend/drm/util.h
@@ -35,8 +35,8 @@ enum {
  * This solution is left in out.
  * Returns the total number of matched solutions.
  */
-size_t match_obj(size_t num_objs, const uint32_t objs[static restrict num_objs],
-		size_t num_res, const uint32_t res[static restrict num_res],
-		uint32_t out[static restrict num_res]);
+size_t match_obj(size_t num_objs, const uint32_t objs[restrict num_objs],
+		size_t num_res, const uint32_t res[restrict num_res],
+		uint32_t out[restrict num_res]);
 
 #endif

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -30,15 +30,15 @@ struct wlr_renderer_impl {
 	void (*begin)(struct wlr_renderer *renderer, uint32_t width,
 		uint32_t height);
 	void (*end)(struct wlr_renderer *renderer);
-	void (*clear)(struct wlr_renderer *renderer, const float color[static 4]);
+	void (*clear)(struct wlr_renderer *renderer, const float color[4]);
 	void (*scissor)(struct wlr_renderer *renderer, struct wlr_box *box);
 	bool (*render_texture_with_matrix)(struct wlr_renderer *renderer,
-		struct wlr_texture *texture, const float matrix[static 9],
+		struct wlr_texture *texture, const float matrix[9],
 		float alpha);
 	void (*render_quad_with_matrix)(struct wlr_renderer *renderer,
-		const float color[static 4], const float matrix[static 9]);
+		const float color[4], const float matrix[9]);
 	void (*render_ellipse_with_matrix)(struct wlr_renderer *renderer,
-		const float color[static 4], const float matrix[static 9]);
+		const float color[4], const float matrix[9]);
 	const enum wl_shm_format *(*formats)(
 		struct wlr_renderer *renderer, size_t *len);
 	bool (*format_supported)(struct wlr_renderer *renderer,

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -37,7 +37,7 @@ struct wlr_renderer *wlr_renderer_autocreate(struct wlr_egl *egl, EGLenum platfo
 
 void wlr_renderer_begin(struct wlr_renderer *r, int width, int height);
 void wlr_renderer_end(struct wlr_renderer *r);
-void wlr_renderer_clear(struct wlr_renderer *r, const float color[static 4]);
+void wlr_renderer_clear(struct wlr_renderer *r, const float color[4]);
 /**
  * Defines a scissor box. Only pixels that lie within the scissor box can be
  * modified by drawing functions. Providing a NULL `box` disables the scissor
@@ -48,32 +48,32 @@ void wlr_renderer_scissor(struct wlr_renderer *r, struct wlr_box *box);
  * Renders the requested texture.
  */
 bool wlr_render_texture(struct wlr_renderer *r, struct wlr_texture *texture,
-	const float projection[static 9], int x, int y, float alpha);
+	const float projection[9], int x, int y, float alpha);
 /**
  * Renders the requested texture using the provided matrix.
  */
 bool wlr_render_texture_with_matrix(struct wlr_renderer *r,
-	struct wlr_texture *texture, const float matrix[static 9], float alpha);
+	struct wlr_texture *texture, const float matrix[9], float alpha);
 /**
  * Renders a solid rectangle in the specified color.
  */
 void wlr_render_rect(struct wlr_renderer *r, const struct wlr_box *box,
-	const float color[static 4], const float projection[static 9]);
+	const float color[4], const float projection[9]);
 /**
  * Renders a solid quadrangle in the specified color with the specified matrix.
  */
 void wlr_render_quad_with_matrix(struct wlr_renderer *r,
-	const float color[static 4], const float matrix[static 9]);
+	const float color[4], const float matrix[9]);
 /**
  * Renders a solid ellipse in the specified color.
  */
 void wlr_render_ellipse(struct wlr_renderer *r, const struct wlr_box *box,
-	const float color[static 4], const float projection[static 9]);
+	const float color[4], const float projection[9]);
 /**
  * Renders a solid ellipse in the specified color with the specified matrix.
  */
 void wlr_render_ellipse_with_matrix(struct wlr_renderer *r,
-	const float color[static 4], const float matrix[static 9]);
+	const float color[4], const float matrix[9]);
 /**
  * Returns a list of pixel formats supported by this renderer.
  */

--- a/include/wlr/types/wlr_matrix.h
+++ b/include/wlr/types/wlr_matrix.h
@@ -21,39 +21,39 @@
 #include <wlr/types/wlr_box.h>
 
 /** Writes the identity matrix into mat */
-void wlr_matrix_identity(float mat[static 9]);
+void wlr_matrix_identity(float mat[9]);
 
 /** mat ← a × b */
-void wlr_matrix_multiply(float mat[static 9], const float a[static 9],
-	const float b[static 9]);
+void wlr_matrix_multiply(float mat[9], const float a[9],
+	const float b[9]);
 
-void wlr_matrix_transpose(float mat[static 9], const float a[static 9]);
+void wlr_matrix_transpose(float mat[9], const float a[9]);
 
 /** Writes a 2D translation matrix to mat of magnitude (x, y) */
-void wlr_matrix_translate(float mat[static 9], float x, float y);
+void wlr_matrix_translate(float mat[9], float x, float y);
 
 /** Writes a 2D scale matrix to mat of magnitude (x, y) */
-void wlr_matrix_scale(float mat[static 9], float x, float y);
+void wlr_matrix_scale(float mat[9], float x, float y);
 
 /** Writes a 2D rotation matrix to mat at an angle of rad radians */
-void wlr_matrix_rotate(float mat[static 9], float rad);
+void wlr_matrix_rotate(float mat[9], float rad);
 
 /** Writes a transformation matrix which applies the specified
  *  wl_output_transform to mat */
-void wlr_matrix_transform(float mat[static 9],
+void wlr_matrix_transform(float mat[9],
 	enum wl_output_transform transform);
 
 /** Writes a 2D orthographic projection matrix to mat of (width, height) with a
  *  specified wl_output_transform*/
-void wlr_matrix_projection(float mat[static 9], int width, int height,
+void wlr_matrix_projection(float mat[9], int width, int height,
 	enum wl_output_transform transform);
 
 /** Shortcut for the various matrix operations involved in projecting the
  *  specified wlr_box onto a given orthographic projection with a given
  *  rotation. The result is written to mat, which can be applied to each
  *  coordinate of the box to get a new coordinate from [-1,1]. */
-void wlr_matrix_project_box(float mat[static 9], const struct wlr_box *box,
+void wlr_matrix_project_box(float mat[9], const struct wlr_box *box,
 	enum wl_output_transform transform, float rotation,
-	const float projection[static 9]);
+	const float projection[9]);
 
 #endif

--- a/include/wlr/xwayland.h
+++ b/include/wlr/xwayland.h
@@ -116,7 +116,7 @@ struct wlr_xwayland_surface {
 	bool mapped;
 
 	char *title;
-	char *class;
+	char *class_name;
 	char *instance;
 	char *role;
 	pid_t pid;

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -57,7 +57,7 @@ static void gles2_end(struct wlr_renderer *wlr_renderer) {
 }
 
 static void gles2_clear(struct wlr_renderer *wlr_renderer,
-		const float color[static 4]) {
+		const float color[4]) {
 	gles2_get_renderer_in_context(wlr_renderer);
 
 	PUSH_GLES2_DEBUG;
@@ -112,7 +112,7 @@ static void draw_quad(void) {
 }
 
 static bool gles2_render_texture_with_matrix(struct wlr_renderer *wlr_renderer,
-		struct wlr_texture *wlr_texture, const float matrix[static 9],
+		struct wlr_texture *wlr_texture, const float matrix[9],
 		float alpha) {
 	struct wlr_gles2_renderer *renderer =
 		gles2_get_renderer_in_context(wlr_renderer);
@@ -171,7 +171,7 @@ static bool gles2_render_texture_with_matrix(struct wlr_renderer *wlr_renderer,
 
 
 static void gles2_render_quad_with_matrix(struct wlr_renderer *wlr_renderer,
-		const float color[static 4], const float matrix[static 9]) {
+		const float color[4], const float matrix[9]) {
 	struct wlr_gles2_renderer *renderer =
 		gles2_get_renderer_in_context(wlr_renderer);
 
@@ -190,7 +190,7 @@ static void gles2_render_quad_with_matrix(struct wlr_renderer *wlr_renderer,
 }
 
 static void gles2_render_ellipse_with_matrix(struct wlr_renderer *wlr_renderer,
-		const float color[static 4], const float matrix[static 9]) {
+		const float color[4], const float matrix[9]) {
 	struct wlr_gles2_renderer *renderer =
 		gles2_get_renderer_in_context(wlr_renderer);
 

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -56,7 +56,7 @@ void wlr_renderer_end(struct wlr_renderer *r) {
 	r->rendering = false;
 }
 
-void wlr_renderer_clear(struct wlr_renderer *r, const float color[static 4]) {
+void wlr_renderer_clear(struct wlr_renderer *r, const float color[4]) {
 	assert(r->rendering);
 	r->impl->clear(r, color);
 }
@@ -67,7 +67,7 @@ void wlr_renderer_scissor(struct wlr_renderer *r, struct wlr_box *box) {
 }
 
 bool wlr_render_texture(struct wlr_renderer *r, struct wlr_texture *texture,
-		const float projection[static 9], int x, int y, float alpha) {
+		const float projection[9], int x, int y, float alpha) {
 	struct wlr_box box = { .x = x, .y = y };
 	wlr_texture_get_size(texture, &box.width, &box.height);
 
@@ -79,14 +79,14 @@ bool wlr_render_texture(struct wlr_renderer *r, struct wlr_texture *texture,
 }
 
 bool wlr_render_texture_with_matrix(struct wlr_renderer *r,
-		struct wlr_texture *texture, const float matrix[static 9],
+		struct wlr_texture *texture, const float matrix[9],
 		float alpha) {
 	assert(r->rendering);
 	return r->impl->render_texture_with_matrix(r, texture, matrix, alpha);
 }
 
 void wlr_render_rect(struct wlr_renderer *r, const struct wlr_box *box,
-		const float color[static 4], const float projection[static 9]) {
+		const float color[4], const float projection[9]) {
 	float matrix[9];
 	wlr_matrix_project_box(matrix, box, WL_OUTPUT_TRANSFORM_NORMAL, 0,
 		projection);
@@ -95,13 +95,13 @@ void wlr_render_rect(struct wlr_renderer *r, const struct wlr_box *box,
 }
 
 void wlr_render_quad_with_matrix(struct wlr_renderer *r,
-		const float color[static 4], const float matrix[static 9]) {
+		const float color[4], const float matrix[9]) {
 	assert(r->rendering);
 	r->impl->render_quad_with_matrix(r, color, matrix);
 }
 
 void wlr_render_ellipse(struct wlr_renderer *r, const struct wlr_box *box,
-		const float color[static 4], const float projection[static 9]) {
+		const float color[4], const float projection[9]) {
 	float matrix[9];
 	wlr_matrix_project_box(matrix, box, WL_OUTPUT_TRANSFORM_NORMAL, 0,
 		projection);
@@ -110,7 +110,7 @@ void wlr_render_ellipse(struct wlr_renderer *r, const struct wlr_box *box,
 }
 
 void wlr_render_ellipse_with_matrix(struct wlr_renderer *r,
-		const float color[static 4], const float matrix[static 9]) {
+		const float color[4], const float matrix[9]) {
 	assert(r->rendering);
 	r->impl->render_ellipse_with_matrix(r, color, matrix);
 }

--- a/types/wlr_matrix.c
+++ b/types/wlr_matrix.c
@@ -5,7 +5,7 @@
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_output.h>
 
-void wlr_matrix_identity(float mat[static 9]) {
+void wlr_matrix_identity(float mat[9]) {
 	static const float identity[9] = {
 		1.0f, 0.0f, 0.0f,
 		0.0f, 1.0f, 0.0f,
@@ -14,8 +14,8 @@ void wlr_matrix_identity(float mat[static 9]) {
 	memcpy(mat, identity, sizeof(identity));
 }
 
-void wlr_matrix_multiply(float mat[static 9], const float a[static 9],
-		const float b[static 9]) {
+void wlr_matrix_multiply(float mat[9], const float a[9],
+		const float b[9]) {
 	float product[9];
 
 	product[0] = a[0]*b[0] + a[1]*b[3] + a[2]*b[6];
@@ -33,7 +33,7 @@ void wlr_matrix_multiply(float mat[static 9], const float a[static 9],
 	memcpy(mat, product, sizeof(product));
 }
 
-void wlr_matrix_transpose(float mat[static 9], const float a[static 9]) {
+void wlr_matrix_transpose(float mat[9], const float a[9]) {
 	float transposition[9] = {
 		a[0], a[3], a[6],
 		a[1], a[4], a[7],
@@ -42,7 +42,7 @@ void wlr_matrix_transpose(float mat[static 9], const float a[static 9]) {
 	memcpy(mat, transposition, sizeof(transposition));
 }
 
-void wlr_matrix_translate(float mat[static 9], float x, float y) {
+void wlr_matrix_translate(float mat[9], float x, float y) {
 	float translate[9] = {
 		1.0f, 0.0f, x,
 		0.0f, 1.0f, y,
@@ -51,7 +51,7 @@ void wlr_matrix_translate(float mat[static 9], float x, float y) {
 	wlr_matrix_multiply(mat, mat, translate);
 }
 
-void wlr_matrix_scale(float mat[static 9], float x, float y) {
+void wlr_matrix_scale(float mat[9], float x, float y) {
 	float scale[9] = {
 		x,    0.0f, 0.0f,
 		0.0f, y,    0.0f,
@@ -60,7 +60,7 @@ void wlr_matrix_scale(float mat[static 9], float x, float y) {
 	wlr_matrix_multiply(mat, mat, scale);
 }
 
-void wlr_matrix_rotate(float mat[static 9], float rad) {
+void wlr_matrix_rotate(float mat[9], float rad) {
 	float rotate[9] = {
 		cos(rad), -sin(rad), 0.0f,
 		sin(rad),  cos(rad), 0.0f,
@@ -112,13 +112,13 @@ static const float transforms[][9] = {
 	},
 };
 
-void wlr_matrix_transform(float mat[static 9],
+void wlr_matrix_transform(float mat[9],
 		enum wl_output_transform transform) {
 	wlr_matrix_multiply(mat, mat, transforms[transform]);
 }
 
 // Equivalent to glOrtho(0, width, 0, height, 1, -1) with the transform applied
-void wlr_matrix_projection(float mat[static 9], int width, int height,
+void wlr_matrix_projection(float mat[9], int width, int height,
 		enum wl_output_transform transform) {
 	memset(mat, 0, sizeof(*mat) * 9);
 
@@ -140,9 +140,9 @@ void wlr_matrix_projection(float mat[static 9], int width, int height,
 	mat[8] = 1.0f;
 }
 
-void wlr_matrix_project_box(float mat[static 9], const struct wlr_box *box,
+void wlr_matrix_project_box(float mat[9], const struct wlr_box *box,
 		enum wl_output_transform transform, float rotation,
-		const float projection[static 9]) {
+		const float projection[9]) {
 	int x = box->x;
 	int y = box->y;
 	int width = box->width;

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -351,7 +351,7 @@ static void xwayland_surface_destroy(
 	wl_event_source_remove(xsurface->ping_timer);
 
 	free(xsurface->title);
-	free(xsurface->class);
+	free(xsurface->class_name);
 	free(xsurface->instance);
 	free(xsurface->role);
 	free(xsurface->window_type);
@@ -380,15 +380,15 @@ static void read_surface_class(struct wlr_xwm *xwm,
 	} else {
 		surface->instance = NULL;
 	}
-	free(surface->class);
+	free(surface->class_name);
 	if (len > 0) {
-		surface->class = strndup(class, len);
+		surface->class_name = strndup(class, len);
 	} else {
-		surface->class = NULL;
+		surface->class_name = NULL;
 	}
 
 	wlr_log(WLR_DEBUG, "XCB_ATOM_WM_CLASS: %s %s", surface->instance,
-		surface->class);
+		surface->class_name);
 	wlr_signal_emit_safe(&surface->events.set_class, surface);
 }
 


### PR DESCRIPTION
Hi wlroots Team :wave: 

When working on my compositor I have noticed there are a small number of statements that cause some incompatibilities with C++.
 
- A few `static` array statements are peppered throughout the headers. 
- The `xwayland` struct has a member named `class` which is a reserved keyword.

I humbly raise this PR to make the adjustments to fix up these issues. Other than these pretty much everything else works great with C++.

Thanks for all the work on such a great framework, i hope this doesn't inconvenience too much.