### PR TITLE
Send pointer enter/leave on capability change

### DIFF
--- a/include/types/wlr_seat.h
+++ b/include/types/wlr_seat.h
@@ -11,6 +11,8 @@ extern const struct wlr_touch_grab_interface default_touch_grab_impl;
 void seat_client_create_pointer(struct wlr_seat_client *seat_client,
 	uint32_t version, uint32_t id);
 void seat_client_destroy_pointer(struct wl_resource *resource);
+void seat_client_send_pointer_leave_raw(struct wlr_seat_client *seat_client,
+	struct wlr_surface *surface);
 
 void seat_client_create_keyboard(struct wlr_seat_client *seat_client,
 	uint32_t version, uint32_t id);

--- a/types/seat/wlr_seat.c
+++ b/types/seat/wlr_seat.c
@@ -316,6 +316,18 @@ void wlr_seat_set_capabilities(struct wlr_seat *wlr_seat,
 	wl_list_for_each(client, &wlr_seat->clients, link) {
 		// Make resources inert if necessary
 		if ((capabilities & WL_SEAT_CAPABILITY_POINTER) == 0) {
+			struct wlr_seat_client *focused_client =
+				wlr_seat->pointer_state.focused_client;
+			struct wlr_surface *focused_surface =
+				wlr_seat->pointer_state.focused_surface;
+
+			if (focused_client != NULL && focused_surface != NULL) {
+				seat_client_send_pointer_leave_raw(focused_client, focused_surface);
+			}
+
+			// Note: we don't set focused client/surface to NULL since we need
+			// them to send the enter event if the pointer is recreated
+
 			struct wl_resource *resource, *tmp;
 			wl_resource_for_each_safe(resource, tmp, &client->pointers) {
 				seat_client_destroy_pointer(resource);


### PR DESCRIPTION
This is more correct according to the protocol and fixes issues with
clients that wait for an enter event before processing pointer events.

This can be tested by typing a url into alacritty, switching to a tty and back
with alacritty focused, then hovering over the link. Without this commit, the
pointer is ignored and no underline is shown.  With this commit the url is
underlined and clickable.

Fixes https://github.com/swaywm/sway/issues/3244