### PR TITLE
Remove libcap support

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -2,7 +2,6 @@ image: alpine/edge
 packages:
   - eudev-dev
   - ffmpeg-dev
-  - libcap-dev
   - libinput-dev
   - libxkbcommon-dev
   - mesa-dev

--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -2,7 +2,6 @@ image: archlinux
 packages:
   - clang
   - ffmpeg
-  - libcap
   - libinput
   - libxkbcommon
   - mesa

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -23,5 +23,5 @@ sources:
 tasks:
 - wlroots: |
     cd wlroots
-    meson build -Dauto_features=enabled -Dlogind=disabled -Dlibcap=disabled
+    meson build -Dauto_features=enabled -Dlogind=disabled
     ninja -C build

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Install dependencies:
 * pixman
 * systemd (optional, for logind support)
 * elogind (optional, for logind support on systems without systemd)
-* libcap (optional, for capability support)
 
 If you choose to enable X11 support:
 

--- a/backend/session/direct-ipc.c
+++ b/backend/session/direct-ipc.c
@@ -24,23 +24,6 @@
 
 enum { DRM_MAJOR = 226 };
 
-#if WLR_HAS_LIBCAP
-#include <sys/capability.h>
-
-static bool have_permissions(void) {
-	cap_t cap = cap_get_proc();
-	cap_flag_value_t val;
-
-	if (!cap || cap_get_flag(cap, CAP_SYS_ADMIN, CAP_PERMITTED, &val) || val != CAP_SET) {
-		wlr_log(WLR_ERROR, "Do not have CAP_SYS_ADMIN; cannot become DRM master");
-		cap_free(cap);
-		return false;
-	}
-
-	cap_free(cap);
-	return true;
-}
-#else
 static bool have_permissions(void) {
 #ifdef __linux__
 	if (geteuid() != 0) {
@@ -50,7 +33,6 @@ static bool have_permissions(void) {
 #endif
 	return true;
 }
-#endif
 
 static void send_msg(int sock, int fd, void *buf, size_t buf_len) {
 	char control[CMSG_SPACE(sizeof(fd))] = {0};

--- a/backend/session/meson.build
+++ b/backend/session/meson.build
@@ -62,23 +62,3 @@ if logind_found
 	wlr_files += files('logind.c')
 	wlr_deps += logind
 endif
-
-# libcap
-
-msg = []
-if get_option('libcap').enabled()
-	msg += 'Install "libcap" or pass "-Dlibcap=disabled".'
-endif
-if not get_option('libcap').disabled()
-	msg += 'Required for POSIX capability support (Not needed if using logind).'
-endif
-
-libcap = dependency('libcap',
-	required: get_option('libcap'),
-	not_found_message: '\n'.join(msg),
-)
-if libcap.found()
-	conf_data.set10('WLR_HAS_LIBCAP', true)
-	wlr_deps += libcap
-endif
-

--- a/meson.build
+++ b/meson.build
@@ -80,7 +80,6 @@ else
 endif
 
 conf_data = configuration_data()
-conf_data.set10('WLR_HAS_LIBCAP', false)
 conf_data.set10('WLR_HAS_SYSTEMD', false)
 conf_data.set10('WLR_HAS_ELOGIND', false)
 conf_data.set10('WLR_HAS_X11_BACKEND', false)
@@ -170,7 +169,6 @@ wlroots = declare_dependency(
 meson.override_dependency('wlroots', wlroots)
 
 summary({
-	'libcap': conf_data.get('WLR_HAS_LIBCAP', 0),
 	'systemd': conf_data.get('WLR_HAS_SYSTEMD', 0),
 	'elogind': conf_data.get('WLR_HAS_ELOGIND', 0),
 	'xwayland': conf_data.get('WLR_HAS_XWAYLAND', 0),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,3 @@
-option('libcap', type: 'feature', value: 'auto', description: 'Enable support for rootless session via capabilities (cap_sys_admin)')
 option('logind', type: 'feature', value: 'auto', description: 'Enable support for rootless session via logind')
 option('logind-provider', type: 'combo', choices: ['auto', 'systemd', 'elogind'], value: 'auto', description: 'Provider of logind support library')
 option('xcb-errors', type: 'feature', value: 'auto', description: 'Use xcb-errors util library')


### PR DESCRIPTION
This is simply a false sense of security, and is worse than just using
setuid. CAP_SYS_ADMIN is an extremely serious capability that is
effectively as powerful as root.

It also required users to be in the input group, which allows any
process to keylog the entire system.