### PR TITLE
Make EGL/eglmesaext.h header inclusion optional, only if present. Makes wlroots compile on any egl/gles driver.

### DIFF
--- a/include/wlr/config.h.in
+++ b/include/wlr/config.h.in
@@ -1,6 +1,8 @@
 #ifndef WLR_CONFIG_H
 #define WLR_CONFIG_H
 
+#mesondefine WLR_HAS_EGLMESAEXT_H
+
 #mesondefine WLR_HAS_LIBCAP
 
 #mesondefine WLR_HAS_SYSTEMD

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -16,10 +16,14 @@
 #define EGL_NO_X11
 #endif
 
+#include <wlr/config.h>
+
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
+#if WLR_HAS_EGLMESAEXT_H
 // TODO: remove eglmesaext.h
 #include <EGL/eglmesaext.h>
+#endif
 #include <pixman.h>
 #include <stdbool.h>
 #include <wayland-server-core.h>

--- a/meson.build
+++ b/meson.build
@@ -86,6 +86,7 @@ conf_data.set10('WLR_HAS_X11_BACKEND', false)
 conf_data.set10('WLR_HAS_XWAYLAND', false)
 conf_data.set10('WLR_HAS_XCB_ERRORS', false)
 conf_data.set10('WLR_HAS_XCB_ICCCM', false)
+conf_data.set10('WLR_HAS_EGLMESAEXT_H', false)
 
 # Clang complains about some zeroed initializer lists (= {0}), even though they
 # are valid
@@ -108,6 +109,10 @@ udev = dependency('libudev')
 pixman = dependency('pixman-1')
 math = cc.find_library('m')
 rt = cc.find_library('rt')
+
+if cc.has_header('EGL/eglmesaext.h', dependencies: egl)
+	conf_data.set10('WLR_HAS_EGLMESAEXT_H', true)
+endif
 
 wlr_files = []
 wlr_deps = [


### PR DESCRIPTION
This pull request makes the EGL/eglmesaext.h header included only if present. The EGL_WL_bind_wayland_display is now standard, and some EGL/GLES drivers are providing it without the eglmesaext.h file.

Those patches were tested in Buildroot, compiled with imx-gpu-viv gpu driver, on an i.MX8M Mini EVK board (case without eglmesaext.h).
They were also tested against a Mesa 20.0.6 (case with eglmesaext.h).