### PR TITLE
backend/drm: don't unset EGL context before swapping buffers

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -556,8 +556,6 @@ static bool drm_connector_commit(struct wlr_output *output) {
 		}
 	}
 
-	wlr_egl_unset_current(&drm->renderer.egl);
-
 	return true;
 }
 
@@ -966,8 +964,6 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 		if (!drm_fb_lock_surface(&plane->pending_fb, &plane->surf)) {
 			return false;
 		}
-
-		wlr_egl_unset_current(&plane->surf.renderer->egl);
 
 		plane->cursor_enabled = true;
 	}

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -277,6 +277,8 @@ bool drm_fb_lock_surface(struct wlr_drm_fb *fb, struct wlr_drm_surface *surf) {
 		return false;
 	}
 
+	wlr_egl_unset_current(&surf->renderer->egl);
+
 	fb->bo = gbm_surface_lock_front_buffer(surf->gbm);
 	if (!fb->bo) {
 		wlr_log(WLR_ERROR, "Failed to lock front buffer");
@@ -369,8 +371,6 @@ bool drm_surface_render_black_frame(struct wlr_drm_surface *surf) {
 	wlr_renderer_begin(renderer, surf->width, surf->height);
 	wlr_renderer_clear(renderer, (float[]){ 0.0, 0.0, 0.0, 1.0 });
 	wlr_renderer_end(renderer);
-
-	wlr_egl_unset_current(&surf->renderer->egl);
 
 	return true;
 }


### PR DESCRIPTION
drm_fb_lock_surface swaps buffers. We need to make sure that the EGL
context is current before calling wlr_egl_swap_buffers.

Move the wlr_egl_unset_current call into drm_fb_lock_surface to avoid
other surprises like this.

Fixes: d28a7da95d1a ("backend/drm: add missing wlr_egl_unset_current")
Closes: https://github.com/swaywm/wlroots/issues/2209

* * *

This is ready for review, but let's wait for user feedback before merging it, in case I missed something again.