### PR TITLE
Keyboard shortcuts inhibit

### DIFF
--- a/examples/keyboard-shortcuts-inhibit.c
+++ b/examples/keyboard-shortcuts-inhibit.c
@@ -1,0 +1,263 @@
+#include <GLES2/gl2.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wayland-client.h>
+#include <wayland-egl.h>
+#include <wlr/render/egl.h>
+#include "keyboard-shortcuts-inhibit-unstable-v1-client-protocol.h"
+#include "xdg-shell-client-protocol.h"
+
+#include <linux/input-event-codes.h>
+
+/**
+ * Usage: keyboard-shortcuts-inhibit
+ * Creates a xdg-toplevel using the keyboard-shortcuts-inhibit protocol.
+ * It will be solid green, when it has an keyboard shortcuts inhibitor, and
+ * solid yellow if it does not.
+ * Left click with a pointer will toggle this state. (Touch is not supported
+ * for now).
+ * The compositor (de-)activating the inhibitor will also toggle state.
+ * With a compositor supporting the protocol, compositor shortcuts will be
+ * suspended while the inhibitor is active and the window has focus.
+ */
+
+static int width = 500, height = 300;
+
+static struct wl_compositor *compositor = NULL;
+static struct wl_seat *seat = NULL;
+static struct xdg_wm_base *wm_base = NULL;
+static struct zwp_keyboard_shortcuts_inhibit_manager_v1 *
+	keyboard_shortcuts_inhibit_manager = NULL;
+static struct zwp_keyboard_shortcuts_inhibitor_v1 *
+	keyboard_shortcuts_inhibitor = NULL;
+static bool active = false;
+
+struct wlr_egl egl;
+struct wl_egl_window *egl_window;
+struct wlr_egl_surface *egl_surface;
+
+static void draw(void) {
+	eglMakeCurrent(egl.display, egl_surface, egl_surface, egl.context);
+
+	float color[] = {1.0, 1.0, 0.0, 1.0};
+	if (keyboard_shortcuts_inhibitor) {
+		color[0] = 0.0;
+	}
+
+	glViewport(0, 0, width, height);
+	glClearColor(color[0], color[1], color[2], 1.0);
+	glClear(GL_COLOR_BUFFER_BIT);
+
+	eglSwapBuffers(egl.display, egl_surface);
+}
+
+static void keyboard_shortcuts_inhibit_handle_active(void *data,
+		struct zwp_keyboard_shortcuts_inhibitor_v1 *
+			zwp_keyboard_shortcuts_inhibitor_v1) {
+	active = 1;
+	draw();
+}
+
+static void keyboard_shortcuts_inhibit_handle_inactive(void *data,
+		struct zwp_keyboard_shortcuts_inhibitor_v1 *
+			zwp_keyboard_shortcuts_inhibitor_v1) {
+	active = 0;
+	draw();
+}
+
+static const struct zwp_keyboard_shortcuts_inhibitor_v1_listener
+keyboard_shortcuts_inhibitor_listener = {
+	.active = keyboard_shortcuts_inhibit_handle_active,
+	.inactive = keyboard_shortcuts_inhibit_handle_inactive,
+};
+
+static void pointer_handle_button(void *data, struct wl_pointer *pointer, uint32_t serial,
+		uint32_t time, uint32_t button, uint32_t state_w) {
+	struct wl_surface *surface = data;
+
+	if (button == BTN_LEFT && state_w == WL_POINTER_BUTTON_STATE_PRESSED) {
+		if (keyboard_shortcuts_inhibitor) {
+			zwp_keyboard_shortcuts_inhibitor_v1_destroy(
+					keyboard_shortcuts_inhibitor);
+			keyboard_shortcuts_inhibitor = NULL;
+			active = false;
+		} else {
+			keyboard_shortcuts_inhibitor =
+				zwp_keyboard_shortcuts_inhibit_manager_v1_inhibit_shortcuts(
+					keyboard_shortcuts_inhibit_manager, surface, seat);
+			zwp_keyboard_shortcuts_inhibitor_v1_add_listener(
+					keyboard_shortcuts_inhibitor,
+					&keyboard_shortcuts_inhibitor_listener, NULL);
+		}
+	}
+
+	draw();
+}
+
+static void pointer_handle_enter(void *data, struct wl_pointer *wl_pointer,
+		uint32_t serial, struct wl_surface *surface,
+		wl_fixed_t surface_x, wl_fixed_t surface_y) {
+	// This space intentionally left blank
+}
+
+static void pointer_handle_leave(void *data, struct wl_pointer *wl_pointer,
+		uint32_t serial, struct wl_surface *surface) {
+	// This space intentionally left blank
+}
+
+static void pointer_handle_motion(void *data, struct wl_pointer *wl_pointer,
+		uint32_t time, wl_fixed_t surface_x, wl_fixed_t surface_y) {
+	// This space intentionally left blank
+}
+
+static void pointer_handle_axis(void *data, struct wl_pointer *wl_pointer,
+		uint32_t time, uint32_t axis, wl_fixed_t value) {
+	// This space intentionally left blank
+}
+
+static void pointer_handle_frame(void *data, struct wl_pointer *wl_pointer) {
+	// This space intentionally left blank
+}
+
+static void pointer_handle_axis_source(void *data,
+		struct wl_pointer *wl_pointer, uint32_t axis_source) {
+	// This space intentionally left blank
+}
+
+static void pointer_handle_axis_stop(void *data,
+		struct wl_pointer *wl_pointer, uint32_t time, uint32_t axis) {
+	// This space intentionally left blank
+}
+
+static void pointer_handle_axis_discrete(void *data,
+		struct wl_pointer *wl_pointer, uint32_t axis, int32_t discrete) {
+	// This space intentionally left blank
+}
+
+static const struct wl_pointer_listener pointer_listener = {
+	.enter = pointer_handle_enter,
+	.leave = pointer_handle_leave,
+	.motion = pointer_handle_motion,
+	.button = pointer_handle_button,
+	.axis = pointer_handle_axis,
+	.frame = pointer_handle_frame,
+	.axis_source = pointer_handle_axis_source,
+	.axis_stop = pointer_handle_axis_stop,
+	.axis_discrete = pointer_handle_axis_discrete,
+};
+
+static void xdg_surface_handle_configure(void *data,
+		struct xdg_surface *xdg_surface, uint32_t serial) {
+	xdg_surface_ack_configure(xdg_surface, serial);
+	wl_egl_window_resize(egl_window, width, height, 0, 0);
+	draw();
+}
+
+static const struct xdg_surface_listener xdg_surface_listener = {
+	.configure = xdg_surface_handle_configure,
+};
+
+static void xdg_toplevel_handle_configure(void *data,
+		struct xdg_toplevel *xdg_toplevel, int32_t w, int32_t h,
+		struct wl_array *states) {
+	width = w;
+	height = h;
+}
+
+static void xdg_toplevel_handle_close(void *data,
+		struct xdg_toplevel *xdg_toplevel) {
+	exit(EXIT_SUCCESS);
+}
+
+static const struct xdg_toplevel_listener xdg_toplevel_listener = {
+	.configure = xdg_toplevel_handle_configure,
+	.close = xdg_toplevel_handle_close,
+};
+
+static void handle_global(void *data, struct wl_registry *registry,
+		uint32_t name, const char *interface, uint32_t version) {
+	if (strcmp(interface, "wl_compositor") == 0) {
+		compositor = wl_registry_bind(registry, name,
+			&wl_compositor_interface, 1);
+	} else if (strcmp(interface, xdg_wm_base_interface.name) == 0) {
+		wm_base = wl_registry_bind(registry, name, &xdg_wm_base_interface, 1);
+	} else if (strcmp(interface, zwp_keyboard_shortcuts_inhibit_manager_v1_interface.name) == 0) {
+		keyboard_shortcuts_inhibit_manager = wl_registry_bind(registry, name,
+			&zwp_keyboard_shortcuts_inhibit_manager_v1_interface, 1);
+	} else if (strcmp(interface, wl_seat_interface.name) == 0) {
+		seat = wl_registry_bind(registry, name, &wl_seat_interface, version);
+	}
+}
+
+static void handle_global_remove(void *data, struct wl_registry *registry,
+		uint32_t name) {
+	// who cares
+}
+
+static const struct wl_registry_listener registry_listener = {
+	.global = handle_global,
+	.global_remove = handle_global_remove,
+};
+
+int main(int argc, char **argv) {
+	struct wl_display *display = wl_display_connect(NULL);
+	if (display == NULL) {
+		fprintf(stderr, "Failed to create display\n");
+		return EXIT_FAILURE;
+	}
+
+	struct wl_registry *registry = wl_display_get_registry(display);
+	wl_registry_add_listener(registry, &registry_listener, NULL);
+	wl_display_dispatch(display);
+	wl_display_roundtrip(display);
+
+	if (compositor == NULL) {
+		fprintf(stderr, "wl-compositor not available\n");
+		return EXIT_FAILURE;
+	}
+	if (wm_base == NULL) {
+		fprintf(stderr, "xdg-shell not available\n");
+		return EXIT_FAILURE;
+	}
+	if (keyboard_shortcuts_inhibit_manager == NULL) {
+		fprintf(stderr, "keyboard-shortcuts-inhibit not available\n");
+		return EXIT_FAILURE;
+	}
+
+	wlr_egl_init(&egl, EGL_PLATFORM_WAYLAND_EXT, display, NULL,
+		WL_SHM_FORMAT_ARGB8888);
+
+	struct wl_surface *surface = wl_compositor_create_surface(compositor);
+	struct xdg_surface *xdg_surface =
+		xdg_wm_base_get_xdg_surface(wm_base, surface);
+	struct xdg_toplevel *xdg_toplevel = xdg_surface_get_toplevel(xdg_surface);
+
+	struct wl_pointer *pointer = wl_seat_get_pointer(seat);
+	wl_pointer_add_listener(pointer, &pointer_listener, surface);
+
+	xdg_surface_add_listener(xdg_surface, &xdg_surface_listener, NULL);
+	xdg_toplevel_add_listener(xdg_toplevel, &xdg_toplevel_listener, NULL);
+
+	wl_surface_commit(surface);
+
+	egl_window = wl_egl_window_create(surface, width, height);
+	egl_surface = wlr_egl_create_surface(&egl, egl_window);
+
+	wl_display_roundtrip(display);
+
+	keyboard_shortcuts_inhibitor =
+		zwp_keyboard_shortcuts_inhibit_manager_v1_inhibit_shortcuts(
+				keyboard_shortcuts_inhibit_manager, surface, seat);
+	zwp_keyboard_shortcuts_inhibitor_v1_add_listener(
+			keyboard_shortcuts_inhibitor,
+			&keyboard_shortcuts_inhibitor_listener, NULL);
+
+	draw();
+
+	while (wl_display_dispatch(display) != -1) {
+		// This space intentionally left blank
+	}
+
+	return EXIT_SUCCESS;
+}

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -60,6 +60,14 @@ clients = {
 			'xdg-shell',
 		],
 	},
