### PR TITLE
input/tablet: populate tool tip event position

### DIFF
--- a/backend/libinput/tablet_tool.c
+++ b/backend/libinput/tablet_tool.c
@@ -333,6 +333,9 @@ void handle_tablet_tool_tip(struct libinput_event *event,
 	wlr_event.tool = &tool->wlr_tool;
 	wlr_event.time_msec =
 		usec_to_msec(libinput_event_tablet_tool_get_time_usec(tevent));
+	wlr_event.x = libinput_event_tablet_tool_get_x_transformed(tevent, 1);
+	wlr_event.y = libinput_event_tablet_tool_get_y_transformed(tevent, 1);
+
 	switch (libinput_event_tablet_tool_get_tip_state(tevent)) {
 	case LIBINPUT_TABLET_TOOL_TIP_UP:
 		wlr_event.state = WLR_TABLET_TOOL_TIP_UP;


### PR DESCRIPTION
This commit doesn't fix any issue that I'm aware of, since sway
incidentally does not use these fields. Still, they exist, so they
should probably be filled in to prevent fun surprises in the future.