### PR TITLE
backend/drm: refactor modesetting

### DIFF
--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -97,7 +97,7 @@ static void session_signal(struct wl_listener *listener, void *data) {
 				drm_connector_set_mode(&conn->output,
 						conn->output.current_mode);
 			} else {
-				enable_drm_connector(&conn->output, false);
+				drm_connector_set_mode(&conn->output, NULL);
 			}
 		}
 	} else {

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -94,10 +94,9 @@ static void session_signal(struct wl_listener *listener, void *data) {
 		struct wlr_drm_connector *conn;
 		wl_list_for_each(conn, &drm->outputs, link){
 			if (conn->output.enabled && conn->output.current_mode != NULL) {
-				drm_connector_set_mode(&conn->output,
-						conn->output.current_mode);
+				drm_connector_set_mode(conn, conn->output.current_mode);
 			} else {
-				drm_connector_set_mode(&conn->output, NULL);
+				drm_connector_set_mode(conn, NULL);
 			}
 		}
 	} else {

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -564,7 +564,7 @@ static bool drm_connector_commit(struct wlr_output *output) {
 			}
 		}
 
-		if (!drm_connector_set_mode(output, wlr_mode)) {
+		if (!drm_connector_set_mode(conn, wlr_mode)) {
 			return false;
 		}
 	}
@@ -770,17 +770,17 @@ static void attempt_enable_needs_modeset(struct wlr_drm_backend *drm) {
 				conn->desired_enabled) {
 			wlr_log(WLR_DEBUG, "Output %s has a desired mode and a CRTC, "
 				"attempting a modeset", conn->output.name);
-			drm_connector_set_mode(&conn->output, conn->desired_mode);
+			drm_connector_set_mode(conn, conn->desired_mode);
 		}
 	}
 }
 
 static void drm_connector_cleanup(struct wlr_drm_connector *conn);
 
-bool drm_connector_set_mode(struct wlr_output *output,
+bool drm_connector_set_mode(struct wlr_drm_connector *conn,
 		struct wlr_output_mode *wlr_mode) {
-	struct wlr_drm_connector *conn = get_drm_connector_from_output(output);
-	struct wlr_drm_backend *drm = get_drm_backend_from_backend(output->backend);
+	struct wlr_drm_backend *drm =
+		get_drm_backend_from_backend(conn->output.backend);
 
 	conn->desired_enabled = wlr_mode != NULL;
 	conn->desired_mode = wlr_mode;
@@ -1061,7 +1061,7 @@ static void dealloc_crtc(struct wlr_drm_connector *conn) {
 	wlr_log(WLR_DEBUG, "De-allocating CRTC %zu for output '%s'",
 		conn->crtc - drm->crtcs, conn->output.name);
 
-	drm_connector_set_mode(&conn->output, NULL);
+	drm_connector_set_mode(conn, NULL);
 	drm_plane_finish_surface(conn->crtc->primary);
 	drm_plane_finish_surface(conn->crtc->cursor);
 	if (conn->crtc->cursor != NULL) {

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -42,16 +42,16 @@ struct wlr_drm_plane {
 	union wlr_drm_plane_props props;
 };
 
-enum wlr_drm_crtc_field {
-	WLR_DRM_CRTC_MODE = 1 << 0,
+struct wlr_drm_crtc_state {
+	bool active;
+	struct wlr_drm_mode *mode;
 };
 
 struct wlr_drm_crtc {
 	uint32_t id;
-	uint32_t pending; // bitfield of enum wlr_drm_crtc_field
 
-	bool active;
-	drmModeModeInfo mode;
+	bool pending_modeset;
+	struct wlr_drm_crtc_state pending, current;
 
 	// Atomic modesetting only
 	uint32_t mode_id;

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -151,7 +151,7 @@ void finish_drm_resources(struct wlr_drm_backend *drm);
 void restore_drm_outputs(struct wlr_drm_backend *drm);
 void scan_drm_connectors(struct wlr_drm_backend *state);
 int handle_drm_event(int fd, uint32_t mask, void *data);
-bool drm_connector_set_mode(struct wlr_output *output,
+bool drm_connector_set_mode(struct wlr_drm_connector *conn,
 	struct wlr_output_mode *mode);
 size_t drm_crtc_get_gamma_lut_size(struct wlr_drm_backend *drm,
 	struct wlr_drm_crtc *crtc);

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -131,7 +131,6 @@ struct wlr_drm_connector {
 
 	drmModeCrtc *old_crtc;
 
-	struct wl_event_source *retry_pageflip;
 	struct wl_list link;
 
 	/*

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -151,7 +151,6 @@ void finish_drm_resources(struct wlr_drm_backend *drm);
 void restore_drm_outputs(struct wlr_drm_backend *drm);
 void scan_drm_connectors(struct wlr_drm_backend *state);
 int handle_drm_event(int fd, uint32_t mask, void *data);
-bool enable_drm_connector(struct wlr_output *output, bool enable);
 bool drm_connector_set_mode(struct wlr_output *output,
 	struct wlr_output_mode *mode);
 size_t drm_crtc_get_gamma_lut_size(struct wlr_drm_backend *drm,


### PR DESCRIPTION
See individual commits. Overall this brings us closer to being able to expose test-only atomic commits.