### PR TITLE
output: remove wlr_output_impl.schedule_frame

### DIFF
--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -415,20 +415,6 @@ static bool output_move_cursor(struct wlr_output *_output, int x, int y) {
 	return true;
 }
 
-static bool output_schedule_frame(struct wlr_output *wlr_output) {
-	struct wlr_wl_output *output = get_wl_output_from_output(wlr_output);
-
-	if (output->frame_callback != NULL) {
-		wlr_log(WLR_ERROR, "Skipping frame scheduling");
-		return true;
-	}
-
-	output->frame_callback = wl_surface_frame(output->surface);
-	wl_callback_add_listener(output->frame_callback, &frame_listener, output);
-	wl_surface_commit(output->surface);
-	return true;
-}
-
 static const struct wlr_output_impl output_impl = {
 	.destroy = output_destroy,
 	.attach_render = output_attach_render,
@@ -436,7 +422,6 @@ static const struct wlr_output_impl output_impl = {
 	.commit = output_commit,
 	.set_cursor = output_set_cursor,
 	.move_cursor = output_move_cursor,
-	.schedule_frame = output_schedule_frame,
 };
 
 bool wlr_output_is_wl(struct wlr_output *wlr_output) {

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -27,7 +27,6 @@ struct wlr_output_impl {
 	size_t (*get_gamma_size)(struct wlr_output *output);
 	bool (*export_dmabuf)(struct wlr_output *output,
 		struct wlr_dmabuf_attributes *attribs);
-	bool (*schedule_frame)(struct wlr_output *output);
 	bool (*attach_buffer)(struct wlr_output *output, struct wlr_buffer *buffer);
 };
 

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -599,11 +599,8 @@ void wlr_output_send_frame(struct wlr_output *output) {
 static void schedule_frame_handle_idle_timer(void *data) {
 	struct wlr_output *output = data;
 	output->idle_frame = NULL;
-	if (!output->frame_pending && output->impl->schedule_frame) {
-		// Ask the backend to send a frame event when appropriate
-		if (output->impl->schedule_frame(output)) {
-			output->frame_pending = true;
-		}
+	if (!output->frame_pending) {
+		wlr_output_send_frame(output);
 	}
 }
 


### PR DESCRIPTION
This function allowed backends to provide a custom function for frame
scheduling. Before resuming the rendering loop, the DRM and Wayland
backends would wait for vsync.

There isn't a clear benefit of doing this. The only upside is that we
get more stable timings: the delay between two repaints doesn't change too
much and is close to a mutliple of the refresh rate.

However this introduces latency, especially when a client misses a
frame. For instance a fullscreen game missing vblank will need to wait
more than a whole frame before being able to display new content. This
worst case scenario happens as follows:

- Client is still rendering its frame and cannot submit it in time
- Deadline is reached
- Compositor decides to stop the rendering loop since nothing changed on
  screen
- Client finally manages to render its frame, submits it
- Compositor calls wlr_output_schedule_frame
- DRM backend waits for next vblank
- The wlr_output frame event is fired, compositor draws new content on screen
- On the second next vblank, the new content reaches the screen

With this patch, the wlr_output frame event is fired immediately when
the client submits its late frame.

This change also makes it easier to support variable refresh rate, since
VRR is all about being able to present too-late frames earlier.

References: https://github.com/swaywm/wlroots/issues/1925

cc @ascent12 @YaLTeR 