### PR TITLE
backend/drm: fix combined modeset+enable commits

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -529,9 +529,7 @@ static bool drm_connector_commit(struct wlr_output *output) {
 			}
 			break;
 		}
-	}
-
-	if (output->pending.committed & WLR_OUTPUT_STATE_ENABLED) {
+	} else if (output->pending.committed & WLR_OUTPUT_STATE_ENABLED) {
 		if (!enable_drm_connector(output, output->pending.enabled)) {
 			return false;
 		}


### PR DESCRIPTION
When an output is enabled and modeset at the same time,
drm_connector_commit would first try to modeset then try to commit. This
won't work because both will trigger a page-flip. KMS will reject that.

Change the logic to only enable an output if no modeset has been
requested. The logic in wlr_output already checks that the user isn't
doing a modeset and disabling the output at the same time.