### PR TITLE
Fix error when reconnecting external display

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1677,6 +1677,7 @@ static void drm_connector_cleanup(struct wlr_drm_connector *conn) {
 		dealloc_crtc(conn);
 		conn->possible_crtc = 0;
 		conn->desired_mode = NULL;
+		conn->pageflip_pending = false;
 		wlr_signal_emit_safe(&conn->output.events.destroy, &conn->output);
 		break;
 	case WLR_DRM_CONN_DISCONNECTED:


### PR DESCRIPTION
Reconnecting an external display fails on initial
page-flip.  This occurs when the pageflip_pending flag
has been set on the connector at the time the monitor
is removed.  Once the connector's CRTC has been deallocated,
page_flip_handler cannot find the connector by its crtc_id,
so pageflip_pending will remain set.  This causes
initialization to fail when the monitor is reconnected
with the error messages:

    Skipping pageflip on output 'X'
    Failed to initialize renderer on connector 'X': initial page-flip failed

To fix this problem, clear the pageflip_pending flag
when cleaning up the connector.

Test plan:
1. Start sway (I tested with https://github.com/swaywm/sway/commit/59acc12b32736dc3f7b8b7060c165c2b49359f15 and https://github.com/swaywm/wlroots/commit/22d345d98200b421abf91b4b2700b101bdca2ce1)
2. Connect an external display (I used: Dell Inc. DELL U2414H RXP1N7450G1L).
3. Disconnect the external display.
4. Connect the external display again.

Before this commit, the new display would remain blank with "no input detected" and these logs in Sway: [sway-on-master-reconnect-display.log](https://github.com/swaywm/wlroots/files/4564431/sway-on-master-reconnect-display.log).   After this commit, the display shows a workspace from Sway.