### PR TITLE
input/keyboard: expose keymap matching helper

### DIFF
--- a/include/wlr/types/wlr_keyboard.h
+++ b/include/wlr/types/wlr_keyboard.h
@@ -105,6 +105,9 @@ struct wlr_event_keyboard_key {
 
 bool wlr_keyboard_set_keymap(struct wlr_keyboard *kb,
 	struct xkb_keymap *keymap);
+
+bool wlr_keyboard_keymaps_match(struct xkb_keymap *km1, struct xkb_keymap *km2);
+
 /**
  * Sets the keyboard repeat info. `rate` is in key repeats/second and delay is
  * in milliseconds.

--- a/types/wlr_keyboard.c
+++ b/types/wlr_keyboard.c
@@ -232,3 +232,19 @@ uint32_t wlr_keyboard_get_modifiers(struct wlr_keyboard *kb) {
 	}
 	return modifiers;
 }
+
+bool wlr_keyboard_keymaps_match(struct xkb_keymap *km1,
+		struct xkb_keymap *km2) {
+	if (!km1 && !km2) {
+		return true;
+	}
+	if (!km1 || !km2) {
+		return false;
+	}
+	char *km1_str = xkb_keymap_get_as_string(km1, XKB_KEYMAP_FORMAT_TEXT_V1);
+	char *km2_str = xkb_keymap_get_as_string(km2, XKB_KEYMAP_FORMAT_TEXT_V1);
+	bool result = strcmp(km1_str, km2_str) == 0;
+	free(km1_str);
+	free(km2_str);
+	return result;
+}


### PR DESCRIPTION
sway needs this logic too, and currently ships a version that has fallen
behind in terms of bugfixes (b1a63bc). It might be reasonable for
wlroots to expose this functionality instead.