### PR TITLE
output: add comment about needs_frame in wlr_output_schedule_frame

### DIFF
--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -621,6 +621,9 @@ static void schedule_frame_handle_idle_timer(void *data) {
 }
 
 void wlr_output_schedule_frame(struct wlr_output *output) {
+	// Make sure the compositor commits a new frame. This is necessary to make
+	// clients which ask for frame callbacks without submitting a new buffer
+	// work.
 	wlr_output_update_needs_frame(output);
 
 	if (output->frame_pending || output->idle_frame != NULL) {


### PR DESCRIPTION
Add a comment to not forget why this call is necessary.

References: https://github.com/swaywm/wlroots/pull/2053