### PR TITLE
xcursor: un-hardcode /usr/share in default XCURSORPATH

### DIFF
--- a/xcursor/meson.build
+++ b/xcursor/meson.build
@@ -1,3 +1,8 @@
+prefix = get_option('prefix')
+datadir = get_option('datadir')
+
+add_project_arguments('-DDATADIR="@0@"'.format(join_paths(prefix, datadir)), language : 'c')
+
 wlr_files += files(
 	'wlr_xcursor.c',
 	'xcursor.c',

--- a/xcursor/xcursor.c
+++ b/xcursor/xcursor.c
@@ -618,7 +618,7 @@ XcursorFileLoadImages (FILE *file, int size)
 #endif
 
 #ifndef XCURSORPATH
-#define XCURSORPATH "~/.local/share/icons:~/.icons:/usr/share/icons:/usr/share/pixmaps:"ICONDIR
+#define XCURSORPATH "~/.local/share/icons:~/.icons:"DATADIR"/icons:"DATADIR"/pixmaps:"ICONDIR
 #endif
 
 static const char *


### PR DESCRIPTION
Without this change Sway won't apply cursor theme on empty workspaces on FreeBSD (uses `/usr/local` by default). Xwayland and Gtk3 know where to find icons (for cursors and not), so hovering over applications will often use client-side cursor, hiding the issue. CC @raichoo

A similar bug exists in libwayland but not libXcursor.