### PR TITLE
backend/drm: make page-flip error scarier

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -341,7 +341,8 @@ static bool drm_crtc_page_flip(struct wlr_drm_connector *conn,
 	drmModeModeInfo *drm_mode = mode ? &mode->drm_mode : NULL;
 
 	if (conn->pageflip_pending) {
-		wlr_log(WLR_ERROR, "Skipping pageflip on output '%s'", conn->output.name);
+		wlr_log(WLR_ERROR, "Failed to page-flip output '%s': "
+			"a page-flip is already pending", conn->output.name);
 		return false;
 	}
 


### PR DESCRIPTION
The logs don't currently display the importance of a line. It's easy to
read "skipping page-flip" as a debug message instead of an error
message.

Change the error message to make it more explicit.

References: https://github.com/swaywm/wlroots/pull/2147