### PR TITLE
xwayland: hidpi support

### DIFF
--- a/include/wlr/xwayland.h
+++ b/include/wlr/xwayland.h
@@ -30,6 +30,8 @@ struct wlr_xwayland {
 
 	time_t server_start;
 
+	int32_t scale;
+
 	/* Anything above display is reset on Xwayland restart, rest is conserved */
 
 	int display;
@@ -204,6 +206,8 @@ struct wlr_xwayland *wlr_xwayland_create(struct wl_display *wl_display,
 	struct wlr_compositor *compositor, bool lazy);
 
 void wlr_xwayland_destroy(struct wlr_xwayland *wlr_xwayland);
+
+void wlr_xwayland_set_scale(struct wlr_xwayland *wlr_xwayland, int32_t scale);
 
 void wlr_xwayland_set_cursor(struct wlr_xwayland *wlr_xwayland,
 	uint8_t *pixels, uint32_t stride, uint32_t width, uint32_t height,

--- a/include/xwayland/xwm.h
+++ b/include/xwayland/xwm.h
@@ -80,6 +80,9 @@ enum atom_name {
 	DND_ACTION_ASK,
 	DND_ACTION_PRIVATE,
 	NET_CLIENT_LIST,
+	XSETTINGS_SETTINGS,
+	XSETTINGS_S0,
+	MANAGER,
 	ATOM_LAST // keep last
 };
 
@@ -106,6 +109,9 @@ struct wlr_xwm {
 	xcb_render_pictformat_t render_format_id;
 	xcb_cursor_t cursor;
 
+	xcb_window_t xsettings_window;
+	int32_t xsettings_serial;
+
 	xcb_window_t selection_window;
 	struct wlr_xwm_selection clipboard_selection;
 	struct wlr_xwm_selection primary_selection;
@@ -122,6 +128,7 @@ struct wlr_xwm {
 	struct wlr_xwayland_surface *drag_focus;
 
 	const xcb_query_extension_reply_t *xfixes;
+	const xcb_query_extension_reply_t *xwayland_ext;
 #if WLR_HAS_XCB_ERRORS
 	xcb_errors_context_t *errors_context;
 #endif
@@ -154,5 +161,7 @@ void xwm_set_seat(struct wlr_xwm *xwm, struct wlr_seat *seat);
 char *xwm_get_atom_name(struct wlr_xwm *xwm, xcb_atom_t atom);
 bool xwm_atoms_contains(struct wlr_xwm *xwm, xcb_atom_t *atoms,
 	size_t num_atoms, enum atom_name needle);
+
+void xwm_scale_changed(struct wlr_xwm *xwm);
 
 #endif

--- a/xwayland/xwayland.c
+++ b/xwayland/xwayland.c
@@ -440,6 +440,9 @@ error_alloc:
 
 void wlr_xwayland_set_scale(struct wlr_xwayland *wlr_xwayland, int32_t scale) {
 	wlr_xwayland->scale = scale;
+	if (wlr_xwayland->xwm != NULL) {
+		xwm_scale_changed(wlr_xwayland->xwm);
+	}
 }
 
 void wlr_xwayland_set_cursor(struct wlr_xwayland *wlr_xwayland,

--- a/xwayland/xwayland.c
+++ b/xwayland/xwayland.c
@@ -66,7 +66,7 @@ _Noreturn static void exec_xwayland(struct wlr_xwayland *wlr_xwayland) {
 
 	char *argv[] = {
 		"Xwayland", NULL /* display, e.g. :1 */,
-		"-rootless", "-terminate",
+		"-rootless", "-terminate", "-max-factor-rescale",
 		"-listen", NULL /* x_fd[0] */,
 		"-listen", NULL /* x_fd[1] */,
 		"-wm", NULL /* wm_fd[1] */,
@@ -409,6 +409,8 @@ struct wlr_xwayland *wlr_xwayland_create(struct wl_display *wl_display,
 	wlr_xwayland->wl_fd[0] = wlr_xwayland->wl_fd[1] = -1;
 	wlr_xwayland->wm_fd[0] = wlr_xwayland->wm_fd[1] = -1;
 
+	wlr_xwayland->scale = 1;
+
 	wl_signal_init(&wlr_xwayland->events.new_surface);
 	wl_signal_init(&wlr_xwayland->events.ready);
 
@@ -434,6 +436,10 @@ error_display:
 error_alloc:
 	free(wlr_xwayland);
 	return NULL;
+}
+
+void wlr_xwayland_set_scale(struct wlr_xwayland *wlr_xwayland, int32_t scale) {
+	wlr_xwayland->scale = scale;
 }
 
 void wlr_xwayland_set_cursor(struct wlr_xwayland *wlr_xwayland,

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -16,6 +16,15 @@
 #include "util/signal.h"
 #include "xwayland/xwm.h"
 
+
+static int32_t scale(struct wlr_xwm *xwm, int32_t val) {
+	return val * xwm->xwayland->scale;
+}
+
+static int32_t unscale(struct wlr_xwm *xwm, int32_t val) {
+	return (val + xwm->xwayland->scale/2) / xwm->xwayland->scale;
+}
+
 const char *atom_map[ATOM_LAST] = {
 	[WL_SURFACE_ID] = "WL_SURFACE_ID",
 	[WM_DELETE_WINDOW] = "WM_DELETE_WINDOW",
@@ -834,8 +843,13 @@ static void xwm_handle_create_notify(struct wlr_xwm *xwm,
 		return;
 	}
 
-	xwayland_surface_create(xwm, ev->window, ev->x, ev->y,
-		ev->width, ev->height, ev->override_redirect);
+	xwayland_surface_create(xwm, ev->window,
+		unscale(xwm, ev->x),
+		unscale(xwm, ev->y),
+		unscale(xwm, ev->width),
+		unscale(xwm, ev->height),
+		ev->override_redirect
+	);
 }
 
 static void xwm_handle_destroy_notify(struct wlr_xwm *xwm,
@@ -866,10 +880,10 @@ static void xwm_handle_configure_request(struct wlr_xwm *xwm,
 
 	struct wlr_xwayland_surface_configure_event wlr_event = {
 		.surface = surface,
-		.x = mask & XCB_CONFIG_WINDOW_X ? ev->x : surface->x,
-		.y = mask & XCB_CONFIG_WINDOW_Y ? ev->y : surface->y,
-		.width = mask & XCB_CONFIG_WINDOW_WIDTH ? ev->width : surface->width,
-		.height = mask & XCB_CONFIG_WINDOW_HEIGHT ? ev->height : surface->height,
+		.x = unscale(xwm, mask & XCB_CONFIG_WINDOW_X ? ev->x : surface->x),
+		.y = unscale(xwm, mask & XCB_CONFIG_WINDOW_Y ? ev->y : surface->y),
+		.width = unscale(xwm, mask & XCB_CONFIG_WINDOW_WIDTH ? ev->width : surface->width),
+		.height = unscale(xwm, mask & XCB_CONFIG_WINDOW_HEIGHT ? ev->height : surface->height),
 		.mask = mask,
 	};
 	wlr_log(WLR_DEBUG, "XCB_CONFIGURE_REQUEST (%u) [%ux%u+%d,%d]", ev->window,
@@ -885,10 +899,10 @@ static void xwm_handle_configure_notify(struct wlr_xwm *xwm,
 		return;
 	}
 
-	xsurface->x = ev->x;
-	xsurface->y = ev->y;
-	xsurface->width = ev->width;
-	xsurface->height = ev->height;
+	xsurface->x = unscale(xwm, ev->x);
+	xsurface->y = unscale(xwm, ev->y);
+	xsurface->width = unscale(xwm, ev->width);
+	xsurface->height = unscale(xwm, ev->height);
 
 	if (xsurface->override_redirect != ev->override_redirect) {
 		xsurface->override_redirect = ev->override_redirect;
@@ -1431,7 +1445,13 @@ void wlr_xwayland_surface_configure(struct wlr_xwayland_surface *xsurface,
 	uint32_t mask = XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y |
 		XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT |
 		XCB_CONFIG_WINDOW_BORDER_WIDTH;
-	uint32_t values[] = {x, y, width, height, 0};
+	uint32_t values[] = {
+		scale(xsurface->xwm, x),
+		scale(xsurface->xwm, y),
+		scale(xsurface->xwm, width),
+		scale(xsurface->xwm, height),
+		0,
+	};
 	xcb_configure_window(xwm->xcb_conn, xsurface->window_id, mask, values);
 	xcb_flush(xwm->xcb_conn);
 }


### PR DESCRIPTION
This PR adds hidpi support to xwayland using a strategy based on https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/111 . The required xserver patches are available at https://gitlab.freedesktop.org/dirbaio/xserver/tree/xwlScaling . They consist on the PR + some fixes + implementing an X extension to control the scale factor from wlroots.

A single, global scale factor is chosen. This scale factor is used for the entire X server, so all x11 apps
are rendered at that same scale. wlroots will then scale rendered windows on outputs with scale different to the globa scale factor.

For optimal text rendering, the global scale factor should match the output's, but text is the correct size in all cases (no tiny/huge text on mismatches). 

The xserver patches allow the Wayland compositor to control the global scale factor and change it on the fly via a X protocol extension. This is the main difference with the original xserver PR: that one automatically sets the scale factor to the max of the outputs' scales. 

IMO having the scale factor configurable is the best choice, because the user can choose on which monitor the text is rendered best. For example: a 4K laptop (scale 2x) attached to a big 1080p external monitor (scale 1x) where the external monitor is the "main" display used for eg coding. The user will want the text to look best on the external monitor, so they'll set the global scale factor to 1.

To communicate the global scale factor to the apps, the X WM registers itself as the xsettings owner, and publishes the setting `Gdk/WindowScalingFactor`. The setting is updated on scaling factor change, triggering apps to dynamically re-render themselves at the new scale. This leads to a very seamless UX, but will conflict with the user's xsettings daemon if they're running any. In that case, what will happen is the user's daemon will override wlroots's, and if the user doesn't set `Gdk/WindowScalingFactor` correctly they'll get huge/tiny text.

ToDo items:
- Get the xserver patches upstream
- The current code assumes the xserver extension is supported, it should fall back to forcing scale factor to 1 if it's not supported (eg user is running an old x server)
- the code in xwm_xsettings_set is very ugly and inflexible.

Working apps:
- VSCode (scroll wheel is 2x faster in 2x scale, but I think it's a vscode bug)
- Firefox
- Chromium
- GNOME calculator (forcing it to x11 mode by unsetting WAYLAND_DISPLAY)
- Nautilus (forcing it to x11 mode by unsetting WAYLAND_DISPLAY)

Not working apps:
- Spotify: always renders at 1x, so it looks tiny. It doesn't seem to be following xsettings for some reason.
- GIMP: same