+	'keyboard-shortcuts-inhibit': {
+		'src': 'keyboard-shortcuts-inhibit.c',
+		'dep': [wayland_cursor, wlroots],
+		'proto': [
+			'keyboard-shortcuts-inhibit-unstable-v1',
+			'xdg-shell',
+		],
+	},
 	'layer-shell': {
 		'src': 'layer-shell.c',
 		'dep': [wayland_cursor, wlroots],

--- a/include/wlr/types/wlr_keyboard_shortcuts_inhibit_v1.h
+++ b/include/wlr/types/wlr_keyboard_shortcuts_inhibit_v1.h
@@ -1,0 +1,85 @@
+/*
+ * This an unstable interface of wlroots. No guarantees are made regarding the
+ * future consistency of this API.
+ */
+#ifndef WLR_USE_UNSTABLE
+#error "Add -DWLR_USE_UNSTABLE to enable unstable wlroots features"
+#endif
+
+#ifndef WLR_TYPES_WLR_KEYBOARD_SHORTCUTS_INHIBIT_V1_H
+#define WLR_TYPES_WLR_KEYBOARD_SHORTCUTS_INHIBIT_V1_H
+
+#include <wayland-server-core.h>
+#include <wlr/types/wlr_seat.h>
+
+/* This interface permits clients to inhibit keyboard shortcut processing by
+ * the compositor.
+ *
+ * This allows clients to pass them on to e.g. remote desktops or virtual
+ * machine guests.
+ *
+ * Inhibitors are created for surfaces and seats. They should only be in effect
+ * while this surface has focus.
+ */
+
+struct wlr_keyboard_shortcuts_inhibit_manager_v1 {
+	// wlr_keyboard_shortcuts_inhibitor_v1::link
+	struct wl_list inhibitors;
+	struct wl_global *global;
+
+	struct wl_listener display_destroy;
+
+	struct {
+		struct wl_signal new_inhibitor;	// wlr_keyboard_shortcuts_inhibitor_v1
+		struct wl_signal destroy;
+	} events;
+
+	void *data;
+};
+
+struct wlr_keyboard_shortcuts_inhibitor_v1 {
+	struct wlr_surface *surface;
+	struct wlr_seat *seat;
+	bool active;
+	struct wl_resource *resource;
+
+	struct wl_listener surface_destroy;
+	struct wl_listener seat_destroy;
+
+	// wlr_keyboard_shortcuts_inhibit_manager_v1::inhibitors
+	struct wl_list link;
+
+	struct {
+		struct wl_signal destroy;
+	} events;
+
+	void *data;
+};
+
+/*
+ * A compositor creating a manager will handle the new_inhibitor event and call
+ * wlr_keyboard_shortcuts_inhibitor_v1_activate() if it decides to honour the
+ * inhibitor. This will send the active event to the client, confirming
+ * activation of the inhibitor. From then on the compositor should respect the
+ * inhibitor until it calls wlr_keyboard_shortcuts_inhibitor_v1_deactivate() to
+ * suspend the inhibitor with an inactive event to the client or receives the
+ * destroy signal from wlroots, telling it that the inhibitor has been
+ * destroyed.
+ *
+ * Not sending the active event to the client is the only way under the
+ * protocol to let the client know that the compositor will not be honouring an
+ * inhibitor. It's the client's job to somehow deal with not receiving the
+ * event, i.e. not assume that shortcuts are inhibited and maybe destroy the
+ * pending and request a new inhibitor after a timeout.
+ */
+
+struct wlr_keyboard_shortcuts_inhibit_manager_v1 *
+wlr_keyboard_shortcuts_inhibit_v1_create(struct wl_display *display);
+
+void wlr_keyboard_shortcuts_inhibitor_v1_activate(
+	struct wlr_keyboard_shortcuts_inhibitor_v1 *inhibitor);
+
+void wlr_keyboard_shortcuts_inhibitor_v1_deactivate(
+	struct wlr_keyboard_shortcuts_inhibitor_v1 *inhibitor);
+
+#endif

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -17,6 +17,7 @@ protocols = {
 	# Unstable upstream protocols
 	'fullscreen-shell-unstable-v1': wl_protocol_dir / 'unstable/fullscreen-shell/fullscreen-shell-unstable-v1.xml',
 	'idle-inhibit-unstable-v1': wl_protocol_dir / 'unstable/idle-inhibit/idle-inhibit-unstable-v1.xml',
+	'keyboard-shortcuts-inhibit-unstable-v1': wl_protocol_dir / 'unstable/keyboard-shortcuts-inhibit/keyboard-shortcuts-inhibit-unstable-v1.xml',
 	'linux-dmabuf-unstable-v1': wl_protocol_dir / 'unstable/linux-dmabuf/linux-dmabuf-unstable-v1.xml',
 	'pointer-constraints-unstable-v1': wl_protocol_dir / 'unstable/pointer-constraints/pointer-constraints-unstable-v1.xml',
 	'pointer-gestures-unstable-v1': wl_protocol_dir / 'unstable/pointer-gestures/pointer-gestures-unstable-v1.xml',

--- a/types/meson.build
+++ b/types/meson.build
@@ -38,6 +38,7 @@ wlr_files += files(
 	'wlr_input_method_v2.c',
 	'wlr_keyboard.c',
 	'wlr_keyboard_group.c',
+	'wlr_keyboard_shortcuts_inhibit_v1.c',
 	'wlr_layer_shell_v1.c',
 	'wlr_linux_dmabuf_v1.c',
 	'wlr_list.c',

--- a/types/wlr_keyboard_shortcuts_inhibit_v1.c
+++ b/types/wlr_keyboard_shortcuts_inhibit_v1.c
@@ -1,0 +1,227 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <util/signal.h>
+#include <wlr/types/wlr_keyboard_shortcuts_inhibit_v1.h>
+#include "keyboard-shortcuts-inhibit-unstable-v1-protocol.h"
+
+static const struct zwp_keyboard_shortcuts_inhibit_manager_v1_interface
+	keyboard_shortcuts_inhibit_impl;
+
+static const struct zwp_keyboard_shortcuts_inhibitor_v1_interface
+	keyboard_shortcuts_inhibitor_impl;
+
+static struct wlr_keyboard_shortcuts_inhibit_manager_v1 *
+wlr_keyboard_shortcuts_inhibit_manager_v1_from_resource(
+		struct wl_resource *manager_resource) {
+	assert(wl_resource_instance_of(manager_resource,
+		&zwp_keyboard_shortcuts_inhibit_manager_v1_interface,
+		&keyboard_shortcuts_inhibit_impl));
+	return wl_resource_get_user_data(manager_resource);
+}
+
+static struct wlr_keyboard_shortcuts_inhibitor_v1 *
+wlr_keyboard_shortcuts_inhibitor_v1_from_resource(
+		struct wl_resource *inhibitor_resource) {
+	assert(wl_resource_instance_of(inhibitor_resource,
+		&zwp_keyboard_shortcuts_inhibitor_v1_interface,
+		&keyboard_shortcuts_inhibitor_impl));
+	return wl_resource_get_user_data(inhibitor_resource);
+}
+
+static void keyboard_shortcuts_inhibitor_v1_destroy(
+		struct wlr_keyboard_shortcuts_inhibitor_v1 *inhibitor) {
+	if (!inhibitor) {
+		return;
+	}
+
+	wlr_signal_emit_safe(&inhibitor->events.destroy, inhibitor);
+
+	wl_resource_set_user_data(inhibitor->resource, NULL);
+	wl_list_remove(&inhibitor->link);
+	wl_list_remove(&inhibitor->surface_destroy.link);
+	wl_list_remove(&inhibitor->seat_destroy.link);
+	free(inhibitor);
+}
+
+static void keyboard_shortcuts_inhibitor_v1_handle_resource_destroy(
+		struct wl_resource *inhibitor_resource) {
+	struct wlr_keyboard_shortcuts_inhibitor_v1 *inhibitor =
+		wlr_keyboard_shortcuts_inhibitor_v1_from_resource(
+				inhibitor_resource);
+	keyboard_shortcuts_inhibitor_v1_destroy(inhibitor);
+}
+
+static void keyboard_shortcuts_inhibitor_handle_surface_destroy(
+		struct wl_listener *listener, void *data) {
+	struct wlr_keyboard_shortcuts_inhibitor_v1 *inhibitor =
+		wl_container_of(listener, inhibitor, surface_destroy);
+
+	// be gracious and notify client that destruction of a referenced
+	// resource makes inhibitor moot
+	wlr_keyboard_shortcuts_inhibitor_v1_deactivate(inhibitor);
+	keyboard_shortcuts_inhibitor_v1_destroy(inhibitor);
+}
+
+static void keyboard_shortcuts_inhibitor_handle_seat_destroy(
+		struct wl_listener *listener, void *data) {
+	struct wlr_keyboard_shortcuts_inhibitor_v1 *inhibitor =
+		wl_container_of(listener, inhibitor, seat_destroy);
+	wlr_keyboard_shortcuts_inhibitor_v1_deactivate(inhibitor);
+	keyboard_shortcuts_inhibitor_v1_destroy(inhibitor);
+}
+
+static void keyboard_shortcuts_inhibitor_v1_handle_destroy(
+		struct wl_client *client,
+		struct wl_resource *inhibitor_resource) {
+	wl_resource_destroy(inhibitor_resource);
+}
+
+static const struct zwp_keyboard_shortcuts_inhibitor_v1_interface
+keyboard_shortcuts_inhibitor_impl = {
+	.destroy = keyboard_shortcuts_inhibitor_v1_handle_destroy,
+};
+
+static void manager_handle_inhibit_shortcuts(struct wl_client *client,
+		struct wl_resource *manager_resource, uint32_t id,
+		struct wl_resource *surface_resource,
+		struct wl_resource *seat_resource) {
+	struct wlr_surface *surface =
+		wlr_surface_from_resource(surface_resource);
+	struct wlr_seat_client *seat_client =
+		wlr_seat_client_from_resource(seat_resource);
+	struct wlr_keyboard_shortcuts_inhibit_manager_v1 *manager =
+		wlr_keyboard_shortcuts_inhibit_manager_v1_from_resource(
+				manager_resource);
+
+	struct wlr_seat *seat = seat_client->seat;
+	struct wlr_keyboard_shortcuts_inhibitor_v1 *existing_inhibitor;
+	wl_list_for_each(existing_inhibitor, &manager->inhibitors, link) {
+		if (existing_inhibitor->surface != surface ||
+				existing_inhibitor->seat != seat) {
+			continue;
+		}
+
+		wl_resource_post_error(manager_resource,
+			ZWP_KEYBOARD_SHORTCUTS_INHIBIT_MANAGER_V1_ERROR_ALREADY_INHIBITED,
+			"this surface already has keyboard shortcuts "
+			"inhibited on this seat");
+		return;
+	}
+
+	struct wlr_keyboard_shortcuts_inhibitor_v1 *inhibitor =
+		calloc(1, sizeof(struct wlr_keyboard_shortcuts_inhibitor_v1));
+	if (!inhibitor) {
+		wl_client_post_no_memory(client);
+		return;
+	}
+
+	uint32_t version = wl_resource_get_version(manager_resource);
+	struct wl_resource *inhibitor_resource = wl_resource_create(client,
+		&zwp_keyboard_shortcuts_inhibitor_v1_interface, version, id);
+	if (!inhibitor_resource) {
+		wl_client_post_no_memory(client);
+		free(inhibitor);
+		return;
+	}
+
+	inhibitor->resource = inhibitor_resource;
+	inhibitor->surface = surface;
+	inhibitor->seat = seat;
+	inhibitor->active = false;
+	wl_signal_init(&inhibitor->events.destroy);
+
+	inhibitor->surface_destroy.notify =
+		keyboard_shortcuts_inhibitor_handle_surface_destroy;
+	wl_signal_add(&surface->events.destroy, &inhibitor->surface_destroy);
+
+	inhibitor->seat_destroy.notify =
+		keyboard_shortcuts_inhibitor_handle_seat_destroy;
+	wl_signal_add(&seat->events.destroy, &inhibitor->seat_destroy);
+
+	wl_resource_set_implementation(inhibitor_resource,
+		&keyboard_shortcuts_inhibitor_impl, inhibitor,
+		keyboard_shortcuts_inhibitor_v1_handle_resource_destroy);
+
+	wl_list_insert(&manager->inhibitors, &inhibitor->link);
+	wlr_signal_emit_safe(&manager->events.new_inhibitor, inhibitor);
+}
+
+static void manager_handle_destroy(struct wl_client *client,
+		struct wl_resource *manager_resource) {
+	wl_resource_destroy(manager_resource);
+}
+
+static const struct zwp_keyboard_shortcuts_inhibit_manager_v1_interface
+keyboard_shortcuts_inhibit_impl = {
+	.destroy = manager_handle_destroy,
+	.inhibit_shortcuts = manager_handle_inhibit_shortcuts,
+};
+
+static void handle_display_destroy(struct wl_listener *listener, void *data) {
+	struct wlr_keyboard_shortcuts_inhibit_manager_v1 *manager =
+		wl_container_of(listener, manager, display_destroy);
+	wlr_signal_emit_safe(&manager->events.destroy, manager);
+	wl_list_remove(&manager->display_destroy.link);
+	wl_global_destroy(manager->global);
+	free(manager);
+}
+
+static void keyboard_shortcuts_inhibit_bind(struct wl_client *wl_client,
+		void *data, uint32_t version, uint32_t id) {
+	struct wlr_keyboard_shortcuts_inhibit_manager_v1 *manager = data;
+
+	struct wl_resource *manager_resource = wl_resource_create(wl_client,
+		&zwp_keyboard_shortcuts_inhibit_manager_v1_interface,
+		version, id);
+	if (!manager_resource) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+
+	wl_resource_set_implementation(manager_resource,
+		&keyboard_shortcuts_inhibit_impl, manager, NULL);
+}
+
+struct wlr_keyboard_shortcuts_inhibit_manager_v1 *
+wlr_keyboard_shortcuts_inhibit_v1_create(struct wl_display *display) {
+	struct wlr_keyboard_shortcuts_inhibit_manager_v1 *manager =
+		calloc(1, sizeof(struct wlr_keyboard_shortcuts_inhibit_manager_v1));
+	if (!manager) {
+		return NULL;
+	}
+
+	wl_list_init(&manager->inhibitors);
+	wl_signal_init(&manager->events.new_inhibitor);
+	wl_signal_init(&manager->events.destroy);
+
+	manager->global = wl_global_create(display,
+		&zwp_keyboard_shortcuts_inhibit_manager_v1_interface, 1,
+		manager, keyboard_shortcuts_inhibit_bind);
+	if (!manager->global) {
+		free(manager);
+		return NULL;
+	}
+
+	manager->display_destroy.notify = handle_display_destroy;
+	wl_display_add_destroy_listener(display, &manager->display_destroy);
+
+	return manager;
+}
+
+void wlr_keyboard_shortcuts_inhibitor_v1_activate(
+		struct wlr_keyboard_shortcuts_inhibitor_v1 *inhibitor) {
+	if (!inhibitor->active) {
+		zwp_keyboard_shortcuts_inhibitor_v1_send_active(
+				inhibitor->resource);
+		inhibitor->active = true;
+	}
+}
+
+void wlr_keyboard_shortcuts_inhibitor_v1_deactivate(
+		struct wlr_keyboard_shortcuts_inhibitor_v1 *inhibitor) {
+	if (inhibitor->active) {
+		zwp_keyboard_shortcuts_inhibitor_v1_send_inactive(
+				inhibitor->resource);
+		inhibitor->active = false;
+	}
+}


### PR DESCRIPTION
The keyboard shortcuts inhibitor protocol is useful for remote desktop
and virtualization software in order to request all keyboard events to
be passed to it and (almost) none being resonded to by the compositor.
This allows the session at the other end of the remote desktop
connection or inside the virtual machine to be interacted with as usual
(e.g. Alt+Tab to switch windows on the remote system instead of
locally).

Add the wayland protocol to the meson build files.

Copy'n'search'n'replace the very similar idle inhibit protocol
implementation. This already provides all the basic functionality:
- creating and destroying inhibitors upon request by a client,
- destruction in reaction to destruction of surfaces or displays,
- a list of inhibitors to search through for existing ones as well as
- a signal to be sent to the compositor upon registration of a new
  inhibitor.

Beyond that we add the active and inactive events to be sent to the
client and wire those to activate and deactivate functions for the
compositor to call in confirmation of activation of a new inhibitor or
(un-)suspending of an existing inhibitor e.g. in response to a special
key combination entered by the user as suggested by the protocol.

As mandated by the protocol, we check the existance of an inhibitor for
a given surface and seat upon creation and return the error provided by
the protocol for that purpose.

~~As an optimisation we add a list of per-surface inhibitors to
wlr_surface and a helper that looks up the inhibitor for a given seat
and surface based on the focused surface being tracked in the seat's
keyboard. This is done on the assumption that most compositors will want
to know if the surface keyboard input would currently be sent to if it
wasn't interpreted as compositor shortcuts has an inhibitor attached.
This also avoids passing the inhibitor manager around to all the places
such a check would be needed and then searching the list of all
registered inhibitors.~~

Again, copy'n'search'n'replace the idle inhibit example to become a
simple keyboard shortcuts inhibit example, adding the active and
inactive events.
