### PR TITLE
xcursor: look under ${datadir}/icons instead of /usr/X11R6/lib/X11/icons by default

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,3 +6,4 @@ option('xcb-icccm', type: 'feature', value: 'auto', description: 'Use xcb-icccm 
 option('xwayland', type: 'feature', value: 'auto', yield: true, description: 'Enable support for X11 applications')
 option('x11-backend', type: 'feature', value: 'auto', description: 'Enable X11 backend')
 option('examples', type: 'boolean', value: true, description: 'Build example applications')
+option('icon_directory', description: 'Location used to look for cursors (default: ${datadir}/icons)', type: 'string', value: '')

--- a/xcursor/meson.build
+++ b/xcursor/meson.build
@@ -1,3 +1,10 @@
+icondir = get_option('icon_directory')
+if icondir == ''
+	icondir = join_paths(get_option('prefix'), get_option('datadir'), 'icons')
+endif
+
+add_project_arguments('-DICONDIR="@0@"'.format(icondir), language : 'c')
+
 wlr_files += files(
 	'wlr_xcursor.c',
 	'xcursor.c',


### PR DESCRIPTION
Some Linux distributions and all BSDs install packages somewhere other than `/usr` by default. This breaks server-side theming e.g., on Sway empty workspaces use unstyled cursor vs. styled cursor in Gtk3 and X11 applications. To fix just override `ICONDIR` like libwayland and libXcursor have been doing for years.

Same as https://github.com/swaywm/wlroots/pull/2049.
