### PR TITLE
backend/drm: simplify atomic commit logic

### DIFF
--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -9,57 +9,42 @@
 
 struct atomic {
 	drmModeAtomicReq *req;
-	int cursor;
 	bool failed;
 };
 
-static void atomic_begin(struct wlr_drm_crtc *crtc, struct atomic *atom) {
-	if (!crtc->atomic) {
-		crtc->atomic = drmModeAtomicAlloc();
-		if (!crtc->atomic) {
-			wlr_log_errno(WLR_ERROR, "Allocation failed");
-			atom->failed = true;
-			return;
-		}
-	}
+static void atomic_begin(struct atomic *atom) {
+	memset(atom, 0, sizeof(*atom));
 
-	atom->req = crtc->atomic;
-	atom->cursor = drmModeAtomicGetCursor(atom->req);
-	atom->failed = false;
+	atom->req = drmModeAtomicAlloc();
+	if (!atom->req) {
+		wlr_log_errno(WLR_ERROR, "Allocation failed");
+		atom->failed = true;
+		return;
+	}
 }
 
-static bool atomic_end(int drm_fd, uint32_t flags, struct atomic *atom) {
-	if (atom->failed) {
-		return false;
-	}
-
-	flags |= DRM_MODE_ATOMIC_TEST_ONLY;
-	if (drmModeAtomicCommit(drm_fd, atom->req, flags, NULL)) {
-		wlr_log_errno(WLR_DEBUG, "Atomic test failed");
-		drmModeAtomicSetCursor(atom->req, atom->cursor);
-		return false;
-	}
-
-	return true;
-}
-
-static bool atomic_commit(int drm_fd, struct atomic *atom,
-		struct wlr_drm_connector *conn, uint32_t flags, bool modeset) {
+static bool atomic_commit(struct atomic *atom,
+		struct wlr_drm_connector *conn, uint32_t flags) {
 	struct wlr_drm_backend *drm =
 		get_drm_backend_from_backend(conn->output.backend);
 	if (atom->failed) {
 		return false;
 	}
 
-	int ret = drmModeAtomicCommit(drm_fd, atom->req, flags, drm);
+	int ret = drmModeAtomicCommit(drm->fd, atom->req, flags, drm);
 	if (ret) {
-		wlr_log_errno(WLR_ERROR, "%s: Atomic commit failed (%s)",
-			conn->output.name, modeset ? "modeset" : "pageflip");
+		wlr_log_errno(WLR_ERROR, "%s: Atomic %s failed (%s)",
+			conn->output.name,
+			(flags & DRM_MODE_ATOMIC_TEST_ONLY) ? "test" : "commit",
+			(flags & DRM_MODE_ATOMIC_ALLOW_MODESET) ? "modeset" : "pageflip");
+		return false;
 	}
 
-	drmModeAtomicSetCursor(atom->req, 0);
+	return true;
+}
 
-	return !ret;
+static void atomic_finish(struct atomic *atom) {
+	drmModeAtomicFree(atom->req);
 }
 
 static void atomic_add(struct atomic *atom, uint32_t id, uint32_t prop, uint64_t val) {
@@ -200,7 +185,7 @@ static bool atomic_crtc_commit(struct wlr_drm_backend *drm,
 	}
 
 	struct atomic atom;
-	atomic_begin(crtc, &atom);
+	atomic_begin(&atom);
 	atomic_add(&atom, conn->id, conn->props.crtc_id,
 		crtc->active ? crtc->id : 0);
 	if (modeset && crtc->active && conn->props.link_status != 0) {
@@ -227,17 +212,9 @@ static bool atomic_crtc_commit(struct wlr_drm_backend *drm,
 		}
 	}
 
-	if (!atomic_end(drm->fd, modeset ? DRM_MODE_ATOMIC_ALLOW_MODESET : 0,
-			&atom)) {
-		drmModeAtomicSetCursor(atom.req, 0);
-		return false;
-	}
-
-	if (!atomic_commit(drm->fd, &atom, conn, flags, modeset)) {
-		return false;
-	}
-
-	return true;
+	bool ok = atomic_commit(&atom, conn, flags);
+	atomic_finish(&atom);
+	return ok;
 }
 
 static size_t atomic_crtc_get_gamma_size(struct wlr_drm_backend *drm,

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -296,7 +296,6 @@ void finish_drm_resources(struct wlr_drm_backend *drm) {
 	for (size_t i = 0; i < drm->num_crtcs; ++i) {
 		struct wlr_drm_crtc *crtc = &drm->crtcs[i];
 
-		drmModeAtomicFree(crtc->atomic);
 		drmModeFreeCrtc(crtc->legacy_crtc);
 
 		if (crtc->mode_id) {

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -57,7 +57,6 @@ struct wlr_drm_crtc {
 	// Atomic modesetting only
 	uint32_t mode_id;
 	uint32_t gamma_lut;
-	drmModeAtomicReq *atomic;
 
 	// Legacy only
 	drmModeCrtc *legacy_crtc;


### PR DESCRIPTION
We don't need a per-CRTC atomic request anymore. Let's make the request
per-commit so that it's easier to debug.

This is also groundwork for supporting wlr_output_test properly.