### PR TITLE
render/drm_format_set: disallow DRM_FORMAT_INVALID

### DIFF
--- a/render/drm_format_set.c
+++ b/render/drm_format_set.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <drm_fourcc.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -57,6 +58,7 @@ bool wlr_drm_format_set_has(const struct wlr_drm_format_set *set,
 
 bool wlr_drm_format_set_add(struct wlr_drm_format_set *set, uint32_t format,
 		uint64_t modifier) {
+	assert(format != DRM_FORMAT_INVALID);
 	struct wlr_drm_format **ptr = format_set_get_ref(set, format);
 
 	if (ptr) {


### PR DESCRIPTION
It doesn't make sense to add DRM_FORMAT_INVALID to a format set. Adding
an assertion allows us to safely query the format set with
DRM_FORMAT_INVALID. See [1].

[1]: https://github.com/swaywm/wlroots/pull/2021#discussion_r385839668