### PR TITLE
drm: Use DRM_FORMAT_MOD_LINEAR when no other format modifiers are present

### DIFF
--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -90,6 +90,10 @@ bool init_drm_surface(struct wlr_drm_surface *surf,
 		if (drm_format != NULL) {
 			surf->gbm = gbm_surface_create_with_modifiers(renderer->gbm,
 				width, height, format, drm_format->modifiers, drm_format->len);
+		} else {
+			uint64_t formats[] = { DRM_FORMAT_MOD_LINEAR };
+			surf->gbm = gbm_surface_create_with_modifiers(renderer->gbm,
+				width, height, format, formats, 1);
 		}
 	}
 


### PR DESCRIPTION
The absence of modifiers means "assume linear" not "don't use any
modifier". This prevents gallium from using plain resource_create but
rather resource_create_with_modifiers.

This unbreaks broken rendering on etnaviv as resource_create assumes
it can supertile (which makes sense since e.g. dcss and ipuv3 can
handle these formats). However lcdif/mxsfb can't handle this so
be explicit about the modifier.

Weston does the same, see drm_plane_populate_formats().

This is basically a safety net if the display controller does not
announce supported modifiers. We'll fix this as well in the kernel but having
good default is useful too.