### PR TITLE
Fix wl_output_transform rotation direction, and composition

### DIFF
--- a/types/wlr_box.c
+++ b/types/wlr_box.c
@@ -91,32 +91,32 @@ void wlr_box_transform(struct wlr_box *dest, const struct wlr_box *box,
 		dest->y = src.y;
 		break;
 	case WL_OUTPUT_TRANSFORM_90:
-		dest->x = src.y;
-		dest->y = width - src.x - src.width;
+		dest->x = height - src.y - src.height;
+		dest->y = src.x;
 		break;
 	case WL_OUTPUT_TRANSFORM_180:
 		dest->x = width - src.x - src.width;
 		dest->y = height - src.y - src.height;
 		break;
 	case WL_OUTPUT_TRANSFORM_270:
-		dest->x = height - src.y - src.height;
-		dest->y = src.x;
+		dest->x = src.y;
+		dest->y = width - src.x - src.width;
 		break;
 	case WL_OUTPUT_TRANSFORM_FLIPPED:
 		dest->x = width - src.x - src.width;
 		dest->y = src.y;
 		break;
 	case WL_OUTPUT_TRANSFORM_FLIPPED_90:
-		dest->x = height - src.y - src.height;
-		dest->y = width - src.x - src.width;
+		dest->x = src.y;
+		dest->y = src.x;
 		break;
 	case WL_OUTPUT_TRANSFORM_FLIPPED_180:
 		dest->x = src.x;
 		dest->y = height - src.y - src.height;
 		break;
 	case WL_OUTPUT_TRANSFORM_FLIPPED_270:
-		dest->x = src.y;
-		dest->y = src.x;
+		dest->x = height - src.y - src.height;
+		dest->y = width - src.x - src.width;
 		break;
 	}
 }

--- a/types/wlr_cursor.c
+++ b/types/wlr_cursor.c
@@ -366,32 +366,32 @@ static void apply_output_transform(double *x, double *y,
 		dy = *y;
 		break;
 	case WL_OUTPUT_TRANSFORM_90:
-		dx = *y;
-		dy = width - *x;
+		dx = height - *y;
+		dy = *x;
 		break;
 	case WL_OUTPUT_TRANSFORM_180:
 		dx = width - *x;
 		dy = height - *y;
 		break;
 	case WL_OUTPUT_TRANSFORM_270:
-		dx = height - *y;
-		dy = *x;
+		dx = *y;
+		dy = width - *x;
 		break;
 	case WL_OUTPUT_TRANSFORM_FLIPPED:
 		dx = width - *x;
 		dy = *y;
 		break;
 	case WL_OUTPUT_TRANSFORM_FLIPPED_90:
-		dx = height - *y;
-		dy = width - *x;
+		dx = *y;
+		dy = *x;
 		break;
 	case WL_OUTPUT_TRANSFORM_FLIPPED_180:
 		dx = *x;
 		dy = height - *y;
 		break;
 	case WL_OUTPUT_TRANSFORM_FLIPPED_270:
-		dx = *y;
-		dy = *x;
+		dx = height - *y;
+		dy = width - *x;
 		break;
 	}
 	*x = dx;

