### PR TITLE
backend/drm: Introduce wlr_drm_fb

### DIFF
--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -172,7 +172,7 @@ static bool atomic_crtc_set_cursor(struct wlr_drm_backend *drm,
 
 	if (bo) {
 		uint32_t fb_id =
-			get_fb_for_bo(bo, plane->drm_format, drm->addfb2_modifiers);
+			get_fb_for_bo(bo, drm->addfb2_modifiers);
 		set_plane_props(&atom, plane, crtc->id, fb_id, false);
 	} else {
 		atomic_add(&atom, plane->id, plane->props.fb_id, 0);

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -105,8 +105,13 @@ static void session_signal(struct wl_listener *listener, void *data) {
 			}
 
 			struct wlr_drm_plane *plane = conn->crtc->cursor;
-			drm->iface->crtc_set_cursor(drm, conn->crtc,
-				(plane && plane->cursor_enabled) ? plane->surf.back : NULL);
+			struct gbm_bo *bo = NULL;
+			if (plane->cursor_enabled) {
+				bo = drm_fb_acquire(&plane->current_fb, drm,
+					&plane->mgpu_surf);
+			}
+
+			drm->iface->crtc_set_cursor(drm, conn->crtc, bo);
 			drm->iface->crtc_move_cursor(drm, conn->crtc, conn->cursor_x,
 				conn->cursor_y);
 

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -373,6 +373,13 @@ static bool test_buffer(struct wlr_drm_connector *conn,
 		return false;
 	}
 
+	/* Legacy never gets to have nice things. But I doubt this would ever work,
+	 * and there is no reliable way to try, without risking messing up the
+	 * modesetting state. */
+	if (drm->iface == &legacy_iface) {
+		return false;
+	}
+
 	struct wlr_drm_crtc *crtc = conn->crtc;
 	if (!crtc) {
 		return false;

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -338,9 +338,6 @@ static bool drm_crtc_page_flip(struct wlr_drm_connector *conn,
 		struct wlr_drm_mode *mode) {
 	struct wlr_drm_backend *drm = get_drm_backend_from_backend(conn->output.backend);
 	struct wlr_drm_crtc *crtc = conn->crtc;
-	struct wlr_drm_plane *plane = crtc->primary;
-	struct gbm_bo *bo;
-	uint32_t fb_id;
 	drmModeModeInfo *drm_mode = mode ? &mode->drm_mode : NULL;
 
 	if (conn->pageflip_pending) {
@@ -348,13 +345,7 @@ static bool drm_crtc_page_flip(struct wlr_drm_connector *conn,
 		return false;
 	}
 
-	bo = drm_fb_acquire(&plane->queued_fb, drm, &plane->mgpu_surf);
-	if (!bo) {
-		return false;
-	}
-
-	fb_id = get_fb_for_bo(bo, drm->addfb2_modifiers);
-	if (!drm->iface->crtc_pageflip(drm, conn, crtc, fb_id, drm_mode)) {
+	if (!drm->iface->crtc_pageflip(drm, conn, drm_mode)) {
 		return false;
 	}
 

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -3,6 +3,7 @@
 #include <gbm.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include <wayland-util.h>
 #include <wlr/render/egl.h>
@@ -61,7 +62,7 @@ void finish_drm_renderer(struct wlr_drm_renderer *renderer) {
 	gbm_device_destroy(renderer->gbm);
 }
 
-bool init_drm_surface(struct wlr_drm_surface *surf,
+static bool init_drm_surface(struct wlr_drm_surface *surf,
 		struct wlr_drm_renderer *renderer, uint32_t width, uint32_t height,
 		uint32_t format, struct wlr_drm_format_set *set, uint32_t flags) {
 	if (surf->width == width && surf->height == height) {
@@ -73,14 +74,6 @@ bool init_drm_surface(struct wlr_drm_surface *surf,
 	surf->height = height;
 
 	if (surf->gbm) {
-		if (surf->front) {
-			gbm_surface_release_buffer(surf->gbm, surf->front);
-			surf->front = NULL;
-		}
-		if (surf->back) {
-			gbm_surface_release_buffer(surf->gbm, surf->back);
-			surf->back = NULL;
-		}
 		gbm_surface_destroy(surf->gbm);
 		surf->gbm = NULL;
 	}
@@ -119,16 +112,9 @@ error_zero:
 	return false;
 }
 
-void finish_drm_surface(struct wlr_drm_surface *surf) {
+static void finish_drm_surface(struct wlr_drm_surface *surf) {
 	if (!surf || !surf->renderer) {
 		return;
-	}
-
-	if (surf->front) {
-		gbm_surface_release_buffer(surf->gbm, surf->front);
-	}
-	if (surf->back) {
-		gbm_surface_release_buffer(surf->gbm, surf->back);
 	}
 
 	wlr_egl_destroy_surface(&surf->renderer->egl, surf->egl);
@@ -139,80 +125,9 @@ void finish_drm_surface(struct wlr_drm_surface *surf) {
 	memset(surf, 0, sizeof(*surf));
 }
 
-bool make_drm_surface_current(struct wlr_drm_surface *surf,
+bool drm_surface_make_current(struct wlr_drm_surface *surf,
 		int *buffer_damage) {
 	return wlr_egl_make_current(&surf->renderer->egl, surf->egl, buffer_damage);
-}
-
-struct gbm_bo *swap_drm_surface_buffers(struct wlr_drm_surface *surf,
-		pixman_region32_t *damage) {
-	if (surf->front) {
-		gbm_surface_release_buffer(surf->gbm, surf->front);
-	}
-
-	wlr_egl_swap_buffers(&surf->renderer->egl, surf->egl, damage);
-
-	surf->front = surf->back;
-	surf->back = gbm_surface_lock_front_buffer(surf->gbm);
-	return surf->back;
-}
-
-struct gbm_bo *get_drm_surface_front(struct wlr_drm_surface *surf) {
-	if (surf->front) {
-		return surf->front;
-	}
-
-	make_drm_surface_current(surf, NULL);
-	struct wlr_renderer *renderer = surf->renderer->wlr_rend;
-	wlr_renderer_begin(renderer, surf->width, surf->height);
-	wlr_renderer_clear(renderer, (float[]){ 0.0, 0.0, 0.0, 1.0 });
-	wlr_renderer_end(renderer);
-	return swap_drm_surface_buffers(surf, NULL);
-}
-
-void post_drm_surface(struct wlr_drm_surface *surf) {
-	if (surf->front) {
-		gbm_surface_release_buffer(surf->gbm, surf->front);
-		surf->front = NULL;
-	}
-}
-
-struct gbm_bo *import_gbm_bo(struct wlr_drm_renderer *renderer,
-		struct wlr_dmabuf_attributes *attribs) {
-	if (attribs->modifier == DRM_FORMAT_MOD_INVALID && attribs->n_planes == 1
-			&& attribs->offset[0] == 0) {
-		struct gbm_import_fd_data data = {
-			.fd = attribs->fd[0],
-			.width = attribs->width,
-			.height = attribs->height,
-			.stride = attribs->stride[0],
-			.format = attribs->format,
-		};
-
-		return gbm_bo_import(renderer->gbm, GBM_BO_IMPORT_FD,
-			&data, GBM_BO_USE_SCANOUT);
-	} else {
-		struct gbm_import_fd_modifier_data data = {
-			.width = attribs->width,
-			.height = attribs->height,
-			.format = attribs->format,
-			.num_fds = attribs->n_planes,
-			.modifier = attribs->modifier,
-		};
-
-		if ((size_t)attribs->n_planes > sizeof(data.fds) / sizeof(data.fds[0])) {
-			return NULL;
-		}
-
-		for (size_t i = 0; i < (size_t)attribs->n_planes; ++i) {
-			data.fds[i] = attribs->fd[i];
-			data.strides[i] = attribs->stride[i];
-			data.offsets[i] = attribs->offset[i];
-		}
-
-		return gbm_bo_import(renderer->gbm, GBM_BO_IMPORT_FD_MODIFIER,
-			&data, GBM_BO_USE_SCANOUT);
-	}
 }
 
 bool export_drm_bo(struct gbm_bo *bo, struct wlr_dmabuf_attributes *attribs) {
@@ -268,46 +183,234 @@ static struct wlr_texture *get_tex_for_bo(struct wlr_drm_renderer *renderer,
 	return tex;
 }
 
-struct gbm_bo *copy_drm_surface_mgpu(struct wlr_drm_surface *dest,
-		struct gbm_bo *src) {
-	make_drm_surface_current(dest, NULL);
+void drm_plane_finish_surface(struct wlr_drm_plane *plane) {
+	if (!plane) {
+		return;
+	}
 
-	struct wlr_texture *tex = get_tex_for_bo(dest->renderer, src);
-	assert(tex);
+	drm_fb_clear(&plane->pending_fb);
+	drm_fb_clear(&plane->queued_fb);
+	drm_fb_clear(&plane->current_fb);
 
-	float mat[9];
-	wlr_matrix_projection(mat, 1, 1, WL_OUTPUT_TRANSFORM_NORMAL);
-
-	struct wlr_renderer *renderer = dest->renderer->wlr_rend;
-	wlr_renderer_begin(renderer, dest->width, dest->height);
-	wlr_renderer_clear(renderer, (float[]){ 0.0, 0.0, 0.0, 0.0 });
-	wlr_render_texture_with_matrix(renderer, tex, mat, 1.0f);
-	wlr_renderer_end(renderer);
-
-	return swap_drm_surface_buffers(dest, NULL);
+	finish_drm_surface(&plane->surf);
+	finish_drm_surface(&plane->mgpu_surf);
 }
 
-bool init_drm_plane_surfaces(struct wlr_drm_plane *plane,
+bool drm_plane_init_surface(struct wlr_drm_plane *plane,
 		struct wlr_drm_backend *drm, int32_t width, uint32_t height,
-		uint32_t format, bool with_modifiers) {
+		uint32_t format, uint32_t flags, bool with_modifiers) {
 	struct wlr_drm_format_set *format_set =
 		with_modifiers ? &plane->formats : NULL;
 
+	drm_plane_finish_surface(plane);
+
 	if (!drm->parent) {
 		return init_drm_surface(&plane->surf, &drm->renderer, width, height,
-			format, format_set, GBM_BO_USE_SCANOUT);
+			format, format_set, flags | GBM_BO_USE_SCANOUT);
 	}
 
 	if (!init_drm_surface(&plane->surf, &drm->parent->renderer,
-			width, height, format, NULL, GBM_BO_USE_LINEAR)) {
+			width, height, format, NULL,
+			flags | GBM_BO_USE_LINEAR)) {
 		return false;
 	}
 
 	if (!init_drm_surface(&plane->mgpu_surf, &drm->renderer,
-			width, height, format, format_set, GBM_BO_USE_SCANOUT)) {
+			width, height, format, format_set,
+			flags | GBM_BO_USE_SCANOUT)) {
 		finish_drm_surface(&plane->surf);
 		return false;
 	}
 
 	return true;
+}
+
+void drm_fb_clear(struct wlr_drm_fb *fb) {
+	switch (fb->type) {
+	case WLR_DRM_FB_TYPE_NONE:
+		assert(!fb->bo);
+		break;
+	case WLR_DRM_FB_TYPE_SURFACE:
+		gbm_surface_release_buffer(fb->surf->gbm, fb->bo);
+		break;
+	case WLR_DRM_FB_TYPE_WLR_BUFFER:
+		gbm_bo_destroy(fb->bo);
+		wlr_buffer_unlock(fb->wlr_buf);
+		fb->wlr_buf = NULL;
+		break;
+	}
+
+	fb->type = WLR_DRM_FB_TYPE_NONE;
+	fb->bo = NULL;
+
+	if (fb->mgpu_bo) {
+		assert(fb->mgpu_surf);
+		gbm_surface_release_buffer(fb->mgpu_surf->gbm, fb->mgpu_bo);
+		fb->mgpu_bo = NULL;
+		fb->mgpu_surf = NULL;
+	}
+}
+
+bool drm_fb_lock_surface(struct wlr_drm_fb *fb, struct wlr_drm_surface *surf) {
+	drm_fb_clear(fb);
+
+	if (!wlr_egl_swap_buffers(&surf->renderer->egl, surf->egl, NULL)) {
+		wlr_log(WLR_ERROR, "Failed to swap buffers");
+		return false;
+	}
+
+	fb->bo = gbm_surface_lock_front_buffer(surf->gbm);
+	if (!fb->bo) {
+		wlr_log(WLR_ERROR, "Failed to lock front buffer");
+		return false;
+	}
+
+	fb->type = WLR_DRM_FB_TYPE_SURFACE;
+	fb->surf = surf;
+	return true;
+}
+
+static uint32_t strip_alpha_channel(uint32_t format) {
+	switch (format) {
+	case DRM_FORMAT_ARGB8888:
+		return DRM_FORMAT_XRGB8888;
+	default:
+		return DRM_FORMAT_INVALID;
+	}
+}
+
+bool drm_fb_import_wlr(struct wlr_drm_fb *fb, struct wlr_drm_renderer *renderer,
+		struct wlr_buffer *buf, struct wlr_drm_format_set *set) {
+	drm_fb_clear(fb);
+
+	struct wlr_dmabuf_attributes attribs;
+	if (!wlr_buffer_get_dmabuf(buf, &attribs)) {
+		return false;
+	}
+
+	if (!wlr_drm_format_set_has(set, attribs.format, attribs.modifier)) {
+		// The format isn't supported by the plane. Try stripping the alpha
+		// channel, if any.
+		uint32_t format = strip_alpha_channel(attribs.format);
+		if (wlr_drm_format_set_has(set, format, attribs.modifier)) {
+			attribs.format = format;
+		} else {
+			return false;
+		}
+	}
+
+	if (attribs.modifier != DRM_FORMAT_MOD_INVALID ||
+			attribs.n_planes > 1 || attribs.offset[0] != 0) {
+		struct gbm_import_fd_modifier_data data = {
+			.width = attribs.width,
+			.height = attribs.height,
+			.format = attribs.format,
+			.num_fds = attribs.n_planes,
+			.modifier = attribs.modifier,
+		};
+
+		if ((size_t)attribs.n_planes > sizeof(data.fds) / sizeof(data.fds[0])) {
+			return false;
+		}
+
+		for (size_t i = 0; i < (size_t)attribs.n_planes; ++i) {
+			data.fds[i] = attribs.fd[i];
+			data.strides[i] = attribs.stride[i];
+			data.offsets[i] = attribs.offset[i];
+		}
+
+		fb->bo = gbm_bo_import(renderer->gbm, GBM_BO_IMPORT_FD_MODIFIER,
+			&data, GBM_BO_USE_SCANOUT);
+	} else {
+		struct gbm_import_fd_data data = {
+			.fd = attribs.fd[0],
+			.width = attribs.width,
+			.height = attribs.height,
+			.stride = attribs.stride[0],
+			.format = attribs.format,
+		};
+
+		fb->bo = gbm_bo_import(renderer->gbm, GBM_BO_IMPORT_FD,
+			&data, GBM_BO_USE_SCANOUT);
+	}
+
+	if (!fb->bo) {
+		return false;
+	}
+
+	fb->type = WLR_DRM_FB_TYPE_WLR_BUFFER;
+	fb->wlr_buf = wlr_buffer_lock(buf);
+
+	return true;
+}
+
+void drm_fb_move(struct wlr_drm_fb *new, struct wlr_drm_fb *old) {
+	drm_fb_clear(new);
+
+	*new = *old;
+	memset(old, 0, sizeof(*old));
+}
+
+bool drm_surface_render_black_frame(struct wlr_drm_surface *surf) {
+	struct wlr_renderer *renderer = surf->renderer->wlr_rend;
+
+	if (!drm_surface_make_current(surf, NULL)) {
+		return false;
+	}
+
+	wlr_renderer_begin(renderer, surf->width, surf->height);
+	wlr_renderer_clear(renderer, (float[]){ 0.0, 0.0, 0.0, 1.0 });
+	wlr_renderer_end(renderer);
+	return true;
+}
+
+struct gbm_bo *drm_fb_acquire(struct wlr_drm_fb *fb, struct wlr_drm_backend *drm,
+		struct wlr_drm_surface *mgpu) {
+	if (!fb->bo) {
+		wlr_log(WLR_ERROR, "Tried to acquire an FB with a NULL BO");
+		return NULL;
+	}
+
+	if (!drm->parent) {
+		return fb->bo;
+	}
+
+	if (fb->mgpu_bo) {
+		return fb->mgpu_bo;
+	}
+
+	/* Perform copy across GPUs */
+
+	struct wlr_renderer *renderer = mgpu->renderer->wlr_rend;
+
+	if (!drm_surface_make_current(mgpu, NULL)) {
+		return NULL;
+	}
+
+	struct wlr_texture *tex = get_tex_for_bo(mgpu->renderer, fb->bo);
+	if (!tex) {
+		return NULL;
+	}
+
+	float mat[9];
+	wlr_matrix_projection(mat, 1, 1, WL_OUTPUT_TRANSFORM_NORMAL);
+
+	wlr_renderer_begin(renderer, mgpu->width, mgpu->height);
+	wlr_renderer_clear(renderer, (float[]){ 0.0, 0.0, 0.0, 0.0 });
+	wlr_render_texture_with_matrix(renderer, tex, mat, 1.0f);
+	wlr_renderer_end(renderer);
+
+	if (!wlr_egl_swap_buffers(&mgpu->renderer->egl, mgpu->egl, NULL)) {
+		wlr_log(WLR_ERROR, "Failed to swap buffers");
+		return NULL;
+	}
+
+	fb->mgpu_bo = gbm_surface_lock_front_buffer(mgpu->gbm);
+	if (!fb->mgpu_bo) {
+		wlr_log(WLR_ERROR, "Failed to lock front buffer");
+		return NULL;
+	}
+
+	fb->mgpu_surf = mgpu;
+	return fb->mgpu_bo;
 }

--- a/backend/drm/util.c
+++ b/backend/drm/util.c
@@ -179,8 +179,7 @@ static void free_fb(struct gbm_bo *bo, void *data) {
 	}
 }
 
-uint32_t get_fb_for_bo(struct gbm_bo *bo, uint32_t drm_format,
-		bool with_modifiers) {
+uint32_t get_fb_for_bo(struct gbm_bo *bo, bool with_modifiers) {
 	uint32_t id = (uintptr_t)gbm_bo_get_user_data(bo);
 	if (id) {
 		return id;
@@ -191,6 +190,7 @@ uint32_t get_fb_for_bo(struct gbm_bo *bo, uint32_t drm_format,
 	int fd = gbm_device_get_fd(gbm);
 	uint32_t width = gbm_bo_get_width(bo);
 	uint32_t height = gbm_bo_get_height(bo);
+	uint32_t format = gbm_bo_get_format(bo);
 
 	uint32_t handles[4] = {0};
 	uint32_t strides[4] = {0};
@@ -205,12 +205,12 @@ uint32_t get_fb_for_bo(struct gbm_bo *bo, uint32_t drm_format,
 	}
 
 	if (with_modifiers && gbm_bo_get_modifier(bo) != DRM_FORMAT_MOD_INVALID) {
-		if (drmModeAddFB2WithModifiers(fd, width, height, drm_format, handles,
+		if (drmModeAddFB2WithModifiers(fd, width, height, format, handles,
 				strides, offsets, modifiers, &id, DRM_MODE_FB_MODIFIERS)) {
 			wlr_log_errno(WLR_ERROR, "Unable to add DRM framebuffer");
 		}
 	} else {
-		if (drmModeAddFB2(fd, width, height, drm_format, handles, strides,
+		if (drmModeAddFB2(fd, width, height, format, handles, strides,
 				offsets, &id, 0)) {
 			wlr_log_errno(WLR_ERROR, "Unable to add DRM framebuffer");
 		}

--- a/include/backend/drm/iface.h
+++ b/include/backend/drm/iface.h
@@ -18,8 +18,7 @@ struct wlr_drm_interface {
 		struct wlr_drm_connector *conn, bool enable);
 	// Pageflip on crtc. If mode is non-NULL perform a full modeset using it.
 	bool (*crtc_pageflip)(struct wlr_drm_backend *drm,
-		struct wlr_drm_connector *conn, struct wlr_drm_crtc *crtc,
-		uint32_t fb_id, drmModeModeInfo *mode);
+		struct wlr_drm_connector *conn, drmModeModeInfo *mode);
 	// Enable the cursor buffer on crtc. Set bo to NULL to disable
 	bool (*crtc_set_cursor)(struct wlr_drm_backend *drm,
 		struct wlr_drm_crtc *crtc, struct gbm_bo *bo);

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -10,6 +10,7 @@
 
 struct wlr_drm_backend;
 struct wlr_drm_plane;
+struct wlr_buffer;
 
 struct wlr_drm_renderer {
 	int fd;
@@ -29,33 +30,48 @@ struct wlr_drm_surface {
 
 	struct gbm_surface *gbm;
 	EGLSurface egl;
+};
 
-	struct gbm_bo *front;
-	struct gbm_bo *back;
+enum wlr_drm_fb_type {
+	WLR_DRM_FB_TYPE_NONE,
+	WLR_DRM_FB_TYPE_SURFACE,
+	WLR_DRM_FB_TYPE_WLR_BUFFER
+};
+
+struct wlr_drm_fb {
+	enum wlr_drm_fb_type type;
+	struct gbm_bo *bo;
+
+	struct wlr_drm_surface *mgpu_surf;
+	struct gbm_bo *mgpu_bo;
+
+	union {
+		struct wlr_drm_surface *surf;
+		struct wlr_buffer *wlr_buf;
+	};
 };
 
 bool init_drm_renderer(struct wlr_drm_backend *drm,
 	struct wlr_drm_renderer *renderer, wlr_renderer_create_func_t create_render);
 void finish_drm_renderer(struct wlr_drm_renderer *renderer);
 
-bool init_drm_surface(struct wlr_drm_surface *surf,
-	struct wlr_drm_renderer *renderer, uint32_t width, uint32_t height,
-	uint32_t format, struct wlr_drm_format_set *set, uint32_t flags);
-
-bool init_drm_plane_surfaces(struct wlr_drm_plane *plane,
-	struct wlr_drm_backend *drm, int32_t width, uint32_t height,
-	uint32_t format, bool with_modifiers);
-
-void finish_drm_surface(struct wlr_drm_surface *surf);
-bool make_drm_surface_current(struct wlr_drm_surface *surf, int *buffer_age);
-struct gbm_bo *swap_drm_surface_buffers(struct wlr_drm_surface *surf,
-	pixman_region32_t *damage);
-struct gbm_bo *get_drm_surface_front(struct wlr_drm_surface *surf);
-void post_drm_surface(struct wlr_drm_surface *surf);
-struct gbm_bo *copy_drm_surface_mgpu(struct wlr_drm_surface *dest,
-	struct gbm_bo *src);
-struct gbm_bo *import_gbm_bo(struct wlr_drm_renderer *renderer,
-	struct wlr_dmabuf_attributes *attribs);
+bool drm_surface_make_current(struct wlr_drm_surface *surf, int *buffer_age);
 bool export_drm_bo(struct gbm_bo *bo, struct wlr_dmabuf_attributes *attribs);
+
+void drm_fb_clear(struct wlr_drm_fb *fb);
+bool drm_fb_lock_surface(struct wlr_drm_fb *fb, struct wlr_drm_surface *surf);
+bool drm_fb_import_wlr(struct wlr_drm_fb *fb, struct wlr_drm_renderer *renderer,
+		struct wlr_buffer *buf, struct wlr_drm_format_set *set);
+
+void drm_fb_move(struct wlr_drm_fb *new, struct wlr_drm_fb *old);
+
+bool drm_surface_render_black_frame(struct wlr_drm_surface *surf);
+struct gbm_bo *drm_fb_acquire(struct wlr_drm_fb *fb, struct wlr_drm_backend *drm,
+		struct wlr_drm_surface *mgpu);
+
+bool drm_plane_init_surface(struct wlr_drm_plane *plane,
+		struct wlr_drm_backend *drm, int32_t width, uint32_t height,
+		uint32_t format, uint32_t flags, bool with_modifiers);
+void drm_plane_finish_surface(struct wlr_drm_plane *plane);
 
 #endif

--- a/include/backend/drm/util.h
+++ b/include/backend/drm/util.h
@@ -14,8 +14,7 @@ void parse_edid(struct wlr_output *restrict output, size_t len,
 // Returns the string representation of a DRM output type
 const char *conn_get_name(uint32_t type_id);
 // Returns the DRM framebuffer id for a gbm_bo
-uint32_t get_fb_for_bo(struct gbm_bo *bo, uint32_t drm_format,
-	bool with_modifiers);
+uint32_t get_fb_for_bo(struct gbm_bo *bo, bool with_modifiers);
 
 // Part of match_obj
 enum {


### PR DESCRIPTION
This is a type which manages gbm_surfaces and imported dmabufs in the same place, and makes the lifetime management between the two shared. It should lead to easier to understand code, and fewer special cases.

This also contains a fair bit of refactoring to start using this new type.

---

I was never able to reproduce @kennylevinsen's issue with weird colors/tearing during direct scanout with mpv, so I have no idea whether this actually fixes it or not. I was only really going off of a hunch. Even if it doesn't fix it, this is still a good bit of refactoring that makes the code simpler.

This PR does need more testing before it's merged. I don't really have a super reliable way to do direct scanout, and I haven't gotten around to multi-GPU testing yet.