### PR TITLE
meson.build: update wayland requirement to 1.18

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -95,7 +95,7 @@ if cc.get_id() == 'clang'
 	add_project_arguments('-Wno-missing-braces', language: 'c')
 endif
 
-wayland_server = dependency('wayland-server', version: '>=1.17')
+wayland_server = dependency('wayland-server', version: '>=1.18')
 wayland_client = dependency('wayland-client')
 wayland_egl = dependency('wayland-egl')
 wayland_protos = dependency('wayland-protocols', version: '>=1.17')


### PR DESCRIPTION
This updates the version requirement for wayland-server to 1.18, which
is needed for wl_global_remove and wl_global_set_user_data