### PR TITLE
backend/drm: EGL context fixes for multi-GPU

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -967,6 +967,8 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 			return false;
 		}
 
+		wlr_egl_unset_current(&plane->surf.renderer->egl);
+
 		plane->cursor_enabled = true;
 	}
 

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -390,20 +390,19 @@ struct gbm_bo *drm_fb_acquire(struct wlr_drm_fb *fb, struct wlr_drm_backend *drm
 
 	/* Perform copy across GPUs */
 
-	struct wlr_renderer *renderer = mgpu->renderer->wlr_rend;
-
-	if (!drm_surface_make_current(mgpu, NULL)) {
+	struct wlr_texture *tex = get_tex_for_bo(mgpu->renderer, fb->bo);
+	if (!tex) {
 		return NULL;
 	}
 
-	struct wlr_texture *tex = get_tex_for_bo(mgpu->renderer, fb->bo);
-	if (!tex) {
+	if (!drm_surface_make_current(mgpu, NULL)) {
 		return NULL;
 	}
 
 	float mat[9];
 	wlr_matrix_projection(mat, 1, 1, WL_OUTPUT_TRANSFORM_NORMAL);
 
+	struct wlr_renderer *renderer = mgpu->renderer->wlr_rend;
 	wlr_renderer_begin(renderer, mgpu->width, mgpu->height);
 	wlr_renderer_clear(renderer, (float[]){ 0.0, 0.0, 0.0, 0.0 });
 	wlr_render_texture_with_matrix(renderer, tex, mat, 1.0f);

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -361,15 +361,17 @@ void drm_fb_move(struct wlr_drm_fb *new, struct wlr_drm_fb *old) {
 }
 
 bool drm_surface_render_black_frame(struct wlr_drm_surface *surf) {
-	struct wlr_renderer *renderer = surf->renderer->wlr_rend;
-
 	if (!drm_surface_make_current(surf, NULL)) {
 		return false;
 	}
 
+	struct wlr_renderer *renderer = surf->renderer->wlr_rend;
 	wlr_renderer_begin(renderer, surf->width, surf->height);
 	wlr_renderer_clear(renderer, (float[]){ 0.0, 0.0, 0.0, 1.0 });
 	wlr_renderer_end(renderer);
+
+	wlr_egl_unset_current(&surf->renderer->egl);
+
 	return true;
 }
 
@@ -412,6 +414,8 @@ struct gbm_bo *drm_fb_acquire(struct wlr_drm_fb *fb, struct wlr_drm_backend *drm
 		wlr_log(WLR_ERROR, "Failed to swap buffers");
 		return NULL;
 	}
+
+	wlr_egl_unset_current(&mgpu->renderer->egl);
 
 	fb->mgpu_bo = gbm_surface_lock_front_buffer(mgpu->gbm);
 	if (!fb->mgpu_bo) {


### PR DESCRIPTION
## backend/drm: fix current EGL context on multi-GPU
    
get_tex_for_bo changes the current EGL context. Rendering operations
must immediately follow drm_surface_make_current.
    
Closes: https://github.com/swaywm/wlroots/issues/2209

## backend/drm: add missing wlr_egl_unset_current