### PR TITLE
wlr_keyboard_group: introduce enter and leave

### DIFF
--- a/include/types/wlr_keyboard.h
+++ b/include/types/wlr_keyboard.h
@@ -1,0 +1,8 @@
+#include "wlr/types/wlr_keyboard.h"
+
+void keyboard_key_update(struct wlr_keyboard *keyboard,
+		struct wlr_event_keyboard_key *event);
+
+bool keyboard_modifier_update(struct wlr_keyboard *keyboard);
+
+void keyboard_led_update(struct wlr_keyboard *keyboard);

--- a/include/wlr/types/wlr_keyboard_group.h
+++ b/include/wlr/types/wlr_keyboard_group.h
@@ -18,6 +18,30 @@ struct wlr_keyboard_group {
 	struct wlr_input_device *input_device;
 	struct wl_list devices; // keyboard_group_device::link
 	struct wl_list keys; // keyboard_group_key::link
+
+	struct {
+		/*
+		 * Sent when a keyboard has entered the group with keys currently
+		 * pressed that are not pressed by any other keyboard in the group. The
+		 * data for this signal will be a wl_array containing the key codes.
+		 * This should be used to update the compositor's internal state.
+		 * Bindings should not be triggered based off of these key codes and
+		 * they should also not notify any surfaces of the key press.
+		 */
+		struct wl_signal enter;
+
+		/*
+		 * Sent when a keyboard has left the group with keys currently pressed
+		 * that are not pressed by any other keyboard in the group. The data for
+		 * this signal will be a wl_array containing the key codes. This should
+		 * be used to update the compositor's internal state. Bindings should
+		 * not be triggered based off of these key codes. Additionally, surfaces
+		 * should only be notified if they received a corresponding key press
+		 * for the key code.
+		 */
+		struct wl_signal leave;
+	} events;
+
 	void *data;
 };
 

--- a/types/wlr_keyboard.c
+++ b/types/wlr_keyboard.c
@@ -6,9 +6,10 @@
 #include <wlr/interfaces/wlr_keyboard.h>
 #include <wlr/types/wlr_keyboard.h>
 #include <wlr/util/log.h>
+#include "types/wlr_keyboard.h"
 #include "util/signal.h"
 
-static void keyboard_led_update(struct wlr_keyboard *keyboard) {
+void keyboard_led_update(struct wlr_keyboard *keyboard) {
 	if (keyboard->xkb_state == NULL) {
 		return;
 	}
@@ -27,7 +28,7 @@ static void keyboard_led_update(struct wlr_keyboard *keyboard) {
  * Update the modifier state of the wlr-keyboard. Returns true if the modifier
  * state changed.
  */
-static bool keyboard_modifier_update(struct wlr_keyboard *keyboard) {
+bool keyboard_modifier_update(struct wlr_keyboard *keyboard) {
 	if (keyboard->xkb_state == NULL) {
 		return false;
 	}
@@ -55,7 +56,7 @@ static bool keyboard_modifier_update(struct wlr_keyboard *keyboard) {
 	return true;
 }
 
-static void keyboard_key_update(struct wlr_keyboard *keyboard,
+void keyboard_key_update(struct wlr_keyboard *keyboard,
 		struct wlr_event_keyboard_key *event) {
 	if (event->state == WLR_KEY_PRESSED) {
 		set_add(keyboard->keycodes, &keyboard->num_keycodes,


### PR DESCRIPTION
Related swaywm/sway#4975
Sway PR: swaywm/sway#5393

This introduces the enter and leave events for wlr_keyboard_group.

The enter event is emitted when a keyboard is added to the group while a
key is pressed that is not pressed by any other keyboard in the group.
The data is a wl_array of the pressed key codes unique to the keyboard
that should now be considered pressed.

Similarly the leave event is emitted when a keyboard is removed from the
group while at least one key is pressed that is not pressed by any other
keyboard in the group. The data is a wl_array of the pressed key codes
unique to the keyboard that should now be considered released.

The purpose of these events are to allow the compositor to update its
state to avoid corruption. Additionally, for the leave event, the
focused surface may have been notified of a key press for some or all of
the key codes and needs to be notified of a key release to avoid state
corruption.

These were previously emitted as normal key events, but they are not
normal key events. There is no actual key press or release associated
with the events. It's purely for state keeping purposes. Emitting them
as separate events allows the compositor to handle them differently.
Since these are purely for state keeping purposes and are not associated
with an actual key being pressed or released, bindings should not be
triggered as a result of these events.