### PR TITLE
render/egl: unset current context after swapping buffers

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -556,8 +556,6 @@ static bool drm_connector_commit(struct wlr_output *output) {
 		}
 	}
 
-	wlr_egl_unset_current(&drm->renderer.egl);
-
 	return true;
 }
 
@@ -966,8 +964,6 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 		if (!drm_fb_lock_surface(&plane->pending_fb, &plane->surf)) {
 			return false;
 		}
-
-		wlr_egl_unset_current(&plane->surf.renderer->egl);
 
 		plane->cursor_enabled = true;
 	}

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -370,8 +370,6 @@ bool drm_surface_render_black_frame(struct wlr_drm_surface *surf) {
 	wlr_renderer_clear(renderer, (float[]){ 0.0, 0.0, 0.0, 1.0 });
 	wlr_renderer_end(renderer);
 
-	wlr_egl_unset_current(&surf->renderer->egl);
-
 	return true;
 }
 
@@ -414,8 +412,6 @@ struct gbm_bo *drm_fb_acquire(struct wlr_drm_fb *fb, struct wlr_drm_backend *drm
 		wlr_log(WLR_ERROR, "Failed to swap buffers");
 		return NULL;
 	}
-
-	wlr_egl_unset_current(&mgpu->renderer->egl);
 
 	fb->mgpu_bo = gbm_surface_lock_front_buffer(mgpu->gbm);
 	if (!fb->mgpu_bo) {

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -300,8 +300,6 @@ static bool output_commit(struct wlr_output *wlr_output) {
 		}
 	}
 
-	wlr_egl_unset_current(&output->backend->egl);
-
 	return true;
 }
 
@@ -377,7 +375,6 @@ static bool output_set_cursor(struct wlr_output *wlr_output,
 
 		wlr_egl_swap_buffers(&backend->egl, egl_surface, NULL);
 		wlr_egl_destroy_surface(&backend->egl, egl_surface);
-		wlr_egl_unset_current(&backend->egl);
 	} else {
 		wl_surface_attach(surface, NULL, 0, 0);
 		wl_surface_commit(surface);
@@ -584,7 +581,6 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *wlr_backend) {
 			NULL)) {
 		goto error;
 	}
-	wlr_egl_unset_current(&output->backend->egl);
 
 	wl_list_insert(&backend->outputs, &output->link);
 	wlr_output_update_enabled(wlr_output, true);

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -157,8 +157,6 @@ static bool output_commit(struct wlr_output *wlr_output) {
 		wlr_output_send_present(wlr_output, NULL);
 	}
 
-	wlr_egl_unset_current(&x11->egl);
-
 	return true;
 }
 

--- a/render/egl.c
+++ b/render/egl.c
@@ -449,6 +449,8 @@ bool wlr_egl_swap_buffers(struct wlr_egl *egl, EGLSurface surface,
 		wlr_log(WLR_ERROR, "eglSwapBuffers failed");
 		return false;
 	}
+
+	wlr_egl_unset_current(egl);
 	return true;
 }
 


### PR DESCRIPTION
After swapping buffers, it doesn't make sense to perform more rendering
operations. Unset the context to reflect this.

This commit makes it so the context is always only current between
wlr_egl_make_current and wlr_egl_swap_buffers.

This is an alternative to [1].

[1]: https://github.com/swaywm/wlroots/pull/2212

Closes: #2209

* * *

This is ready for review, ~~but let's wait for user feedback before merging it, in case I missed something again~~.