### PR TITLE
xwayland: ignore pointer focus changes

### DIFF
--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -1231,6 +1231,10 @@ static void xwm_handle_focus_in(struct wlr_xwm *xwm,
 			ev->mode == XCB_NOTIFY_MODE_UNGRAB) {
 		return;
 	}
+	// Ignore pointer focus change events
+	if (ev->detail == XCB_NOTIFY_DETAIL_POINTER) {
+		return;
+	}
 
 	// Do not let X clients change the focus behind the compositor's
 	// back. Reset the focus to the old one if it changed.


### PR DESCRIPTION
This reflects what i3 does [1].

[1]: https://github.com/i3/i3/blob/b3faf9fca9254679a4715486a4de80ebaee70410/src/handlers.c#L1076

Fixes: c067fbc010da ("xwm: allow applications to change focus between their own surfaces")
Closes: https://github.com/swaywm/sway/issues/4926