### PR TITLE
examples: Fix compositor-examples

### DIFF
--- a/examples/fullscreen-shell.c
+++ b/examples/fullscreen-shell.c
@@ -163,6 +163,8 @@ static void server_handle_new_output(struct wl_listener *listener, void *data) {
 
 	wlr_output_layout_add_auto(server->output_layout, wlr_output);
 	wlr_output_create_global(wlr_output);
+
+	wlr_output_commit(wlr_output);
 }
 
 static void server_handle_present_surface(struct wl_listener *listener,

--- a/examples/multi-pointer.c
+++ b/examples/multi-pointer.c
@@ -171,6 +171,8 @@ static void new_output_notify(struct wl_listener *listener, void *data) {
 			cursor->cursor->y);
 	}
 	wl_list_insert(&sample->outputs, &sample_output->link);
+
+	wlr_output_commit(output);
 }
 
 static void keyboard_key_notify(struct wl_listener *listener, void *data) {

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -169,6 +169,8 @@ static void new_output_notify(struct wl_listener *listener, void *data) {
 	sample_output->frame.notify = output_frame_notify;
 	wl_signal_add(&output->events.destroy, &sample_output->destroy);
 	sample_output->destroy.notify = output_remove_notify;
+
+	wlr_output_commit(output);
 }
 
 static void keyboard_key_notify(struct wl_listener *listener, void *data) {

--- a/examples/pointer.c
+++ b/examples/pointer.c
@@ -265,6 +265,8 @@ static void new_output_notify(struct wl_listener *listener, void *data) {
 	wlr_xcursor_manager_load(sample->xcursor_manager, output->scale);
 	wlr_xcursor_manager_set_cursor_image(sample->xcursor_manager, "left_ptr",
 		sample->cursor);
+
+	wlr_output_commit(output);
 }
 
 

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -123,6 +123,8 @@ static void new_output_notify(struct wl_listener *listener, void *data) {
 	wl_signal_add(&output->events.destroy, &sample_output->destroy);
 	sample_output->destroy.notify = output_remove_notify;
 	wl_list_insert(&sample->outputs, &sample_output->link);
+
+	wlr_output_commit(output);
 }
 
 static void keyboard_key_notify(struct wl_listener *listener, void *data) {

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -91,6 +91,8 @@ static void new_output_notify(struct wl_listener *listener, void *data) {
 	sample_output->frame.notify = output_frame_notify;
 	wl_signal_add(&output->events.destroy, &sample_output->destroy);
 	sample_output->destroy.notify = output_remove_notify;
+
+	wlr_output_commit(sample_output->output);
 }
 
 static void keyboard_key_notify(struct wl_listener *listener, void *data) {

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -248,6 +248,8 @@ static void new_output_notify(struct wl_listener *listener, void *data) {
 	sample_output->frame.notify = output_frame_notify;
 	wl_signal_add(&output->events.destroy, &sample_output->destroy);
 	sample_output->destroy.notify = output_remove_notify;
+
+	wlr_output_commit(output);
 }
 
 static void keyboard_key_notify(struct wl_listener *listener, void *data) {

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -161,6 +161,8 @@ static void new_output_notify(struct wl_listener *listener, void *data) {
 	sample_output->frame.notify = output_frame_notify;
 	wl_signal_add(&output->events.destroy, &sample_output->destroy);
 	sample_output->destroy.notify = output_remove_notify;
+
+	wlr_output_commit(output);
 }
 
 static void keyboard_key_notify(struct wl_listener *listener, void *data) {


### PR DESCRIPTION
Due to the way the wlr_output API was changed, these examples would
never get a frame event to start the rendering loop. We now commit the
outputs to start it.