### PR TITLE
Fix uint32 overflow in fill_empty_gamma_table on Icelake platform

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -501,6 +501,7 @@ static bool drm_connector_commit(struct wlr_output *output) {
 
 static void fill_empty_gamma_table(size_t size,
 		uint16_t *r, uint16_t *g, uint16_t *b) {
+	assert(0xFFFF < UINT64_MAX / (size - 1));	
 	for (uint32_t i = 0; i < size; ++i) {
 		uint16_t val = (uint64_t)0xffff * i / (size - 1);
 		r[i] = g[i] = b[i] = val;

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -502,7 +502,7 @@ static bool drm_connector_commit(struct wlr_output *output) {
 static void fill_empty_gamma_table(size_t size,
 		uint16_t *r, uint16_t *g, uint16_t *b) {
 	for (uint32_t i = 0; i < size; ++i) {
-		uint16_t val = (uint32_t)0xffff * i / (size - 1);
+		uint16_t val = (uint64_t)0xffff * i / (size - 1);
 		r[i] = g[i] = b[i] = val;
 	}
 }


### PR DESCRIPTION
Because of the larger gamma table on Icelake platforms, there is a 32 bit overflow leading to the issue https://github.com/swaywm/sway/issues/4826

Closes https://github.com/swaywm/sway/issues/4826