### PR TITLE
Send keyboard enter/leave on capability change

### DIFF
--- a/include/types/wlr_seat.h
+++ b/include/types/wlr_seat.h
@@ -15,6 +15,8 @@ void seat_client_destroy_pointer(struct wl_resource *resource);
 void seat_client_create_keyboard(struct wlr_seat_client *seat_client,
 	uint32_t version, uint32_t id);
 void seat_client_destroy_keyboard(struct wl_resource *resource);
+void seat_client_send_keyboard_leave_raw(struct wlr_seat_client *seat_client,
+	struct wlr_surface *surface);
 
 void seat_client_create_touch(struct wlr_seat_client *seat_client,
 	uint32_t version, uint32_t id);

--- a/types/seat/wlr_seat.c
+++ b/types/seat/wlr_seat.c
@@ -322,6 +322,19 @@ void wlr_seat_set_capabilities(struct wlr_seat *wlr_seat,
 			}
 		}
 		if ((capabilities & WL_SEAT_CAPABILITY_KEYBOARD) == 0) {
+			struct wlr_seat_client *focused_client =
+				wlr_seat->keyboard_state.focused_client;
+			struct wlr_surface *focused_surface =
+				wlr_seat->keyboard_state.focused_surface;
+
+			if (focused_client != NULL && focused_surface != NULL) {
+				seat_client_send_keyboard_leave_raw(focused_client,
+						focused_surface);
+			}
+
+			// Note: we don't set focused client/surface to NULL since we need
+			// them to send the enter event if the keyboard is recreated
+
 			struct wl_resource *resource, *tmp;
 			wl_resource_for_each_safe(resource, tmp, &client->keyboards) {
 				seat_client_destroy_keyboard(resource);


### PR DESCRIPTION
This is more correct according to the protocol and fixes issues with
clients that wait for an enter event before processing key events.

This can be tested by focusing alacritty, switching to a tty and back, then typing.  Without this commit, input is ignored as the client is waiting for an enter event.

Fixes https://github.com/swaywm/sway/issues/5085 (though it was closed as a duplicate already)

A second PR doing the same thing for pointers is in the works.