### PR TITLE
Add comments for missing tablet tool entries

### DIFF
--- a/backend/wayland/tablet_v2.c
+++ b/backend/wayland/tablet_v2.c
@@ -481,8 +481,10 @@ static enum wlr_tablet_tool_type tablet_type_to_wlr_type(enum zwp_tablet_tool_v2
 		return WLR_TABLET_TOOL_TYPE_MOUSE;
 	case ZWP_TABLET_TOOL_V2_TYPE_LENS:
 		return WLR_TABLET_TOOL_TYPE_LENS;
-	default:
-		break;
+	case ZWP_TABLET_TOOL_V2_TYPE_FINGER:
+		// unused, see:
+		// https://gitlab.freedesktop.org/wayland/wayland-protocols/-/issues/18
+		abort();
 	}
 	abort(); // unreachable
 }

--- a/types/tablet_v2/wlr_tablet_v2_tool.c
+++ b/types/tablet_v2/wlr_tablet_v2_tool.c
@@ -73,10 +73,12 @@ static enum zwp_tablet_tool_v2_type tablet_type_from_wlr_type(
 		return ZWP_TABLET_TOOL_V2_TYPE_MOUSE;
 	case WLR_TABLET_TOOL_TYPE_LENS:
 		return ZWP_TABLET_TOOL_V2_TYPE_LENS;
-	default:
-		/* We skip these devices earlier on */
-		abort(); // unreachable
+	case WLR_TABLET_TOOL_TYPE_TOTEM:
+		// missing, see:
+		// https://gitlab.freedesktop.org/wayland/wayland-protocols/-/issues/19
+		abort();
 	}
+	abort(); // unreachable
 }
 
 void destroy_tablet_tool_v2(struct wl_resource *resource) {


### PR DESCRIPTION
And stop using default cases, so that we know which parts of the code
need an update when adding a new enum entry.

Closes: https://github.com/swaywm/wlroots/issues/2208