### PR TITLE
backend/session: allow GPU enumeration on FreeBSD

### DIFF
--- a/backend/session/session.c
+++ b/backend/session/session.c
@@ -288,11 +288,6 @@ size_t wlr_session_find_gpus(struct wlr_session *session,
 		return explicit_find_gpus(session, ret_len, ret, explicit);
 	}
 
-#ifdef __FreeBSD__
-	// XXX: libudev-devd does not return any GPUs (yet?)
-	return explicit_find_gpus(session, ret_len, ret, "/dev/drm/0");
-#else
-
 	struct udev_enumerate *en = udev_enumerate_new(session->udev);
 	if (!en) {
 		wlr_log(WLR_ERROR, "Failed to create udev enumeration");
@@ -360,5 +355,4 @@ size_t wlr_session_find_gpus(struct wlr_session *session,
 	udev_enumerate_unref(en);
 
 	return i;
-#endif
 }


### PR DESCRIPTION
Depends on https://github.com/FreeBSDDesktop/libudev-devd/pull/7 ([D23715](https://reviews.freebsd.org/D23715) in ports). CC @myfreeweb, @zeising