### PR TITLE
backend/drm: atomic improvements

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -336,7 +336,7 @@ static bool drm_crtc_commit(struct wlr_drm_connector *conn, uint32_t flags) {
 		get_drm_backend_from_backend(conn->output.backend);
 	struct wlr_drm_crtc *crtc = conn->crtc;
 	bool ok = drm->iface->crtc_commit(drm, conn, flags);
-	if (ok) {
+	if (ok && !(flags & DRM_MODE_ATOMIC_TEST_ONLY)) {
 		memcpy(&crtc->current, &crtc->pending, sizeof(struct wlr_drm_crtc_state));
 	} else {
 		memcpy(&crtc->pending, &crtc->current, sizeof(struct wlr_drm_crtc_state));

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -564,12 +564,17 @@ static bool drm_connector_commit(struct wlr_output *output) {
 		if (!drm_connector_set_mode(conn, wlr_mode)) {
 			return false;
 		}
-	}
-
-	// TODO: support modesetting with a buffer
-	if (output->pending.committed & WLR_OUTPUT_STATE_BUFFER &&
-			!(output->pending.committed & WLR_OUTPUT_STATE_MODE)) {
+	} else if (output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
+		// TODO: support modesetting with a buffer
 		if (!drm_connector_commit_buffer(output)) {
+			return false;
+		}
+	} else if (output->pending.committed &
+			(WLR_OUTPUT_STATE_ADAPTIVE_SYNC_ENABLED |
+			WLR_OUTPUT_STATE_GAMMA_LUT)) {
+		assert(conn->crtc != NULL);
+		// TODO: maybe request a page-flip event here?
+		if (!drm_crtc_commit(conn, 0)) {
 			return false;
 		}
 	}

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -369,7 +369,6 @@ static bool drm_crtc_page_flip(struct wlr_drm_connector *conn) {
 	}
 
 	conn->pageflip_pending = true;
-	wlr_output_update_enabled(&conn->output, true);
 	return true;
 }
 

--- a/backend/drm/legacy.c
+++ b/backend/drm/legacy.c
@@ -62,6 +62,23 @@ static bool legacy_crtc_commit(struct wlr_drm_backend *drm,
 		}
 	}
 
+	if ((output->pending.committed & WLR_OUTPUT_STATE_ADAPTIVE_SYNC_ENABLED) &&
+			drm_connector_supports_vrr(conn)) {
+		if (drmModeObjectSetProperty(drm->fd, crtc->id, DRM_MODE_OBJECT_CRTC,
+				crtc->props.vrr_enabled,
+				output->pending.adaptive_sync_enabled) != 0) {
+			wlr_log_errno(WLR_ERROR,
+				"drmModeObjectSetProperty(VRR_ENABLED) failed");
+			return false;
+		}
+		output->adaptive_sync_status = output->pending.adaptive_sync_enabled ?
+			WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED :
+			WLR_OUTPUT_ADAPTIVE_SYNC_DISABLED;
+		wlr_log(WLR_DEBUG, "VRR %s on connector '%s'",
+			output->pending.adaptive_sync_enabled ? "enabled" : "disabled",
+			output->name);
+	}
+
 	if (cursor != NULL && drm_connector_is_cursor_visible(conn)) {
 		struct wlr_drm_fb *cursor_fb = plane_get_next_fb(cursor);
 		struct gbm_bo *cursor_bo =

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -153,6 +153,7 @@ int handle_drm_event(int fd, uint32_t mask, void *data);
 bool drm_connector_set_mode(struct wlr_drm_connector *conn,
 	struct wlr_output_mode *mode);
 bool drm_connector_is_cursor_visible(struct wlr_drm_connector *conn);
+bool drm_connector_supports_vrr(struct wlr_drm_connector *conn);
 size_t drm_crtc_get_gamma_lut_size(struct wlr_drm_backend *drm,
 	struct wlr_drm_crtc *crtc);
 


### PR DESCRIPTION
This PR:

- Makes adaptive sync atomic
- Performs a blocking atomic commit if no modeset or buffer is pending

The second point fixes output state updates not applied when no modeset or page-flip is performed. For instance, `wlr_output_set_gamma` followed by `wlr_output_commit` was a no-op (but shouldn't be).

No Sway PR required, since `wlr_output_enable_adaptive_sync` is already followed by `wlr_output_commit`.

Closes: https://github.com/swaywm/wlroots/issues/2096

* * *

Breaking change: `wlr_output_enable_adaptive_sync` must now be followed by `wlr_output_commit` to apply the change.