### PR TITLE
xwm: correctly send focus event to new window

### DIFF
--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -1245,6 +1245,7 @@ static void xwm_handle_focus_in(struct wlr_xwm *xwm,
 		xwm_send_focus_window(xwm, xwm->focus_surface);
 	} else {
 		xwm->focus_surface = requested_focus;
+		xwm_send_focus_window(xwm, xwm->focus_surface);
 	}
 }
 


### PR DESCRIPTION
Even if we allow the focus change to the new window, we have to send the
focus explicitly. Otherwise the focus may get lost when we close a
window belonging to the same process, but do not send focus to the
remaining window.

Fixes swaywm/sway#4926