### PR TITLE
output: introduce wlr_output_test

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -334,6 +334,10 @@ static bool drm_connector_attach_render(struct wlr_output *output,
 	return make_drm_surface_current(&conn->crtc->primary->surf, buffer_age);
 }
 
+static bool drm_connector_test(struct wlr_output *output) {
+	return true;
+}
+
 static bool drm_connector_commit_buffer(struct wlr_output *output) {
 	struct wlr_drm_connector *conn = get_drm_connector_from_output(output);
 	struct wlr_drm_backend *drm = get_drm_backend_from_backend(output->backend);
@@ -455,6 +459,10 @@ static bool drm_connector_set_custom_mode(struct wlr_output *output,
 static bool drm_connector_commit(struct wlr_output *output) {
 	struct wlr_drm_backend *drm = get_drm_backend_from_backend(output->backend);
 
+	if (!drm_connector_test(output)) {
+		return false;
+	}
+
 	if (!drm->session->active) {
 		return false;
 	}
@@ -501,7 +509,7 @@ static bool drm_connector_commit(struct wlr_output *output) {
 
 static void fill_empty_gamma_table(size_t size,
 		uint16_t *r, uint16_t *g, uint16_t *b) {
-	assert(0xFFFF < UINT64_MAX / (size - 1));	
+	assert(0xFFFF < UINT64_MAX / (size - 1));
 	for (uint32_t i = 0; i < size; ++i) {
 		uint16_t val = (uint64_t)0xffff * i / (size - 1);
 		r[i] = g[i] = b[i] = val;
@@ -1068,6 +1076,7 @@ static const struct wlr_output_impl output_impl = {
 	.move_cursor = drm_connector_move_cursor,
 	.destroy = drm_connector_destroy,
 	.attach_render = drm_connector_attach_render,
+	.test = drm_connector_test,
 	.commit = drm_connector_commit,
 	.set_gamma = set_drm_connector_gamma,
 	.get_gamma_size = drm_connector_get_gamma_size,

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -334,7 +334,67 @@ static bool drm_connector_attach_render(struct wlr_output *output,
 	return make_drm_surface_current(&conn->crtc->primary->surf, buffer_age);
 }
 
+static uint32_t strip_alpha_channel(uint32_t format) {
+	switch (format) {
+	case DRM_FORMAT_ARGB8888:
+		return DRM_FORMAT_XRGB8888;
+	default:
+		return DRM_FORMAT_INVALID;
+	}
+}
+
+static bool test_buffer(struct wlr_drm_connector *conn,
+		struct wlr_buffer *wlr_buffer) {
+	struct wlr_output *output = &conn->output;
+	struct wlr_drm_backend *drm = get_drm_backend_from_backend(output->backend);
+
+	if (!drm->session->active) {
+		return false;
+	}
+
+	struct wlr_drm_crtc *crtc = conn->crtc;
+	if (!crtc) {
+		return false;
+	}
+
+	struct wlr_dmabuf_attributes attribs;
+	if (!wlr_buffer_get_dmabuf(wlr_buffer, &attribs)) {
+		return false;
+	}
+
+	if (attribs.flags != 0) {
+		return false;
+	}
+	if (attribs.width != output->width || attribs.height != output->height) {
+		return false;
+	}
+
+	if (!wlr_drm_format_set_has(&crtc->primary->formats,
+			attribs.format, attribs.modifier)) {
+		// The format isn't supported by the plane. Try stripping the alpha
+		// channel, if any.
+		uint32_t format = strip_alpha_channel(attribs.format);
+		if (format != DRM_FORMAT_INVALID && wlr_drm_format_set_has(
+				&crtc->primary->formats, format, attribs.modifier)) {
+			attribs.format = format;
+		} else {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 static bool drm_connector_test(struct wlr_output *output) {
+	struct wlr_drm_connector *conn = get_drm_connector_from_output(output);
+
+	if ((output->pending.committed & WLR_OUTPUT_STATE_BUFFER) &&
+			output->pending.buffer_type == WLR_OUTPUT_STATE_BUFFER_SCANOUT) {
+		if (!test_buffer(conn, output->pending.buffer)) {
+			return false;
+		}
+	}
+
 	return true;
 }
 
@@ -377,8 +437,13 @@ static bool drm_connector_commit_buffer(struct wlr_output *output) {
 			return false;
 		}
 		break;
-	case WLR_OUTPUT_STATE_BUFFER_SCANOUT:
-		bo = import_gbm_bo(&drm->renderer, &conn->pending_dmabuf);
+	case WLR_OUTPUT_STATE_BUFFER_SCANOUT:;
+		struct wlr_dmabuf_attributes attribs;
+		if (!wlr_buffer_get_dmabuf(output->pending.buffer, &attribs)) {
+			return false;
+		}
+
+		bo = import_gbm_bo(&drm->renderer, &attribs);
 		if (bo == NULL) {
 			wlr_log(WLR_ERROR, "import_gbm_bo failed");
 			return false;
@@ -1011,57 +1076,6 @@ static bool drm_connector_move_cursor(struct wlr_output *output,
 	return ok;
 }
 
-static uint32_t strip_alpha_channel(uint32_t format) {
-	switch (format) {
-	case DRM_FORMAT_ARGB8888:
-		return DRM_FORMAT_XRGB8888;
-	default:
-		return DRM_FORMAT_INVALID;
-	}
-}
-
-static bool drm_connector_attach_buffer(struct wlr_output *output,
-		struct wlr_buffer *buffer) {
-	struct wlr_drm_connector *conn = get_drm_connector_from_output(output);
-	struct wlr_drm_backend *drm = get_drm_backend_from_backend(output->backend);
-	if (!drm->session->active) {
-		return false;
-	}
-
-	struct wlr_drm_crtc *crtc = conn->crtc;
-	if (!crtc) {
-		return false;
-	}
-
-	struct wlr_dmabuf_attributes attribs;
-	if (!wlr_buffer_get_dmabuf(buffer, &attribs)) {
-		return false;
-	}
-
-	if (attribs.flags != 0) {
-		return false;
-	}
-	if (attribs.width != output->width || attribs.height != output->height) {
-		return false;
-	}
-
-	if (!wlr_drm_format_set_has(&crtc->primary->formats,
-			attribs.format, attribs.modifier)) {
-		// The format isn't supported by the plane. Try stripping the alpha
-		// channel, if any.
-		uint32_t format = strip_alpha_channel(attribs.format);
-		if (format != DRM_FORMAT_INVALID && wlr_drm_format_set_has(
-				&crtc->primary->formats, format, attribs.modifier)) {
-			attribs.format = format;
-		} else {
-			return false;
-		}
-	}
-
-	memcpy(&conn->pending_dmabuf, &attribs, sizeof(attribs));
-	return true;
-}
-
 static void drm_connector_destroy(struct wlr_output *output) {
 	struct wlr_drm_connector *conn = get_drm_connector_from_output(output);
 	drm_connector_cleanup(conn);
@@ -1081,7 +1095,6 @@ static const struct wlr_output_impl output_impl = {
 	.set_gamma = set_drm_connector_gamma,
 	.get_gamma_size = drm_connector_get_gamma_size,
 	.export_dmabuf = drm_connector_export_dmabuf,
-	.attach_buffer = drm_connector_attach_buffer,
 };
 
 bool wlr_output_is_drm(struct wlr_output *output) {

--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -57,7 +57,7 @@ static bool output_attach_render(struct wlr_output *wlr_output,
 		buffer_age);
 }
 
-static bool output_commit(struct wlr_output *wlr_output) {
+static bool output_test(struct wlr_output *wlr_output) {
 	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_ENABLED) {
 		wlr_log(WLR_DEBUG, "Cannot disable a headless output");
 		return false;
@@ -65,6 +65,17 @@ static bool output_commit(struct wlr_output *wlr_output) {
 
 	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_MODE) {
 		assert(wlr_output->pending.mode_type == WLR_OUTPUT_STATE_MODE_CUSTOM);
+	}
+
+	return true;
+}
+
+static bool output_commit(struct wlr_output *wlr_output) {
+	if (!output_test(wlr_output)) {
+		return false;
+	}
+
+	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_MODE) {
 		if (!output_set_custom_mode(wlr_output,
 				wlr_output->pending.custom_mode.width,
 				wlr_output->pending.custom_mode.height,

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -127,20 +127,35 @@ static const struct wl_buffer_listener buffer_listener = {
 	.release = buffer_handle_release,
 };
 
-static struct wlr_wl_buffer *create_wl_buffer(struct wlr_wl_backend *wl,
+static bool test_buffer(struct wlr_wl_backend *wl,
 		struct wlr_buffer *wlr_buffer,
 		int required_width, int required_height) {
 	struct wlr_dmabuf_attributes attribs;
 	if (!wlr_buffer_get_dmabuf(wlr_buffer, &attribs)) {
-		return NULL;
+		return false;
 	}
 
 	if (attribs.width != required_width || attribs.height != required_height) {
-		return NULL;
+		return false;
 	}
 
 	if (!wlr_drm_format_set_has(&wl->linux_dmabuf_v1_formats,
 			attribs.format, attribs.modifier)) {
+		return false;
+	}
+
+	return true;
+}
+
+static struct wlr_wl_buffer *create_wl_buffer(struct wlr_wl_backend *wl,
+		struct wlr_buffer *wlr_buffer,
+		int required_width, int required_height) {
+	if (!test_buffer(wl, wlr_buffer, required_width, required_height)) {
+		return NULL;
+	}
+
+	struct wlr_dmabuf_attributes attribs;
+	if (!wlr_buffer_get_dmabuf(wlr_buffer, &attribs)) {
 		return NULL;
 	}
 
@@ -178,23 +193,6 @@ static struct wlr_wl_buffer *create_wl_buffer(struct wlr_wl_backend *wl,
 	wl_buffer_add_listener(wl_buffer, &buffer_listener, buffer);
 
 	return buffer;
-}
-
-static bool output_attach_buffer(struct wlr_output *wlr_output,
-		struct wlr_buffer *wlr_buffer) {
-	struct wlr_wl_output *output =
-		get_wl_output_from_output(wlr_output);
-	struct wlr_wl_backend *wl = output->backend;
-
-	struct wlr_wl_buffer *buffer = create_wl_buffer(wl, wlr_buffer,
-		wlr_output->width, wlr_output->height);
-	if (buffer == NULL) {
-		return false;
-	}
-
-	destroy_wl_buffer(output->pending_buffer);
-	output->pending_buffer = buffer;
-	return true;
 }
 
 static bool output_test(struct wlr_output *wlr_output) {
@@ -254,10 +252,14 @@ static bool output_commit(struct wlr_output *wlr_output) {
 				return false;
 			}
 			break;
-		case WLR_OUTPUT_STATE_BUFFER_SCANOUT:
-			assert(output->pending_buffer != NULL);
-			wl_surface_attach(output->surface,
-				output->pending_buffer->wl_buffer, 0, 0);
+		case WLR_OUTPUT_STATE_BUFFER_SCANOUT:;
+			struct wlr_wl_buffer *buffer = create_wl_buffer(output->backend,
+				wlr_output->pending.buffer, wlr_output->width, wlr_output->height);
+			if (buffer == NULL) {
+				return false;
+			}
+
+			wl_surface_attach(output->surface, buffer->wl_buffer, 0, 0);
 
 			if (damage == NULL) {
 				wl_surface_damage_buffer(output->surface,
@@ -273,8 +275,6 @@ static bool output_commit(struct wlr_output *wlr_output) {
 				}
 			}
 			wl_surface_commit(output->surface);
-
-			output->pending_buffer = NULL;
 			break;
 		}
 
@@ -400,8 +400,6 @@ static void output_destroy(struct wlr_output *wlr_output) {
 		presentation_feedback_destroy(feedback);
 	}
 
-	destroy_wl_buffer(output->pending_buffer);
-
 	wlr_egl_destroy_surface(&output->backend->egl, output->egl_surface);
 	wl_egl_window_destroy(output->egl_window);
 	if (output->zxdg_toplevel_decoration_v1) {
@@ -429,7 +427,6 @@ static bool output_move_cursor(struct wlr_output *_output, int x, int y) {
 static const struct wlr_output_impl output_impl = {
 	.destroy = output_destroy,
 	.attach_render = output_attach_render,
-	.attach_buffer  = output_attach_buffer,
 	.test = output_test,
 	.commit = output_commit,
 	.set_cursor = output_set_cursor,

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -197,10 +197,7 @@ static bool output_attach_buffer(struct wlr_output *wlr_output,
 	return true;
 }
 
-static bool output_commit(struct wlr_output *wlr_output) {
-	struct wlr_wl_output *output =
-		get_wl_output_from_output(wlr_output);
-
+static bool output_test(struct wlr_output *wlr_output) {
 	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_ENABLED) {
 		wlr_log(WLR_DEBUG, "Cannot disable a Wayland output");
 		return false;
@@ -208,6 +205,20 @@ static bool output_commit(struct wlr_output *wlr_output) {
 
 	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_MODE) {
 		assert(wlr_output->pending.mode_type == WLR_OUTPUT_STATE_MODE_CUSTOM);
+	}
+
+	return true;
+}
+
+static bool output_commit(struct wlr_output *wlr_output) {
+	struct wlr_wl_output *output =
+		get_wl_output_from_output(wlr_output);
+
+	if (!output_test(wlr_output)) {
+		return false;
+	}
+
+	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_MODE) {
 		if (!output_set_custom_mode(wlr_output,
 				wlr_output->pending.custom_mode.width,
 				wlr_output->pending.custom_mode.height,
@@ -419,6 +430,7 @@ static const struct wlr_output_impl output_impl = {
 	.destroy = output_destroy,
 	.attach_render = output_attach_render,
 	.attach_buffer  = output_attach_buffer,
+	.test = output_test,
 	.commit = output_commit,
 	.set_cursor = output_set_cursor,
 	.move_cursor = output_move_cursor,

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -99,10 +99,7 @@ static bool output_attach_render(struct wlr_output *wlr_output,
 	return wlr_egl_make_current(&x11->egl, output->surf, buffer_age);
 }
 
-static bool output_commit(struct wlr_output *wlr_output) {
-	struct wlr_x11_output *output = get_x11_output_from_output(wlr_output);
-	struct wlr_x11_backend *x11 = output->x11;
-
+static bool output_test(struct wlr_output *wlr_output) {
 	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_ENABLED) {
 		wlr_log(WLR_DEBUG, "Cannot disable an X11 output");
 		return false;
@@ -110,6 +107,20 @@ static bool output_commit(struct wlr_output *wlr_output) {
 
 	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_MODE) {
 		assert(wlr_output->pending.mode_type == WLR_OUTPUT_STATE_MODE_CUSTOM);
+	}
+
+	return true;
+}
+
+static bool output_commit(struct wlr_output *wlr_output) {
+	struct wlr_x11_output *output = get_x11_output_from_output(wlr_output);
+	struct wlr_x11_backend *x11 = output->x11;
+
+	if (!output_test(wlr_output)) {
+		return false;
+	}
+
+	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_MODE) {
 		if (!output_set_custom_mode(wlr_output,
 				wlr_output->pending.custom_mode.width,
 				wlr_output->pending.custom_mode.height,
@@ -152,6 +163,7 @@ static bool output_commit(struct wlr_output *wlr_output) {
 static const struct wlr_output_impl output_impl = {
 	.destroy = output_destroy,
 	.attach_render = output_attach_render,
+	.test = output_test,
 	.commit = output_commit,
 };
 

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -128,8 +128,6 @@ struct wlr_drm_connector {
 	struct wl_event_source *retry_pageflip;
 	struct wl_list link;
 
-	// DMA-BUF to be displayed on next commit
-	struct wlr_dmabuf_attributes pending_dmabuf;
 	// Buffer submitted to the kernel but not yet displayed
 	struct wlr_buffer *pending_buffer;
 	struct gbm_bo *pending_bo;

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -72,7 +72,6 @@ struct wlr_wl_output {
 	struct zxdg_toplevel_decoration_v1 *zxdg_toplevel_decoration_v1;
 	struct wl_egl_window *egl_window;
 	EGLSurface egl_surface;
-	struct wlr_wl_buffer *pending_buffer;
 	struct wl_list presentation_feedbacks;
 
 	uint32_t enter_serial;

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -28,7 +28,6 @@ struct wlr_output_impl {
 	size_t (*get_gamma_size)(struct wlr_output *output);
 	bool (*export_dmabuf)(struct wlr_output *output,
 		struct wlr_dmabuf_attributes *attribs);
-	bool (*attach_buffer)(struct wlr_output *output, struct wlr_buffer *buffer);
 };
 
 void wlr_output_init(struct wlr_output *output, struct wlr_backend *backend,

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -21,6 +21,7 @@ struct wlr_output_impl {
 	bool (*move_cursor)(struct wlr_output *output, int x, int y);
 	void (*destroy)(struct wlr_output *output);
 	bool (*attach_render)(struct wlr_output *output, int *buffer_age);
+	bool (*test)(struct wlr_output *output);
 	bool (*commit)(struct wlr_output *output);
 	bool (*set_gamma)(struct wlr_output *output, size_t size,
 		const uint16_t *r, const uint16_t *g, const uint16_t *b);

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -338,6 +338,14 @@ bool wlr_output_preferred_read_format(struct wlr_output *output,
 void wlr_output_set_damage(struct wlr_output *output,
 	pixman_region32_t *damage);
 /**
+ * Test whether the pending output state would be accepted by the backend. If
+ * this function returns true, `wlr_output_commit` can only fail due to a
+ * runtime error.
+ *
+ * This function doesn't mutate the pending state.
+ */
+bool wlr_output_test(struct wlr_output *output);
+/**
  * Commit the pending output state. If `wlr_output_attach_render` has been
  * called, the pending frame will be submitted for display and a `frame` event
  * will be scheduled.

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -314,8 +314,11 @@ bool wlr_output_attach_render(struct wlr_output *output, int *buffer_age);
 /**
  * Attach a buffer to the output. Compositors should call `wlr_output_commit`
  * to submit the new frame. The output needs to be enabled.
+ *
+ * Not all backends support direct scan-out on all buffers. Compositors can
+ * check whether a buffer is supported by calling `wlr_output_test`.
  */
-bool wlr_output_attach_buffer(struct wlr_output *output,
+void wlr_output_attach_buffer(struct wlr_output *output,
 	struct wlr_buffer *buffer);
 /**
  * Get the preferred format for reading pixels.


### PR DESCRIPTION
This PR adds `wlr_output_test`, which can be used to check whether pending output changes would be accepted by the backend. This allows compositors to try different changes before attempting a commit.

Right now this function just performs the check previously done in `attach_buffer` and `commit`. This change allows test-only commits to be run in `wlr_output_test`, which is necessary for using libliftoff (thus necessary for DRM support of output layers introduced in https://github.com/swaywm/wlroots/pull/1985).

Compositors implementing wlr-output-management can now call this function instead of returning true unconditionally.

Should `wlr_output_test` be implicitly called in `wlr_output_commit`? This would add a guarantee for backends that the output changes are valid when their `commit` function is called.

Sway PR: https://github.com/swaywm/sway/pull/5188

* * *

Breaking changes:

* For compositors: `wlr_output_attach_buffer` doesn't return a `bool` anymore. The checks previously performed in this function are now performed in `wlr_output_commit` and the new `wlr_output_test` function.
* For backends: `wlr_output_impl.attach_buffer` is gone, buffer checks now need to be performed in `commit`. A new `test` function has been added.