### PR TITLE
Implement the viewporter protocol

### DIFF
--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -32,9 +32,9 @@ struct wlr_renderer_impl {
 	void (*end)(struct wlr_renderer *renderer);
 	void (*clear)(struct wlr_renderer *renderer, const float color[static 4]);
 	void (*scissor)(struct wlr_renderer *renderer, struct wlr_box *box);
-	bool (*render_texture_with_matrix)(struct wlr_renderer *renderer,
-		struct wlr_texture *texture, const float matrix[static 9],
-		float alpha);
+	bool (*render_subtexture_with_matrix)(struct wlr_renderer *renderer,
+		struct wlr_texture *texture, const struct wlr_fbox *box,
+		const float matrix[static 9], float alpha);
 	void (*render_quad_with_matrix)(struct wlr_renderer *renderer,
 		const float color[static 4], const float matrix[static 9]);
 	void (*render_ellipse_with_matrix)(struct wlr_renderer *renderer,

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -55,6 +55,13 @@ bool wlr_render_texture(struct wlr_renderer *r, struct wlr_texture *texture,
 bool wlr_render_texture_with_matrix(struct wlr_renderer *r,
 	struct wlr_texture *texture, const float matrix[static 9], float alpha);
 /**
+ * Renders the requested texture using the provided matrix, after cropping it
+ * to the provided rectangle.
+ */
+bool wlr_render_subtexture_with_matrix(struct wlr_renderer *r,
+	struct wlr_texture *texture, const struct wlr_fbox *box,
+	const float matrix[static 9], float alpha);
+/**
  * Renders a solid rectangle in the specified color.
  */
 void wlr_render_rect(struct wlr_renderer *r, const struct wlr_box *box,

--- a/include/wlr/types/wlr_box.h
+++ b/include/wlr/types/wlr_box.h
@@ -18,6 +18,11 @@ struct wlr_box {
 	int width, height;
 };
 
+struct wlr_fbox {
+	double x, y;
+	double width, height;
+};
+
 void wlr_box_closest_point(const struct wlr_box *box, double x, double y,
 	double *dest_x, double *dest_y);
 

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -262,4 +262,15 @@ void wlr_surface_for_each_surface(struct wlr_surface *surface,
 void wlr_surface_get_effective_damage(struct wlr_surface *surface,
 	pixman_region32_t *damage);
 
+/**
+ * Get the source rectangle describing the region of the buffer that needs to
+ * be sampled to render this surface's current state. The box is in
+ * buffer-local coordinates.
+ *
+ * If the viewport's source rectangle is unset, the position is zero and the
+ * size is the buffer's.
+ */
+void wlr_surface_get_buffer_source_box(struct wlr_surface *surface,
+	struct wlr_fbox *box);
+
 #endif

--- a/include/wlr/types/wlr_viewporter.h
+++ b/include/wlr/types/wlr_viewporter.h
@@ -1,0 +1,34 @@
+/*
+ * This an unstable interface of wlroots. No guarantees are made regarding the
+ * future consistency of this API.
+ */
+#ifndef WLR_USE_UNSTABLE
+#error "Add -DWLR_USE_UNSTABLE to enable unstable wlroots features"
+#endif
+
+#ifndef WLR_TYPES_WLR_VIEWPORTER_H
+#define WLR_TYPES_WLR_VIEWPORTER_H
+
+#include <wayland-server-core.h>
+
+struct wlr_viewporter {
+	struct wl_global *global;
+
+	struct {
+		struct wl_signal destroy;
+	} events;
+
+	struct wl_listener display_destroy;
+};
+
+struct wlr_viewport {
+	struct wl_resource *resource;
+	struct wlr_surface *surface;
+
+	struct wl_listener surface_destroy;
+	struct wl_listener surface_commit;
+};
+
+struct wlr_viewporter *wlr_viewporter_create(struct wl_display *display);
+
+#endif

--- a/include/wlr/util/region.h
+++ b/include/wlr/util/region.h
@@ -30,6 +30,9 @@
 void wlr_region_scale(pixman_region32_t *dst, pixman_region32_t *src,
 	float scale);
 
+void wlr_region_scale_xy(pixman_region32_t *dst, pixman_region32_t *src,
+	float scale_x, float scale_y);
+
 /**
  * Applies a transform to a region inside a box of size `width` x `height`.
  */

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -14,6 +14,7 @@ protocols = {
 	# Stable upstream protocols
 	'xdg-shell': wl_protocol_dir / 'stable/xdg-shell/xdg-shell.xml',
 	'presentation-time': wl_protocol_dir / 'stable/presentation-time/presentation-time.xml',
+	'viewporter': wl_protocol_dir / 'stable/viewporter/viewporter.xml',
 	# Unstable upstream protocols
 	'fullscreen-shell-unstable-v1': wl_protocol_dir / 'unstable/fullscreen-shell/fullscreen-shell-unstable-v1.xml',
 	'idle-inhibit-unstable-v1': wl_protocol_dir / 'unstable/idle-inhibit/idle-inhibit-unstable-v1.xml',

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -86,7 +86,8 @@ static void gles2_scissor(struct wlr_renderer *wlr_renderer,
 	POP_GLES2_DEBUG;
 }
 
-static void draw_quad(void) {
+static void draw_quad_with_texcoord(GLfloat x1, GLfloat y1,
+		GLfloat x2, GLfloat y2) {
 	GLfloat verts[] = {
 		1, 0, // top right
 		0, 0, // top left
@@ -94,10 +95,10 @@ static void draw_quad(void) {
 		0, 1, // bottom left
 	};
 	GLfloat texcoord[] = {
-		1, 0, // top right
-		0, 0, // top left
-		1, 1, // bottom right
-		0, 1, // bottom left
+		x2, y1, // top right
+		x1, y1, // top left
+		x2, y2, // bottom right
+		x1, y2, // bottom left
 	};
 
 	glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, verts);
@@ -112,8 +113,13 @@ static void draw_quad(void) {
 	glDisableVertexAttribArray(1);
 }
 
-static bool gles2_render_texture_with_matrix(struct wlr_renderer *wlr_renderer,
-		struct wlr_texture *wlr_texture, const float matrix[static 9],
+static void draw_quad(void) {
+	draw_quad_with_texcoord(0, 0, 1, 1);
+}
+
+static bool gles2_render_subtexture_with_matrix(
+		struct wlr_renderer *wlr_renderer, struct wlr_texture *wlr_texture,
+		const struct wlr_fbox *box, const float matrix[static 9],
 		float alpha) {
 	struct wlr_gles2_renderer *renderer =
 		gles2_get_renderer_in_context(wlr_renderer);
@@ -162,7 +168,11 @@ static bool gles2_render_texture_with_matrix(struct wlr_renderer *wlr_renderer,
 	glUniform1i(shader->tex, 0);
 	glUniform1f(shader->alpha, alpha);
 
-	draw_quad();
+	GLfloat x1 = box->x / wlr_texture->width;
+	GLfloat y1 = box->y / wlr_texture->height;
+	GLfloat x2 = (box->x + box->width) / wlr_texture->width;
+	GLfloat y2 = (box->y + box->height) / wlr_texture->height;
+	draw_quad_with_texcoord(x1, y1, x2, y2);
 
 	glBindTexture(texture->target, 0);
 
@@ -412,7 +422,7 @@ static const struct wlr_renderer_impl renderer_impl = {
 	.end = gles2_end,
 	.clear = gles2_clear,
 	.scissor = gles2_scissor,
-	.render_texture_with_matrix = gles2_render_texture_with_matrix,
+	.render_subtexture_with_matrix = gles2_render_subtexture_with_matrix,
 	.render_quad_with_matrix = gles2_render_quad_with_matrix,
 	.render_ellipse_with_matrix = gles2_render_ellipse_with_matrix,
 	.formats = gles2_renderer_formats,

--- a/render/gles2/shaders.c
+++ b/render/gles2/shaders.c
@@ -50,7 +50,7 @@ const GLchar tex_vertex_src[] =
 "void main() {\n"
 "	gl_Position = vec4(proj * vec3(pos, 1.0), 1.0);\n"
 "	if (invert_y) {\n"
-"		v_texcoord = vec2(texcoord.s, 1.0 - texcoord.t);\n"
+"		v_texcoord = vec2(texcoord.x, 1.0 - texcoord.y);\n"
 "	} else {\n"
 "		v_texcoord = texcoord;\n"
 "	}\n"

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -13,7 +13,7 @@ void wlr_renderer_init(struct wlr_renderer *renderer,
 	assert(impl->begin);
 	assert(impl->clear);
 	assert(impl->scissor);
-	assert(impl->render_texture_with_matrix);
+	assert(impl->render_subtexture_with_matrix);
 	assert(impl->render_quad_with_matrix);
 	assert(impl->render_ellipse_with_matrix);
 	assert(impl->formats);
@@ -80,8 +80,21 @@ bool wlr_render_texture(struct wlr_renderer *r, struct wlr_texture *texture,
 bool wlr_render_texture_with_matrix(struct wlr_renderer *r,
 		struct wlr_texture *texture, const float matrix[static 9],
 		float alpha) {
+	struct wlr_fbox box = {
+		.x = 0,
+		.y = 0,
+		.width = texture->width,
+		.height = texture->height,
+	};
+	return wlr_render_subtexture_with_matrix(r, texture, &box, matrix, alpha);
+}
+
+bool wlr_render_subtexture_with_matrix(struct wlr_renderer *r,
+		struct wlr_texture *texture, const struct wlr_fbox *box,
+		const float matrix[static 9], float alpha) {
 	assert(r->rendering);
-	return r->impl->render_texture_with_matrix(r, texture, matrix, alpha);
+	return r->impl->render_subtexture_with_matrix(r, texture,
+		box, matrix, alpha);
 }
 
 void wlr_render_rect(struct wlr_renderer *r, const struct wlr_box *box,

--- a/types/meson.build
+++ b/types/meson.build
@@ -64,6 +64,7 @@ wlr_files += files(
 	'wlr_tablet_tool.c',
 	'wlr_text_input_v3.c',
 	'wlr_touch.c',
+	'wlr_viewporter.c',
 	'wlr_virtual_keyboard_v1.c',
 	'wlr_virtual_pointer_v1.c',
 	'wlr_xcursor_manager.c',

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -1226,3 +1226,26 @@ void wlr_surface_get_effective_damage(struct wlr_surface *surface,
 			surface->previous.width, surface->previous.height);
 	}
 }
+
+void wlr_surface_get_buffer_source_box(struct wlr_surface *surface,
+		struct wlr_fbox *box) {
+	box->x = box->y = 0;
+	box->width = surface->current.buffer_width;
+	box->height = surface->current.buffer_height;
+
+	if (surface->current.viewport.has_src) {
+		box->x = surface->current.viewport.src.x * surface->current.scale;
+		box->y = surface->current.viewport.src.y * surface->current.scale;
+		box->width = surface->current.viewport.src.width * surface->current.scale;
+		box->height = surface->current.viewport.src.height * surface->current.scale;
+		if ((surface->current.transform & WL_OUTPUT_TRANSFORM_90) != 0) {
+			double tmp = box->x;
+			box->x = box->y;
+			box->y = tmp;
+
+			tmp = box->width;
+			box->width = box->height;
+			box->height = tmp;
+		}
+	}
+}

--- a/types/wlr_viewporter.c
+++ b/types/wlr_viewporter.c
@@ -1,0 +1,224 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <wlr/types/wlr_surface.h>
+#include <wlr/types/wlr_viewporter.h>
+#include <wlr/util/log.h>
+#include "util/signal.h"
+#include "viewporter-protocol.h"
+
+#define VIEWPORTER_VERSION 1
+
+static const struct wp_viewport_interface viewport_impl;
+
+// Returns NULL if the viewport is inert
+static struct wlr_viewport *viewport_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &wp_viewport_interface,
+		&viewport_impl));
+	return wl_resource_get_user_data(resource);
+}
+
+static void viewport_handle_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+
+static void viewport_handle_set_source(struct wl_client *client,
+		struct wl_resource *resource, wl_fixed_t x_fixed, wl_fixed_t y_fixed,
+		wl_fixed_t width_fixed, wl_fixed_t height_fixed) {
+	struct wlr_viewport *viewport = viewport_from_resource(resource);
+	if (viewport == NULL) {
+		wl_resource_post_error(resource, WP_VIEWPORT_ERROR_NO_SURFACE,
+			"wp_viewport.set_source sent after wl_surface has been destroyed");
+		return;
+	}
+
+	struct wlr_surface_state *pending = &viewport->surface->pending;
+
+	double x = wl_fixed_to_double(x_fixed);
+	double y = wl_fixed_to_double(y_fixed);
+	double width = wl_fixed_to_double(width_fixed);
+	double height = wl_fixed_to_double(height_fixed);
+
+	if (x == -1.0 && y == -1.0 && width == -1.0 && height == -1.0) {
+		pending->viewport.has_src = false;
+	} else if (x < 0 || y < 0 || width <= 0 || height <= 0) {
+		wl_resource_post_error(resource, WP_VIEWPORT_ERROR_BAD_VALUE,
+			"wl_viewport.set_source sent with invalid values");
+		return;
+	} else {
+		pending->viewport.has_src = true;
+	}
+
+	pending->viewport.src.x = x;
+	pending->viewport.src.y = y;
+	pending->viewport.src.width = width;
+	pending->viewport.src.height = height;
+
+	pending->committed |= WLR_SURFACE_STATE_VIEWPORT;
+}
+
+static void viewport_handle_set_destination(struct wl_client *client,
+		struct wl_resource *resource, int32_t width, int32_t height) {
+	struct wlr_viewport *viewport = viewport_from_resource(resource);
+	if (viewport == NULL) {
+		wl_resource_post_error(resource, WP_VIEWPORT_ERROR_NO_SURFACE,
+			"wp_viewport.set_destination sent after wl_surface has been destroyed");
+		return;
+	}
+
+	struct wlr_surface_state *pending = &viewport->surface->pending;
+
+	if (width == -1 && height == -1) {
+		pending->viewport.has_dst = false;
+	} else if (width <= 0 || height <= 0) {
+		wl_resource_post_error(resource, WP_VIEWPORT_ERROR_BAD_VALUE,
+			"wl_viewport.set_destination sent with invalid values");
+		return;
+	} else {
+		pending->viewport.has_dst = true;
+	}
+
+	pending->viewport.dst_width = width;
+	pending->viewport.dst_height = height;
+
+	pending->committed |= WLR_SURFACE_STATE_VIEWPORT;
+}
+
+static const struct wp_viewport_interface viewport_impl = {
+	.destroy = viewport_handle_destroy,
+	.set_source = viewport_handle_set_source,
+	.set_destination = viewport_handle_set_destination,
+};
+
+static void viewport_destroy(struct wlr_viewport *viewport) {
+	if (viewport == NULL) {
+		return;
+	}
+	wl_resource_set_user_data(viewport->resource, NULL);
+	wl_list_remove(&viewport->surface_destroy.link);
+	wl_list_remove(&viewport->surface_commit.link);
+	free(viewport);
+}
+
+static void viewport_handle_resource_destroy(struct wl_resource *resource) {
+	struct wlr_viewport *viewport = viewport_from_resource(resource);
+	viewport_destroy(viewport);
+}
+
+static void viewport_handle_surface_destroy(struct wl_listener *listener,
+		void *data) {
+	struct wlr_viewport *viewport =
+		wl_container_of(listener, viewport, surface_destroy);
+	viewport_destroy(viewport);
+}
+
+static void viewport_handle_surface_commit(struct wl_listener *listener,
+		void *data) {
+	struct wlr_viewport *viewport =
+		wl_container_of(listener, viewport, surface_commit);
+
+	struct wlr_surface_state *current = &viewport->surface->pending;
+
+	if (!current->viewport.has_dst &&
+			(floor(current->viewport.src.width) != current->viewport.src.width ||
+			floor(current->viewport.src.height) != current->viewport.src.height)) {
+		wl_resource_post_error(viewport->resource, WP_VIEWPORT_ERROR_BAD_SIZE,
+			"wl_viewport.set_source width and height must be integers "
+			"when the destination rectangle is unset");
+		return;
+	}
+
+	if (current->viewport.has_src && current->buffer_resource != NULL &&
+			(current->viewport.src.x + current->viewport.src.width >
+				current->buffer_width ||
+			current->viewport.src.y + current->viewport.src.height >
+				current->buffer_height)) {
+		wl_resource_post_error(viewport->resource, WP_VIEWPORT_ERROR_OUT_OF_BUFFER,
+			"source rectangle out of buffer bounds");
+		return;
+	}
+}
+
+static void viewporter_handle_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+
+static void viewporter_handle_get_viewport(struct wl_client *client,
+		struct wl_resource *resource, uint32_t id,
+		struct wl_resource *surface_resource) {
+	struct wlr_surface *surface = wlr_surface_from_resource(surface_resource);
+
+	struct wlr_viewport *viewport = calloc(1, sizeof(*viewport));
+	if (viewport == NULL) {
+		wl_client_post_no_memory(client);
+		return;
+	}
+
+	uint32_t version = wl_resource_get_version(resource);
+	viewport->resource = wl_resource_create(client, &wp_viewport_interface,
+		version, id);
+	if (viewport->resource == NULL) {
+		wl_client_post_no_memory(client);
+		free(viewport);
+		return;
+	}
+	wl_resource_set_implementation(viewport->resource, &viewport_impl,
+		viewport, viewport_handle_resource_destroy);
+
+	viewport->surface = surface;
+
+	viewport->surface_destroy.notify = viewport_handle_surface_destroy;
+	wl_signal_add(&surface->events.destroy, &viewport->surface_destroy);
+
+	viewport->surface_commit.notify = viewport_handle_surface_commit;
+	wl_signal_add(&surface->events.commit, &viewport->surface_commit);
+}
+
+static const struct wp_viewporter_interface viewporter_impl = {
+	.destroy = viewporter_handle_destroy,
+	.get_viewport = viewporter_handle_get_viewport,
+};
+
+static void viewporter_bind(struct wl_client *client, void *data,
+		uint32_t version, uint32_t id) {
+	struct wlr_viewporter *viewporter = data;
+
+	struct wl_resource *resource = wl_resource_create(client,
+		&wp_viewporter_interface, version, id);
+	if (resource == NULL) {
+		wl_client_post_no_memory(client);
+		return;
+	}
+	wl_resource_set_implementation(resource, &viewporter_impl, viewporter, NULL);
+}
+
+static void handle_display_destroy(struct wl_listener *listener, void *data) {
+	struct wlr_viewporter *viewporter =
+		wl_container_of(listener, viewporter, display_destroy);
+	wlr_signal_emit_safe(&viewporter->events.destroy, NULL);
+	wl_global_destroy(viewporter->global);
+	free(viewporter);
+}
+
+struct wlr_viewporter *wlr_viewporter_create(struct wl_display *display) {
+	struct wlr_viewporter *viewporter = calloc(1, sizeof(*viewporter));
+	if (viewporter == NULL) {
+		return NULL;
+	}
+
+	viewporter->global = wl_global_create(display, &wp_viewporter_interface,
+		VIEWPORTER_VERSION, viewporter, viewporter_bind);
+	if (viewporter->global == NULL) {
+		free(viewporter);
+		return NULL;
+	}
+
+	wl_signal_init(&viewporter->events.destroy);
+
+	viewporter->display_destroy.notify = handle_display_destroy;
+	wl_display_add_destroy_listener(display, &viewporter->display_destroy);
+
+	return viewporter;
+}

--- a/util/region.c
+++ b/util/region.c
@@ -7,7 +7,12 @@
 
 void wlr_region_scale(pixman_region32_t *dst, pixman_region32_t *src,
 		float scale) {
-	if (scale == 1) {
+	wlr_region_scale_xy(dst, src, scale, scale);
+}
+
+void wlr_region_scale_xy(pixman_region32_t *dst, pixman_region32_t *src,
+		float scale_x, float scale_y) {
+	if (scale_x == 1.0 && scale_y == 1.0) {
 		pixman_region32_copy(dst, src);
 		return;
 	}
@@ -21,10 +26,10 @@ void wlr_region_scale(pixman_region32_t *dst, pixman_region32_t *src,
 	}
 
 	for (int i = 0; i < nrects; ++i) {
-		dst_rects[i].x1 = floor(src_rects[i].x1 * scale);
-		dst_rects[i].x2 = ceil(src_rects[i].x2 * scale);
-		dst_rects[i].y1 = floor(src_rects[i].y1 * scale);
-		dst_rects[i].y2 = ceil(src_rects[i].y2 * scale);
+		dst_rects[i].x1 = floor(src_rects[i].x1 * scale_x);
+		dst_rects[i].x2 = ceil(src_rects[i].x2 * scale_x);
+		dst_rects[i].y1 = floor(src_rects[i].y1 * scale_y);
+		dst_rects[i].y2 = ceil(src_rects[i].y2 * scale_y);
 	}
 
 	pixman_region32_fini(dst);


### PR DESCRIPTION
The [viewporter protocol](https://gitlab.freedesktop.org/wayland/wayland-protocols/blob/master/stable/viewporter/viewporter.xml) allows clients to ask the compositor to crop and scale buffers during composition. This allows clients to avoid having to crop and scale in an intermediary buffer. The use-cases are:

- Xwayland games that expect to be able to perform modeset
- Video players that present DMA-BUFs coming out of VA-API
- Optimized scrolling in web browsers

TODO:

- [x] Apply viewport transforms to damage
- [x] Error out when src_width or src_height are not integers and destination size is not set
- [x] Compositor implementation: https://github.com/swaywm/sway/pull/5433

Test plan:

- [x] `weston-scaler -s`
- [x] `weston-scaler -d`
- [x] `weston-scaler -b`

Future plans: wire this up with direct scan-out. With my [wlr_output_layer proposal](https://github.com/swaywm/wlroots/pull/1985), I think we can extend [the API](https://github.com/swaywm/wlroots/pull/1985/files#diff-bc323577ae8471cb9563146f750574a7) to allow compositors to feed src/dst rectangles to the backend:

```c
/**
 * Set the layer's final size. If the size is different from the attached buffer's,
 * the buffer will be scaled.
 */
void wlr_output_layer_scale(struct wlr_output_layer *layer, int width, int height);
/**
 * Set the layer's source box. This defines what area of the buffer will be used
 * as a source. This can be used to crop the buffer.
 */
void wlr_output_layer_set_src_box(struct wlr_output_layer *layer,
        const struct wlr_fbox *box);
```

`wlr_output_layer_scale` maps directly to the `CRTC_W` and `CRTC_H` KMS properties. `wlr_output_layer_set_buffer_src_box` maps directly to the `SRC_*` KMS properties.

Closes: https://github.com/swaywm/wlroots/issues/633

* * *

Breaking change: renderer implementations need to be updated, `render_texture_with_matrix` has been replaced with `render_subtexture_with_matrix` which allows specifying a source rectangle.