### PR TITLE
wlr_surface: Post error if multiple role objects created

### DIFF
--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -667,8 +667,14 @@ bool wlr_surface_set_role(struct wlr_surface *surface,
 		}
 		return false;
 	}
+	if (surface->role_data != NULL && surface->role_data != role_data) {
+		wl_resource_post_error(error_resource, error_code,
+			"Cannot reassign role %s to wl_surface@%d,"
+			"role object still exists", role->name,
+			wl_resource_get_id(surface->resource));
+		return false;
+	}
 
-	assert(surface->role_data == NULL);
 	surface->role = role;
 	surface->role_data = role_data;
 	return true;


### PR DESCRIPTION
Fixes #2074 

This fixes an assertion failure if a client tries to do this, e.g. by
creating multiple toplevel objects for the same surface. If the same
role data is set multiple times, this does not cause an error, which is
how cursors use this interface.