### PR TITLE
output: make wlr_output_schedule_frame set output->needs_frame

### DIFF
--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -667,6 +667,9 @@ bool wlr_output_export_dmabuf(struct wlr_output *output,
 }
 
 void wlr_output_update_needs_frame(struct wlr_output *output) {
+	if (output->needs_frame) {
+		return;
+	}
 	output->needs_frame = true;
 	wlr_signal_emit_safe(&output->events.needs_frame, output);
 }

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -605,6 +605,8 @@ static void schedule_frame_handle_idle_timer(void *data) {
 }
 
 void wlr_output_schedule_frame(struct wlr_output *output) {
+	wlr_output_update_needs_frame(output);
+
 	if (output->frame_pending || output->idle_frame != NULL) {
 		return;
 	}


### PR DESCRIPTION
This way, wlr_output_schedule_frame will always be followed by a
wlr_output_commit. This forces the compositor to render an extra
frame before stopping the rendering loop.

To test, run wleird's frame-callback [1], make sure it's the only
visible client on the output and check the interval between frame
events is the output's refresh period instead of zero.

[1]: https://github.com/emersion/wleird/blob/master/frame-callback.c

Closes: https://github.com/swaywm/wlroots/issues/2051