### PR TITLE
output: make wlr_output_set_gamma atomic

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -305,8 +305,6 @@ void finish_drm_resources(struct wlr_drm_backend *drm) {
 			drmModeDestroyPropertyBlob(drm->fd, crtc->gamma_lut);
 		}
 
-		free(crtc->gamma_table);
-
 		if (crtc->primary) {
 			wlr_drm_format_set_finish(&crtc->primary->formats);
 			free(crtc->primary);
@@ -568,24 +566,8 @@ static void drm_connector_rollback(struct wlr_output *output) {
 	wlr_egl_make_current(&drm->renderer.egl, EGL_NO_SURFACE, NULL);
 }
 
-static void fill_empty_gamma_table(size_t size,
-		uint16_t *r, uint16_t *g, uint16_t *b) {
-	assert(0xFFFF < UINT64_MAX / (size - 1));
-	for (uint32_t i = 0; i < size; ++i) {
-		uint16_t val = (uint64_t)0xffff * i / (size - 1);
-		r[i] = g[i] = b[i] = val;
-	}
-}
-
-static size_t drm_connector_get_gamma_size(struct wlr_output *output) {
-	struct wlr_drm_connector *conn = get_drm_connector_from_output(output);
-	struct wlr_drm_backend *drm = get_drm_backend_from_backend(output->backend);
-	struct wlr_drm_crtc *crtc = conn->crtc;
-
-	if (crtc == NULL) {
-		return 0;
-	}
-
+size_t drm_crtc_get_gamma_lut_size(struct wlr_drm_backend *drm,
+		struct wlr_drm_crtc *crtc) {
 	if (crtc->props.gamma_lut_size == 0) {
 		return (size_t)crtc->legacy_crtc->gamma_size;
 	}
@@ -600,47 +582,16 @@ static size_t drm_connector_get_gamma_size(struct wlr_output *output) {
 	return gamma_lut_size;
 }
 
-bool set_drm_connector_gamma(struct wlr_output *output, size_t size,
-		const uint16_t *r, const uint16_t *g, const uint16_t *b) {
+static size_t drm_connector_get_gamma_size(struct wlr_output *output) {
 	struct wlr_drm_connector *conn = get_drm_connector_from_output(output);
+	struct wlr_drm_backend *drm = get_drm_backend_from_backend(output->backend);
+	struct wlr_drm_crtc *crtc = conn->crtc;
 
-	if (!conn->crtc) {
-		return false;
+	if (crtc == NULL) {
+		return 0;
 	}
 
-	bool reset = false;
-	if (size == 0) {
-		reset = true;
-		size = drm_connector_get_gamma_size(output);
-		if (size == 0) {
-			return false;
-		}
-	}
-
-	uint16_t *gamma_table = malloc(3 * size * sizeof(uint16_t));
-	if (gamma_table == NULL) {
-		wlr_log(WLR_ERROR, "Failed to allocate gamma table");
-		return false;
-	}
-	uint16_t *_r = gamma_table;
-	uint16_t *_g = gamma_table + size;
-	uint16_t *_b = gamma_table + 2 * size;
-
-	if (reset) {
-		fill_empty_gamma_table(size, _r, _g, _b);
-	} else {
-		memcpy(_r, r, size * sizeof(uint16_t));
-		memcpy(_g, g, size * sizeof(uint16_t));
-		memcpy(_b, b, size * sizeof(uint16_t));
-	}
-
-	conn->crtc->pending |= WLR_DRM_CRTC_GAMMA_LUT;
-	free(conn->crtc->gamma_table);
-	conn->crtc->gamma_table = gamma_table;
-	conn->crtc->gamma_table_size = size;
-
-	wlr_output_update_needs_frame(output);
-	return true; // will be applied on next page-flip
+	return drm_crtc_get_gamma_lut_size(drm, crtc);
 }
 
 static bool drm_connector_export_dmabuf(struct wlr_output *output,
@@ -1082,7 +1033,6 @@ static const struct wlr_output_impl output_impl = {
 	.test = drm_connector_test,
 	.commit = drm_connector_commit,
 	.rollback = drm_connector_rollback,
-	.set_gamma = set_drm_connector_gamma,
 	.get_gamma_size = drm_connector_get_gamma_size,
 	.export_dmabuf = drm_connector_export_dmabuf,
 };
@@ -1117,7 +1067,6 @@ static void dealloc_crtc(struct wlr_drm_connector *conn) {
 	wlr_log(WLR_DEBUG, "De-allocating CRTC %zu for output '%s'",
 		conn->crtc - drm->crtcs, conn->output.name);
 
-	set_drm_connector_gamma(&conn->output, 0, NULL, NULL, NULL);
 	enable_drm_connector(&conn->output, false);
 	drm_plane_finish_surface(conn->crtc->primary);
 	drm_plane_finish_surface(conn->crtc->cursor);

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -44,7 +44,6 @@ struct wlr_drm_plane {
 
 enum wlr_drm_crtc_field {
 	WLR_DRM_CRTC_MODE = 1 << 0,
-	WLR_DRM_CRTC_GAMMA_LUT = 1 << 1,
 };
 
 struct wlr_drm_crtc {
@@ -72,9 +71,6 @@ struct wlr_drm_crtc {
 	uint32_t *overlays;
 
 	union wlr_drm_crtc_props props;
-
-	uint16_t *gamma_table;
-	size_t gamma_table_size;
 };
 
 struct wlr_drm_backend {
@@ -156,16 +152,11 @@ void restore_drm_outputs(struct wlr_drm_backend *drm);
 void scan_drm_connectors(struct wlr_drm_backend *state);
 int handle_drm_event(int fd, uint32_t mask, void *data);
 bool enable_drm_connector(struct wlr_output *output, bool enable);
-bool set_drm_connector_gamma(struct wlr_output *output, size_t size,
-	const uint16_t *r, const uint16_t *g, const uint16_t *b);
 bool drm_connector_set_mode(struct wlr_output *output,
 	struct wlr_output_mode *mode);
+size_t drm_crtc_get_gamma_lut_size(struct wlr_drm_backend *drm,
+	struct wlr_drm_crtc *crtc);
 
 struct wlr_drm_fb *plane_get_next_fb(struct wlr_drm_plane *plane);
-
-bool legacy_crtc_set_cursor(struct wlr_drm_backend *drm,
-	struct wlr_drm_crtc *crtc, struct gbm_bo *bo);
-bool legacy_crtc_move_cursor(struct wlr_drm_backend *drm,
-	struct wlr_drm_crtc *crtc, int x, int y);
 
 #endif

--- a/include/backend/drm/iface.h
+++ b/include/backend/drm/iface.h
@@ -22,6 +22,6 @@ extern const struct wlr_drm_interface atomic_iface;
 extern const struct wlr_drm_interface legacy_iface;
 
 bool drm_legacy_crtc_set_gamma(struct wlr_drm_backend *drm,
-	struct wlr_drm_crtc *crtc);
+	struct wlr_drm_crtc *crtc, size_t size, uint16_t *lut);
 
 #endif

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -24,8 +24,6 @@ struct wlr_output_impl {
 	bool (*test)(struct wlr_output *output);
 	bool (*commit)(struct wlr_output *output);
 	void (*rollback)(struct wlr_output *output);
-	bool (*set_gamma)(struct wlr_output *output, size_t size,
-		const uint16_t *r, const uint16_t *g, const uint16_t *b);
 	size_t (*get_gamma_size)(struct wlr_output *output);
 	bool (*export_dmabuf)(struct wlr_output *output,
 		struct wlr_dmabuf_attributes *attribs);

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -60,6 +60,7 @@ enum wlr_output_state_field {
 	WLR_OUTPUT_STATE_SCALE = 1 << 4,
 	WLR_OUTPUT_STATE_TRANSFORM = 1 << 5,
 	WLR_OUTPUT_STATE_ADAPTIVE_SYNC_ENABLED = 1 << 6,
+	WLR_OUTPUT_STATE_GAMMA_LUT = 1 << 7,
 };
 
 enum wlr_output_state_buffer_type {
@@ -94,6 +95,10 @@ struct wlr_output_state {
 		int32_t width, height;
 		int32_t refresh; // mHz, may be zero
 	} custom_mode;
+
+	// only valid if WLR_OUTPUT_STATE_GAMMA_LUT
+	uint16_t *gamma_lut;
+	size_t gamma_lut_size;
 };
 
 struct wlr_output_impl;
@@ -375,8 +380,10 @@ size_t wlr_output_get_gamma_size(struct wlr_output *output);
  * the value returned by `wlr_output_get_gamma_size`.
  *
  * Providing zero-sized ramps resets the gamma table.
+ *
+ * The gamma table is double-buffered state, see `wlr_output_commit`.
  */
-bool wlr_output_set_gamma(struct wlr_output *output, size_t size,
+void wlr_output_set_gamma(struct wlr_output *output, size_t size,
 	const uint16_t *r, const uint16_t *g, const uint16_t *b);
 bool wlr_output_export_dmabuf(struct wlr_output *output,
 	struct wlr_dmabuf_attributes *attribs);

--- a/types/wlr_gamma_control_v1.c
+++ b/types/wlr_gamma_control_v1.c
@@ -105,12 +105,15 @@ static void gamma_control_handle_set_gamma(struct wl_client *client,
 	uint16_t *g = table + ramp_size;
 	uint16_t *b = table + 2 * ramp_size;
 
-	bool ok = wlr_output_set_gamma(gamma_control->output, ramp_size, r, g, b);
-	if (!ok) {
+	wlr_output_set_gamma(gamma_control->output, ramp_size, r, g, b);
+	if (!wlr_output_test(gamma_control->output)) {
 		gamma_control_send_failed(gamma_control);
 		goto error_table;
 	}
 	free(table);
+
+	// Gamma LUT will be applied on next output commit
+	wlr_output_schedule_frame(gamma_control->output);
 
 	return;
 
@@ -175,7 +178,8 @@ static void gamma_control_manager_get_gamma_control(struct wl_client *client,
 
 	wl_list_init(&gamma_control->link);
 
-	if (!output->impl->set_gamma) {
+	size_t gamma_size = wlr_output_get_gamma_size(output);
+	if (gamma_size == 0) {
 		zwlr_gamma_control_v1_send_failed(gamma_control->resource);
 		gamma_control_destroy(gamma_control);
 		return;
@@ -192,8 +196,7 @@ static void gamma_control_manager_get_gamma_control(struct wl_client *client,
 
 	wl_list_remove(&gamma_control->link);
 	wl_list_insert(&manager->controls, &gamma_control->link);
-	zwlr_gamma_control_v1_send_gamma_size(gamma_control->resource,
-		wlr_output_get_gamma_size(output));
+	zwlr_gamma_control_v1_send_gamma_size(gamma_control->resource, gamma_size);
 }
 
 static void gamma_control_manager_destroy(struct wl_client *client,


### PR DESCRIPTION
wlr_output_set_gamma is now double-buffered and applies the gamma LUT on
the next output commit.

* * *

Breaking changes:

* `wlr_output_set_gamma` is now double-buffered and applied on the next output commit
* `wlr_output_impl.set_gamma` is gone. Backends now need to read the pending output state on commit instead.