### PR TITLE
Fix -Wreturn-type warnings

### DIFF
--- a/backend/libinput/tablet_tool.c
+++ b/backend/libinput/tablet_tool.c
@@ -118,8 +118,7 @@ static enum wlr_tablet_tool_type wlr_type_from_libinput_type(
 		return WLR_TABLET_TOOL_TYPE_TOTEM;
 #endif
 	}
-
-	assert(false && "UNREACHABLE");
+	abort(); // unreachable
 }
 
 static struct wlr_libinput_tablet_tool *get_wlr_tablet_tool(

--- a/backend/wayland/tablet_v2.c
+++ b/backend/wayland/tablet_v2.c
@@ -466,7 +466,6 @@ static void handle_tablet_tool_done(void *data,
 }
 
 static enum wlr_tablet_tool_type tablet_type_to_wlr_type(enum zwp_tablet_tool_v2_type type) {
-
 	switch (type) {
 	case ZWP_TABLET_TOOL_V2_TYPE_PEN:
 		return WLR_TABLET_TOOL_TYPE_PEN;
@@ -485,8 +484,7 @@ static enum wlr_tablet_tool_type tablet_type_to_wlr_type(enum zwp_tablet_tool_v2
 	default:
 		break;
 	}
-
-	assert(false && "Unreachable");
+	abort(); // unreachable
 }
 
 static void handle_tablet_tool_type(void *data,

--- a/types/tablet_v2/wlr_tablet_v2_tool.c
+++ b/types/tablet_v2/wlr_tablet_v2_tool.c
@@ -75,10 +75,8 @@ static enum zwp_tablet_tool_v2_type tablet_type_from_wlr_type(
 		return ZWP_TABLET_TOOL_V2_TYPE_LENS;
 	default:
 		/* We skip these devices earlier on */
-		assert(false && "Unreachable");
+		abort(); // unreachable
 	}
-
-	assert(false && "Unreachable");
 }
 
 void destroy_tablet_tool_v2(struct wl_resource *resource) {

--- a/types/xdg_shell/wlr_xdg_positioner.c
+++ b/types/xdg_shell/wlr_xdg_positioner.c
@@ -176,7 +176,7 @@ static bool positioner_anchor_has_edge(enum xdg_positioner_anchor anchor,
 			anchor == XDG_POSITIONER_ANCHOR_TOP_RIGHT ||
 			anchor == XDG_POSITIONER_ANCHOR_BOTTOM_RIGHT;
 	default:
-		assert(false); // not reached
+		abort(); // unreachable
 	}
 }
 


### PR DESCRIPTION
When calling assert(0) instead of returning a value, -Wreturn-type
warnings are triggered because assertions can be disabled. Replace these
assertions with abort().