### PR TITLE
output: misc. wlr_output_test fixes

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -365,9 +365,6 @@ static bool test_buffer(struct wlr_drm_connector *conn,
 	if (attribs.flags != 0) {
 		return false;
 	}
-	if (attribs.width != output->width || attribs.height != output->height) {
-		return false;
-	}
 
 	if (!wlr_drm_format_set_has(&crtc->primary->formats,
 			attribs.format, attribs.modifier)) {

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -190,6 +190,9 @@ static struct wlr_wl_buffer *create_wl_buffer(struct wlr_wl_backend *wl,
 }
 
 static bool output_test(struct wlr_output *wlr_output) {
+	struct wlr_wl_output *output =
+		get_wl_output_from_output(wlr_output);
+
 	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_ENABLED) {
 		wlr_log(WLR_DEBUG, "Cannot disable a Wayland output");
 		return false;
@@ -197,6 +200,12 @@ static bool output_test(struct wlr_output *wlr_output) {
 
 	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_MODE) {
 		assert(wlr_output->pending.mode_type == WLR_OUTPUT_STATE_MODE_CUSTOM);
+	}
+
+	if ((wlr_output->pending.committed & WLR_OUTPUT_STATE_BUFFER) &&
+			wlr_output->pending.buffer_type == WLR_OUTPUT_STATE_BUFFER_SCANOUT &&
+			!test_buffer(output->backend, wlr_output->pending.buffer)) {
+		return false;
 	}
 
 	return true;

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -128,14 +128,9 @@ static const struct wl_buffer_listener buffer_listener = {
 };
 
 static bool test_buffer(struct wlr_wl_backend *wl,
-		struct wlr_buffer *wlr_buffer,
-		int required_width, int required_height) {
+		struct wlr_buffer *wlr_buffer) {
 	struct wlr_dmabuf_attributes attribs;
 	if (!wlr_buffer_get_dmabuf(wlr_buffer, &attribs)) {
-		return false;
-	}
-
-	if (attribs.width != required_width || attribs.height != required_height) {
 		return false;
 	}
 
@@ -148,9 +143,8 @@ static bool test_buffer(struct wlr_wl_backend *wl,
 }
 
 static struct wlr_wl_buffer *create_wl_buffer(struct wlr_wl_backend *wl,
-		struct wlr_buffer *wlr_buffer,
-		int required_width, int required_height) {
-	if (!test_buffer(wl, wlr_buffer, required_width, required_height)) {
+		struct wlr_buffer *wlr_buffer) {
+	if (!test_buffer(wl, wlr_buffer)) {
 		return NULL;
 	}
 
@@ -253,8 +247,8 @@ static bool output_commit(struct wlr_output *wlr_output) {
 			}
 			break;
 		case WLR_OUTPUT_STATE_BUFFER_SCANOUT:;
-			struct wlr_wl_buffer *buffer = create_wl_buffer(output->backend,
-				wlr_output->pending.buffer, wlr_output->width, wlr_output->height);
+			struct wlr_wl_buffer *buffer =
+				create_wl_buffer(output->backend, wlr_output->pending.buffer);
 			if (buffer == NULL) {
 				return false;
 			}

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -473,6 +473,25 @@ static void output_state_clear(struct wlr_output_state *state) {
 	state->committed = 0;
 }
 
+static void output_pending_resolution(struct wlr_output *output, int *width,
+		int *height) {
+	if (output->pending.committed & WLR_OUTPUT_STATE_MODE) {
+		switch (output->pending.mode_type) {
+		case WLR_OUTPUT_STATE_MODE_FIXED:
+			*width = output->pending.mode->width;
+			*height = output->pending.mode->height;
+			break;
+		case WLR_OUTPUT_STATE_MODE_CUSTOM:
+			*width = output->pending.custom_mode.width;
+			*height = output->pending.custom_mode.height;
+			break;
+		}
+	} else {
+		*width = output->width;
+		*height = output->height;
+	}
+}
+
 static bool output_basic_test(struct wlr_output *output) {
 	if (output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
 		if (output->frame_pending) {
@@ -495,8 +514,14 @@ static bool output_basic_test(struct wlr_output *output) {
 				}
 			}
 
-			// TOOD: check width/height matches the output's, since scaling
-			// isn't supported
+			// If the size doesn't match, reject buffer (scaling is not
+			// supported)
+			int pending_width, pending_height;
+			output_pending_resolution(output, &pending_width, &pending_height);
+			if (output->pending.buffer->width != pending_width ||
+					output->pending.buffer->height != pending_height) {
+				return false;
+			}
 		}
 	}
 


### PR DESCRIPTION
## output: check for buffer size compatibility in common code 

Instead of checking for buffer size compatibility in each backend,
centralize the check in wlr_output itself.

## backend/wayland: check scan-out buffer is compatible in output_test

If the buffer doesn't have a supported format/modifier, make the test
fail.