### PR TITLE
backend/drm: remove missing cursor plane workaround

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -941,14 +941,8 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 	}
 
 	struct wlr_drm_plane *plane = crtc->cursor;
-	if (!plane) {
-		// We don't have a real cursor plane, so we make a fake one
-		plane = calloc(1, sizeof(*plane));
-		if (!plane) {
-			wlr_log_errno(WLR_ERROR, "Allocation failed");
-			return false;
-		}
-		crtc->cursor = plane;
+	if (plane == NULL) {
+		return false;
 	}
 
 	if (!plane->surf.gbm) {


### PR DESCRIPTION
We have a workaround for legacy drivers that support drmModeSetCursor
without exposing a cursor plane. It doesn't work anymore now that we've
moved to a more atomic interface.

Let's just remove this workaround and fallback to software cursors.

Closes: https://github.com/swaywm/wlroots/issues/2166