### PR TITLE
output: fix maybe-uninitialized warning

### DIFF
--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -480,12 +480,13 @@ static void output_pending_resolution(struct wlr_output *output, int *width,
 		case WLR_OUTPUT_STATE_MODE_FIXED:
 			*width = output->pending.mode->width;
 			*height = output->pending.mode->height;
-			break;
+			return;
 		case WLR_OUTPUT_STATE_MODE_CUSTOM:
 			*width = output->pending.custom_mode.width;
 			*height = output->pending.custom_mode.height;
-			break;
+			return;
 		}
+		abort();
 	} else {
 		*width = output->width;
 		*height = output->height;


### PR DESCRIPTION
GCC is complaining about a maybe-uninitialized variable when doing a
release build. Even if that can't actually happen because all enum
values are handled, add an abort call to silence the warning.