### PR TITLE
util/log: use bright black rather than black for WLR_DEBUG

### DIFF
--- a/util/log.c
+++ b/util/log.c
@@ -17,7 +17,7 @@ static const char *verbosity_colors[] = {
 	[WLR_SILENT] = "",
 	[WLR_ERROR] = "\x1B[1;31m",
 	[WLR_INFO] = "\x1B[1;34m",
-	[WLR_DEBUG] = "\x1B[1;30m",
+	[WLR_DEBUG] = "\x1B[1;90m",
 };
 
 static const char *verbosity_headers[] = {


### PR DESCRIPTION
On some terminals under default settings, black is truly rendered as
`#000`, making it unreadable when the background is also black.

Refs swaywm/sway#5141.