### PR TITLE
text_input_v3: Note features supported by the text field

### DIFF
--- a/include/wlr/types/wlr_text_input_v3.h
+++ b/include/wlr/types/wlr_text_input_v3.h
@@ -13,6 +13,12 @@
 #include <wlr/types/wlr_seat.h>
 #include <wlr/types/wlr_surface.h>
 
+enum wlr_text_input_v3_features {
+	WLR_TEXT_INPUT_V3_FEATURE_SURROUNDING_TEXT = 1 << 0,
+	WLR_TEXT_INPUT_v3_FEATURE_CONTENT_TYPE = 1 << 1,
+	WLR_TEXT_INPUT_V3_FEATURE_CURSOR_RECTANGLE = 1 << 2,
+};
+
 struct wlr_text_input_v3_state {
 	struct {
 		char *text; // NULL is allowed and equivalent to empty string
@@ -33,6 +39,10 @@ struct wlr_text_input_v3_state {
 		int32_t width;
 		int32_t height;
 	} cursor_rectangle;
+
+	// Tracks which features were used in the current commit.
+	// Useful in the enabling commit, where usage means support.
+	uint32_t features; // OR'ed wlr_text_input_v3_features
 };
 
 struct wlr_text_input_v3 {
@@ -44,6 +54,8 @@ struct wlr_text_input_v3 {
 	uint32_t current_serial; // next in line to send
 	bool pending_enabled;
 	bool current_enabled;
+	// supported in the current text input, more granular than surface
+	uint32_t active_features; // OR'ed wlr_text_input_v3_features
 
 	struct wl_list link;
 

--- a/types/wlr_text_input_v3.c
+++ b/types/wlr_text_input_v3.c
@@ -121,7 +121,7 @@ static void text_input_set_surrounding_text(struct wl_client *client,
 	if (!text_input->pending.surrounding.text) {
 		wl_client_post_no_memory(client);
 	}
-
+	text_input->pending.features |= WLR_TEXT_INPUT_V3_FEATURE_SURROUNDING_TEXT;
 	text_input->pending.surrounding.cursor = cursor;
 	text_input->pending.surrounding.anchor = anchor;
 }
@@ -141,6 +141,7 @@ static void text_input_set_content_type(struct wl_client *client,
 	if (!text_input) {
 		return;
 	}
+	text_input->pending.features |= WLR_TEXT_INPUT_v3_FEATURE_CONTENT_TYPE;
 	text_input->pending.content_type.hint = hint;
 	text_input->pending.content_type.purpose = purpose;
 }
@@ -152,6 +153,7 @@ static void text_input_set_cursor_rectangle(struct wl_client *client,
 	if (!text_input) {
 		return;
 	}
+	text_input->pending.features |= WLR_TEXT_INPUT_V3_FEATURE_CURSOR_RECTANGLE;
 	text_input->pending.cursor_rectangle.x = x;
 	text_input->pending.cursor_rectangle.y = y;
 	text_input->pending.cursor_rectangle.width = width;
@@ -180,8 +182,10 @@ static void text_input_commit(struct wl_client *client,
 	}
 
 	if (!old_enabled && text_input->current_enabled) {
+		text_input->active_features	= text_input->current.features;
 		wlr_signal_emit_safe(&text_input->events.enable, text_input);
 	} else if (old_enabled && !text_input->current_enabled) {
+		text_input->active_features	= 0;
 		wlr_signal_emit_safe(&text_input->events.disable, text_input);
 	} else { // including never enabled
 		wlr_signal_emit_safe(&text_input->events.commit, text_input);


### PR DESCRIPTION
With this information, consumers can realize they will never retrieve some state, and adjust their strategy.

---

The protocol specifies that features are either supported or unsupported, so while the API user is able to determine this by the received calls, this functionality will be required by pretty much every API user in exactly the same form, so it makes sense to make it available here.