### PR TITLE
Add wlr_surface_accepts_touch

### DIFF
--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -678,4 +678,9 @@ struct wlr_seat_client *wlr_seat_client_from_resource(
 struct wlr_seat_client *wlr_seat_client_from_pointer_resource(
 	struct wl_resource *resource);
 
+/**
+ * Check whether a surface has bound to touch events.
+ */
+bool wlr_surface_accepts_touch(struct wlr_seat *wlr_seat, struct wlr_surface *surface);
+
 #endif

--- a/types/seat/wlr_seat_touch.c
+++ b/types/seat/wlr_seat_touch.c
@@ -403,3 +403,12 @@ bool wlr_seat_validate_touch_grab_serial(struct wlr_seat *seat,
 		"invalid origin surface");
 	return false;
 }
+
+bool wlr_surface_accepts_touch(struct wlr_seat *wlr_seat, struct wlr_surface *surface) {
+	struct wl_client *client = wl_resource_get_client(surface->resource);
+	struct wlr_seat_client *seat_client = wlr_seat_client_for_wl_client(wlr_seat, client);
+	if (!seat_client) {
+		return false;
+	}
+	return !wl_list_empty(&seat_client->touches);
+}


### PR DESCRIPTION
This is needed to simulate pointer events when a surface hasn't bound to touch events.