### PR TITLE
Augment wlr_buffer to support swapchains

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -404,8 +404,8 @@ static bool drm_connector_commit_buffer(struct wlr_output *output) {
 
 	conn->pageflip_pending = true;
 	if (output->pending.buffer_type == WLR_OUTPUT_STATE_BUFFER_SCANOUT) {
-		wlr_buffer_unref(conn->pending_buffer);
-		conn->pending_buffer = wlr_buffer_ref(output->pending.buffer);
+		wlr_buffer_unlock(conn->pending_buffer);
+		conn->pending_buffer = wlr_buffer_lock(output->pending.buffer);
 	}
 
 	wlr_output_update_enabled(output, true);
@@ -1538,7 +1538,7 @@ static void page_flip_handler(int fd, unsigned seq,
 
 	// Release the old buffer as it's not displayed anymore. The pending
 	// buffer becomes the current buffer.
-	wlr_buffer_unref(conn->current_buffer);
+	wlr_buffer_unlock(conn->current_buffer);
 	conn->current_buffer = conn->pending_buffer;
 	conn->pending_buffer = NULL;
 
@@ -1659,8 +1659,8 @@ static void drm_connector_cleanup(struct wlr_drm_connector *conn) {
 		conn->output.needs_frame = false;
 		conn->output.frame_pending = false;
 
-		wlr_buffer_unref(conn->pending_buffer);
-		wlr_buffer_unref(conn->current_buffer);
+		wlr_buffer_unlock(conn->pending_buffer);
+		wlr_buffer_unlock(conn->current_buffer);
 		conn->pending_buffer = conn->current_buffer = NULL;
 
 		/* Fallthrough */

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -114,7 +114,7 @@ static void destroy_wl_buffer(struct wlr_wl_buffer *buffer) {
 		return;
 	}
 	wl_buffer_destroy(buffer->wl_buffer);
-	wlr_buffer_unref(buffer->buffer);
+	wlr_buffer_unlock(buffer->buffer);
 	free(buffer);
 }
 
@@ -173,7 +173,7 @@ static struct wlr_wl_buffer *create_wl_buffer(struct wlr_wl_backend *wl,
 		return NULL;
 	}
 	buffer->wl_buffer = wl_buffer;
-	buffer->buffer = wlr_buffer_ref(wlr_buffer);
+	buffer->buffer = wlr_buffer_lock(wlr_buffer);
 
 	wl_buffer_add_listener(wl_buffer, &buffer_listener, buffer);
 

--- a/include/wlr/types/wlr_buffer.h
+++ b/include/wlr/types/wlr_buffer.h
@@ -32,6 +32,8 @@ struct wlr_buffer_impl {
 struct wlr_buffer {
 	const struct wlr_buffer_impl *impl;
 
+	int width, height;
+
 	bool dropped;
 	size_t n_locks;
 
@@ -47,7 +49,7 @@ struct wlr_buffer {
  * they should call wlr_buffer_drop.
  */
 void wlr_buffer_init(struct wlr_buffer *buffer,
-	const struct wlr_buffer_impl *impl);
+	const struct wlr_buffer_impl *impl, int width, int height);
 /**
  * Unreference the buffer. This function should be called by producers when
  * they are done with the buffer.

--- a/include/wlr/types/wlr_buffer.h
+++ b/include/wlr/types/wlr_buffer.h
@@ -25,6 +25,10 @@ struct wlr_buffer {
 	const struct wlr_buffer_impl *impl;
 
 	size_t n_refs;
+
+	struct {
+		struct wl_signal destroy;
+	} events;
 };
 
 void wlr_buffer_init(struct wlr_buffer *buffer,

--- a/include/wlr/types/wlr_buffer.h
+++ b/include/wlr/types/wlr_buffer.h
@@ -21,27 +21,49 @@ struct wlr_buffer_impl {
 		struct wlr_dmabuf_attributes *attribs);
 };
 
+/**
+ * A buffer containing pixel data.
+ *
+ * A buffer has a single producer (the party who created the buffer) and
+ * multiple consumers (parties reading the buffer). When all consumers are done
+ * with the buffer, it gets released and can be re-used by the producer. When
+ * the producer and all consumers are done with the buffer, it gets destroyed.
+ */
 struct wlr_buffer {
 	const struct wlr_buffer_impl *impl;
 
-	size_t n_refs;
+	bool dropped;
+	size_t n_locks;
 
 	struct {
 		struct wl_signal destroy;
+		struct wl_signal release;
 	} events;
 };
 
+/**
+ * Initialize a buffer. This function should be called by producers. The
+ * initialized buffer is referenced: once the producer is done with the buffer
+ * they should call wlr_buffer_drop.
+ */
 void wlr_buffer_init(struct wlr_buffer *buffer,
 	const struct wlr_buffer_impl *impl);
 /**
- * Reference the buffer.
+ * Unreference the buffer. This function should be called by producers when
+ * they are done with the buffer.
  */
-struct wlr_buffer *wlr_buffer_ref(struct wlr_buffer *buffer);
+void wlr_buffer_drop(struct wlr_buffer *buffer);
 /**
- * Unreference the buffer. After this call, `buffer` may not be accessed
- * anymore.
+ * Lock the buffer. This function should be called by consumers to make
+ * sure the buffer can be safely read from. Once the consumer is done with the
+ * buffer, they should call wlr_buffer_unlock.
  */
-void wlr_buffer_unref(struct wlr_buffer *buffer);
+struct wlr_buffer *wlr_buffer_lock(struct wlr_buffer *buffer);
+/**
+ * Unlock the buffer. This function should be called by consumers once they are
+ * done with the buffer.
+ */
+void wlr_buffer_unlock(struct wlr_buffer *buffer);
 /**
  * Reads the DMA-BUF attributes of the buffer. If this buffer isn't a DMA-BUF,
  * returns false.
@@ -70,6 +92,7 @@ struct wlr_client_buffer {
 	struct wlr_texture *texture;
 
 	struct wl_listener resource_destroy;
+	struct wl_listener release;
 };
 
 struct wlr_renderer;
@@ -84,9 +107,11 @@ bool wlr_resource_is_buffer(struct wl_resource *resource);
 bool wlr_resource_get_buffer_size(struct wl_resource *resource,
 	struct wlr_renderer *renderer, int *width, int *height);
 /**
- * Upload a buffer to the GPU and reference it.
+ * Import a client buffer and lock it.
+ *
+ * Once the caller is done with the buffer, they must call wlr_buffer_unlock.
  */
-struct wlr_client_buffer *wlr_client_buffer_create(
+struct wlr_client_buffer *wlr_client_buffer_import(
 	struct wlr_renderer *renderer, struct wl_resource *resource);
 /**
  * Try to update the buffer's content. On success, returns the updated buffer

--- a/types/wlr_buffer.c
+++ b/types/wlr_buffer.c
@@ -4,12 +4,14 @@
 #include <wlr/types/wlr_buffer.h>
 #include <wlr/types/wlr_linux_dmabuf_v1.h>
 #include <wlr/util/log.h>
+#include "util/signal.h"
 
 void wlr_buffer_init(struct wlr_buffer *buffer,
 		const struct wlr_buffer_impl *impl) {
 	assert(impl->destroy);
 	buffer->impl = impl;
 	buffer->n_refs = 1;
+	wl_signal_init(&buffer->events.destroy);
 }
 
 struct wlr_buffer *wlr_buffer_ref(struct wlr_buffer *buffer) {
@@ -27,6 +29,8 @@ void wlr_buffer_unref(struct wlr_buffer *buffer) {
 	if (buffer->n_refs > 0) {
 		return;
 	}
+
+	wlr_signal_emit_safe(&buffer->events.destroy, NULL);
 
 	buffer->impl->destroy(buffer);
 }

--- a/types/wlr_buffer.c
+++ b/types/wlr_buffer.c
@@ -7,9 +7,11 @@
 #include "util/signal.h"
 
 void wlr_buffer_init(struct wlr_buffer *buffer,
-		const struct wlr_buffer_impl *impl) {
+		const struct wlr_buffer_impl *impl, int width, int height) {
 	assert(impl->destroy);
 	buffer->impl = impl;
+	buffer->width = width;
+	buffer->height = height;
 	wl_signal_init(&buffer->events.destroy);
 	wl_signal_init(&buffer->events.release);
 }
@@ -212,6 +214,9 @@ struct wlr_client_buffer *wlr_client_buffer_import(
 		return NULL;
 	}
 
+	int width, height;
+	wlr_resource_get_buffer_size(resource, renderer, &width, &height);
+
 	struct wlr_client_buffer *buffer =
 		calloc(1, sizeof(struct wlr_client_buffer));
 	if (buffer == NULL) {
@@ -219,7 +224,7 @@ struct wlr_client_buffer *wlr_client_buffer_import(
 		wl_resource_post_no_memory(resource);
 		return NULL;
 	}
-	wlr_buffer_init(&buffer->base, &client_buffer_impl);
+	wlr_buffer_init(&buffer->base, &client_buffer_impl, width, height);
 	buffer->resource = resource;
 	buffer->texture = texture;
 	buffer->resource_released = resource_released;

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -430,7 +430,7 @@ static void output_state_clear_buffer(struct wlr_output_state *state) {
 		return;
 	}
 
-	wlr_buffer_unref(state->buffer);
+	wlr_buffer_unlock(state->buffer);
 	state->buffer = NULL;
 
 	state->committed &= ~WLR_OUTPUT_STATE_BUFFER;
@@ -603,7 +603,7 @@ bool wlr_output_attach_buffer(struct wlr_output *output,
 	output_state_clear_buffer(&output->pending);
 	output->pending.committed |= WLR_OUTPUT_STATE_BUFFER;
 	output->pending.buffer_type = WLR_OUTPUT_STATE_BUFFER_SCANOUT;
-	output->pending.buffer = wlr_buffer_ref(buffer);
+	output->pending.buffer = wlr_buffer_lock(buffer);
 	return true;
 }
 

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -283,7 +283,7 @@ static void surface_apply_damage(struct wlr_surface *surface) {
 	if (resource == NULL) {
 		// NULL commit
 		if (surface->buffer != NULL) {
-			wlr_buffer_unref(&surface->buffer->base);
+			wlr_buffer_unlock(&surface->buffer->base);
 		}
 		surface->buffer = NULL;
 		return;
@@ -300,14 +300,14 @@ static void surface_apply_damage(struct wlr_surface *surface) {
 	}
 
 	struct wlr_client_buffer *buffer =
-		wlr_client_buffer_create(surface->renderer, resource);
+		wlr_client_buffer_import(surface->renderer, resource);
 	if (buffer == NULL) {
 		wlr_log(WLR_ERROR, "Failed to upload buffer");
 		return;
 	}
 
 	if (surface->buffer != NULL) {
-		wlr_buffer_unref(&surface->buffer->base);
+		wlr_buffer_unlock(&surface->buffer->base);
 	}
 	surface->buffer = buffer;
 }
@@ -580,7 +580,7 @@ static void surface_handle_resource_destroy(struct wl_resource *resource) {
 	pixman_region32_fini(&surface->opaque_region);
 	pixman_region32_fini(&surface->input_region);
 	if (surface->buffer != NULL) {
-		wlr_buffer_unref(&surface->buffer->base);
+		wlr_buffer_unlock(&surface->buffer->base);
 	}
 	free(surface);
 }


### PR DESCRIPTION
~~Depends on https://github.com/swaywm/wlroots/pull/2043~~

This PR adds the required infrastructure to `wlr_buffer` to support swapchains. glider has been updated to use it: https://github.com/emersion/glider/pull/7.

Once this PR is merged, it will be possible to add DRM support to https://github.com/swaywm/wlroots/pull/1985 via libliftoff.

* * *

`wlr_buffer` now has a concept of "released", "producer" and "consumer". A buffer is created by a producer (the allocator or the client). It's then referenced by consumers (e.g. the backend or the compositor). Once all consumers are done with the buffer (ie. once they have un-referenced the buffer), the buffer is released and can be re-used (by the swapchain or the client).

This is inspired from glider's buffer: https://github.com/emersion/glider/blob/c66847dd1cf8ae5e68666ce7cb3be41427b38dc7/include/allocator.h#L17. ~~One difference is that this PR is less explicit: both consumers and producers call `wlr_buffer_unref`. On glider, there's one API for producers (`glider_buffer_init`, `glider_buffer_unref`) and a separate API for consumers (`glider_buffer_lock`, `glider_buffer_unlock`). This makes it more obvious when the buffer is released. Is it worth it to make this breaking change?~~ Renamed.

glider's buffer is itself inspired from the renderer v6's `wlr_image` type: https://github.com/swaywm/wlroots/pull/1355/files#diff-6105fb2a3a3620a8a1aabaa7b11beb84R16

* * *

Breaking changes:

- Compositors that want to keep a reference to a `wlr_buffer`  to read it later should call `wlr_buffer_lock` and `wlr_buffer_unlock` instead of `wlr_buffer_ref` and `wlr_buffer_unref`. Same applies to backends.
- `wlr_client_buffer_create` has been renamed to `wlr_client_buffer_import`. Callers need to `wlr_buffer_unlock` the resulting buffer once they're done with it.
- Users who create buffers need to call `wlr_buffer_drop` instead of `wlr_buffer_unref`.

Sway PR: https://github.com/swaywm/sway/pull/5088