### PR TITLE
backend/drm: disable cursor in dealloc_crtc

### DIFF
--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -106,6 +106,7 @@ static void set_plane_props(struct atomic *atom, struct wlr_drm_backend *drm,
 	return;
 
 error:
+	wlr_log(WLR_ERROR, "Failed to set plane %"PRIu32" properties", plane->id);
 	atom->failed = true;
 }
 

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1122,6 +1122,9 @@ static void dealloc_crtc(struct wlr_drm_connector *conn) {
 	set_drm_connector_gamma(&conn->output, 0, NULL, NULL, NULL);
 	drm_plane_finish_surface(conn->crtc->primary);
 	drm_plane_finish_surface(conn->crtc->cursor);
+	if (conn->crtc->cursor != NULL) {
+		conn->crtc->cursor->cursor_enabled = false;
+	}
 
 	drm->iface->conn_enable(drm, conn, false);
 


### PR DESCRIPTION
dealloc_crtc was destroying GBM surfaces, but the cursor_enabled flag
was left as-is. When re-enabling the output, atomic_crtc_pageflip would
try enabling the cursor plane, but would fail because no framebuffer is
available.

Closes: https://github.com/swaywm/wlroots/issues/2150