### PR TITLE
export-dmabuf: Keep frame->output = NULL until frame is ready

### DIFF
--- a/types/wlr_export_dmabuf_v1.c
+++ b/types/wlr_export_dmabuf_v1.c
@@ -98,7 +98,6 @@ static void manager_handle_capture_output(struct wl_client *client,
 		return;
 	}
 	frame->manager = manager;
-	frame->output = output;
 	wl_list_init(&frame->output_precommit.link);
 
 	uint32_t version = wl_resource_get_version(manager_resource);
@@ -128,6 +127,8 @@ static void manager_handle_capture_output(struct wl_client *client,
 		frame_destroy(frame);
 		return;
 	}
+
+	frame->output = output;
 
 	wlr_output_lock_attach_render(frame->output, true);
 	if (overlay_cursor) {


### PR DESCRIPTION
This fixes a crash that happens when a client requests a frame on a
backend that does not implement export_dmabuf.

An assertion fails with the message:
sway: types/wlr_output.c:777: wlr_output_lock_attach_render: Assertion
`output->attach_render_locks > 0' failed.