### PR TITLE
xwayland: send focus change event unconditionally

### DIFF
--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -1243,12 +1243,12 @@ static void xwm_handle_focus_in(struct wlr_xwm *xwm,
 	// Because of that, we allow changing focus between surfaces belonging to the
 	// same application.
 	struct wlr_xwayland_surface *requested_focus = lookup_surface(xwm, ev->event);
-	if (!xwm->focus_surface || !requested_focus ||
-			requested_focus->pid != xwm->focus_surface->pid) {
-		xwm_send_focus_window(xwm, xwm->focus_surface);
-	} else {
+	if (xwm->focus_surface && requested_focus &&
+			requested_focus->pid == xwm->focus_surface->pid) {
 		xwm->focus_surface = requested_focus;
 	}
+
+	xwm_send_focus_window(xwm, xwm->focus_surface);
 }
 
 static void xwm_handle_xcb_error(struct wlr_xwm *xwm, xcb_value_error_t *ev) {


### PR DESCRIPTION
This fixes issues with (at least) dialogs in Jetbrains IDEs becoming
unclickable if they ever lost focus (ref. swaywm/sway#5373). Prior to
this change, since `xwm->focus_surface` would be set prior to
`xwm_surface_activate` being called, the latter would short-circuit
immediately and not notify the application of the focus change.