### PR TITLE
renderer: Add an ability to render to texture

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -888,7 +888,7 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 		float matrix[9];
 		wlr_matrix_project_box(matrix, &cursor_box, transform, 0, plane->matrix);
 
-		wlr_renderer_begin(rend, plane->surf.width, plane->surf.height);
+		wlr_renderer_begin(rend, plane->surf.width, plane->surf.height, NULL);
 		wlr_renderer_clear(rend, (float[]){ 0.0, 0.0, 0.0, 0.0 });
 		wlr_render_texture_with_matrix(rend, texture, matrix, 1.0);
 		wlr_renderer_end(rend);

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -162,7 +162,7 @@ struct gbm_bo *get_drm_surface_front(struct wlr_drm_surface *surf) {
 
 	make_drm_surface_current(surf, NULL);
 	struct wlr_renderer *renderer = surf->renderer->wlr_rend;
-	wlr_renderer_begin(renderer, surf->width, surf->height);
+	wlr_renderer_begin(renderer, surf->width, surf->height, NULL);
 	wlr_renderer_clear(renderer, (float[]){ 0.0, 0.0, 0.0, 1.0 });
 	wlr_renderer_end(renderer);
 	return swap_drm_surface_buffers(surf, NULL);
@@ -277,7 +277,7 @@ struct gbm_bo *copy_drm_surface_mgpu(struct wlr_drm_surface *dest,
 	wlr_matrix_projection(mat, 1, 1, WL_OUTPUT_TRANSFORM_NORMAL);
 
 	struct wlr_renderer *renderer = dest->renderer->wlr_rend;
-	wlr_renderer_begin(renderer, dest->width, dest->height);
+	wlr_renderer_begin(renderer, dest->width, dest->height, NULL);
 	wlr_renderer_clear(renderer, (float[]){ 0.0, 0.0, 0.0, 0.0 });
 	wlr_render_texture_with_matrix(renderer, tex, mat, 1.0f);
 	wlr_renderer_end(renderer);

--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -148,7 +148,7 @@ struct wlr_output *wlr_headless_add_output(struct wlr_backend *wlr_backend,
 		goto error;
 	}
 
-	wlr_renderer_begin(backend->renderer, wlr_output->width, wlr_output->height);
+	wlr_renderer_begin(backend->renderer, wlr_output->width, wlr_output->height, NULL);
 	wlr_renderer_clear(backend->renderer, (float[]){ 1.0, 1.0, 1.0, 1.0 });
 	wlr_renderer_end(backend->renderer);
 

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -348,7 +348,7 @@ static bool output_set_cursor(struct wlr_output *wlr_output,
 		float matrix[9];
 		wlr_matrix_project_box(matrix, &cursor_box, transform, 0, projection);
 
-		wlr_renderer_begin(backend->renderer, width, height);
+		wlr_renderer_begin(backend->renderer, width, height, NULL);
 		wlr_renderer_clear(backend->renderer, (float[]){ 0.0, 0.0, 0.0, 0.0 });
 		wlr_render_texture_with_matrix(backend->renderer, texture, matrix, 1.0);
 		wlr_renderer_end(backend->renderer);
@@ -566,7 +566,7 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *wlr_backend) {
 		goto error;
 	}
 
-	wlr_renderer_begin(backend->renderer, wlr_output->width, wlr_output->height);
+	wlr_renderer_begin(backend->renderer, wlr_output->width, wlr_output->height, NULL);
 	wlr_renderer_clear(backend->renderer, (float[]){ 1.0, 1.0, 1.0, 1.0 });
 	wlr_renderer_end(backend->renderer);
 

--- a/examples/fullscreen-shell.c
+++ b/examples/fullscreen-shell.c
@@ -93,7 +93,7 @@ static void output_handle_frame(struct wl_listener *listener, void *data) {
 		return;
 	}
 
-	wlr_renderer_begin(renderer, width, height);
+	wlr_renderer_begin(renderer, width, height, NULL);
 
 	float color[4] = {0.3, 0.3, 0.3, 1.0};
 	wlr_renderer_clear(renderer, color);

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -115,7 +115,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	struct wlr_output *wlr_output = output->output;
 
 	wlr_output_attach_render(wlr_output, NULL);
-	wlr_renderer_begin(sample->renderer, wlr_output->width, wlr_output->height);
+	wlr_renderer_begin(sample->renderer, wlr_output->width, wlr_output->height, NULL);
 	wlr_renderer_clear(sample->renderer, (float[]){0.25f, 0.25f, 0.25f, 1});
 
 	animate_cat(sample, output->output);

--- a/examples/pointer.c
+++ b/examples/pointer.c
@@ -98,7 +98,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	assert(renderer);
 
 	wlr_output_attach_render(wlr_output, NULL);
-	wlr_renderer_begin(renderer, wlr_output->width, wlr_output->height);
+	wlr_renderer_begin(renderer, wlr_output->width, wlr_output->height, NULL);
 	wlr_renderer_clear(renderer, state->clear_color);
 	wlr_output_render_software_cursors(wlr_output, NULL);
 	wlr_output_commit(wlr_output);

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -60,7 +60,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	wlr_output_effective_resolution(wlr_output, &width, &height);
 
 	wlr_output_attach_render(wlr_output, NULL);
-	wlr_renderer_begin(sample->renderer, wlr_output->width, wlr_output->height);
+	wlr_renderer_begin(sample->renderer, wlr_output->width, wlr_output->height, NULL);
 	wlr_renderer_clear(sample->renderer, (float[]){0.25f, 0.25f, 0.25f, 1});
 
 	for (int y = -128 + (int)sample_output->y_offs; y < height; y += 128) {

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -86,7 +86,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	wlr_output_effective_resolution(wlr_output, &width, &height);
 
 	wlr_output_attach_render(wlr_output, NULL);
-	wlr_renderer_begin(sample->renderer, wlr_output->width, wlr_output->height);
+	wlr_renderer_begin(sample->renderer, wlr_output->width, wlr_output->height, NULL);
 	wlr_renderer_clear(sample->renderer, (float[]){0.25f, 0.25f, 0.25f, 1});
 
 	float distance = 0.8f * (1 - sample->distance);

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -73,7 +73,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	wlr_output_effective_resolution(wlr_output, &width, &height);
 
 	wlr_output_attach_render(wlr_output, NULL);
-	wlr_renderer_begin(sample->renderer, wlr_output->width, wlr_output->height);
+	wlr_renderer_begin(sample->renderer, wlr_output->width, wlr_output->height, NULL);
 	wlr_renderer_clear(sample->renderer, (float[]){0.25f, 0.25f, 0.25f, 1});
 
 	int tex_width, tex_height;

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -78,6 +78,7 @@ struct wlr_gles2_texture {
 	//   GL_TEXTURE_EXTERNAL_OES == immutable
 	GLenum target;
 	GLuint tex;
+	GLuint fbo;
 
 	EGLImageKHR image;
 
@@ -97,6 +98,8 @@ const enum wl_shm_format *get_gles2_wl_formats(size_t *len);
 
 struct wlr_gles2_texture *gles2_get_texture(
 	struct wlr_texture *wlr_texture);
+
+GLuint wlr_gles2_texture_get_fbo(struct wlr_gles2_texture *texture);
 
 void push_gles2_marker(const char *file, const char *func);
 void pop_gles2_marker(void);

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -28,7 +28,7 @@
 
 struct wlr_renderer_impl {
 	void (*begin)(struct wlr_renderer *renderer, uint32_t width,
-		uint32_t height);
+		uint32_t height, struct wlr_texture *target);
 	void (*end)(struct wlr_renderer *renderer);
 	void (*clear)(struct wlr_renderer *renderer, const float color[static 4]);
 	void (*scissor)(struct wlr_renderer *renderer, struct wlr_box *box);

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -35,7 +35,11 @@ struct wlr_renderer {
 struct wlr_renderer *wlr_renderer_autocreate(struct wlr_egl *egl, EGLenum platform,
 	void *remote_display, EGLint *config_attribs, EGLint visual_id);
 
-void wlr_renderer_begin(struct wlr_renderer *r, int width, int height);
+/**
+ * Begins the rendering.
+ * If `target` is not NULL, the rendering will be done to a provided texture.
+ */
+void wlr_renderer_begin(struct wlr_renderer *r, int width, int height, struct wlr_texture *target);
 void wlr_renderer_end(struct wlr_renderer *r);
 void wlr_renderer_clear(struct wlr_renderer *r, const float color[static 4]);
 /**

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -31,12 +31,14 @@ static struct wlr_gles2_renderer *gles2_get_renderer_in_context(
 }
 
 static void gles2_begin(struct wlr_renderer *wlr_renderer, uint32_t width,
-		uint32_t height) {
+		uint32_t height, struct wlr_texture *target) {
 	struct wlr_gles2_renderer *renderer =
 		gles2_get_renderer_in_context(wlr_renderer);
 
 	PUSH_GLES2_DEBUG;
 
+	glBindFramebuffer(GL_FRAMEBUFFER,
+		target ? wlr_gles2_texture_get_fbo(gles2_get_texture(target)) : 0);
 	glViewport(0, 0, width, height);
 	renderer->viewport_width = width;
 	renderer->viewport_height = height;

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -47,6 +47,18 @@ static bool gles2_texture_is_opaque(struct wlr_texture *wlr_texture) {
 	return !texture->has_alpha;
 }
 
+GLuint wlr_gles2_texture_get_fbo(struct wlr_gles2_texture *texture) {
+	if (!texture->fbo) {
+		PUSH_GLES2_DEBUG;
+		glGenFramebuffers(1, &texture->fbo);
+		glBindFramebuffer(GL_FRAMEBUFFER, texture->fbo);
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture->tex, 0);
+		POP_GLES2_DEBUG;
+	}
+
+	return texture->fbo;
+}
+
 static bool gles2_texture_write_pixels(struct wlr_texture *wlr_texture,
 		uint32_t stride, uint32_t width, uint32_t height,
 		uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y,
@@ -126,6 +138,9 @@ static void gles2_texture_destroy(struct wlr_texture *wlr_texture) {
 
 	PUSH_GLES2_DEBUG;
 
+	if (texture->fbo) {
+		glDeleteFramebuffers(1, &texture->fbo);
+	}
 	glDeleteTextures(1, &texture->tex);
 	wlr_egl_destroy_image(texture->egl, texture->image);
 

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -38,10 +38,10 @@ void wlr_renderer_destroy(struct wlr_renderer *r) {
 	}
 }
 
-void wlr_renderer_begin(struct wlr_renderer *r, int width, int height) {
+void wlr_renderer_begin(struct wlr_renderer *r, int width, int height, struct wlr_texture *target) {
 	assert(!r->rendering);
 
-	r->impl->begin(r, width, height);
+	r->impl->begin(r, width, height, target);
 
 	r->rendering = true;
 }

--- a/tinywl/tinywl.c
+++ b/tinywl/tinywl.c
@@ -599,7 +599,7 @@ static void output_frame(struct wl_listener *listener, void *data) {
 	int width, height;
 	wlr_output_effective_resolution(output->wlr_output, &width, &height);
 	/* Begin the renderer (calls glViewport and some other GL sanity checks) */
-	wlr_renderer_begin(renderer, width, height);
+	wlr_renderer_begin(renderer, width, height, NULL);
 
 	float color[4] = {0.3, 0.3, 0.3, 1.0};
 	wlr_renderer_clear(renderer, color);


### PR DESCRIPTION
This can be useful for features like window thumbnails or correct
alpha blending of windows with subsurfaces.

This introduces a new wlr_renderer_begin argument - target texture.
Passing NULL makes it stay at current behavior (render to screen).