### PR TITLE
render: only expose linux-dmabuf if EGL extension is supported

### DIFF
--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -355,9 +355,14 @@ static bool gles2_init_wl_display(struct wlr_renderer *wlr_renderer,
 		struct wl_display *wl_display) {
 	struct wlr_gles2_renderer *renderer =
 		gles2_get_renderer(wlr_renderer);
-	if (!wlr_egl_bind_display(renderer->egl, wl_display)) {
-		wlr_log(WLR_INFO, "failed to bind wl_display to EGL");
-		return false;
+
+	if (renderer->egl->exts.bind_wayland_display_wl) {
+		if (!wlr_egl_bind_display(renderer->egl, wl_display)) {
+			wlr_log(WLR_ERROR, "Failed to bind wl_display to EGL");
+			return false;
+		}
+	} else {
+		wlr_log(WLR_INFO, "EGL_WL_bind_wayland_display is not supported");
 	}
 	return true;
 }

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -10,6 +10,7 @@
 #include <wlr/render/interface.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_matrix.h>
+#include <wlr/types/wlr_linux_dmabuf_v1.h>
 #include <wlr/util/log.h>
 #include "render/gles2.h"
 
@@ -364,6 +365,15 @@ static bool gles2_init_wl_display(struct wlr_renderer *wlr_renderer,
 	} else {
 		wlr_log(WLR_INFO, "EGL_WL_bind_wayland_display is not supported");
 	}
+
+	if (renderer->egl->exts.image_dmabuf_import_ext) {
+		if (wlr_linux_dmabuf_v1_create(wl_display, wlr_renderer) == NULL) {
+			return false;
+		}
+	} else {
+		wlr_log(WLR_INFO, "EGL_EXT_image_dma_buf_import is not supported");
+	}
+
 	return true;
 }
 

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -4,7 +4,6 @@
 #include <wlr/render/gles2.h>
 #include <wlr/render/interface.h>
 #include <wlr/render/wlr_renderer.h>
-#include <wlr/types/wlr_linux_dmabuf_v1.h>
 #include <wlr/types/wlr_matrix.h>
 #include <wlr/util/log.h>
 #include "util/signal.h"
@@ -179,12 +178,6 @@ bool wlr_renderer_init_wl_display(struct wlr_renderer *r,
 		if (formats[i] != WL_SHM_FORMAT_ARGB8888 &&
 				formats[i] != WL_SHM_FORMAT_XRGB8888) {
 			wl_display_add_shm_format(wl_display, formats[i]);
-		}
-	}
-
-	if (r->impl->texture_from_dmabuf) {
-		if (wlr_linux_dmabuf_v1_create(wl_display, r) == NULL) {
-			return false;
 		}
 	}
 


### PR DESCRIPTION
Only expose linux-dmabuf extension if EGL_EXT_image_dmabuf_import_ext is
supported.

Closes: https://github.com/swaywm/wlroots/issues/2076