### PR TITLE
wlr_cursor: expose a wlr_cursor_frame function

### DIFF
--- a/include/wlr/types/wlr_cursor.h
+++ b/include/wlr/types/wlr_cursor.h
@@ -151,6 +151,14 @@ void wlr_cursor_set_surface(struct wlr_cursor *cur, struct wlr_surface *surface,
 	int32_t hotspot_x, int32_t hotspot_y);
 
 /**
+ * Emits a frame event for the surface. This is not normally needed as the
+ * input backends emit this signal themselves. However, this can be used by
+ * compositors for cursor event simulation. For example, in combination with
+ * wlr_cursor_move to simulate cursor movement.
+ */
+void wlr_cursor_frame(struct wlr_cursor *cur);
+
+/**
  * Attaches this input device to this cursor. The input device must be one of:
  *
  * - WLR_INPUT_DEVICE_POINTER

--- a/types/wlr_cursor.c
+++ b/types/wlr_cursor.c
@@ -348,6 +348,10 @@ void wlr_cursor_set_surface(struct wlr_cursor *cur, struct wlr_surface *surface,
 	}
 }
 
+void wlr_cursor_frame(struct wlr_cursor *cur) {
+	wlr_signal_emit_safe(&cur->events.frame, cur);
+}
+
 static void handle_pointer_motion(struct wl_listener *listener, void *data) {
 	struct wlr_event_pointer_motion *event = data;
 	struct wlr_cursor_device *device =


### PR DESCRIPTION
Related to swaywm/sway#5361
Required by swaywm/sway#5400

This exposes a wlr_cursor_frame function for compositors to use when
simulating cursor events. In can be used in combination with
wlr_cursor_move and other related functions.

wlr_signal_emit_safe is not exposed to compositors so this wrapper
is needed.