### PR TITLE
Add check for NULL keyboard (fix sway #5205)

### DIFF
--- a/types/seat/wlr_seat_keyboard.c
+++ b/types/seat/wlr_seat_keyboard.c
@@ -411,8 +411,9 @@ void seat_client_create_keyboard(struct wlr_seat_client *seat_client,
 	wl_list_insert(&seat_client->keyboards, wl_resource_get_link(resource));
 
 	struct wlr_keyboard *keyboard = seat_client->seat->keyboard_state.keyboard;
-	if (keyboard == NULL)
+	if (keyboard == NULL) {
 		return;
+	}
 	seat_client_send_keymap(seat_client, keyboard);
 	seat_client_send_repeat_info(seat_client, keyboard);
 

--- a/types/seat/wlr_seat_keyboard.c
+++ b/types/seat/wlr_seat_keyboard.c
@@ -411,6 +411,8 @@ void seat_client_create_keyboard(struct wlr_seat_client *seat_client,
 	wl_list_insert(&seat_client->keyboards, wl_resource_get_link(resource));
 
 	struct wlr_keyboard *keyboard = seat_client->seat->keyboard_state.keyboard;
+	if (keyboard == NULL)
+		return;
 	seat_client_send_keymap(seat_client, keyboard);
 	seat_client_send_repeat_info(seat_client, keyboard);
 


### PR DESCRIPTION
Check for a NULL keyboard_state.keyboard value in
seat_client_create_keyboard() before trying to use it, as is done in
other functions like seat_client_send_repeat_info(). Prevents a segfault
in certain situations on keyboard removal, as seen in the sway issue.

Closes: https://github.com/swaywm/sway/issues/5205
Closes: https://github.com/swaywm/wlroots/issues/2073