--- a/types/wlr_matrix.c
+++ b/types/wlr_matrix.c
@@ -76,8 +76,8 @@ static const float transforms[][9] = {
 		0.0f, 0.0f, 1.0f,
 	},
 	[WL_OUTPUT_TRANSFORM_90] = {
-		0.0f, -1.0f, 0.0f,
-		1.0f, 0.0f, 0.0f,
+		0.0f, 1.0f, 0.0f,
+		-1.0f, 0.0f, 0.0f,
 		0.0f, 0.0f, 1.0f,
 	},
 	[WL_OUTPUT_TRANSFORM_180] = {
@@ -86,8 +86,8 @@ static const float transforms[][9] = {
 		0.0f, 0.0f, 1.0f,
 	},
 	[WL_OUTPUT_TRANSFORM_270] = {
-		0.0f, 1.0f, 0.0f,
-		-1.0f, 0.0f, 0.0f,
+		0.0f, -1.0f, 0.0f,
+		1.0f, 0.0f, 0.0f,
 		0.0f, 0.0f, 1.0f,
 	},
 	[WL_OUTPUT_TRANSFORM_FLIPPED] = {
@@ -96,8 +96,8 @@ static const float transforms[][9] = {
 		0.0f, 0.0f, 1.0f,
 	},
 	[WL_OUTPUT_TRANSFORM_FLIPPED_90] = {
-		0.0f, -1.0f, 0.0f,
-		-1.0f, 0.0f, 0.0f,
+		0.0f, 1.0f, 0.0f,
+		1.0f, 0.0f, 0.0f,
 		0.0f, 0.0f, 1.0f,
 	},
 	[WL_OUTPUT_TRANSFORM_FLIPPED_180] = {
@@ -106,8 +106,8 @@ static const float transforms[][9] = {
 		0.0f, 0.0f, 1.0f,
 	},
 	[WL_OUTPUT_TRANSFORM_FLIPPED_270] = {
-		0.0f, 1.0f, 0.0f,
-		1.0f, 0.0f, 0.0f,
+		0.0f, -1.0f, 0.0f,
+		-1.0f, 0.0f, 0.0f,
 		0.0f, 0.0f, 1.0f,
 	},
 };

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -1108,7 +1108,15 @@ enum wl_output_transform wlr_output_transform_invert(
 enum wl_output_transform wlr_output_transform_compose(
 		enum wl_output_transform tr_a, enum wl_output_transform tr_b) {
 	uint32_t flipped = (tr_a ^ tr_b) & WL_OUTPUT_TRANSFORM_FLIPPED;
-	uint32_t rotated =
-		(tr_a + tr_b) & (WL_OUTPUT_TRANSFORM_90 | WL_OUTPUT_TRANSFORM_180);
+	uint32_t rotation_mask = WL_OUTPUT_TRANSFORM_90 | WL_OUTPUT_TRANSFORM_180;
+	uint32_t rotated;
+	if (tr_b & WL_OUTPUT_TRANSFORM_FLIPPED) {
+		// When a rotation of k degrees is followed by a flip, the
+		// equivalent transform is a flip followed by a rotation of
+		// -k degrees.
+		rotated = (tr_b - tr_a) & rotation_mask;
+	} else {
+		rotated = (tr_a + tr_b) & rotation_mask;
+	}
 	return flipped | rotated;
 }

--- a/util/region.c
+++ b/util/region.c
@@ -56,10 +56,10 @@ void wlr_region_transform(pixman_region32_t *dst, pixman_region32_t *src,
 			dst_rects[i].y2 = src_rects[i].y2;
 			break;
 		case WL_OUTPUT_TRANSFORM_90:
-			dst_rects[i].x1 = src_rects[i].y1;
-			dst_rects[i].y1 = width - src_rects[i].x2;
-			dst_rects[i].x2 = src_rects[i].y2;
-			dst_rects[i].y2 = width - src_rects[i].x1;
+			dst_rects[i].x1 = height - src_rects[i].y2;
+			dst_rects[i].y1 = src_rects[i].x1;
+			dst_rects[i].x2 = height - src_rects[i].y1;
+			dst_rects[i].y2 = src_rects[i].x2;
 			break;
 		case WL_OUTPUT_TRANSFORM_180:
 			dst_rects[i].x1 = width - src_rects[i].x2;
@@ -68,10 +68,10 @@ void wlr_region_transform(pixman_region32_t *dst, pixman_region32_t *src,
 			dst_rects[i].y2 = height - src_rects[i].y1;
 			break;
 		case WL_OUTPUT_TRANSFORM_270:
-			dst_rects[i].x1 = height - src_rects[i].y2;
-			dst_rects[i].y1 = src_rects[i].x1;
-			dst_rects[i].x2 = height - src_rects[i].y1;
-			dst_rects[i].y2 = src_rects[i].x2;
+			dst_rects[i].x1 = src_rects[i].y1;
+			dst_rects[i].y1 = width - src_rects[i].x2;
+			dst_rects[i].x2 = src_rects[i].y2;
+			dst_rects[i].y2 = width - src_rects[i].x1;
 			break;
 		case WL_OUTPUT_TRANSFORM_FLIPPED:
 			dst_rects[i].x1 = width - src_rects[i].x2;
@@ -80,10 +80,10 @@ void wlr_region_transform(pixman_region32_t *dst, pixman_region32_t *src,
 			dst_rects[i].y2 = src_rects[i].y2;
 			break;
 		case WL_OUTPUT_TRANSFORM_FLIPPED_90:
-			dst_rects[i].x1 = height - src_rects[i].y2;
-			dst_rects[i].y1 = width - src_rects[i].x2;
-			dst_rects[i].x2 = height - src_rects[i].y1;
-			dst_rects[i].y2 = width - src_rects[i].x1;
+			dst_rects[i].x1 = src_rects[i].y1;
+			dst_rects[i].y1 = src_rects[i].x1;
+			dst_rects[i].x2 = src_rects[i].y2;
+			dst_rects[i].y2 = src_rects[i].x2;
 			break;
 		case WL_OUTPUT_TRANSFORM_FLIPPED_180:
 			dst_rects[i].x1 = src_rects[i].x1;
@@ -92,10 +92,10 @@ void wlr_region_transform(pixman_region32_t *dst, pixman_region32_t *src,
 			dst_rects[i].y2 = height - src_rects[i].y1;
 			break;
 		case WL_OUTPUT_TRANSFORM_FLIPPED_270:
-			dst_rects[i].x1 = src_rects[i].y1;
-			dst_rects[i].y1 = src_rects[i].x1;
-			dst_rects[i].x2 = src_rects[i].y2;
-			dst_rects[i].y2 = src_rects[i].x2;
+			dst_rects[i].x1 = height - src_rects[i].y2;
+			dst_rects[i].y1 = width - src_rects[i].x2;
+			dst_rects[i].x2 = height - src_rects[i].y1;
+			dst_rects[i].y2 = width - src_rects[i].x1;
 			break;
 		}
 	}


### PR DESCRIPTION
See https://gitlab.freedesktop.org/wayland/weston/issues/99 for motivation. I also found and fixed a small issue in `wlr_output_transform_compose` when composing transforms with flips and rotations.

This change breaks forward compatibility for past versions of wlroots; for example, upgrading wlroots with a corresponding patch, without upgrading sway, could change monitor orientations for anyone using sway's https://github.com/swaywm/sway/blob/master/sway/commands/output/transform.c .

I have tested these changes using ~the wlroots example `rotation` compositor~ and `swaymsg output eDP-1 transform flipped-90 clockwise`, and by patching an image display program to call wl_surface::set_buffer_transform() with a given value.

* * *

Breaking change: output transformations have been aligned with the Wayland protocol's definition