### PR TITLE
backend/drm: GAMMA_LUT_SIZE isn't atomic

### DIFF
--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -240,23 +240,6 @@ static bool atomic_crtc_commit(struct wlr_drm_backend *drm,
 	return true;
 }
 
-static size_t atomic_crtc_get_gamma_size(struct wlr_drm_backend *drm,
-		struct wlr_drm_crtc *crtc) {
-	if (crtc->props.gamma_lut_size == 0) {
-		return legacy_iface.crtc_get_gamma_size(drm, crtc);
-	}
-
-	uint64_t gamma_lut_size;
-	if (!get_drm_prop(drm->fd, crtc->id, crtc->props.gamma_lut_size,
-			&gamma_lut_size)) {
-		wlr_log(WLR_ERROR, "Unable to get gamma lut size");
-		return 0;
-	}
-
-	return (size_t)gamma_lut_size;
-}
-
 const struct wlr_drm_interface atomic_iface = {
 	.crtc_commit = atomic_crtc_commit,
-	.crtc_get_gamma_size = atomic_crtc_get_gamma_size,
 };

--- a/backend/drm/legacy.c
+++ b/backend/drm/legacy.c
@@ -117,12 +117,6 @@ bool drm_legacy_crtc_set_gamma(struct wlr_drm_backend *drm,
 	return true;
 }
 
-static size_t legacy_crtc_get_gamma_size(struct wlr_drm_backend *drm,
-		struct wlr_drm_crtc *crtc) {
-	return (size_t)crtc->legacy_crtc->gamma_size;
-}
-
 const struct wlr_drm_interface legacy_iface = {
 	.crtc_commit = legacy_crtc_commit,
-	.crtc_get_gamma_size = legacy_crtc_get_gamma_size,
 };

--- a/include/backend/drm/iface.h
+++ b/include/backend/drm/iface.h
@@ -16,9 +16,6 @@ struct wlr_drm_interface {
 	// Commit al pending changes on a CRTC.
 	bool (*crtc_commit)(struct wlr_drm_backend *drm,
 		struct wlr_drm_connector *conn, uint32_t flags);
-	// Get the gamma lut size of a crtc
-	size_t (*crtc_get_gamma_size)(struct wlr_drm_backend *drm,
-		struct wlr_drm_crtc *crtc);
 };
 
 extern const struct wlr_drm_interface atomic_iface;

--- a/include/backend/drm/properties.h
+++ b/include/backend/drm/properties.h
@@ -31,13 +31,13 @@ union wlr_drm_crtc_props {
 		uint32_t rotation;
 		uint32_t scaling_mode;
 		uint32_t vrr_enabled;
+		uint32_t gamma_lut;
+		uint32_t gamma_lut_size;
 
 		// atomic-modesetting only
 
 		uint32_t active;
 		uint32_t mode_id;
-		uint32_t gamma_lut;
-		uint32_t gamma_lut_size;
 	};
 	uint32_t props[6];
 };


### PR DESCRIPTION
GAMMA_LUT_SIZE isn't an atomic property. It can be used with the legacy
interface too. So we can unify both codepaths and remove
wlr_drm_interface.crtc_get_gamma_size.

It's no guaranteed to exist though, so we still need to keep the
fallback.