### PR TITLE
logind: Avoid unnecessary ReleaseDevice calls

### DIFF
--- a/backend/multi/backend.c
+++ b/backend/multi/backend.c
@@ -49,6 +49,8 @@ static void multi_backend_destroy(struct wlr_backend *wlr_backend) {
 
 	wl_list_remove(&backend->display_destroy.link);
 
+	wlr_session_shutdown(backend->session);
+
 	struct subbackend_state *sub, *next;
 	wl_list_for_each_safe(sub, next, &backend->backends, link) {
 		wlr_backend_destroy(sub->backend);

--- a/backend/session/logind.c
+++ b/backend/session/logind.c
@@ -101,6 +101,13 @@ out:
 }
 
 static void logind_release_device(struct wlr_session *base, int fd) {
+	if (base->shutdown) {
+		// All our devices will be released by ReleaseControl later, so let's
+		// not waste time chatting with logind here. We do need to close the
+		// fd, as not doing so causes short hangs on exit.
+		close(fd);
+		return;
+	}
 	struct logind_session *session = logind_session_from_session(base);
 
 	struct stat st;

--- a/backend/session/session.c
+++ b/backend/session/session.c
@@ -98,6 +98,7 @@ struct wlr_session *wlr_session_create(struct wl_display *disp) {
 	}
 
 	session->active = true;
+	session->shutdown = false;
 	wl_signal_init(&session->session_signal);
 	wl_signal_init(&session->events.destroy);
 	wl_list_init(&session->devices);
@@ -156,7 +157,15 @@ void wlr_session_destroy(struct wlr_session *session) {
 	session->impl->destroy(session);
 }
 
+void wlr_session_shutdown(struct wlr_session *session) {
+	if (!session) {
+		return;
+	}
+	session->shutdown = true;
+}
+
 int wlr_session_open_file(struct wlr_session *session, const char *path) {
+	assert(!session->shutdown);
 	int fd = session->impl->open(session, path);
 	if (fd < 0) {
 		return fd;

--- a/include/wlr/backend/session.h
+++ b/include/wlr/backend/session.h
@@ -23,7 +23,7 @@ struct wlr_session {
 	 * It's called when we swap virtual terminal.
 	 */
 	struct wl_signal session_signal;
-	bool active;
+	bool active, shutdown;
 
 	/*
 	 * 0 if virtual terminals are not supported
@@ -63,6 +63,13 @@ struct wlr_session *wlr_session_create(struct wl_display *disp);
  * with wlr_session_open_file before you call this.
  */
 void wlr_session_destroy(struct wlr_session *session);
+
+/*
+ * Informs the session that it is being shut down, and that it will be
+ * destroyed after all files have been closed. This information is used by some
+ * backends to speed up the teardown process.
+ */
+void wlr_session_shutdown(struct wlr_session *session);
 
 /*
  * Opens the file at path.


### PR DESCRIPTION
Libinput releases its devices one at a time on shutdown. When using the
logind session implementation, each device closure leads to a
ReleaseDevice call. With the 28 event devices on my machine, that adds
up to ~1.4 seconds of waiting.

As all devices requested via TakeControl are automatically released when
ReleaseControl is called or when the dbus connection is terminated, we
do not need to spend time calling ReleaseDevice.

Implement a new session shutdown flag that informs the logind session
implementation that we are not interested in ReleaseDevice calls.