### PR TITLE
backend/multi: add backends at end of list

### DIFF
--- a/backend/multi/backend.c
+++ b/backend/multi/backend.c
@@ -183,7 +183,7 @@ bool wlr_multi_backend_add(struct wlr_backend *_multi,
 		wlr_log(WLR_ERROR, "Could not add backend: allocation failed");
 		return false;
 	}
-	wl_list_insert(&multi->backends, &sub->link);
+	wl_list_insert(multi->backends.prev, &sub->link);
 
 	sub->backend = backend;
 	sub->container = &multi->backend;


### PR DESCRIPTION
This allows wlr_multi_for_each_backend to iterate on the backends in the
order where they have been added.