### PR TITLE
backend/libinput: correctly populate x/y fields on tablet proximity in

### DIFF
--- a/backend/libinput/tablet_tool.c
+++ b/backend/libinput/tablet_tool.c
@@ -269,6 +269,9 @@ void handle_tablet_tool_proximity(struct libinput_event *event,
 	wlr_event.device = wlr_dev;
 	wlr_event.time_msec =
 		usec_to_msec(libinput_event_tablet_tool_get_time_usec(tevent));
+	wlr_event.x = libinput_event_tablet_tool_get_x_transformed(tevent, 1);
+	wlr_event.y = libinput_event_tablet_tool_get_y_transformed(tevent, 1);
+
 	switch (libinput_event_tablet_tool_get_proximity_state(tevent)) {
 	case LIBINPUT_TABLET_TOOL_PROXIMITY_STATE_OUT:
 		wlr_event.state = WLR_TABLET_TOOL_PROXIMITY_OUT;


### PR DESCRIPTION
Otherwise, the cursor will briefly jump to (0, 0). This is particularly
noticeable in the referenced issue (the game osu!).

Refs swaywm/sway#3633