### PR TITLE
render/egl: stop including eglmesaext.h

### DIFF
--- a/include/wlr/config.h.in
+++ b/include/wlr/config.h.in
@@ -1,8 +1,6 @@
 #ifndef WLR_CONFIG_H
 #define WLR_CONFIG_H
 
-#mesondefine WLR_HAS_EGLMESAEXT_H
-
 #mesondefine WLR_HAS_LIBCAP
 
 #mesondefine WLR_HAS_SYSTEMD

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -20,10 +20,6 @@
 
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
-#if WLR_HAS_EGLMESAEXT_H
-// TODO: remove eglmesaext.h
-#include <EGL/eglmesaext.h>
-#endif
 #include <pixman.h>
 #include <stdbool.h>
 #include <wayland-server-core.h>

--- a/meson.build
+++ b/meson.build
@@ -86,7 +86,6 @@ conf_data.set10('WLR_HAS_X11_BACKEND', false)
 conf_data.set10('WLR_HAS_XWAYLAND', false)
 conf_data.set10('WLR_HAS_XCB_ERRORS', false)
 conf_data.set10('WLR_HAS_XCB_ICCCM', false)
-conf_data.set10('WLR_HAS_EGLMESAEXT_H', false)
 
 # Clang complains about some zeroed initializer lists (= {0}), even though they
 # are valid
@@ -109,10 +108,6 @@ udev = dependency('libudev')
 pixman = dependency('pixman-1')
 math = cc.find_library('m')
 rt = cc.find_library('rt')
-
-if cc.has_header('EGL/eglmesaext.h', dependencies: egl)
-	conf_data.set10('WLR_HAS_EGLMESAEXT_H', true)
-endif
 
 wlr_files = []
 wlr_deps = [


### PR DESCRIPTION
This is a Mesa-specific header that was needed because some Wayland EGL
extensions were missing from the Khronos registry. Now that this has
been fixed [1] and Mesa [2] & glvnd [3] have sync'ed their headers, we
can drop this workaround.

[1]: https://github.com/KhronosGroup/EGL-Registry/pull/95
[2]: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/4953
[3]: https://gitlab.freedesktop.org/glvnd/libglvnd/-/merge_requests/225

* * *

* [glvnd 1.3.2](https://gitlab.freedesktop.org/glvnd/libglvnd/-/tags/v1.3.2) contains the patch
* [Mesa 20.2.0](https://docs.mesa3d.org/relnotes/20.2.0.html) contains the patch