### PR TITLE
build: Add 'auto' to logind-provider combo option

### DIFF
--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -18,8 +18,8 @@ sources:
 tasks:
   - setup: |
       cd wlroots
-      CC=gcc meson build-gcc -Dauto_features=enabled
-      CC=clang meson build-clang -Dauto_features=enabled
+      CC=gcc meson build-gcc -Dauto_features=enabled -Dlogind-provider=systemd
+      CC=clang meson build-clang -Dauto_features=enabled -Dlogind-provider=systemd
   - gcc: |
       cd wlroots/build-gcc
       ninja

--- a/backend/session/meson.build
+++ b/backend/session/meson.build
@@ -21,15 +21,46 @@ if not get_option('logind').disabled()
 	msg += 'You may need to pass "-Dlogind-provider=elogind" or "-Dlogind-provider=systemd" to ensure the correct library is detected.'
 endif
 
-logind = dependency('lib' + get_option('logind-provider'),
-	required: get_option('logind'),
-	not_found_message: '\n'.join(msg).format(get_option('logind-provider')),
-	version: '>=237',
-)
-if logind.found()
+logind_version = '>=237'
+logind_found = false
+
+if get_option('logind-provider') == 'auto'
+	if not get_option('logind').disabled()
+		assert(get_option('auto_features').auto(), '-Dlogind-provider must be set to systemd or elogind since auto_features != auto')
+		logind = dependency('libsystemd',
+			required: get_option('logind'),
+			not_found_message: 'libsystemd not found, trying libelogind\n' + '\n'.join(msg),
+			version: logind_version,
+		)
+		if logind.found()
+			conf_data.set10('WLR_HAS_SYSTEMD', true)
+		else
+			logind = dependency('libelogind',
+				required: get_option('logind'),
+				not_found_message: 'libelogind not found\n' + '\n'.join(msg),
+				version: logind_version,
+			)
+			if logind.found()
+				conf_data.set10('WLR_HAS_ELOGIND', true)
+			endif
+		endif
+		logind_found = logind.found()
+	endif
+else
+	logind = dependency('lib' + get_option('logind-provider'),
+		required: get_option('logind'),
+		not_found_message: '\n'.join(msg).format(get_option('logind-provider')),
+		version: logind_version,
+	)
+	if logind.found()
+		conf_data.set10('WLR_HAS_' + get_option('logind-provider').to_upper(), true)
+		logind_found = true
+	endif
+endif
+
+if logind_found
 	wlr_files += files('logind.c')
 	wlr_deps += logind
-	conf_data.set10('WLR_HAS_' + get_option('logind-provider').to_upper(), true)
 endif
 
 # libcap

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,6 @@
 option('libcap', type: 'feature', value: 'auto', description: 'Enable support for rootless session via capabilities (cap_sys_admin)')
 option('logind', type: 'feature', value: 'auto', description: 'Enable support for rootless session via logind')
-option('logind-provider', type: 'combo', choices: ['systemd', 'elogind'], value: 'systemd', description: 'Provider of logind support library')
+option('logind-provider', type: 'combo', choices: ['auto', 'systemd', 'elogind'], value: 'auto', description: 'Provider of logind support library')
 option('xcb-errors', type: 'feature', value: 'auto', description: 'Use xcb-errors util library')
 option('xcb-icccm', type: 'feature', value: 'auto', description: 'Use xcb-icccm util library')
 option('xwayland', type: 'feature', value: 'auto', yield: true, description: 'Enable support for X11 applications')


### PR DESCRIPTION
The logind provider defaulted to systemd and in order to use elogind,
-Dlogin-provider=elogind was required. This adds 'auto' as a choice
for the login-provider option and sets it as default. Using 'auto',
the build will check for systemd first and if it's not found, try
to find and use elogind automatically.