### PR TITLE
xdg_surface: send error on no role commit

### DIFF
--- a/types/xdg_shell/wlr_xdg_surface.c
+++ b/types/xdg_shell/wlr_xdg_surface.c
@@ -357,7 +357,10 @@ void handle_xdg_surface_commit(struct wlr_surface *wlr_surface) {
 
 	switch (surface->role) {
 	case WLR_XDG_SURFACE_ROLE_NONE:
-		assert(false);
+		wl_resource_post_error(surface->resource,
+			XDG_SURFACE_ERROR_NOT_CONSTRUCTED,
+			"xdg_surface must have a role");
+		return;
 	case WLR_XDG_SURFACE_ROLE_TOPLEVEL:
 		handle_xdg_surface_toplevel_committed(surface);
 		break;


### PR DESCRIPTION
Send an error to the client if it wants to commit a surface without a
role instead of crashing the compositor.

Fixes #2056

Set to draft because I have not quite figured out how this call is reached.