### PR TITLE
Make wlr_xcursor_manager_load() return a bool

### DIFF
--- a/include/wlr/types/wlr_xcursor_manager.h
+++ b/include/wlr/types/wlr_xcursor_manager.h
@@ -46,7 +46,7 @@ void wlr_xcursor_manager_destroy(struct wlr_xcursor_manager *manager);
 /**
  * Ensures an xcursor theme at the given scale factor is loaded in the manager.
  */
-int wlr_xcursor_manager_load(struct wlr_xcursor_manager *manager,
+bool wlr_xcursor_manager_load(struct wlr_xcursor_manager *manager,
 	float scale);
 
 /**

--- a/types/wlr_xcursor_manager.c
+++ b/types/wlr_xcursor_manager.c
@@ -32,27 +32,27 @@ void wlr_xcursor_manager_destroy(struct wlr_xcursor_manager *manager) {
 	free(manager);
 }
 
-int wlr_xcursor_manager_load(struct wlr_xcursor_manager *manager,
+bool wlr_xcursor_manager_load(struct wlr_xcursor_manager *manager,
 		float scale) {
 	struct wlr_xcursor_manager_theme *theme;
 	wl_list_for_each(theme, &manager->scaled_themes, link) {
 		if (theme->scale == scale) {
-			return 0;
+			return true;
 		}
 	}
 
 	theme = calloc(1, sizeof(struct wlr_xcursor_manager_theme));
 	if (theme == NULL) {
-		return 1;
+		return false;
 	}
 	theme->scale = scale;
 	theme->theme = wlr_xcursor_theme_load(manager->name, manager->size * scale);
 	if (theme->theme == NULL) {
 		free(theme);
-		return 1;
+		return false;
 	}
 	wl_list_insert(&manager->scaled_themes, &theme->link);
-	return 0;
+	return true;
 }
 
 struct wlr_xcursor *wlr_xcursor_manager_get_xcursor(


### PR DESCRIPTION
This is currently inconsistent with the rest of the library and a bit of
a footgun for new compositors. However, this breaks the API in a very
unfortunate way for existing compositors.

* * *

Breaking change: `wlr_xcursor_manager_load` now returns a bool, making it consistent with other wlroots functions. Compositors that check the return value need to invert their check.