### PR TITLE
backend/drm: replace all interface setters with a unified commit

### DIFF
--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -144,8 +144,8 @@ error:
 	atom->failed = true;
 }
 
-static bool atomic_crtc_pageflip(struct wlr_drm_backend *drm,
-		struct wlr_drm_connector *conn) {
+static bool atomic_crtc_commit(struct wlr_drm_backend *drm,
+		struct wlr_drm_connector *conn, uint32_t flags) {
 	struct wlr_drm_crtc *crtc = conn->crtc;
 
 	bool modeset = crtc->pending & WLR_DRM_CRTC_MODE;
@@ -179,7 +179,6 @@ static bool atomic_crtc_pageflip(struct wlr_drm_backend *drm,
 		}
 	}
 
-	uint32_t flags = DRM_MODE_PAGE_FLIP_EVENT;
 	if (modeset) {
 		flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
 	} else {
@@ -267,7 +266,7 @@ static size_t atomic_crtc_get_gamma_size(struct wlr_drm_backend *drm,
 
 const struct wlr_drm_interface atomic_iface = {
 	.conn_enable = atomic_conn_enable,
-	.crtc_pageflip = atomic_crtc_pageflip,
+	.crtc_commit = atomic_crtc_commit,
 	.crtc_set_cursor = atomic_crtc_set_cursor,
 	.crtc_get_gamma_size = atomic_crtc_get_gamma_size,
 };

--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -237,15 +237,6 @@ static bool atomic_crtc_commit(struct wlr_drm_backend *drm,
 		return false;
 	}
 
-	if (crtc->active && crtc->cursor) {
-		drm_fb_move(&crtc->cursor->queued_fb, &crtc->cursor->pending_fb);
-	}
-	return true;
-}
-
-static bool atomic_crtc_set_cursor(struct wlr_drm_backend *drm,
-		struct wlr_drm_crtc *crtc, struct gbm_bo *bo) {
-	/* Cursor updates happen when we pageflip */
 	return true;
 }
 
@@ -267,6 +258,5 @@ static size_t atomic_crtc_get_gamma_size(struct wlr_drm_backend *drm,
 
 const struct wlr_drm_interface atomic_iface = {
 	.crtc_commit = atomic_crtc_commit,
-	.crtc_set_cursor = atomic_crtc_set_cursor,
 	.crtc_get_gamma_size = atomic_crtc_get_gamma_size,
 };

--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -69,6 +69,22 @@ static void atomic_add(struct atomic *atom, uint32_t id, uint32_t prop, uint64_t
 	}
 }
 
+static bool create_mode_blob(struct wlr_drm_backend *drm,
+		struct wlr_drm_crtc *crtc, uint32_t *blob_id) {
+	if (!crtc->active) {
+		*blob_id = 0;
+		return true;
+	}
+
+	if (drmModeCreatePropertyBlob(drm->fd, &crtc->mode,
+			sizeof(drmModeModeInfo), blob_id)) {
+		wlr_log_errno(WLR_ERROR, "Unable to create mode property blob");
+		return false;
+	}
+
+	return true;
+}
+
 static bool create_gamma_lut_blob(struct wlr_drm_backend *drm,
 		struct wlr_drm_crtc *crtc, uint32_t *blob_id) {
 	if (crtc->gamma_table_size == 0) {
@@ -148,15 +164,12 @@ static bool atomic_crtc_commit(struct wlr_drm_backend *drm,
 		struct wlr_drm_connector *conn, uint32_t flags) {
 	struct wlr_drm_crtc *crtc = conn->crtc;
 
-	bool modeset = crtc->pending & WLR_DRM_CRTC_MODE;
-	if (modeset) {
+	if (crtc->pending & WLR_DRM_CRTC_MODE) {
 		if (crtc->mode_id != 0) {
 			drmModeDestroyPropertyBlob(drm->fd, crtc->mode_id);
 		}
 
-		if (drmModeCreatePropertyBlob(drm->fd, &crtc->mode,
-				sizeof(drmModeModeInfo), &crtc->mode_id)) {
-			wlr_log_errno(WLR_ERROR, "Unable to create mode property blob");
+		if (!create_mode_blob(drm, crtc, &crtc->mode_id)) {
 			return false;
 		}
 	}
@@ -179,6 +192,7 @@ static bool atomic_crtc_commit(struct wlr_drm_backend *drm,
 		}
 	}
 
+	bool modeset = crtc->pending & WLR_DRM_CRTC_MODE;
 	if (modeset) {
 		flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
 	} else {
@@ -187,20 +201,28 @@ static bool atomic_crtc_commit(struct wlr_drm_backend *drm,
 
 	struct atomic atom;
 	atomic_begin(crtc, &atom);
-	atomic_add(&atom, conn->id, conn->props.crtc_id, crtc->id);
-	if (modeset && conn->props.link_status != 0) {
+	atomic_add(&atom, conn->id, conn->props.crtc_id,
+		crtc->active ? crtc->id : 0);
+	if (modeset && crtc->active && conn->props.link_status != 0) {
 		atomic_add(&atom, conn->id, conn->props.link_status,
 			DRM_MODE_LINK_STATUS_GOOD);
 	}
 	atomic_add(&atom, crtc->id, crtc->props.mode_id, crtc->mode_id);
-	atomic_add(&atom, crtc->id, crtc->props.active, 1);
-	atomic_add(&atom, crtc->id, crtc->props.gamma_lut, crtc->gamma_lut);
-	set_plane_props(&atom, drm, crtc->primary, crtc->id, 0, 0);
-	if (crtc->cursor) {
-		if (crtc->cursor->cursor_enabled) {
-			set_plane_props(&atom, drm, crtc->cursor, crtc->id,
-				conn->cursor_x, conn->cursor_y);
-		} else {
+	atomic_add(&atom, crtc->id, crtc->props.active, crtc->active);
+	if (crtc->active) {
+		atomic_add(&atom, crtc->id, crtc->props.gamma_lut, crtc->gamma_lut);
+		set_plane_props(&atom, drm, crtc->primary, crtc->id, 0, 0);
+		if (crtc->cursor) {
+			if (crtc->cursor->cursor_enabled) {
+				set_plane_props(&atom, drm, crtc->cursor, crtc->id,
+					conn->cursor_x, conn->cursor_y);
+			} else {
+				plane_disable(&atom, crtc->cursor);
+			}
+		}
+	} else {
+		plane_disable(&atom, crtc->primary);
+		if (crtc->cursor) {
 			plane_disable(&atom, crtc->cursor);
 		}
 	}
@@ -215,31 +237,10 @@ static bool atomic_crtc_commit(struct wlr_drm_backend *drm,
 		return false;
 	}
 
-	if (crtc->cursor) {
+	if (crtc->active && crtc->cursor) {
 		drm_fb_move(&crtc->cursor->queued_fb, &crtc->cursor->pending_fb);
 	}
 	return true;
-}
-
-static bool atomic_conn_enable(struct wlr_drm_backend *drm,
-		struct wlr_drm_connector *conn, bool enable) {
-	struct wlr_drm_crtc *crtc = conn->crtc;
-	if (crtc == NULL) {
-		return !enable;
-	}
-
-	struct atomic atom;
-	atomic_begin(crtc, &atom);
-	atomic_add(&atom, crtc->id, crtc->props.active, enable);
-	if (enable) {
-		atomic_add(&atom, conn->id, conn->props.crtc_id, crtc->id);
-		atomic_add(&atom, crtc->id, crtc->props.mode_id, crtc->mode_id);
-	} else {
-		atomic_add(&atom, conn->id, conn->props.crtc_id, 0);
-		atomic_add(&atom, crtc->id, crtc->props.mode_id, 0);
-	}
-	return atomic_commit(drm->fd, &atom, conn, DRM_MODE_ATOMIC_ALLOW_MODESET,
-		true);
 }
 
 static bool atomic_crtc_set_cursor(struct wlr_drm_backend *drm,
@@ -265,7 +266,6 @@ static size_t atomic_crtc_get_gamma_size(struct wlr_drm_backend *drm,
 }
 
 const struct wlr_drm_interface atomic_iface = {
-	.conn_enable = atomic_conn_enable,
 	.crtc_commit = atomic_crtc_commit,
 	.crtc_set_cursor = atomic_crtc_set_cursor,
 	.crtc_get_gamma_size = atomic_crtc_get_gamma_size,

--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -193,12 +193,6 @@ static bool atomic_crtc_set_cursor(struct wlr_drm_backend *drm,
 	return true;
 }
 
-static bool atomic_crtc_move_cursor(struct wlr_drm_backend *drm,
-		struct wlr_drm_crtc *crtc, int x, int y) {
-	/* Cursor updates happen when we pageflip */
-	return true;
-}
-
 static bool atomic_crtc_set_gamma(struct wlr_drm_backend *drm,
 		struct wlr_drm_crtc *crtc, size_t size,
 		uint16_t *r, uint16_t *g, uint16_t *b) {
@@ -258,7 +252,6 @@ const struct wlr_drm_interface atomic_iface = {
 	.conn_enable = atomic_conn_enable,
 	.crtc_pageflip = atomic_crtc_pageflip,
 	.crtc_set_cursor = atomic_crtc_set_cursor,
-	.crtc_move_cursor = atomic_crtc_move_cursor,
 	.crtc_set_gamma = atomic_crtc_set_gamma,
 	.crtc_get_gamma_size = atomic_crtc_get_gamma_size,
 };

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -93,6 +93,7 @@ static void session_signal(struct wl_listener *listener, void *data) {
 
 		struct wlr_drm_connector *conn;
 		wl_list_for_each(conn, &drm->outputs, link){
+			conn->crtc->pending |= WLR_DRM_CRTC_GAMMA_LUT;
 			if (conn->output.enabled && conn->output.current_mode != NULL) {
 				drm_connector_set_mode(&conn->output,
 						conn->output.current_mode);
@@ -112,16 +113,6 @@ static void session_signal(struct wl_listener *listener, void *data) {
 			}
 
 			drm->iface->crtc_set_cursor(drm, conn->crtc, bo);
-
-			if (conn->crtc->gamma_table != NULL) {
-				size_t size = conn->crtc->gamma_table_size;
-				uint16_t *r = conn->crtc->gamma_table;
-				uint16_t *g = conn->crtc->gamma_table + size;
-				uint16_t *b = conn->crtc->gamma_table + 2 * size;
-				drm->iface->crtc_set_gamma(drm, conn->crtc, size, r, g, b);
-			} else {
-				set_drm_connector_gamma(&conn->output, 0, NULL, NULL, NULL);
-			}
 		}
 	} else {
 		wlr_log(WLR_INFO, "DRM fd paused");

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -100,19 +100,6 @@ static void session_signal(struct wl_listener *listener, void *data) {
 			} else {
 				enable_drm_connector(&conn->output, false);
 			}
-
-			if (!conn->crtc) {
-				continue;
-			}
-
-			struct wlr_drm_plane *plane = conn->crtc->cursor;
-			struct gbm_bo *bo = NULL;
-			if (plane->cursor_enabled) {
-				bo = drm_fb_acquire(&plane->current_fb, drm,
-					&plane->mgpu_surf);
-			}
-
-			drm->iface->crtc_set_cursor(drm, conn->crtc, bo);
 		}
 	} else {
 		wlr_log(WLR_INFO, "DRM fd paused");

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -112,8 +112,6 @@ static void session_signal(struct wl_listener *listener, void *data) {
 			}
 
 			drm->iface->crtc_set_cursor(drm, conn->crtc, bo);
-			drm->iface->crtc_move_cursor(drm, conn->crtc, conn->cursor_x,
-				conn->cursor_y);
 
 			if (conn->crtc->gamma_table != NULL) {
 				size_t size = conn->crtc->gamma_table_size;

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -953,11 +953,6 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 		plane->cursor_hotspot_x = hotspot.x;
 		plane->cursor_hotspot_y = hotspot.y;
 
-		if (!drm->iface->crtc_move_cursor(drm, conn->crtc, conn->cursor_x,
-				conn->cursor_y)) {
-			return false;
-		}
-
 		wlr_output_update_needs_frame(output);
 	}
 
@@ -1033,7 +1028,6 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 static bool drm_connector_move_cursor(struct wlr_output *output,
 		int x, int y) {
 	struct wlr_drm_connector *conn = get_drm_connector_from_output(output);
-	struct wlr_drm_backend *drm = get_drm_backend_from_backend(output->backend);
 	if (!conn->crtc) {
 		return false;
 	}
@@ -1056,15 +1050,8 @@ static bool drm_connector_move_cursor(struct wlr_output *output,
 	conn->cursor_x = box.x;
 	conn->cursor_y = box.y;
 
-	if (!drm->session->active) {
-		return true; // will be committed when session is resumed
-	}
-
-	bool ok = drm->iface->crtc_move_cursor(drm, conn->crtc, box.x, box.y);
-	if (ok) {
-		wlr_output_update_needs_frame(output);
-	}
-	return ok;
+	wlr_output_update_needs_frame(output);
+	return true;
 }
 
 static void drm_connector_destroy(struct wlr_output *output) {

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -345,7 +345,7 @@ static bool drm_crtc_page_flip(struct wlr_drm_connector *conn) {
 		return false;
 	}
 
-	bool ok = drm->iface->crtc_pageflip(drm, conn);
+	bool ok = drm->iface->crtc_commit(drm, conn, DRM_MODE_PAGE_FLIP_EVENT);
 
 	crtc->pending = 0;
 

--- a/backend/drm/legacy.c
+++ b/backend/drm/legacy.c
@@ -7,7 +7,7 @@
 #include "backend/drm/util.h"
 
 static bool legacy_crtc_pageflip(struct wlr_drm_backend *drm,
-		struct wlr_drm_connector *conn, drmModeModeInfo *mode) {
+		struct wlr_drm_connector *conn) {
 	struct wlr_drm_crtc *crtc = conn->crtc;
 	struct wlr_drm_plane *cursor = crtc->cursor;
 
@@ -22,9 +22,9 @@ static bool legacy_crtc_pageflip(struct wlr_drm_backend *drm,
 		return false;
 	}
 
-	if (mode) {
+	if (crtc->pending & WLR_DRM_CRTC_MODE) {
 		if (drmModeSetCrtc(drm->fd, crtc->id, fb_id, 0, 0,
-				&conn->id, 1, mode)) {
+				&conn->id, 1, &crtc->mode)) {
 			wlr_log_errno(WLR_ERROR, "%s: Failed to set CRTC", conn->output.name);
 			return false;
 		}

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -65,8 +65,6 @@ struct wlr_drm_crtc {
 
 	union wlr_drm_crtc_props props;
 
-	struct wl_list connectors;
-
 	uint16_t *gamma_table;
 	size_t gamma_table_size;
 };
@@ -125,7 +123,6 @@ struct wlr_drm_connector {
 
 	union wlr_drm_connector_props props;
 
-	uint32_t width, height;
 	int32_t cursor_x, cursor_y;
 
 	drmModeCrtc *old_crtc;

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -44,6 +44,7 @@ struct wlr_drm_plane {
 
 enum wlr_drm_crtc_field {
 	WLR_DRM_CRTC_MODE = 1 << 0,
+	WLR_DRM_CRTC_GAMMA_LUT = 1 << 1,
 };
 
 struct wlr_drm_crtc {

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -42,8 +42,15 @@ struct wlr_drm_plane {
 	union wlr_drm_plane_props props;
 };
 
+enum wlr_drm_crtc_field {
+	WLR_DRM_CRTC_MODE = 1 << 0,
+};
+
 struct wlr_drm_crtc {
 	uint32_t id;
+	uint32_t pending; // bitfield of enum wlr_drm_crtc_field
+
+	drmModeModeInfo mode;
 
 	// Atomic modesetting only
 	uint32_t mode_id;

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -51,6 +51,7 @@ struct wlr_drm_crtc {
 	uint32_t id;
 	uint32_t pending; // bitfield of enum wlr_drm_crtc_field
 
+	bool active;
 	drmModeModeInfo mode;
 
 	// Atomic modesetting only

--- a/include/backend/drm/iface.h
+++ b/include/backend/drm/iface.h
@@ -16,9 +16,9 @@ struct wlr_drm_interface {
 	// Enable or disable DPMS for connector
 	bool (*conn_enable)(struct wlr_drm_backend *drm,
 		struct wlr_drm_connector *conn, bool enable);
-	// Pageflip on crtc.
-	bool (*crtc_pageflip)(struct wlr_drm_backend *drm,
-		struct wlr_drm_connector *conn);
+	// Commit al pending changes on a CRTC.
+	bool (*crtc_commit)(struct wlr_drm_backend *drm,
+		struct wlr_drm_connector *conn, uint32_t flags);
 	// Enable the cursor buffer on crtc. Set bo to NULL to disable
 	bool (*crtc_set_cursor)(struct wlr_drm_backend *drm,
 		struct wlr_drm_crtc *crtc, struct gbm_bo *bo);

--- a/include/backend/drm/iface.h
+++ b/include/backend/drm/iface.h
@@ -16,9 +16,6 @@ struct wlr_drm_interface {
 	// Commit al pending changes on a CRTC.
 	bool (*crtc_commit)(struct wlr_drm_backend *drm,
 		struct wlr_drm_connector *conn, uint32_t flags);
-	// Enable the cursor buffer on crtc. Set bo to NULL to disable
-	bool (*crtc_set_cursor)(struct wlr_drm_backend *drm,
-		struct wlr_drm_crtc *crtc, struct gbm_bo *bo);
 	// Get the gamma lut size of a crtc
 	size_t (*crtc_get_gamma_size)(struct wlr_drm_backend *drm,
 		struct wlr_drm_crtc *crtc);

--- a/include/backend/drm/iface.h
+++ b/include/backend/drm/iface.h
@@ -22,9 +22,6 @@ struct wlr_drm_interface {
 	// Enable the cursor buffer on crtc. Set bo to NULL to disable
 	bool (*crtc_set_cursor)(struct wlr_drm_backend *drm,
 		struct wlr_drm_crtc *crtc, struct gbm_bo *bo);
-	// Move the cursor on crtc
-	bool (*crtc_move_cursor)(struct wlr_drm_backend *drm,
-		struct wlr_drm_crtc *crtc, int x, int y);
 	// Set the gamma lut on crtc
 	bool (*crtc_set_gamma)(struct wlr_drm_backend *drm,
 		struct wlr_drm_crtc *crtc, size_t size,

--- a/include/backend/drm/iface.h
+++ b/include/backend/drm/iface.h
@@ -22,10 +22,6 @@ struct wlr_drm_interface {
 	// Enable the cursor buffer on crtc. Set bo to NULL to disable
 	bool (*crtc_set_cursor)(struct wlr_drm_backend *drm,
 		struct wlr_drm_crtc *crtc, struct gbm_bo *bo);
-	// Set the gamma lut on crtc
-	bool (*crtc_set_gamma)(struct wlr_drm_backend *drm,
-		struct wlr_drm_crtc *crtc, size_t size,
-		uint16_t *r, uint16_t *g, uint16_t *b);
 	// Get the gamma lut size of a crtc
 	size_t (*crtc_get_gamma_size)(struct wlr_drm_backend *drm,
 		struct wlr_drm_crtc *crtc);
@@ -33,5 +29,8 @@ struct wlr_drm_interface {
 
 extern const struct wlr_drm_interface atomic_iface;
 extern const struct wlr_drm_interface legacy_iface;
+
+bool drm_legacy_crtc_set_gamma(struct wlr_drm_backend *drm,
+	struct wlr_drm_crtc *crtc);
 
 #endif

--- a/include/backend/drm/iface.h
+++ b/include/backend/drm/iface.h
@@ -13,9 +13,6 @@ struct wlr_drm_crtc;
 
 // Used to provide atomic or legacy DRM functions
 struct wlr_drm_interface {
-	// Enable or disable DPMS for connector
-	bool (*conn_enable)(struct wlr_drm_backend *drm,
-		struct wlr_drm_connector *conn, bool enable);
 	// Commit al pending changes on a CRTC.
 	bool (*crtc_commit)(struct wlr_drm_backend *drm,
 		struct wlr_drm_connector *conn, uint32_t flags);

--- a/include/backend/drm/iface.h
+++ b/include/backend/drm/iface.h
@@ -16,9 +16,9 @@ struct wlr_drm_interface {
 	// Enable or disable DPMS for connector
 	bool (*conn_enable)(struct wlr_drm_backend *drm,
 		struct wlr_drm_connector *conn, bool enable);
-	// Pageflip on crtc. If mode is non-NULL perform a full modeset using it.
+	// Pageflip on crtc.
 	bool (*crtc_pageflip)(struct wlr_drm_backend *drm,
-		struct wlr_drm_connector *conn, drmModeModeInfo *mode);
+		struct wlr_drm_connector *conn);
 	// Enable the cursor buffer on crtc. Set bo to NULL to disable
 	bool (*crtc_set_cursor)(struct wlr_drm_backend *drm,
 		struct wlr_drm_crtc *crtc, struct gbm_bo *bo);


### PR DESCRIPTION
This PR starts re-working the DRM backend interface to apply all pending state in `crtc_pageflip`, instead of having one function per property.

A new bitfield `wlr_drm_crtc.pending` is introduced and contains the set of modified properties.

This PR doesn't touch the common logic in `drm.c`. Some refactoring will be done after this PR is merged.