### PR TITLE
backend/headless: use FBOs instead of pbuffers

### DIFF
--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -16,7 +16,7 @@ static struct wlr_headless_output *headless_output_from_output(
 
 static bool create_fbo(struct wlr_headless_output *output,
 		unsigned int width, unsigned int height) {
-	if (!wlr_egl_make_current(&output->backend->egl, EGL_NO_SURFACE, NULL)) {
+	if (!wlr_egl_make_current(output->backend->egl, EGL_NO_SURFACE, NULL)) {
 		return false;
 	}
 
@@ -46,7 +46,7 @@ static bool create_fbo(struct wlr_headless_output *output,
 }
 
 static void destroy_fbo(struct wlr_headless_output *output) {
-	if (!wlr_egl_make_current(&output->backend->egl, EGL_NO_SURFACE, NULL)) {
+	if (!wlr_egl_make_current(output->backend->egl, EGL_NO_SURFACE, NULL)) {
 		return;
 	}
 
@@ -82,7 +82,7 @@ static bool output_attach_render(struct wlr_output *wlr_output,
 	struct wlr_headless_output *output =
 		headless_output_from_output(wlr_output);
 
-	if (!wlr_egl_make_current(&output->backend->egl, EGL_NO_SURFACE, NULL)) {
+	if (!wlr_egl_make_current(output->backend->egl, EGL_NO_SURFACE, NULL)) {
 		return false;
 	}
 
@@ -129,7 +129,7 @@ static bool output_commit(struct wlr_output *wlr_output) {
 		wlr_output_send_present(wlr_output, NULL);
 	}
 
-	wlr_egl_make_current(&output->backend->egl, EGL_NO_SURFACE, NULL);
+	wlr_egl_make_current(output->backend->egl, EGL_NO_SURFACE, NULL);
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
 	return true;
@@ -138,7 +138,7 @@ static bool output_commit(struct wlr_output *wlr_output) {
 static void output_rollback(struct wlr_output *wlr_output) {
 	struct wlr_headless_output *output =
 		headless_output_from_output(wlr_output);
-	wlr_egl_make_current(&output->backend->egl, EGL_NO_SURFACE, NULL);
+	wlr_egl_make_current(output->backend->egl, EGL_NO_SURFACE, NULL);
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
 

--- a/include/backend/headless.h
+++ b/include/backend/headless.h
@@ -3,6 +3,7 @@
 
 #include <wlr/backend/headless.h>
 #include <wlr/backend/interface.h>
+#include <wlr/render/gles2.h>
 
 #define HEADLESS_DEFAULT_REFRESH (60 * 1000) // 60 Hz
 
@@ -16,6 +17,7 @@ struct wlr_headless_backend {
 	struct wl_list input_devices;
 	struct wl_listener display_destroy;
 	bool started;
+	GLenum internal_format;
 };
 
 struct wlr_headless_output {
@@ -24,7 +26,8 @@ struct wlr_headless_output {
 	struct wlr_headless_backend *backend;
 	struct wl_list link;
 
-	void *egl_surface;
+	GLuint fbo, rbo;
+
 	struct wl_event_source *frame_timer;
 	int frame_delay; // ms
 };

--- a/include/backend/headless.h
+++ b/include/backend/headless.h
@@ -9,7 +9,8 @@
 
 struct wlr_headless_backend {
 	struct wlr_backend backend;
-	struct wlr_egl egl;
+	struct wlr_egl priv_egl; // may be uninitialized
+	struct wlr_egl *egl;
 	struct wlr_renderer *renderer;
 	struct wl_display *display;
 	struct wl_list outputs;

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -44,6 +44,7 @@ struct wlr_gles2_renderer {
 
 	struct wlr_egl *egl;
 
+	const char *exts_str;
 	struct {
 		bool read_format_bgra_ext;
 		bool debug_khr;

--- a/include/wlr/backend/headless.h
+++ b/include/wlr/backend/headless.h
@@ -20,6 +20,11 @@
 struct wlr_backend *wlr_headless_backend_create(struct wl_display *display,
 	wlr_renderer_create_func_t create_renderer_func);
 /**
+ * Creates a headless backend with an existing renderer.
+ */
+struct wlr_backend *wlr_headless_backend_create_with_renderer(
+	struct wl_display *display, struct wlr_renderer *renderer);
+/**
  * Create a new headless output backed by an in-memory EGL framebuffer. You can
  * read pixels from this framebuffer via wlr_renderer_read_pixels but it is
  * otherwise not displayed.

--- a/include/wlr/render/gles2.h
+++ b/include/wlr/render/gles2.h
@@ -18,6 +18,8 @@ struct wlr_egl;
 struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_egl *egl);
 
 struct wlr_egl *wlr_gles2_renderer_get_egl(struct wlr_renderer *renderer);
+bool wlr_gles2_renderer_check_ext(struct wlr_renderer *renderer,
+	const char *ext);
 
 struct wlr_texture *wlr_gles2_texture_from_pixels(struct wlr_egl *egl,
 	enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width, uint32_t height,

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -575,6 +575,8 @@ struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_egl *egl) {
 		return NULL;
 	}
 
+	renderer->exts_str = exts_str;
+
 	wlr_log(WLR_INFO, "Using %s", glGetString(GL_VERSION));
 	wlr_log(WLR_INFO, "GL vendor: %s", glGetString(GL_VENDOR));
 	wlr_log(WLR_INFO, "GL renderer: %s", glGetString(GL_RENDERER));
@@ -686,4 +688,10 @@ error:
 
 	free(renderer);
 	return NULL;
+}
+
+bool wlr_gles2_renderer_check_ext(struct wlr_renderer *wlr_renderer,
+		const char *ext) {
+	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
+	return check_gl_ext(renderer->exts_str, ext);
 }


### PR DESCRIPTION
Allows the headless backend to use another backend's renderer.