### PR TITLE
render/egl: introduce wlr_egl_unset_current

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -556,14 +556,14 @@ static bool drm_connector_commit(struct wlr_output *output) {
 		}
 	}
 
-	wlr_egl_make_current(&drm->renderer.egl, EGL_NO_SURFACE, NULL);
+	wlr_egl_unset_current(&drm->renderer.egl);
 
 	return true;
 }
 
 static void drm_connector_rollback(struct wlr_output *output) {
 	struct wlr_drm_backend *drm = get_drm_backend_from_backend(output->backend);
-	wlr_egl_make_current(&drm->renderer.egl, EGL_NO_SURFACE, NULL);
+	wlr_egl_unset_current(&drm->renderer.egl);
 }
 
 size_t drm_crtc_get_gamma_lut_size(struct wlr_drm_backend *drm,

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -300,7 +300,7 @@ static bool output_commit(struct wlr_output *wlr_output) {
 		}
 	}
 
-	wlr_egl_make_current(&output->backend->egl, EGL_NO_SURFACE, NULL);
+	wlr_egl_unset_current(&output->backend->egl);
 
 	return true;
 }
@@ -308,7 +308,7 @@ static bool output_commit(struct wlr_output *wlr_output) {
 static void output_rollback(struct wlr_output *wlr_output) {
 	struct wlr_wl_output *output =
 		get_wl_output_from_output(wlr_output);
-	wlr_egl_make_current(&output->backend->egl, EGL_NO_SURFACE, NULL);
+	wlr_egl_unset_current(&output->backend->egl);
 }
 
 static bool output_set_cursor(struct wlr_output *wlr_output,
@@ -377,6 +377,7 @@ static bool output_set_cursor(struct wlr_output *wlr_output,
 
 		wlr_egl_swap_buffers(&backend->egl, egl_surface, NULL);
 		wlr_egl_destroy_surface(&backend->egl, egl_surface);
+		wlr_egl_unset_current(&backend->egl);
 	} else {
 		wl_surface_attach(surface, NULL, 0, 0);
 		wl_surface_commit(surface);
@@ -583,6 +584,7 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *wlr_backend) {
 			NULL)) {
 		goto error;
 	}
+	wlr_egl_unset_current(&output->backend->egl);
 
 	wl_list_insert(&backend->outputs, &output->link);
 	wlr_output_update_enabled(wlr_output, true);

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -157,14 +157,14 @@ static bool output_commit(struct wlr_output *wlr_output) {
 		wlr_output_send_present(wlr_output, NULL);
 	}
 
-	wlr_egl_make_current(&x11->egl, EGL_NO_SURFACE, NULL);
+	wlr_egl_unset_current(&x11->egl);
 
 	return true;
 }
 
 static void output_rollback(struct wlr_output *wlr_output) {
 	struct wlr_x11_output *output = get_x11_output_from_output(wlr_output);
-	wlr_egl_make_current(&output->x11->egl, EGL_NO_SURFACE, NULL);
+	wlr_egl_unset_current(&output->x11->egl);
 }
 
 static const struct wlr_output_impl output_impl = {

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -122,8 +122,17 @@ bool wlr_egl_export_image_to_dmabuf(struct wlr_egl *egl, EGLImageKHR image,
  */
 bool wlr_egl_destroy_image(struct wlr_egl *egl, EGLImageKHR image);
 
+/**
+ * Make the EGL context current. The provided surface will be made current
+ * unless EGL_NO_SURFACE.
+ *
+ * Callers are expected to clear the current context when they are done by
+ * calling wlr_egl_unset_current.
+ */
 bool wlr_egl_make_current(struct wlr_egl *egl, EGLSurface surface,
 	int *buffer_age);
+
+bool wlr_egl_unset_current(struct wlr_egl *egl);
 
 bool wlr_egl_is_current(struct wlr_egl *egl);
 

--- a/render/egl.c
+++ b/render/egl.c
@@ -387,6 +387,15 @@ bool wlr_egl_make_current(struct wlr_egl *egl, EGLSurface surface,
 	return true;
 }
 
+bool wlr_egl_unset_current(struct wlr_egl *egl) {
+	if (!eglMakeCurrent(egl->display, EGL_NO_SURFACE, EGL_NO_SURFACE,
+			EGL_NO_CONTEXT)) {
+		wlr_log(WLR_ERROR, "eglMakeCurrent failed");
+		return false;
+	}
+	return true;
+}
+
 bool wlr_egl_is_current(struct wlr_egl *egl) {
 	return eglGetCurrentContext() == egl->context;
 }
@@ -690,7 +699,7 @@ bool wlr_egl_destroy_surface(struct wlr_egl *egl, EGLSurface surface) {
 		// Reset the current EGL surface in case it's the one we're destroying,
 		// otherwise the next wlr_egl_make_current call will result in a
 		// use-after-free.
-		wlr_egl_make_current(egl, NULL, NULL);
+		wlr_egl_make_current(egl, EGL_NO_SURFACE, NULL);
 	}
 	return eglDestroySurface(egl->display, surface);
 }

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -401,6 +401,8 @@ static void gles2_destroy(struct wlr_renderer *wlr_renderer) {
 		gles2_procs.glDebugMessageCallbackKHR(NULL, NULL);
 	}
 
+	wlr_egl_unset_current(renderer->egl);
+
 	free(renderer);
 }
 
@@ -670,6 +672,8 @@ struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_egl *egl) {
 
 	POP_GLES2_DEBUG;
 
+	wlr_egl_unset_current(renderer->egl);
+
 	return &renderer->wlr_renderer;
 
 error:
@@ -685,6 +689,8 @@ error:
 		glDisable(GL_DEBUG_OUTPUT_KHR);
 		gles2_procs.glDebugMessageCallbackKHR(NULL, NULL);
 	}
+
+	wlr_egl_unset_current(renderer->egl);
 
 	free(renderer);
 	return NULL;


### PR DESCRIPTION
This function can be called after wlr_egl_make_current to cleanup the
EGL context. This avoids having lingering EGL contexts that make things
work by chance.

Closes: https://github.com/swaywm/wlroots/issues/2197