### PR TITLE
output: fix blurred hw cursors with fractional scaling

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -906,7 +906,7 @@ struct wlr_output_mode *wlr_drm_connector_add_mode(struct wlr_output *output,
 }
 
 static bool drm_connector_set_cursor(struct wlr_output *output,
-		struct wlr_texture *texture, int32_t scale,
+		struct wlr_texture *texture, float scale,
 		enum wl_output_transform transform,
 		int32_t hotspot_x, int32_t hotspot_y, bool update_texture) {
 	struct wlr_drm_connector *conn = get_drm_connector_from_output(output);

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -309,7 +309,7 @@ static void output_rollback(struct wlr_output *wlr_output) {
 }
 
 static bool output_set_cursor(struct wlr_output *wlr_output,
-		struct wlr_texture *texture, int32_t scale,
+		struct wlr_texture *texture, float scale,
 		enum wl_output_transform transform,
 		int32_t hotspot_x, int32_t hotspot_y, bool update_texture) {
 	struct wlr_wl_output *output = get_wl_output_from_output(wlr_output);

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -16,7 +16,7 @@
 
 struct wlr_output_impl {
 	bool (*set_cursor)(struct wlr_output *output, struct wlr_texture *texture,
-		int32_t scale, enum wl_output_transform transform,
+		float scale, enum wl_output_transform transform,
 		int32_t hotspot_x, int32_t hotspot_y, bool update_texture);
 	bool (*move_cursor)(struct wlr_output *output, int x, int y);
 	void (*destroy)(struct wlr_output *output);

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -928,7 +928,7 @@ static void output_cursor_update_visible(struct wlr_output_cursor *cursor) {
 }
 
 static bool output_cursor_attempt_hardware(struct wlr_output_cursor *cursor) {
-	int32_t scale = cursor->output->scale;
+	float scale = cursor->output->scale;
 	enum wl_output_transform transform = WL_OUTPUT_TRANSFORM_NORMAL;
 	struct wlr_texture *texture = cursor->texture;
 	if (cursor->surface != NULL) {


### PR DESCRIPTION
The scaling factor was being implicitly cast to an int.

Closes: https://github.com/swaywm/sway/issues/4927

* * *

Breaking change for backends: `wlr_output_impl.set_cursor` now takes a `float scale` instead of an `int32_t`.