### PR TITLE
export-dmabuf: Schedule output frame on request

### DIFF
--- a/types/wlr_export_dmabuf_v1.c
+++ b/types/wlr_export_dmabuf_v1.c
@@ -150,6 +150,8 @@ static void manager_handle_capture_output(struct wl_client *client,
 			attribs->fd[i], size, attribs->offset[i], attribs->stride[i], i);
 	}
 
+	wlr_output_schedule_frame(output);
+
 	wl_list_remove(&frame->output_precommit.link);
 	wl_signal_add(&output->events.precommit, &frame->output_precommit);
 	frame->output_precommit.notify = frame_output_handle_precommit;


### PR DESCRIPTION
A client requesting frames in the ready callback may miss frames that
happen while it is waiting to receive the event or sending the request.
If that happens, the client will have an outdated frame for an
indefinite period. A new frame might not be scheduled for a very long
time.

With this change, clients will receive new frames immediately upon
request.