### PR TITLE
xdg-shell: fix popups rendered outside of the screen

### DIFF
--- a/types/xdg_shell/wlr_xdg_popup.c
+++ b/types/xdg_shell/wlr_xdg_popup.c
@@ -454,10 +454,10 @@ static bool xdg_popup_unconstrain_flip(struct wlr_xdg_popup *popup,
 	}
 
 	// revert the positioner back if it didn't fix it and go to the next part
-	if (flip_x) {
+	if (offset_x && flip_x) {
 		wlr_positioner_invert_x(&popup->positioner);
 	}
-	if (flip_y) {
+	if (offset_y && flip_y) {
 		wlr_positioner_invert_y(&popup->positioner);
 	}
 

--- a/types/xdg_shell_v6/wlr_xdg_popup_v6.c
+++ b/types/xdg_shell_v6/wlr_xdg_popup_v6.c
@@ -474,10 +474,10 @@ static bool xdg_popup_v6_unconstrain_flip(struct wlr_xdg_popup_v6 *popup,
 	}
 
 	// revert the positioner back if it didn't fix it and go to the next part
-	if (flip_x) {
+	if (offset_x && flip_x) {
 		wlr_positioner_v6_invert_x(&popup->positioner);
 	}
-	if (flip_y) {
+	if (offset_y && flip_y) {
 		wlr_positioner_v6_invert_y(&popup->positioner);
 	}
 


### PR DESCRIPTION
Leave positioner inverted on the individual axis if it's no longer constrained. Otherwise constraint adjustment like `slide_x & flip_y` could render popup outside of the screen when both axes are constrained.

Fixes Alexays/Waybar#532