### PR TITLE
output-management: add current_configuration_dirty

### DIFF
--- a/include/wlr/types/wlr_output_management_v1.h
+++ b/include/wlr/types/wlr_output_management_v1.h
@@ -20,6 +20,7 @@ struct wlr_output_manager_v1 {
 
 	struct wl_list heads; // wlr_output_head_v1::link
 	uint32_t serial;
+	bool current_configuration_dirty;
 
 	struct {
 		/**

--- a/types/wlr_output_management_v1.c
+++ b/types/wlr_output_management_v1.c
@@ -57,6 +57,7 @@ static void head_handle_output_destroy(struct wl_listener *listener,
 		void *data) {
 	struct wlr_output_head_v1 *head =
 		wl_container_of(listener, head, output_destroy);
+	head->manager->current_configuration_dirty = true;
 	head_destroy(head);
 }
 
@@ -817,7 +818,7 @@ static bool manager_update_head(struct wlr_output_manager_v1 *manager,
 void wlr_output_manager_v1_set_configuration(
 		struct wlr_output_manager_v1 *manager,
 		struct wlr_output_configuration_v1 *config) {
-	bool changed = false;
+	bool changed = manager->current_configuration_dirty;
 
 	// Either update or destroy existing heads
 	struct wlr_output_head_v1 *existing_head, *head_tmp;
@@ -868,4 +869,5 @@ void wlr_output_manager_v1_set_configuration(
 		zwlr_output_manager_v1_send_done(manager_resource,
 			manager->serial);
 	}
+	manager->current_configuration_dirty = false;
 }


### PR DESCRIPTION
Previously, if the current configuration contains an output X which is destroyed, its head is automatically removed. If the compositor submits the new configuration after X was removed, the current output configuration is incorrectly detected to be the same as the previous one, and no done event is sent. To prevent this, we can just keep track of whether the current configuration is dirty, i.e whether we have sent a done event for it.