### PR TITLE
Allow keyboard and pointer grabs to hook clear_focus()

### DIFF
--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -391,19 +391,6 @@ void wlr_seat_pointer_send_axis(struct wlr_seat *wlr_seat, uint32_t time_msec,
 void wlr_seat_pointer_send_frame(struct wlr_seat *wlr_seat);
 
 /**
- * Start a grab of the pointer of this seat. The grabber is responsible for
- * handling all pointer events until the grab ends.
- */
-void wlr_seat_pointer_start_grab(struct wlr_seat *wlr_seat,
-		struct wlr_seat_pointer_grab *grab);
-
-/**
- * End the grab of the pointer of this seat. This reverts the grab back to the
- * default grab for the pointer.
- */
-void wlr_seat_pointer_end_grab(struct wlr_seat *wlr_seat);
-
-/**
  * Notify the seat of a pointer enter event to the given surface and request it
  * to be the focused surface for the pointer. Pass surface-local coordinates
  * where the enter occurred.
@@ -440,6 +427,19 @@ void wlr_seat_pointer_notify_axis(struct wlr_seat *wlr_seat, uint32_t time_msec,
 void wlr_seat_pointer_notify_frame(struct wlr_seat *wlr_seat);
 
 /**
+ * Start a grab of the pointer of this seat. The grabber is responsible for
+ * handling all pointer events until the grab ends.
+ */
+void wlr_seat_pointer_start_grab(struct wlr_seat *wlr_seat,
+		struct wlr_seat_pointer_grab *grab);
+
+/**
+ * End the grab of the pointer of this seat. This reverts the grab back to the
+ * default grab for the pointer.
+ */
+void wlr_seat_pointer_end_grab(struct wlr_seat *wlr_seat);
+
+/**
  * Whether or not the pointer has a grab other than the default grab.
  */
 bool wlr_seat_pointer_has_grab(struct wlr_seat *seat);
@@ -455,19 +455,6 @@ void wlr_seat_set_keyboard(struct wlr_seat *seat, struct wlr_input_device *dev);
 struct wlr_keyboard *wlr_seat_get_keyboard(struct wlr_seat *seat);
 
 /**
- * Start a grab of the keyboard of this seat. The grabber is responsible for
- * handling all keyboard events until the grab ends.
- */
-void wlr_seat_keyboard_start_grab(struct wlr_seat *wlr_seat,
-		struct wlr_seat_keyboard_grab *grab);
-
-/**
- * End the grab of the keyboard of this seat. This reverts the grab back to the
- * default grab for the keyboard.
- */
-void wlr_seat_keyboard_end_grab(struct wlr_seat *wlr_seat);
-
-/**
  * Send the keyboard key to focused keyboard resources. Compositors should use
  * `wlr_seat_notify_key()` to respect keyboard grabs.
  */
@@ -475,33 +462,10 @@ void wlr_seat_keyboard_send_key(struct wlr_seat *seat, uint32_t time_msec,
 		uint32_t key, uint32_t state);
 
 /**
- * Notify the seat that a key has been pressed on the keyboard. Defers to any
- * keyboard grabs.
- */
-void wlr_seat_keyboard_notify_key(struct wlr_seat *seat, uint32_t time_msec,
-		uint32_t key, uint32_t state);
-
-/**
  * Send the modifier state to focused keyboard resources. Compositors should use
  * `wlr_seat_keyboard_notify_modifiers()` to respect any keyboard grabs.
  */
 void wlr_seat_keyboard_send_modifiers(struct wlr_seat *seat,
-		struct wlr_keyboard_modifiers *modifiers);
-
-/**
- * Notify the seat that the modifiers for the keyboard have changed. Defers to
- * any keyboard grabs.
- */
-void wlr_seat_keyboard_notify_modifiers(struct wlr_seat *seat,
-		struct wlr_keyboard_modifiers *modifiers);
-
-/**
- * Notify the seat that the keyboard focus has changed and request it to be the
- * focused surface for this keyboard. Defers to any current grab of the seat's
- * keyboard.
- */
-void wlr_seat_keyboard_notify_enter(struct wlr_seat *seat,
-		struct wlr_surface *surface, uint32_t keycodes[], size_t num_keycodes,
 		struct wlr_keyboard_modifiers *modifiers);
 
 /**
@@ -521,22 +485,45 @@ void wlr_seat_keyboard_enter(struct wlr_seat *seat,
 void wlr_seat_keyboard_clear_focus(struct wlr_seat *wlr_seat);
 
 /**
+ * Notify the seat that a key has been pressed on the keyboard. Defers to any
+ * keyboard grabs.
+ */
+void wlr_seat_keyboard_notify_key(struct wlr_seat *seat, uint32_t time_msec,
+		uint32_t key, uint32_t state);
+
+/**
+ * Notify the seat that the modifiers for the keyboard have changed. Defers to
+ * any keyboard grabs.
+ */
+void wlr_seat_keyboard_notify_modifiers(struct wlr_seat *seat,
+		struct wlr_keyboard_modifiers *modifiers);
+
+/**
+ * Notify the seat that the keyboard focus has changed and request it to be the
+ * focused surface for this keyboard. Defers to any current grab of the seat's
+ * keyboard.
+ */
+void wlr_seat_keyboard_notify_enter(struct wlr_seat *seat,
+		struct wlr_surface *surface, uint32_t keycodes[], size_t num_keycodes,
+		struct wlr_keyboard_modifiers *modifiers);
+
+/**
+ * Start a grab of the keyboard of this seat. The grabber is responsible for
+ * handling all keyboard events until the grab ends.
+ */
+void wlr_seat_keyboard_start_grab(struct wlr_seat *wlr_seat,
+		struct wlr_seat_keyboard_grab *grab);
+
+/**
+ * End the grab of the keyboard of this seat. This reverts the grab back to the
+ * default grab for the keyboard.
+ */
+void wlr_seat_keyboard_end_grab(struct wlr_seat *wlr_seat);
+
+/**
  * Whether or not the keyboard has a grab other than the default grab
  */
 bool wlr_seat_keyboard_has_grab(struct wlr_seat *seat);
-
-/**
- * Start a grab of the touch device of this seat. The grabber is responsible for
- * handling all touch events until the grab ends.
- */
-void wlr_seat_touch_start_grab(struct wlr_seat *wlr_seat,
-		struct wlr_seat_touch_grab *grab);
-
-/**
- * End the grab of the touch device of this seat. This reverts the grab back to
- * the default grab for the touch device.
- */
-void wlr_seat_touch_end_grab(struct wlr_seat *wlr_seat);
 
 /**
  * Get the active touch point with the given `touch_id`. If the touch point does
@@ -544,30 +531,6 @@ void wlr_seat_touch_end_grab(struct wlr_seat *wlr_seat);
  */
 struct wlr_touch_point *wlr_seat_touch_get_point(struct wlr_seat *seat,
 		int32_t touch_id);
-
-/**
- * Notify the seat of a touch down on the given surface. Defers to any grab of
- * the touch device.
- */
-uint32_t wlr_seat_touch_notify_down(struct wlr_seat *seat,
-		struct wlr_surface *surface, uint32_t time_msec,
-		int32_t touch_id, double sx, double sy);
-
-/**
- * Notify the seat that the touch point given by `touch_id` is up. Defers to any
- * grab of the touch device.
- */
-void wlr_seat_touch_notify_up(struct wlr_seat *seat, uint32_t time_msec,
-		int32_t touch_id);
-
-/**
- * Notify the seat that the touch point given by `touch_id` has moved. Defers to
- * any grab of the touch device. The seat should be notified of touch motion
- * even if the surface is not the owner of the touch point for processing by
- * grabs.
- */
-void wlr_seat_touch_notify_motion(struct wlr_seat *seat, uint32_t time_msec,
-		int32_t touch_id, double sx, double sy);
 
 /**
  * Notify the seat that the touch point given by `touch_id` has entered a new
@@ -615,9 +578,46 @@ void wlr_seat_touch_send_motion(struct wlr_seat *seat, uint32_t time_msec,
 		int32_t touch_id, double sx, double sy);
 
 /**
+ * Notify the seat of a touch down on the given surface. Defers to any grab of
+ * the touch device.
+ */
+uint32_t wlr_seat_touch_notify_down(struct wlr_seat *seat,
+		struct wlr_surface *surface, uint32_t time_msec,
+		int32_t touch_id, double sx, double sy);
+
+/**
+ * Notify the seat that the touch point given by `touch_id` is up. Defers to any
+ * grab of the touch device.
+ */
+void wlr_seat_touch_notify_up(struct wlr_seat *seat, uint32_t time_msec,
+		int32_t touch_id);
+
+/**
+ * Notify the seat that the touch point given by `touch_id` has moved. Defers to
+ * any grab of the touch device. The seat should be notified of touch motion
+ * even if the surface is not the owner of the touch point for processing by
+ * grabs.
+ */
+void wlr_seat_touch_notify_motion(struct wlr_seat *seat, uint32_t time_msec,
+		int32_t touch_id, double sx, double sy);
+
+/**
  * How many touch points are currently down for the seat.
  */
 int wlr_seat_touch_num_points(struct wlr_seat *seat);
+
+/**
+ * Start a grab of the touch device of this seat. The grabber is responsible for
+ * handling all touch events until the grab ends.
+ */
+void wlr_seat_touch_start_grab(struct wlr_seat *wlr_seat,
+		struct wlr_seat_touch_grab *grab);
+
+/**
+ * End the grab of the touch device of this seat. This reverts the grab back to
+ * the default grab for the touch device.
+ */
+void wlr_seat_touch_end_grab(struct wlr_seat *wlr_seat);
 
 /**
  * Whether or not the seat has a touch grab other than the default grab.

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -345,8 +345,8 @@ bool wlr_seat_pointer_surface_has_focus(struct wlr_seat *wlr_seat,
  * Send a pointer enter event to the given surface and consider it to be the
  * focused surface for the pointer. This will send a leave event to the last
  * surface that was entered. Coordinates for the enter event are surface-local.
- * Compositor should use `wlr_seat_pointer_notify_enter()` to change pointer
- * focus to respect pointer grabs.
+ * This function does not respect pointer grabs: you probably want
+ * `wlr_seat_pointer_notify_enter()` instead.
  */
 void wlr_seat_pointer_enter(struct wlr_seat *wlr_seat,
 		struct wlr_surface *surface, double sx, double sy);
@@ -358,62 +358,64 @@ void wlr_seat_pointer_clear_focus(struct wlr_seat *wlr_seat);
 
 /**
  * Send a motion event to the surface with pointer focus. Coordinates for the
- * motion event are surface-local. Compositors should use
- * `wlr_seat_pointer_notify_motion()` to send motion events to respect pointer
- * grabs.
+ * motion event are surface-local. This function does not respect pointer grabs:
+ * you probably want `wlr_seat_pointer_notify_motion()` instead.
  */
 void wlr_seat_pointer_send_motion(struct wlr_seat *wlr_seat, uint32_t time_msec,
 		double sx, double sy);
 
 /**
  * Send a button event to the surface with pointer focus. Coordinates for the
- * button event are surface-local. Returns the serial. Compositors should use
- * `wlr_seat_pointer_notify_button()` to send button events to respect pointer
- * grabs.
+ * button event are surface-local. Returns the serial. This function does not
+ * respect pointer grabs: you probably want `wlr_seat_pointer_notify_button()`
+ * instead.
  */
 uint32_t wlr_seat_pointer_send_button(struct wlr_seat *wlr_seat,
 		uint32_t time_msec, uint32_t button, enum wlr_button_state state);
 
 /**
- * Send an axis event to the surface with pointer focus. Compositors should use
- * `wlr_seat_pointer_notify_axis()` to send axis events to respect pointer
- * grabs.
- **/
+ * Send an axis event to the surface with pointer focus. This function does not
+ * respect pointer grabs: you probably want `wlr_seat_pointer_notify_axis()`
+ * instead.
+ */
 void wlr_seat_pointer_send_axis(struct wlr_seat *wlr_seat, uint32_t time_msec,
 		enum wlr_axis_orientation orientation, double value,
 		int32_t value_discrete, enum wlr_axis_source source);
 
 /**
- * Send a frame event to the surface with pointer focus. Compositors should use
- * `wlr_seat_pointer_notify_frame()` to send axis events to respect pointer
- * grabs.
+ * Send a frame event to the surface with pointer focus. This function does not
+ * respect pointer grabs: you probably want `wlr_seat_pointer_notify_frame()`
+ * instead.
  */
 void wlr_seat_pointer_send_frame(struct wlr_seat *wlr_seat);
 
 /**
  * Notify the seat of a pointer enter event to the given surface and request it
  * to be the focused surface for the pointer. Pass surface-local coordinates
- * where the enter occurred.
+ * where the enter occurred. This will send a leave event to the currently-
+ * focused surface. Defers to any grab of the pointer.
  */
 void wlr_seat_pointer_notify_enter(struct wlr_seat *wlr_seat,
 		struct wlr_surface *surface, double sx, double sy);
 
 /**
  * Notify the seat of motion over the given surface. Pass surface-local
- * coordinates where the pointer motion occurred.
+ * coordinates where the pointer motion occurred. Defers to any grab of the
+ * pointer.
  */
 void wlr_seat_pointer_notify_motion(struct wlr_seat *wlr_seat,
 		uint32_t time_msec, double sx, double sy);
 
 /**
  * Notify the seat that a button has been pressed. Returns the serial of the
- * button press or zero if no button press was sent.
+ * button press or zero if no button press was sent. Defers to any grab of the
+ * pointer.
  */
 uint32_t wlr_seat_pointer_notify_button(struct wlr_seat *wlr_seat,
 		uint32_t time_msec, uint32_t button, enum wlr_button_state state);
 
 /**
- * Notify the seat of an axis event.
+ * Notify the seat of an axis event. Defers to any grab of the pointer.
  */
 void wlr_seat_pointer_notify_axis(struct wlr_seat *wlr_seat, uint32_t time_msec,
 		enum wlr_axis_orientation orientation, double value,
@@ -422,7 +424,7 @@ void wlr_seat_pointer_notify_axis(struct wlr_seat *wlr_seat, uint32_t time_msec,
 /**
  * Notify the seat of a frame event. Frame events are sent to end a group of
  * events that logically belong together. Motion, button and axis events should
- * all be followed by a frame event.
+ * all be followed by a frame event. Defers to any grab of the pointer.
  */
 void wlr_seat_pointer_notify_frame(struct wlr_seat *wlr_seat);
 
@@ -455,15 +457,17 @@ void wlr_seat_set_keyboard(struct wlr_seat *seat, struct wlr_input_device *dev);
 struct wlr_keyboard *wlr_seat_get_keyboard(struct wlr_seat *seat);
 
 /**
- * Send the keyboard key to focused keyboard resources. Compositors should use
- * `wlr_seat_notify_key()` to respect keyboard grabs.
+ * Send the keyboard key to focused keyboard resources. This function does not
+ * respect keyboard grabs: you probably want `wlr_seat_keyboard_notify_key()`
+ * instead.
  */
 void wlr_seat_keyboard_send_key(struct wlr_seat *seat, uint32_t time_msec,
 		uint32_t key, uint32_t state);
 
 /**
- * Send the modifier state to focused keyboard resources. Compositors should use
- * `wlr_seat_keyboard_notify_modifiers()` to respect any keyboard grabs.
+ * Send the modifier state to focused keyboard resources. This function does
+ * not respect keyboard grabs: you probably want
+ * `wlr_seat_keyboard_notify_modifiers()` instead.
  */
 void wlr_seat_keyboard_send_modifiers(struct wlr_seat *seat,
 		struct wlr_keyboard_modifiers *modifiers);
@@ -471,9 +475,8 @@ void wlr_seat_keyboard_send_modifiers(struct wlr_seat *seat,
 /**
  * Send a keyboard enter event to the given surface and consider it to be the
  * focused surface for the keyboard. This will send a leave event to the last
- * surface that was entered. Compositors should use
- * `wlr_seat_keyboard_notify_enter()` to change keyboard focus to respect
- * keyboard grabs.
+ * surface that was entered. This function does not respect keyboard grabs: you
+ * probably want `wlr_seat_keyboard_notify_enter()` instead.
  */
 void wlr_seat_keyboard_enter(struct wlr_seat *seat,
 		struct wlr_surface *surface, uint32_t keycodes[], size_t num_keycodes,
@@ -552,8 +555,8 @@ void wlr_seat_touch_point_clear_focus(struct wlr_seat *seat, uint32_t time_msec,
  * events for this point will go to this surface. If the touch down is valid,
  * this will add a new touch point with the given `touch_id`. The touch down may
  * not be valid if the surface seat client does not accept touch input.
- * Coordinates are surface-local. Compositors should use
- * `wlr_seat_touch_notify_down()` to respect any grabs of the touch device.
+ * Coordinates are surface-local. This function does not respect touch grabs:
+ * you probably want `wlr_seat_touch_notify_down()` instead.
  */
 uint32_t wlr_seat_touch_send_down(struct wlr_seat *seat,
 		struct wlr_surface *surface, uint32_t time_msec,
@@ -562,8 +565,8 @@ uint32_t wlr_seat_touch_send_down(struct wlr_seat *seat,
 /**
  * Send a touch up event for the touch point given by the `touch_id`. The event
  * will go to the client for the surface given in the corresponding touch down
- * event. This will remove the touch point. Compositors should use
- * `wlr_seat_touch_notify_up()` to respect any grabs of the touch device.
+ * event. This will remove the touch point. This function does not respect touch
+ * grabs: you probably want `wlr_seat_touch_notify_up()` instead.
  */
 void wlr_seat_touch_send_up(struct wlr_seat *seat, uint32_t time_msec,
 		int32_t touch_id);
@@ -571,8 +574,8 @@ void wlr_seat_touch_send_up(struct wlr_seat *seat, uint32_t time_msec,
 /**
  * Send a touch motion event for the touch point given by the `touch_id`. The
  * event will go to the client for the surface given in the corresponding touch
- * down event. Compositors should use `wlr_seat_touch_notify_motion()` to
- * respect any grabs of the touch device.
+ * down event. This function does not respect touch grabs: you probably want
+ * `wlr_seat_touch_notify_motion()` instead.
  */
 void wlr_seat_touch_send_motion(struct wlr_seat *seat, uint32_t time_msec,
 		int32_t touch_id, double sx, double sy);

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -78,6 +78,7 @@ struct wlr_seat_pointer_grab;
 struct wlr_pointer_grab_interface {
 	void (*enter)(struct wlr_seat_pointer_grab *grab,
 			struct wlr_surface *surface, double sx, double sy);
+	void (*clear_focus)(struct wlr_seat_pointer_grab *grab);
 	void (*motion)(struct wlr_seat_pointer_grab *grab, uint32_t time_msec,
 			double sx, double sy);
 	uint32_t (*button)(struct wlr_seat_pointer_grab *grab, uint32_t time_msec,
@@ -95,6 +96,7 @@ struct wlr_keyboard_grab_interface {
 	void (*enter)(struct wlr_seat_keyboard_grab *grab,
 			struct wlr_surface *surface, uint32_t keycodes[],
 			size_t num_keycodes, struct wlr_keyboard_modifiers *modifiers);
+	void (*clear_focus)(struct wlr_seat_keyboard_grab *grab);
 	void (*key)(struct wlr_seat_keyboard_grab *grab, uint32_t time_msec,
 			uint32_t key, uint32_t state);
 	void (*modifiers)(struct wlr_seat_keyboard_grab *grab,
@@ -353,6 +355,8 @@ void wlr_seat_pointer_enter(struct wlr_seat *wlr_seat,
 
 /**
  * Clear the focused surface for the pointer and leave all entered surfaces.
+ * This function does not respect pointer grabs: you probably want
+ * `wlr_seat_pointer_notify_clear_focus()` instead.
  */
 void wlr_seat_pointer_clear_focus(struct wlr_seat *wlr_seat);
 
@@ -397,6 +401,12 @@ void wlr_seat_pointer_send_frame(struct wlr_seat *wlr_seat);
  */
 void wlr_seat_pointer_notify_enter(struct wlr_seat *wlr_seat,
 		struct wlr_surface *surface, double sx, double sy);
+
+/**
+ * Notify the seat of a pointer leave event to the currently-focused surface.
+ * Defers to any grab of the pointer.
+ */
+void wlr_seat_pointer_notify_clear_focus(struct wlr_seat *wlr_seat);
 
 /**
  * Notify the seat of motion over the given surface. Pass surface-local
@@ -484,6 +494,8 @@ void wlr_seat_keyboard_enter(struct wlr_seat *seat,
 
 /**
  * Clear the focused surface for the keyboard and leave all entered surfaces.
+ * This function does not respect keyboard grabs: you probably want
+ * `wlr_seat_keyboard_notify_clear_focus()` instead.
  */
 void wlr_seat_keyboard_clear_focus(struct wlr_seat *wlr_seat);
 
@@ -509,6 +521,12 @@ void wlr_seat_keyboard_notify_modifiers(struct wlr_seat *seat,
 void wlr_seat_keyboard_notify_enter(struct wlr_seat *seat,
 		struct wlr_surface *surface, uint32_t keycodes[], size_t num_keycodes,
 		struct wlr_keyboard_modifiers *modifiers);
+
+/**
+ * Notify the seat of a keyboard leave event to the currently-focused surface.
+ * Defers to any keyboard grabs.
+ */
+void wlr_seat_keyboard_notify_clear_focus(struct wlr_seat *wlr_seat);
 
 /**
  * Start a grab of the keyboard of this seat. The grabber is responsible for

--- a/types/data_device/wlr_drag.c
+++ b/types/data_device/wlr_drag.c
@@ -159,6 +159,11 @@ static void drag_handle_pointer_enter(struct wlr_seat_pointer_grab *grab,
 	drag_set_focus(drag, surface, sx, sy);
 }
 
+static void drag_handle_pointer_clear_focus(struct wlr_seat_pointer_grab *grab) {
+	struct wlr_drag *drag = grab->data;
+	drag_set_focus(drag, NULL, 0, 0);
+}
+
 static void drag_handle_pointer_motion(struct wlr_seat_pointer_grab *grab,
 		uint32_t time, double sx, double sy) {
 	struct wlr_drag *drag = grab->data;
@@ -238,6 +243,7 @@ static void drag_handle_pointer_cancel(struct wlr_seat_pointer_grab *grab) {
 static const struct wlr_pointer_grab_interface
 		data_device_pointer_drag_interface = {
 	.enter = drag_handle_pointer_enter,
+	.clear_focus = drag_handle_pointer_clear_focus,
 	.motion = drag_handle_pointer_motion,
 	.button = drag_handle_pointer_button,
 	.axis = drag_handle_pointer_axis,
@@ -303,6 +309,10 @@ static void drag_handle_keyboard_enter(struct wlr_seat_keyboard_grab *grab,
 	// nothing has keyboard focus during drags
 }
 
+static void drag_handle_keyboard_clear_focus(struct wlr_seat_keyboard_grab *grab) {
+	// nothing has keyboard focus during drags
+}
+
 static void drag_handle_keyboard_key(struct wlr_seat_keyboard_grab *grab,
 		uint32_t time, uint32_t key, uint32_t state) {
 	// no keyboard input during drags
@@ -323,6 +333,7 @@ static void drag_handle_keyboard_cancel(struct wlr_seat_keyboard_grab *grab) {
 static const struct wlr_keyboard_grab_interface
 		data_device_keyboard_drag_interface = {
 	.enter = drag_handle_keyboard_enter,
+	.clear_focus = drag_handle_keyboard_clear_focus,
 	.key = drag_handle_keyboard_key,
 	.modifiers = drag_handle_keyboard_modifiers,
 	.cancel = drag_handle_keyboard_cancel,

--- a/types/seat/wlr_seat_keyboard.c
+++ b/types/seat/wlr_seat_keyboard.c
@@ -21,6 +21,10 @@ static void default_keyboard_enter(struct wlr_seat_keyboard_grab *grab,
 	wlr_seat_keyboard_enter(grab->seat, surface, keycodes, num_keycodes, modifiers);
 }
 
+static void default_keyboard_clear_focus(struct wlr_seat_keyboard_grab *grab) {
+	wlr_seat_keyboard_clear_focus(grab->seat);
+}
+
 static void default_keyboard_key(struct wlr_seat_keyboard_grab *grab,
 		uint32_t time, uint32_t key, uint32_t state) {
 	wlr_seat_keyboard_send_key(grab->seat, time, key, state);
@@ -37,6 +41,7 @@ static void default_keyboard_cancel(struct wlr_seat_keyboard_grab *grab) {
 
 const struct wlr_keyboard_grab_interface default_keyboard_grab_impl = {
 	.enter = default_keyboard_enter,
+	.clear_focus = default_keyboard_clear_focus,
 	.key = default_keyboard_key,
 	.modifiers = default_keyboard_modifiers,
 	.cancel = default_keyboard_cancel,
@@ -311,13 +316,20 @@ void wlr_seat_keyboard_enter(struct wlr_seat *seat,
 void wlr_seat_keyboard_notify_enter(struct wlr_seat *seat,
 		struct wlr_surface *surface, uint32_t keycodes[], size_t num_keycodes,
 		struct wlr_keyboard_modifiers *modifiers) {
+	// NULL surfaces are prohibited in the grab-compatible API. Use
+	// wlr_seat_keyboard_notify_clear_focus() instead.
+	assert(surface);
 	struct wlr_seat_keyboard_grab *grab = seat->keyboard_state.grab;
 	grab->interface->enter(grab, surface, keycodes, num_keycodes, modifiers);
 }
 
 void wlr_seat_keyboard_clear_focus(struct wlr_seat *seat) {
-	// TODO respect grabs here?
 	wlr_seat_keyboard_enter(seat, NULL, NULL, 0, NULL);
+}
+
+void wlr_seat_keyboard_notify_clear_focus(struct wlr_seat *seat) {
+	struct wlr_seat_keyboard_grab *grab = seat->keyboard_state.grab;
+	grab->interface->clear_focus(grab);
 }
 
 bool wlr_seat_keyboard_has_grab(struct wlr_seat *seat) {

--- a/types/xdg_shell/wlr_xdg_popup.c
+++ b/types/xdg_shell/wlr_xdg_popup.c
@@ -25,6 +25,10 @@ static void xdg_pointer_grab_enter(struct wlr_seat_pointer_grab *grab,
 	}
 }
 
+static void xdg_pointer_grab_clear_focus(struct wlr_seat_pointer_grab *grab) {
+	wlr_seat_pointer_clear_focus(grab->seat);
+}
+
 static void xdg_pointer_grab_motion(struct wlr_seat_pointer_grab *grab,
 		uint32_t time, double sx, double sy) {
 	wlr_seat_pointer_send_motion(grab->seat, time, sx, sy);
@@ -59,6 +63,7 @@ static void xdg_pointer_grab_cancel(struct wlr_seat_pointer_grab *grab) {
 
 static const struct wlr_pointer_grab_interface xdg_pointer_grab_impl = {
 	.enter = xdg_pointer_grab_enter,
+	.clear_focus = xdg_pointer_grab_clear_focus,
 	.motion = xdg_pointer_grab_motion,
 	.button = xdg_pointer_grab_button,
 	.cancel = xdg_pointer_grab_cancel,
@@ -69,6 +74,10 @@ static const struct wlr_pointer_grab_interface xdg_pointer_grab_impl = {
 static void xdg_keyboard_grab_enter(struct wlr_seat_keyboard_grab *grab,
 		struct wlr_surface *surface, uint32_t keycodes[], size_t num_keycodes,
 		struct wlr_keyboard_modifiers *modifiers) {
+	// keyboard focus should remain on the popup
+}
+
+static void xdg_keyboard_grab_clear_focus(struct wlr_seat_keyboard_grab *grab) {
 	// keyboard focus should remain on the popup
 }
 
@@ -88,6 +97,7 @@ static void xdg_keyboard_grab_cancel(struct wlr_seat_keyboard_grab *grab) {
 
 static const struct wlr_keyboard_grab_interface xdg_keyboard_grab_impl = {
 	.enter = xdg_keyboard_grab_enter,
+	.clear_focus = xdg_keyboard_grab_clear_focus,
 	.key = xdg_keyboard_grab_key,
 	.modifiers = xdg_keyboard_grab_modifiers,
 	.cancel = xdg_keyboard_grab_cancel,

--- a/types/xdg_shell_v6/wlr_xdg_popup_v6.c
+++ b/types/xdg_shell_v6/wlr_xdg_popup_v6.c
@@ -35,6 +35,10 @@ static void xdg_pointer_grab_enter(struct wlr_seat_pointer_grab *grab,
 	}
 }
 
+static void xdg_pointer_grab_clear_focus(struct wlr_seat_pointer_grab *grab) {
+	wlr_seat_pointer_clear_focus(grab->seat);
+}
+
 static void xdg_pointer_grab_motion(struct wlr_seat_pointer_grab *grab,
 		uint32_t time, double sx, double sy) {
 	wlr_seat_pointer_send_motion(grab->seat, time, sx, sy);
@@ -69,6 +73,7 @@ static void xdg_pointer_grab_cancel(struct wlr_seat_pointer_grab *grab) {
 
 static const struct wlr_pointer_grab_interface xdg_pointer_grab_impl = {
 	.enter = xdg_pointer_grab_enter,
+	.clear_focus = xdg_pointer_grab_clear_focus,
 	.motion = xdg_pointer_grab_motion,
 	.button = xdg_pointer_grab_button,
 	.cancel = xdg_pointer_grab_cancel,
@@ -79,6 +84,10 @@ static const struct wlr_pointer_grab_interface xdg_pointer_grab_impl = {
 static void xdg_keyboard_grab_enter(struct wlr_seat_keyboard_grab *grab,
 		struct wlr_surface *surface, uint32_t keycodes[], size_t num_keycodes,
 		struct wlr_keyboard_modifiers *modifiers) {
+	// keyboard focus should remain on the popup
+}
+
+static void xdg_keyboard_grab_clear_focus(struct wlr_seat_keyboard_grab *grab) {
 	// keyboard focus should remain on the popup
 }
 
@@ -98,6 +107,7 @@ static void xdg_keyboard_grab_cancel(struct wlr_seat_keyboard_grab *grab) {
 
 static const struct wlr_keyboard_grab_interface xdg_keyboard_grab_impl = {
 	.enter = xdg_keyboard_grab_enter,
+	.clear_focus = xdg_keyboard_grab_clear_focus,
 	.key = xdg_keyboard_grab_key,
 	.modifiers = xdg_keyboard_grab_modifiers,
 	.cancel = xdg_keyboard_grab_cancel,


### PR DESCRIPTION
This is necessary for some grabs, which currently have no way of knowing when the pointer/keyboard focus has left a surface. For example, without this, a drag-and-drop grab can erroneously drop into a window that the cursor is no longer over.

This is the plumbing needed to properly fix swaywm/sway#5220. The existing fix, swaywm/sway#5222, relies on every grab's `enter()` hook allowing a `NULL` surface. This is not guaranteed by the API and, in fact, is not the case for the xdg-shell popup grab and results in a crash when the cursor leaves a surface and does not immediately enter another one while a popup is open (#2161).

This fix also adds an assertion to wlr_seat_pointer_notify_enter() that ensures it's never called with a `NULL` surface. This will make Sway crash much more until it fixes its usage of the API, so we should land this at the same time as a fix in Sway (which I haven't posted yet).

Also clean up the header declarations a bit in separate commits.

Unanswered questions:
1. Should we rename the `clear_focus` functions to `leave` like suggested by @emersion in #2162? that seems like a more breaking change to me, and I'm not sure it's worth it.
2. Do `wlr_seat_touch_point_focus()` and `wlr_seat_touch_point_clear_focus()` also need the same treatment? I have no touch device to test with, and these functions aren't used by Sway or by tinywl. It looks like they were/are used by rootston, though.
