### PR TITLE
output: always signal needs_frame if damage may have increased [was: backend/drm: damage all buffers after VT switch]

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -555,7 +555,7 @@ bool set_drm_connector_gamma(struct wlr_output *output, size_t size,
 
 	bool ok = drm->iface->crtc_set_gamma(drm, conn->crtc, size, _r, _g, _b);
 	if (ok) {
-		wlr_output_update_needs_frame(output);
+		wlr_output_update_needs_frame(output, true);
 
 		free(conn->crtc->gamma_table);
 		conn->crtc->gamma_table = gamma_table;
@@ -900,7 +900,7 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 			return false;
 		}
 
-		wlr_output_update_needs_frame(output);
+		wlr_output_update_needs_frame(output, true);
 	}
 
 	if (!update_texture) {
@@ -960,7 +960,7 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 	}
 	bool ok = drm->iface->crtc_set_cursor(drm, crtc, bo);
 	if (ok) {
-		wlr_output_update_needs_frame(output);
+		wlr_output_update_needs_frame(output, true);
 	}
 	return ok;
 }
@@ -997,7 +997,7 @@ static bool drm_connector_move_cursor(struct wlr_output *output,
 
 	bool ok = drm->iface->crtc_move_cursor(drm, conn->crtc, box.x, box.y);
 	if (ok) {
-		wlr_output_update_needs_frame(output);
+		wlr_output_update_needs_frame(output, true);
 	}
 	return ok;
 }

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -46,7 +46,7 @@ static void handle_x11_event(struct wlr_x11_backend *x11,
 		struct wlr_x11_output *output =
 			get_x11_output_from_window_id(x11, ev->window);
 		if (output != NULL) {
-			wlr_output_update_needs_frame(&output->wlr_output);
+			wlr_output_update_needs_frame(&output->wlr_output, true);
 		}
 		break;
 	}

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -37,7 +37,7 @@ void wlr_output_update_mode(struct wlr_output *output,
 void wlr_output_update_custom_mode(struct wlr_output *output, int32_t width,
 	int32_t height, int32_t refresh);
 void wlr_output_update_enabled(struct wlr_output *output, bool enabled);
-void wlr_output_update_needs_frame(struct wlr_output *output);
+void wlr_output_update_needs_frame(struct wlr_output *output, bool idempotent);
 void wlr_output_damage_whole(struct wlr_output *output);
 void wlr_output_send_frame(struct wlr_output *output);
 void wlr_output_send_present(struct wlr_output *output,

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -621,7 +621,7 @@ static void schedule_frame_handle_idle_timer(void *data) {
 }
 
 void wlr_output_schedule_frame(struct wlr_output *output) {
-	wlr_output_update_needs_frame(output);
+	wlr_output_update_needs_frame(output, true);
 
 	if (output->frame_pending || output->idle_frame != NULL) {
 		return;
@@ -682,8 +682,8 @@ bool wlr_output_export_dmabuf(struct wlr_output *output,
 	return output->impl->export_dmabuf(output, attribs);
 }
 
-void wlr_output_update_needs_frame(struct wlr_output *output) {
-	if (output->needs_frame) {
+void wlr_output_update_needs_frame(struct wlr_output *output, bool idempotent) {
+	if (output->needs_frame && idempotent) {
 		return;
 	}
 	output->needs_frame = true;
@@ -696,7 +696,7 @@ void wlr_output_damage_whole(struct wlr_output *output) {
 
 	pixman_region32_union_rect(&output->damage, &output->damage, 0, 0,
 		width, height);
-	wlr_output_update_needs_frame(output);
+	wlr_output_update_needs_frame(output, false);
 }
 
 struct wlr_output *wlr_output_from_resource(struct wl_resource *resource) {
@@ -854,7 +854,7 @@ static void output_cursor_damage_whole(struct wlr_output_cursor *cursor) {
 	output_cursor_get_box(cursor, &box);
 	pixman_region32_union_rect(&cursor->output->damage, &cursor->output->damage,
 		box.x, box.y, box.width, box.height);
-	wlr_output_update_needs_frame(cursor->output);
+	wlr_output_update_needs_frame(cursor->output, false);
 }
 
 static void output_cursor_reset(struct wlr_output_cursor *cursor) {


### PR DESCRIPTION
After commit 94fa6c88f ("output: don't emit the mode event if it hasn't changed"), the entire output is directly damaged by drm_connector_set_mode() after each VT switch.
However, wlr_output_damage_whole() only damages the next buffer, not all buffers.

Because of this, after switching to a text VT and back to the one running sway, all areas that have not independently been damaged afterwards stay black in the second buffer, effectively causing those areas to flicker between the correct content and black.

Fix it by adding a new signal invalidate_buffers that drm_connector_set_mode() can use to tell the damage tracking logic that it should apply full damage to all buffers.


I have verified that this fixes the flickering I have observed on my PC; however, I'm not really familiar with the internals of things like VT switching or sway, so it might well be that the way in which I'm fixing it doesn't make much sense.

This issue reproducibly happens on my workstation, which has two displays driven by Intel integrated graphics.

Closes: https://github.com/swaywm/sway/issues/5086