### PR TITLE
backend/drm: fix crash in session_signal

### DIFF
--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -93,7 +93,6 @@ static void session_signal(struct wl_listener *listener, void *data) {
 
 		struct wlr_drm_connector *conn;
 		wl_list_for_each(conn, &drm->outputs, link){
-			conn->crtc->pending |= WLR_DRM_CRTC_GAMMA_LUT;
 			if (conn->output.enabled && conn->output.current_mode != NULL) {
 				drm_connector_set_mode(&conn->output,
 						conn->output.current_mode);


### PR DESCRIPTION
conn->crtc is NULL in case the output is disabled.

However, the DRM backend will set the GAMMA_LUT property anyway. On each
commit the whole state is sent to KMS. Adding WLR_DRM_CRTC_GAMMA_LUT to
the pending state would just make the backend re-create the blob
containing the gamma LUT.