### PR TITLE
Renderer v6, incremental version

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -593,8 +593,8 @@ static bool drm_connector_commit(struct wlr_output *output) {
 }
 
 static void drm_connector_rollback_render(struct wlr_output *output) {
-	struct wlr_drm_backend *drm = get_drm_backend_from_backend(output->backend);
-	wlr_egl_unset_current(&drm->renderer.egl);
+	struct wlr_drm_connector *conn = get_drm_connector_from_output(output);
+	return drm_surface_unset_current(&conn->crtc->primary->surf);
 }
 
 size_t drm_crtc_get_gamma_lut_size(struct wlr_drm_backend *drm,
@@ -883,7 +883,7 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 		return false;
 	}
 
-	if (!plane->surf.gbm) {
+	if (!plane->surf.swapchain) {
 		int ret;
 		uint64_t w, h;
 		ret = drmGetCap(drm->fd, DRM_CAP_CURSOR_WIDTH, &w);

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -681,7 +681,9 @@ static bool drm_connector_pageflip_renderer(struct wlr_drm_connector *conn) {
 	// drm_crtc_page_flip expects a FB to be available
 	struct wlr_drm_plane *plane = crtc->primary;
 	if (!plane_get_next_fb(plane)->bo) {
-		drm_surface_render_black_frame(&plane->surf);
+		if (!drm_surface_render_black_frame(&plane->surf)) {
+			return false;
+		}
 		if (!drm_fb_lock_surface(&plane->pending_fb, &plane->surf)) {
 			return false;
 		}

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -377,7 +377,7 @@ static bool drm_crtc_page_flip(struct wlr_drm_connector *conn) {
 	}
 
 	assert(crtc->pending.active);
-	assert(plane_get_next_fb(crtc->primary)->type != WLR_DRM_FB_TYPE_NONE);
+	assert(plane_get_next_fb(crtc->primary)->bo);
 	if (!drm_crtc_commit(conn, DRM_MODE_PAGE_FLIP_EVENT)) {
 		return false;
 	}
@@ -650,10 +650,10 @@ static bool drm_connector_export_dmabuf(struct wlr_output *output,
 	}
 
 	struct wlr_drm_fb *fb = &crtc->primary->queued_fb;
-	if (fb->type == WLR_DRM_FB_TYPE_NONE) {
+	if (fb->bo == NULL) {
 		fb = &crtc->primary->current_fb;
 	}
-	if (fb->type == WLR_DRM_FB_TYPE_NONE) {
+	if (fb->bo == NULL) {
 		return false;
 	}
 
@@ -661,10 +661,10 @@ static bool drm_connector_export_dmabuf(struct wlr_output *output,
 }
 
 struct wlr_drm_fb *plane_get_next_fb(struct wlr_drm_plane *plane) {
-	if (plane->pending_fb.type != WLR_DRM_FB_TYPE_NONE) {
+	if (plane->pending_fb.bo) {
 		return &plane->pending_fb;
 	}
-	if (plane->queued_fb.type != WLR_DRM_FB_TYPE_NONE) {
+	if (plane->queued_fb.bo) {
 		return &plane->queued_fb;
 	}
 	return &plane->current_fb;
@@ -680,7 +680,7 @@ static bool drm_connector_pageflip_renderer(struct wlr_drm_connector *conn) {
 
 	// drm_crtc_page_flip expects a FB to be available
 	struct wlr_drm_plane *plane = crtc->primary;
-	if (plane_get_next_fb(plane)->type == WLR_DRM_FB_TYPE_NONE) {
+	if (!plane_get_next_fb(plane)->bo) {
 		drm_surface_render_black_frame(&plane->surf);
 		if (!drm_fb_lock_surface(&plane->pending_fb, &plane->surf)) {
 			return false;
@@ -1507,11 +1507,10 @@ static void page_flip_handler(int fd, unsigned seq,
 	}
 
 	struct wlr_drm_plane *plane = conn->crtc->primary;
-	if (plane->queued_fb.type != WLR_DRM_FB_TYPE_NONE) {
+	if (plane->queued_fb.bo) {
 		drm_fb_move(&plane->current_fb, &plane->queued_fb);
 	}
-	if (conn->crtc->cursor &&
-			conn->crtc->cursor->queued_fb.type != WLR_DRM_FB_TYPE_NONE) {
+	if (conn->crtc->cursor && conn->crtc->cursor->queued_fb.bo) {
 		drm_fb_move(&conn->crtc->cursor->current_fb,
 			&conn->crtc->cursor->queued_fb);
 	}
@@ -1522,7 +1521,8 @@ static void page_flip_handler(int fd, unsigned seq,
 	 * data between the GPUs, even if we were using the direct scanout
 	 * interface.
 	 */
-	if (!drm->parent && plane->current_fb.type == WLR_DRM_FB_TYPE_WLR_BUFFER) {
+	if (!drm->parent && plane->current_fb.wlr_buf &&
+			wlr_client_buffer_get(plane->current_fb.wlr_buf)) {
 		present_flags |= WLR_OUTPUT_PRESENT_ZERO_COPY;
 	}
 

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -137,7 +137,7 @@ static void finish_drm_surface(struct wlr_drm_surface *surf) {
 bool drm_surface_make_current(struct wlr_drm_surface *surf,
 		int *buffer_age) {
 	wlr_buffer_unlock(surf->back_buffer);
-	surf->back_buffer = wlr_swapchain_acquire(surf->swapchain);
+	surf->back_buffer = wlr_swapchain_acquire(surf->swapchain, buffer_age);
 	if (surf->back_buffer == NULL) {
 		wlr_log(WLR_ERROR, "Failed to acquire swapchain buffer");
 		return false;
@@ -151,10 +151,6 @@ bool drm_surface_make_current(struct wlr_drm_surface *surf,
 		return false;
 	}
 
-	// TODO: damage tracking
-	if (buffer_age != NULL) {
-		*buffer_age = -1;
-	}
 	return true;
 }
 

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -280,21 +280,15 @@ bool drm_plane_init_surface(struct wlr_drm_plane *plane,
 }
 
 void drm_fb_clear(struct wlr_drm_fb *fb) {
-	switch (fb->type) {
-	case WLR_DRM_FB_TYPE_NONE:
-		assert(!fb->bo);
-		break;
-	case WLR_DRM_FB_TYPE_SURFACE:
-		abort(); // TODO: remove this case entirely
-		break;
-	case WLR_DRM_FB_TYPE_WLR_BUFFER:
-		gbm_bo_destroy(fb->bo);
-		wlr_buffer_unlock(fb->wlr_buf);
-		fb->wlr_buf = NULL;
-		break;
+	if (!fb->bo) {
+		assert(!fb->wlr_buf);
+		return;
 	}
 
-	fb->type = WLR_DRM_FB_TYPE_NONE;
+	gbm_bo_destroy(fb->bo);
+	wlr_buffer_unlock(fb->wlr_buf);
+
+	fb->wlr_buf = NULL;
 	fb->bo = NULL;
 
 	if (fb->mgpu_bo) {
@@ -376,7 +370,6 @@ bool drm_fb_import_wlr(struct wlr_drm_fb *fb, struct wlr_drm_renderer *renderer,
 		return false;
 	}
 
-	fb->type = WLR_DRM_FB_TYPE_WLR_BUFFER;
 	fb->wlr_buf = wlr_buffer_lock(buf);
 
 	return true;

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -12,9 +12,13 @@
 #include <wlr/types/wlr_matrix.h>
 #include <wlr/util/log.h>
 #include "backend/drm/drm.h"
+#include "render/gbm_allocator.h"
+#include "render/swapchain.h"
+#include "render/wlr_renderer.h"
 
 bool init_drm_renderer(struct wlr_drm_backend *drm,
 		struct wlr_drm_renderer *renderer, wlr_renderer_create_func_t create_renderer_func) {
+	// TODO: get rid of renderer->gbm
 	renderer->gbm = gbm_create_device(drm->fd);
 	if (!renderer->gbm) {
 		wlr_log(WLR_ERROR, "Failed to create GBM device");
@@ -44,9 +48,17 @@ bool init_drm_renderer(struct wlr_drm_backend *drm,
 		goto error_gbm;
 	}
 
+	renderer->allocator = wlr_gbm_allocator_create(drm->fd);
+	if (renderer->allocator == NULL) {
+		wlr_log(WLR_ERROR, "Failed to create allocator");
+		goto error_wlr_rend;
+	}
+
 	renderer->fd = drm->fd;
 	return true;
 
+error_wlr_rend:
+	wlr_renderer_destroy(renderer->wlr_rend);
 error_gbm:
 	gbm_device_destroy(renderer->gbm);
 	return false;
@@ -57,6 +69,7 @@ void finish_drm_renderer(struct wlr_drm_renderer *renderer) {
 		return;
 	}
 
+	wlr_allocator_destroy(&renderer->allocator->base);
 	wlr_renderer_destroy(renderer->wlr_rend);
 	wlr_egl_finish(&renderer->egl);
 	gbm_device_destroy(renderer->gbm);
@@ -64,7 +77,7 @@ void finish_drm_renderer(struct wlr_drm_renderer *renderer) {
 
 static bool init_drm_surface(struct wlr_drm_surface *surf,
 		struct wlr_drm_renderer *renderer, uint32_t width, uint32_t height,
-		uint32_t format, struct wlr_drm_format_set *set, uint32_t flags) {
+		uint32_t format, const struct wlr_drm_format_set *set, uint32_t flags) {
 	if (surf->width == width && surf->height == height) {
 		return true;
 	}
@@ -73,43 +86,41 @@ static bool init_drm_surface(struct wlr_drm_surface *surf,
 	surf->width = width;
 	surf->height = height;
 
-	if (surf->gbm) {
-		gbm_surface_destroy(surf->gbm);
-		surf->gbm = NULL;
-	}
-	wlr_egl_destroy_surface(&surf->renderer->egl, surf->egl);
+	wlr_buffer_unlock(surf->back_buffer);
+	surf->back_buffer = NULL;
+	wlr_swapchain_destroy(surf->swapchain);
+	surf->swapchain = NULL;
 
-	if (!(flags & GBM_BO_USE_LINEAR) && set != NULL) {
-		const struct wlr_drm_format *drm_format =
-			wlr_drm_format_set_get(set, format);
-		if (drm_format != NULL) {
-			surf->gbm = gbm_surface_create_with_modifiers(renderer->gbm,
-				width, height, format, drm_format->modifiers, drm_format->len);
+	const struct wlr_drm_format *drm_format = NULL;
+	const struct wlr_drm_format format_no_modifiers = { .format = format };
+	if (set != NULL) {
+		drm_format = wlr_drm_format_set_get(set, format);
+	} else {
+		drm_format = &format_no_modifiers;
+	}
+
+	struct wlr_drm_format *format_linear = NULL;
+	if (flags & GBM_BO_USE_LINEAR) {
+		format_linear = calloc(1, sizeof(struct wlr_drm_format) + sizeof(uint64_t));
+		if (format_linear == NULL) {
+			return false;
 		}
+		format_linear->format = format;
+		format_linear->len = 1;
+		format_linear->modifiers[0] = DRM_FORMAT_MOD_LINEAR;
+		drm_format = format_linear;
 	}
 
-	if (surf->gbm == NULL) {
-		surf->gbm = gbm_surface_create(renderer->gbm, width, height,
-			format, GBM_BO_USE_RENDERING | flags);
-	}
-	if (!surf->gbm) {
-		wlr_log_errno(WLR_ERROR, "Failed to create GBM surface");
-		goto error_zero;
-	}
-
-	surf->egl = wlr_egl_create_surface(&renderer->egl, surf->gbm);
-	if (surf->egl == EGL_NO_SURFACE) {
-		wlr_log(WLR_ERROR, "Failed to create EGL surface");
-		goto error_gbm;
+	surf->swapchain = wlr_swapchain_create(&renderer->allocator->base,
+		width, height, drm_format);
+	free(format_linear);
+	if (surf->swapchain == NULL) {
+		wlr_log(WLR_ERROR, "Failed to create swapchain");
+		memset(surf, 0, sizeof(*surf));
+		return false;
 	}
 
 	return true;
-
-error_gbm:
-	gbm_surface_destroy(surf->gbm);
-error_zero:
-	memset(surf, 0, sizeof(*surf));
-	return false;
 }
 
 static void finish_drm_surface(struct wlr_drm_surface *surf) {
@@ -117,17 +128,44 @@ static void finish_drm_surface(struct wlr_drm_surface *surf) {
 		return;
 	}
 
-	wlr_egl_destroy_surface(&surf->renderer->egl, surf->egl);
-	if (surf->gbm) {
-		gbm_surface_destroy(surf->gbm);
-	}
+	wlr_buffer_unlock(surf->back_buffer);
+	wlr_swapchain_destroy(surf->swapchain);
 
 	memset(surf, 0, sizeof(*surf));
 }
 
 bool drm_surface_make_current(struct wlr_drm_surface *surf,
 		int *buffer_age) {
-	return wlr_egl_make_current(&surf->renderer->egl, surf->egl, buffer_age);
+	wlr_buffer_unlock(surf->back_buffer);
+	surf->back_buffer = wlr_swapchain_acquire(surf->swapchain);
+	if (surf->back_buffer == NULL) {
+		wlr_log(WLR_ERROR, "Failed to acquire swapchain buffer");
+		return false;
+	}
+
+	if (!wlr_egl_make_current(&surf->renderer->egl, EGL_NO_SURFACE, NULL)) {
+		return false;
+	}
+	if (!wlr_renderer_bind_buffer(surf->renderer->wlr_rend, surf->back_buffer)) {
+		wlr_log(WLR_ERROR, "Failed to attach buffer to renderer");
+		return false;
+	}
+
+	// TODO: damage tracking
+	if (buffer_age != NULL) {
+		*buffer_age = -1;
+	}
+	return true;
+}
+
+void drm_surface_unset_current(struct wlr_drm_surface *surf) {
+	assert(surf->back_buffer != NULL);
+
+	wlr_renderer_bind_buffer(surf->renderer->wlr_rend, NULL);
+	wlr_egl_unset_current(&surf->renderer->egl);
+
+	wlr_buffer_unlock(surf->back_buffer);
+	surf->back_buffer = NULL;
 }
 
 bool export_drm_bo(struct gbm_bo *bo, struct wlr_dmabuf_attributes *attribs) {
@@ -251,7 +289,7 @@ void drm_fb_clear(struct wlr_drm_fb *fb) {
 		assert(!fb->bo);
 		break;
 	case WLR_DRM_FB_TYPE_SURFACE:
-		gbm_surface_release_buffer(fb->surf->gbm, fb->bo);
+		abort(); // TODO: remove this case entirely
 		break;
 	case WLR_DRM_FB_TYPE_WLR_BUFFER:
 		gbm_bo_destroy(fb->bo);
@@ -264,29 +302,22 @@ void drm_fb_clear(struct wlr_drm_fb *fb) {
 	fb->bo = NULL;
 
 	if (fb->mgpu_bo) {
-		assert(fb->mgpu_surf);
+		// TODO
+		/*assert(fb->mgpu_surf);
 		gbm_surface_release_buffer(fb->mgpu_surf->gbm, fb->mgpu_bo);
 		fb->mgpu_bo = NULL;
-		fb->mgpu_surf = NULL;
+		fb->mgpu_surf = NULL;*/
 	}
 }
 
 bool drm_fb_lock_surface(struct wlr_drm_fb *fb, struct wlr_drm_surface *surf) {
-	drm_fb_clear(fb);
+	assert(surf->back_buffer != NULL);
 
-	if (!wlr_egl_swap_buffers(&surf->renderer->egl, surf->egl, NULL)) {
-		wlr_log(WLR_ERROR, "Failed to swap buffers");
+	if (!drm_fb_import_wlr(fb, surf->renderer, surf->back_buffer, NULL)) {
 		return false;
 	}
 
-	fb->bo = gbm_surface_lock_front_buffer(surf->gbm);
-	if (!fb->bo) {
-		wlr_log(WLR_ERROR, "Failed to lock front buffer");
-		return false;
-	}
-
-	fb->type = WLR_DRM_FB_TYPE_SURFACE;
-	fb->surf = surf;
+	drm_surface_unset_current(surf);
 	return true;
 }
 
@@ -299,7 +330,7 @@ bool drm_fb_import_wlr(struct wlr_drm_fb *fb, struct wlr_drm_renderer *renderer,
 		return false;
 	}
 
-	if (!wlr_drm_format_set_has(set, attribs.format, attribs.modifier)) {
+	if (set && !wlr_drm_format_set_has(set, attribs.format, attribs.modifier)) {
 		// The format isn't supported by the plane. Try stripping the alpha
 		// channel, if any.
 		uint32_t format = strip_alpha_channel(attribs.format);
@@ -410,7 +441,8 @@ struct gbm_bo *drm_fb_acquire(struct wlr_drm_fb *fb, struct wlr_drm_backend *drm
 	wlr_render_texture_with_matrix(renderer, tex, mat, 1.0f);
 	wlr_renderer_end(renderer);
 
-	if (!wlr_egl_swap_buffers(&mgpu->renderer->egl, mgpu->egl, NULL)) {
+	// TODO
+	/*if (!wlr_egl_swap_buffers(&mgpu->renderer->egl, mgpu->egl, NULL)) {
 		wlr_log(WLR_ERROR, "Failed to swap buffers");
 		return NULL;
 	}
@@ -421,6 +453,6 @@ struct gbm_bo *drm_fb_acquire(struct wlr_drm_fb *fb, struct wlr_drm_backend *drm
 		return NULL;
 	}
 
-	fb->mgpu_surf = mgpu;
+	fb->mgpu_surf = mgpu;*/
 	return fb->mgpu_bo;
 }

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -33,20 +33,12 @@ struct wlr_drm_surface {
 	struct wlr_buffer *back_buffer;
 };
 
-enum wlr_drm_fb_type {
-	WLR_DRM_FB_TYPE_NONE,
-	WLR_DRM_FB_TYPE_SURFACE,
-	WLR_DRM_FB_TYPE_WLR_BUFFER
-};
-
 struct wlr_drm_fb {
-	enum wlr_drm_fb_type type;
 	struct gbm_bo *bo;
+	struct wlr_buffer *wlr_buf;
 
 	struct wlr_drm_surface *mgpu_surf;
 	struct gbm_bo *mgpu_bo;
-
-	struct wlr_buffer *wlr_buf;
 };
 
 bool init_drm_renderer(struct wlr_drm_backend *drm,

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -20,6 +20,7 @@ struct wlr_drm_renderer {
 	uint32_t gbm_format;
 
 	struct wlr_renderer *wlr_rend;
+	struct wlr_gbm_allocator *allocator;
 };
 
 struct wlr_drm_surface {
@@ -28,8 +29,8 @@ struct wlr_drm_surface {
 	uint32_t width;
 	uint32_t height;
 
-	struct gbm_surface *gbm;
-	EGLSurface egl;
+	struct wlr_swapchain *swapchain;
+	struct wlr_buffer *back_buffer;
 };
 
 enum wlr_drm_fb_type {
@@ -45,10 +46,7 @@ struct wlr_drm_fb {
 	struct wlr_drm_surface *mgpu_surf;
 	struct gbm_bo *mgpu_bo;
 
-	union {
-		struct wlr_drm_surface *surf;
-		struct wlr_buffer *wlr_buf;
-	};
+	struct wlr_buffer *wlr_buf;
 };
 
 bool init_drm_renderer(struct wlr_drm_backend *drm,
@@ -56,6 +54,7 @@ bool init_drm_renderer(struct wlr_drm_backend *drm,
 void finish_drm_renderer(struct wlr_drm_renderer *renderer);
 
 bool drm_surface_make_current(struct wlr_drm_surface *surf, int *buffer_age);
+void drm_surface_unset_current(struct wlr_drm_surface *surf);
 bool export_drm_bo(struct gbm_bo *bo, struct wlr_dmabuf_attributes *attribs);
 
 void drm_fb_clear(struct wlr_drm_fb *fb);

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -39,6 +39,7 @@ struct wlr_drm_fb {
 
 	struct wlr_drm_surface *mgpu_surf;
 	struct gbm_bo *mgpu_bo;
+	struct wlr_buffer *mgpu_wlr_buf;
 };
 
 bool init_drm_renderer(struct wlr_drm_backend *drm,

--- a/include/render/allocator.h
+++ b/include/render/allocator.h
@@ -1,0 +1,42 @@
+#ifndef RENDER_ALLOCATOR
+#define RENDER_ALLOCATOR
+
+#include <stdbool.h>
+#include <wayland-server-core.h>
+#include <wlr/render/dmabuf.h>
+#include <wlr/render/drm_format_set.h>
+
+struct wlr_allocator;
+
+struct wlr_allocator_interface {
+	struct wlr_buffer *(*create_buffer)(struct wlr_allocator *alloc,
+		int width, int height, const struct wlr_drm_format *format);
+	void (*destroy)(struct wlr_allocator *alloc);
+};
+
+struct wlr_allocator {
+	const struct wlr_allocator_interface *impl;
+
+	struct {
+		struct wl_signal destroy;
+	} events;
+};
+
+/**
+ * Destroy the allocator.
+ */
+void wlr_allocator_destroy(struct wlr_allocator *alloc);
+/**
+ * Allocate a new buffer.
+ *
+ * When the caller is done with it, they must unreference it by calling
+ * wlr_buffer_drop.
+ */
+struct wlr_buffer *wlr_allocator_create_buffer(struct wlr_allocator *alloc,
+	int width, int height, const struct wlr_drm_format *format);
+
+// For wlr_allocator implementors
+void wlr_allocator_init(struct wlr_allocator *alloc,
+	const struct wlr_allocator_interface *impl);
+
+#endif

--- a/include/render/drm_format_set.h
+++ b/include/render/drm_format_set.h
@@ -1,0 +1,8 @@
+#ifndef RENDER_DRM_FORMAT_SET_H
+#define RENDER_DRM_FORMAT_SET_H
+
+#include <wlr/render/drm_format_set.h>
+
+struct wlr_drm_format *wlr_drm_format_dup(const struct wlr_drm_format *format);
+
+#endif

--- a/include/render/gbm_allocator.h
+++ b/include/render/gbm_allocator.h
@@ -1,0 +1,29 @@
+#ifndef RENDER_GBM_ALLOCATOR_H
+#define RENDER_GBM_ALLOCATOR_H
+
+#include <gbm.h>
+#include <wlr/types/wlr_buffer.h>
+#include "render/allocator.h"
+
+struct wlr_gbm_buffer {
+	struct wlr_buffer base;
+
+	struct gbm_bo *gbm_bo;
+	struct wlr_dmabuf_attributes dmabuf;
+};
+
+struct wlr_gbm_allocator {
+	struct wlr_allocator base;
+
+	int fd;
+	struct gbm_device *gbm_device;
+};
+
+/**
+ * Creates a new GBM allocator from a render FD.
+ *
+ * Takes ownership over the FD.
+ */
+struct wlr_gbm_allocator *wlr_gbm_allocator_create(int render_fd);
+
+#endif

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -72,7 +72,22 @@ struct wlr_gles2_renderer {
 		struct wlr_gles2_tex_shader tex_ext;
 	} shaders;
 
+	struct wl_list buffers; // wlr_gles2_buffer.link
+
+	struct wlr_gles2_buffer *current_buffer;
 	uint32_t viewport_width, viewport_height;
+};
+
+struct wlr_gles2_buffer {
+	struct wlr_buffer *buffer;
+	struct wlr_gles2_renderer *renderer;
+	struct wl_list link; // wlr_gles2_renderer.buffers
+
+	EGLImageKHR image;
+	GLuint rbo;
+	GLuint fbo;
+
+	struct wl_listener buffer_destroy;
 };
 
 struct wlr_gles2_texture {

--- a/include/render/swapchain.h
+++ b/include/render/swapchain.h
@@ -1,0 +1,41 @@
+#ifndef RENDER_SWAPCHAIN_H
+#define RENDER_SWAPCHAIN_H
+
+#include <stdbool.h>
+#include <wayland-server-core.h>
+#include <wlr/render/drm_format_set.h>
+
+#define WLR_SWAPCHAIN_CAP 4
+
+struct wlr_swapchain_slot {
+	struct wlr_buffer *buffer;
+	bool acquired; // waiting for release
+
+	struct wl_listener release;
+};
+
+struct wlr_swapchain {
+	struct wlr_allocator *allocator; // NULL if destroyed
+
+	int width, height;
+	struct wlr_drm_format *format;
+
+	struct wlr_swapchain_slot slots[WLR_SWAPCHAIN_CAP];
+
+	struct wl_listener allocator_destroy;
+};
+
+struct wlr_swapchain *wlr_swapchain_create(
+	struct wlr_allocator *alloc, int width, int height,
+	const struct wlr_drm_format *format);
+void wlr_swapchain_destroy(struct wlr_swapchain *swapchain);
+/**
+ * Acquire a buffer from the swap chain.
+ *
+ * The returned buffer is locked. When the caller is done with it, they must
+ * unlock it by calling wlr_buffer_unlock.
+ */
+struct wlr_buffer *wlr_swapchain_acquire(
+	struct wlr_swapchain *swapchain);
+
+#endif

--- a/include/render/swapchain.h
+++ b/include/render/swapchain.h
@@ -10,6 +10,7 @@
 struct wlr_swapchain_slot {
 	struct wlr_buffer *buffer;
 	bool acquired; // waiting for release
+	int age;
 
 	struct wl_listener release;
 };
@@ -35,7 +36,15 @@ void wlr_swapchain_destroy(struct wlr_swapchain *swapchain);
  * The returned buffer is locked. When the caller is done with it, they must
  * unlock it by calling wlr_buffer_unlock.
  */
-struct wlr_buffer *wlr_swapchain_acquire(
-	struct wlr_swapchain *swapchain);
+struct wlr_buffer *wlr_swapchain_acquire(struct wlr_swapchain *swapchain,
+	int *age);
+/**
+ * Mark the buffer as submitted for presentation. This needs to be called by
+ * swap chain users on frame boundaries.
+ *
+ * If the buffer hasn't been created via the swap chain, the call is ignored.
+ */
+void wlr_swapchain_set_buffer_submitted(struct wlr_swapchain *swapchain,
+	struct wlr_buffer *buffer);
 
 #endif

--- a/include/render/wlr_renderer.h
+++ b/include/render/wlr_renderer.h
@@ -1,0 +1,8 @@
+#ifndef RENDER_WLR_RENDERER_H
+#define RENDER_WLR_RENDERER_H
+
+#include <wlr/render/wlr_renderer.h>
+
+bool wlr_renderer_bind_buffer(struct wlr_renderer *r, struct wlr_buffer *buffer);
+
+#endif

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -30,6 +30,8 @@
 #include <wlr/render/dmabuf.h>
 
 struct wlr_renderer_impl {
+	bool (*bind_buffer)(struct wlr_renderer *renderer,
+		struct wlr_buffer *buffer);
 	void (*begin)(struct wlr_renderer *renderer, uint32_t width,
 		uint32_t height);
 	void (*end)(struct wlr_renderer *renderer);

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -21,6 +21,7 @@ enum wlr_renderer_read_pixels_flags {
 
 struct wlr_renderer_impl;
 struct wlr_drm_format_set;
+struct wlr_buffer;
 
 struct wlr_renderer {
 	const struct wlr_renderer_impl *impl;

--- a/include/wlr/types/wlr_buffer.h
+++ b/include/wlr/types/wlr_buffer.h
@@ -104,6 +104,11 @@ struct wlr_client_buffer {
 struct wlr_renderer;
 
 /**
+ * Get a client buffer from a generic buffer. If the buffer isn't a client
+ * buffer, returns NULL.
+ */
+struct wlr_client_buffer *wlr_client_buffer_get(struct wlr_buffer *buffer);
+/**
  * Check if a resource is a wl_buffer resource.
  */
 bool wlr_resource_is_buffer(struct wl_resource *resource);

--- a/render/allocator.c
+++ b/render/allocator.c
@@ -1,0 +1,20 @@
+#include <assert.h>
+#include <stdlib.h>
+#include "render/allocator.h"
+
+void wlr_allocator_init(struct wlr_allocator *alloc,
+		const struct wlr_allocator_interface *impl) {
+	assert(impl && impl->destroy && impl->create_buffer);
+	alloc->impl = impl;
+	wl_signal_init(&alloc->events.destroy);
+}
+
+void wlr_allocator_destroy(struct wlr_allocator *alloc) {
+	wl_signal_emit(&alloc->events.destroy, NULL);
+	alloc->impl->destroy(alloc);
+}
+
+struct wlr_buffer *wlr_allocator_create_buffer(struct wlr_allocator *alloc,
+		int width, int height, const struct wlr_drm_format *format) {
+	return alloc->impl->create_buffer(alloc, width, height, format);
+}

--- a/render/drm_format_set.c
+++ b/render/drm_format_set.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <wlr/render/drm_format_set.h>
 #include <wlr/util/log.h>
+#include "render/drm_format_set.h"
 
 void wlr_drm_format_set_finish(struct wlr_drm_format_set *set) {
 	for (size_t i = 0; i < set->len; ++i) {
@@ -124,4 +125,15 @@ bool wlr_drm_format_set_add(struct wlr_drm_format_set *set, uint32_t format,
 
 	set->formats[set->len++] = fmt;
 	return true;
+}
+
+struct wlr_drm_format *wlr_drm_format_dup(const struct wlr_drm_format *format) {
+	size_t format_size = sizeof(struct wlr_drm_format) +
+		format->len * sizeof(format->modifiers[0]);
+	struct wlr_drm_format *duped_format = malloc(format_size);
+	if (duped_format == NULL) {
+		return NULL;
+	}
+	memcpy(duped_format, format, format_size);
+	return duped_format;
 }

--- a/render/gbm_allocator.c
+++ b/render/gbm_allocator.c
@@ -1,0 +1,182 @@
+#define _POSIX_C_SOURCE 200809L
+#include <assert.h>
+#include <drm_fourcc.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <wlr/util/log.h>
+#include <xf86drm.h>
+#include "render/gbm_allocator.h"
+
+static const struct wlr_buffer_impl buffer_impl;
+
+static struct wlr_gbm_buffer *get_gbm_buffer_from_buffer(
+		struct wlr_buffer *buffer) {
+	assert(buffer->impl == &buffer_impl);
+	return (struct wlr_gbm_buffer *)buffer;
+}
+
+static struct wlr_gbm_buffer *create_buffer(struct gbm_device *gbm_device,
+		int width, int height, const struct wlr_drm_format *format) {
+	struct gbm_bo *bo = NULL;
+	if (format->len > 0) {
+		bo = gbm_bo_create_with_modifiers(gbm_device, width, height,
+			format->format, format->modifiers, format->len);
+	}
+	if (bo == NULL) {
+		uint32_t usage = GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING;
+		if (format->len == 1 &&
+				format->modifiers[0] == DRM_FORMAT_MOD_LINEAR) {
+			usage |= GBM_BO_USE_LINEAR;
+		}
+		bo = gbm_bo_create(gbm_device, width, height, format->format, usage);
+	}
+	if (bo == NULL) {
+		wlr_log(WLR_ERROR, "gbm_bo_create failed");
+		return NULL;
+	}
+
+	struct wlr_gbm_buffer *buffer = calloc(1, sizeof(*buffer));
+	if (buffer == NULL) {
+		gbm_bo_destroy(bo);
+		return NULL;
+	}
+	wlr_buffer_init(&buffer->base, &buffer_impl, width, height);
+	buffer->gbm_bo = bo;
+
+	wlr_log(WLR_DEBUG, "Allocated %dx%d GBM buffer (format 0x%"PRIX32", "
+		"modifier 0x%"PRIX64")", buffer->base.width, buffer->base.height,
+		gbm_bo_get_format(bo), gbm_bo_get_modifier(bo));
+
+	return buffer;
+}
+
+static void buffer_destroy(struct wlr_buffer *wlr_buffer) {
+	struct wlr_gbm_buffer *buffer =
+		get_gbm_buffer_from_buffer(wlr_buffer);
+	wlr_dmabuf_attributes_finish(&buffer->dmabuf);
+	gbm_bo_destroy(buffer->gbm_bo);
+	free(buffer);
+}
+
+static bool buffer_create_dmabuf(struct wlr_gbm_buffer *buffer) {
+	assert(buffer->dmabuf.n_planes == 0);
+
+	struct gbm_bo *bo = buffer->gbm_bo;
+	struct wlr_dmabuf_attributes attribs = {0};
+
+	attribs.n_planes = gbm_bo_get_plane_count(bo);
+	if (attribs.n_planes > WLR_DMABUF_MAX_PLANES) {
+		wlr_log(WLR_ERROR, "GBM BO contains too many planes (%d)",
+			attribs.n_planes);
+		return false;
+	}
+
+	attribs.width = gbm_bo_get_width(bo);
+	attribs.height = gbm_bo_get_height(bo);
+	attribs.format = gbm_bo_get_format(bo);
+	attribs.modifier = gbm_bo_get_modifier(bo);
+
+	int i;
+	for (i = 0; i < attribs.n_planes; ++i) {
+		union gbm_bo_handle handle = gbm_bo_get_handle_for_plane(bo, i);
+		if (handle.s32 < 0) {
+			wlr_log(WLR_ERROR, "gbm_bo_get_handle_for_plane failed");
+			goto error_fd;
+		}
+
+		int drm_fd = gbm_device_get_fd(gbm_bo_get_device(bo));
+		int ret = drmPrimeHandleToFD(drm_fd, handle.s32,
+			DRM_CLOEXEC, &attribs.fd[i]);
+		if (ret < 0 || attribs.fd[i] < 0) {
+			wlr_log_errno(WLR_ERROR, "drmPrimeHandleToFD failed");
+			goto error_fd;
+		}
+
+		attribs.offset[i] = gbm_bo_get_offset(bo, i);
+		attribs.stride[i] = gbm_bo_get_stride_for_plane(bo, i);
+	}
+
+	memcpy(&buffer->dmabuf, &attribs, sizeof(attribs));
+	return true;
+
+error_fd:
+	for (int j = 0; j < i; ++j) {
+		close(attribs.fd[j]);
+	}
+	return false;
+}
+
+static bool buffer_get_dmabuf(struct wlr_buffer *wlr_buffer,
+		struct wlr_dmabuf_attributes *attribs) {
+	struct wlr_gbm_buffer *buffer =
+		get_gbm_buffer_from_buffer(wlr_buffer);
+
+	memset(attribs, 0, sizeof(*attribs));
+
+	// Only export the buffer once
+	if (buffer->dmabuf.n_planes == 0) {
+		if (!buffer_create_dmabuf(buffer)) {
+			return false;
+		}
+	}
+
+	memcpy(attribs, &buffer->dmabuf, sizeof(buffer->dmabuf));
+	return true;
+}
+
+static const struct wlr_buffer_impl buffer_impl = {
+	.destroy = buffer_destroy,
+	.get_dmabuf = buffer_get_dmabuf,
+};
+
+static const struct wlr_allocator_interface allocator_impl;
+
+static struct wlr_gbm_allocator *get_gbm_alloc_from_alloc(
+		struct wlr_allocator *alloc) {
+	assert(alloc->impl == &allocator_impl);
+	return (struct wlr_gbm_allocator *)alloc;
+}
+
+struct wlr_gbm_allocator *wlr_gbm_allocator_create(int fd) {
+	struct wlr_gbm_allocator *alloc = calloc(1, sizeof(*alloc));
+	if (alloc == NULL) {
+		return NULL;
+	}
+	wlr_allocator_init(&alloc->base, &allocator_impl);
+
+	alloc->fd = fd;
+
+	alloc->gbm_device = gbm_create_device(fd);
+	if (alloc->gbm_device == NULL) {
+		wlr_log(WLR_ERROR, "gbm_create_device failed");
+		free(alloc);
+		return NULL;
+	}
+
+	return alloc;
+}
+
+static void allocator_destroy(struct wlr_allocator *wlr_alloc) {
+	struct wlr_gbm_allocator *alloc = get_gbm_alloc_from_alloc(wlr_alloc);
+	gbm_device_destroy(alloc->gbm_device);
+	close(alloc->fd);
+	free(alloc);
+}
+
+static struct wlr_buffer *allocator_create_buffer(
+		struct wlr_allocator *wlr_alloc, int width, int height,
+		const struct wlr_drm_format *format) {
+	struct wlr_gbm_allocator *alloc = get_gbm_alloc_from_alloc(wlr_alloc);
+	struct wlr_gbm_buffer *buffer =
+		create_buffer(alloc->gbm_device, width, height, format);
+	if (buffer == NULL) {
+		return NULL;
+	}
+	return &buffer->base;
+}
+
+static const struct wlr_allocator_interface allocator_impl = {
+	.destroy = allocator_destroy,
+	.create_buffer = allocator_create_buffer,
+};

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -214,8 +214,12 @@ static void gles2_scissor(struct wlr_renderer *wlr_renderer,
 	push_gles2_debug(renderer);
 	if (box != NULL) {
 		struct wlr_box gl_box;
-		wlr_box_transform(&gl_box, box, WL_OUTPUT_TRANSFORM_FLIPPED_180,
-			renderer->viewport_width, renderer->viewport_height);
+		if (renderer->current_buffer != NULL) {
+			memcpy(&gl_box, box, sizeof(gl_box));
+		} else {
+			wlr_box_transform(&gl_box, box, WL_OUTPUT_TRANSFORM_FLIPPED_180,
+				renderer->viewport_width, renderer->viewport_height);
+		}
 
 		glScissor(gl_box.x, gl_box.y, gl_box.width, gl_box.height);
 		glEnable(GL_SCISSOR_TEST);
@@ -224,6 +228,12 @@ static void gles2_scissor(struct wlr_renderer *wlr_renderer,
 	}
 	pop_gles2_debug(renderer);
 }
+
+static const float flip_180[9] = {
+	1.0f, 0.0f, 0.0f,
+	0.0f, -1.0f, 0.0f,
+	0.0f, 0.0f, 1.0f,
+};
 
 static bool gles2_render_subtexture_with_matrix(
 		struct wlr_renderer *wlr_renderer, struct wlr_texture *wlr_texture,
@@ -257,10 +267,15 @@ static bool gles2_render_subtexture_with_matrix(
 		abort();
 	}
 
+	float gl_matrix[9];
+	if (renderer->current_buffer != NULL) {
+		wlr_matrix_multiply(gl_matrix, flip_180, matrix);
+	} else {
+		memcpy(gl_matrix, matrix, sizeof(gl_matrix));
+	}
 	// OpenGL ES 2 requires the glUniformMatrix3fv transpose parameter to be set
 	// to GL_FALSE
-	float transposition[9];
-	wlr_matrix_transpose(transposition, matrix);
+	wlr_matrix_transpose(gl_matrix, gl_matrix);
 
 	push_gles2_debug(renderer);
 
@@ -271,7 +286,7 @@ static bool gles2_render_subtexture_with_matrix(
 
 	glUseProgram(shader->program);
 
-	glUniformMatrix3fv(shader->proj, 1, GL_FALSE, transposition);
+	glUniformMatrix3fv(shader->proj, 1, GL_FALSE, gl_matrix);
 	glUniform1i(shader->invert_y, texture->inverted_y);
 	glUniform1i(shader->tex, 0);
 	glUniform1f(shader->alpha, alpha);
@@ -309,15 +324,20 @@ static void gles2_render_quad_with_matrix(struct wlr_renderer *wlr_renderer,
 	struct wlr_gles2_renderer *renderer =
 		gles2_get_renderer_in_context(wlr_renderer);
 
+	float gl_matrix[9];
+	if (renderer->current_buffer != NULL) {
+		wlr_matrix_multiply(gl_matrix, flip_180, matrix);
+	} else {
+		memcpy(gl_matrix, matrix, sizeof(gl_matrix));
+	}
 	// OpenGL ES 2 requires the glUniformMatrix3fv transpose parameter to be set
 	// to GL_FALSE
-	float transposition[9];
-	wlr_matrix_transpose(transposition, matrix);
+	wlr_matrix_transpose(gl_matrix, gl_matrix);
 
 	push_gles2_debug(renderer);
 	glUseProgram(renderer->shaders.quad.program);
 
-	glUniformMatrix3fv(renderer->shaders.quad.proj, 1, GL_FALSE, transposition);
+	glUniformMatrix3fv(renderer->shaders.quad.proj, 1, GL_FALSE, gl_matrix);
 	glUniform4f(renderer->shaders.quad.color, color[0], color[1], color[2], color[3]);
 
 	glVertexAttribPointer(renderer->shaders.quad.pos_attrib, 2, GL_FLOAT, GL_FALSE,
@@ -337,10 +357,15 @@ static void gles2_render_ellipse_with_matrix(struct wlr_renderer *wlr_renderer,
 	struct wlr_gles2_renderer *renderer =
 		gles2_get_renderer_in_context(wlr_renderer);
 
+	float gl_matrix[9];
+	if (renderer->current_buffer != NULL) {
+		wlr_matrix_multiply(gl_matrix, flip_180, matrix);
+	} else {
+		memcpy(gl_matrix, matrix, sizeof(gl_matrix));
+	}
 	// OpenGL ES 2 requires the glUniformMatrix3fv transpose parameter to be set
 	// to GL_FALSE
-	float transposition[9];
-	wlr_matrix_transpose(transposition, matrix);
+	wlr_matrix_transpose(gl_matrix, gl_matrix);
 
 	static const GLfloat texcoord[] = {
 		1, 0, // top right
@@ -352,7 +377,7 @@ static void gles2_render_ellipse_with_matrix(struct wlr_renderer *wlr_renderer,
 	push_gles2_debug(renderer);
 	glUseProgram(renderer->shaders.ellipse.program);
 
-	glUniformMatrix3fv(renderer->shaders.ellipse.proj, 1, GL_FALSE, transposition);
+	glUniformMatrix3fv(renderer->shaders.ellipse.proj, 1, GL_FALSE, gl_matrix);
 	glUniform4f(renderer->shaders.ellipse.color, color[0], color[1], color[2], color[3]);
 
 	glVertexAttribPointer(renderer->shaders.ellipse.pos_attrib, 2, GL_FLOAT,
@@ -472,16 +497,32 @@ static bool gles2_read_pixels(struct wlr_renderer *wlr_renderer,
 	if (pack_stride == stride && dst_x == 0 && flags != NULL) {
 		// Under these particular conditions, we can read the pixels with only
 		// one glReadPixels call
-		glReadPixels(src_x, renderer->viewport_height - height - src_y,
-			width, height, fmt->gl_format, fmt->gl_type, p);
-		*flags = WLR_RENDERER_READ_PIXELS_Y_INVERT;
+
+		uint32_t y = src_y;
+		if (renderer->current_buffer == NULL) {
+			y = renderer->viewport_height - height - src_y;
+		}
+
+		glReadPixels(src_x, y, width, height, fmt->gl_format, fmt->gl_type, p);
+
+		if (renderer->current_buffer != NULL) {
+			*flags = 0;
+		} else {
+			*flags = WLR_RENDERER_READ_PIXELS_Y_INVERT;
+		}
 	} else {
 		// Unfortunately GLES2 doesn't support GL_PACK_*, so we have to read
 		// the lines out row by row
 		for (size_t i = 0; i < height; ++i) {
-			glReadPixels(src_x, renderer->viewport_height - src_y - i - 1, width, 1, fmt->gl_format,
+			uint32_t y = src_y + i;
+			if (renderer->current_buffer == NULL) {
+				y = renderer->viewport_height - src_y - i - 1;
+			}
+
+			glReadPixels(src_x, y, width, 1, fmt->gl_format,
 				fmt->gl_type, p + i * stride + dst_x * fmt->bpp / 8);
 		}
+
 		if (flags != NULL) {
 			*flags = 0;
 		}
@@ -510,6 +551,7 @@ static bool gles2_blit_dmabuf(struct wlr_renderer *wlr_renderer,
 		goto restore_context_out;
 	}
 
+	// TODO: get inverted_y right when current_buffer != NULL
 	// This is to take into account y-inversion on both buffers rather than
 	// just the source buffer.
 	bool src_inverted_y =
@@ -517,9 +559,12 @@ static bool gles2_blit_dmabuf(struct wlr_renderer *wlr_renderer,
 	bool dst_inverted_y =
 		!!(dst_attr->flags & WLR_DMABUF_ATTRIBUTES_FLAGS_Y_INVERT);
 	struct wlr_gles2_texture *gles2_src_tex = gles2_get_texture(src_tex);
-	// The result is negated because wlr_matrix_projection y-inverts the
-	// texture.
-	gles2_src_tex->inverted_y = !(src_inverted_y ^ dst_inverted_y);
+	gles2_src_tex->inverted_y = src_inverted_y ^ dst_inverted_y;
+	if (renderer->current_buffer == NULL) {
+		// The result is negated because wlr_matrix_projection y-inverts the
+		// texture.
+		gles2_src_tex->inverted_y = !gles2_src_tex->inverted_y;
+	}
 
 	if (!wlr_egl_make_current(renderer->egl, EGL_NO_SURFACE, NULL)) {
 		goto texture_destroy_out;

--- a/render/meson.build
+++ b/render/meson.build
@@ -3,6 +3,7 @@ wlr_files += files(
 	'dmabuf.c',
 	'egl.c',
 	'drm_format_set.c',
+	'gbm_allocator.c',
 	'gles2/pixel_format.c',
 	'gles2/renderer.c',
 	'gles2/shaders.c',

--- a/render/meson.build
+++ b/render/meson.build
@@ -1,4 +1,5 @@
 wlr_files += files(
+	'allocator.c',
 	'dmabuf.c',
 	'egl.c',
 	'drm_format_set.c',

--- a/render/meson.build
+++ b/render/meson.build
@@ -8,6 +8,7 @@ wlr_files += files(
 	'gles2/renderer.c',
 	'gles2/shaders.c',
 	'gles2/texture.c',
+	'swapchain.c',
 	'wlr_renderer.c',
 	'wlr_texture.c',
 )

--- a/render/swapchain.c
+++ b/render/swapchain.c
@@ -1,0 +1,108 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <wlr/util/log.h>
+#include <wlr/types/wlr_buffer.h>
+#include "render/allocator.h"
+#include "render/drm_format_set.h"
+#include "render/swapchain.h"
+
+static void swapchain_handle_allocator_destroy(struct wl_listener *listener,
+		void *data) {
+	struct wlr_swapchain *swapchain =
+		wl_container_of(listener, swapchain, allocator_destroy);
+	swapchain->allocator = NULL;
+}
+
+struct wlr_swapchain *wlr_swapchain_create(
+		struct wlr_allocator *alloc, int width, int height,
+		const struct wlr_drm_format *format) {
+	struct wlr_swapchain *swapchain = calloc(1, sizeof(*swapchain));
+	if (swapchain == NULL) {
+		return NULL;
+	}
+	swapchain->allocator = alloc;
+	swapchain->width = width;
+	swapchain->height = height;
+
+	swapchain->format = wlr_drm_format_dup(format);
+	if (swapchain->format == NULL) {
+		free(swapchain);
+		return NULL;
+	}
+
+	swapchain->allocator_destroy.notify = swapchain_handle_allocator_destroy;
+	wl_signal_add(&alloc->events.destroy, &swapchain->allocator_destroy);
+
+	return swapchain;
+}
+
+static void slot_reset(struct wlr_swapchain_slot *slot) {
+	if (slot->acquired) {
+		wl_list_remove(&slot->release.link);
+	}
+	wlr_buffer_drop(slot->buffer);
+	memset(slot, 0, sizeof(*slot));
+}
+
+void wlr_swapchain_destroy(struct wlr_swapchain *swapchain) {
+	if (swapchain == NULL) {
+		return;
+	}
+	for (size_t i = 0; i < WLR_SWAPCHAIN_CAP; i++) {
+		slot_reset(&swapchain->slots[i]);
+	}
+	wl_list_remove(&swapchain->allocator_destroy.link);
+	free(swapchain->format);
+	free(swapchain);
+}
+
+static void slot_handle_release(struct wl_listener *listener, void *data) {
+	struct wlr_swapchain_slot *slot =
+		wl_container_of(listener, slot, release);
+	wl_list_remove(&slot->release.link);
+	slot->acquired = false;
+}
+
+static struct wlr_buffer *slot_acquire(struct wlr_swapchain_slot *slot) {
+	assert(!slot->acquired);
+	assert(slot->buffer != NULL);
+
+	slot->acquired = true;
+
+	slot->release.notify = slot_handle_release;
+	wl_signal_add(&slot->buffer->events.release, &slot->release);
+
+	return wlr_buffer_lock(slot->buffer);
+}
+
+struct wlr_buffer *wlr_swapchain_acquire(
+		struct wlr_swapchain *swapchain) {
+	struct wlr_swapchain_slot *free_slot = NULL;
+	for (size_t i = 0; i < WLR_SWAPCHAIN_CAP; i++) {
+		struct wlr_swapchain_slot *slot = &swapchain->slots[i];
+		if (slot->acquired) {
+			continue;
+		}
+		if (slot->buffer != NULL) {
+			return slot_acquire(slot);
+		}
+		free_slot = slot;
+	}
+	if (free_slot == NULL) {
+		wlr_log(WLR_ERROR, "No free output buffer slot");
+		return NULL;
+	}
+
+	if (swapchain->allocator == NULL) {
+		return NULL;
+	}
+
+	wlr_log(WLR_DEBUG, "Allocating new swapchain buffer");
+	free_slot->buffer = wlr_allocator_create_buffer(swapchain->allocator,
+		swapchain->width, swapchain->height, swapchain->format);
+	if (free_slot->buffer == NULL) {
+		wlr_log(WLR_ERROR, "Failed to allocate buffer");
+		return NULL;
+	}
+	return slot_acquire(free_slot);
+}

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -7,6 +7,7 @@
 #include <wlr/types/wlr_matrix.h>
 #include <wlr/util/log.h>
 #include "util/signal.h"
+#include "render/wlr_renderer.h"
 
 void wlr_renderer_init(struct wlr_renderer *renderer,
 		const struct wlr_renderer_impl *impl) {
@@ -35,6 +36,15 @@ void wlr_renderer_destroy(struct wlr_renderer *r) {
 	} else {
 		free(r);
 	}
+}
+
+bool wlr_renderer_bind_buffer(struct wlr_renderer *r,
+		struct wlr_buffer *buffer) {
+	assert(!r->rendering);
+	if (!r->impl->bind_buffer) {
+		return false;
+	}
+	return r->impl->bind_buffer(r, buffer);
 }
 
 void wlr_renderer_begin(struct wlr_renderer *r, uint32_t width, uint32_t height) {

--- a/types/wlr_buffer.c
+++ b/types/wlr_buffer.c
@@ -96,10 +96,18 @@ bool wlr_resource_get_buffer_size(struct wl_resource *resource,
 
 static const struct wlr_buffer_impl client_buffer_impl;
 
+struct wlr_client_buffer *wlr_client_buffer_get(struct wlr_buffer *buffer) {
+	if (buffer->impl != &client_buffer_impl) {
+		return NULL;
+	}
+	return (struct wlr_client_buffer *)buffer;
+}
+
 static struct wlr_client_buffer *client_buffer_from_buffer(
 		struct wlr_buffer *buffer) {
-	assert(buffer->impl == &client_buffer_impl);
-	return (struct wlr_client_buffer *) buffer;
+	struct wlr_client_buffer *client_buffer = wlr_client_buffer_get(buffer);
+	assert(client_buffer != NULL);
+	return client_buffer;
 }
 
 static void client_buffer_destroy(struct wlr_buffer *_buffer) {


### PR DESCRIPTION
This is an alternative to https://github.com/swaywm/wlroots/pull/1355. Instead of re-working the whole API, this PR just uses the new infrastructure inside the DRM backend.

The DRM backend used `EGLSurface` and `gbm_surface` until now. Stop using them and switch to `wlr_allocator` and `wlr_swapchain`. These new interfaces are mostly copied over from [glider](https://github.com/emersion/glider).

This PR doesn't break the wlroots API. For now the new APIs are not exposed in public header, once we add APIs that allow compositors to use it directly, we can easily move the headers to the public dir.

TODO:

- [x] Fix flip & 180 degree rotation
- [x] Damage tracking support (buffer age)
- [x] Multi-GPU
- [x] Debug `EGL_BAD_PARAMETER` failures when calling `eglDestroyImageKHR` on shutdown
- [x] Make sure screencopy + export-dmabuf work fine
- [x] Testing
  - [x] Investigate glClear issue in iris: https://github.com/swaywm/wlroots/pull/2240#issuecomment-673517061 ([upstream bug](https://gitlab.freedesktop.org/mesa/mesa/-/issues/3425), [fix](https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/7384), workaround: `INTEL_DEBUG=nofc` or `MESA_LOADER_DRIVER_OVERRIDE=i965`)
  - [x] Investigate crashes when switching resolution: https://github.com/swaywm/wlroots/pull/2240#issuecomment-674381722
  - [x] Fix inverted captured rect with screencopy

References: https://github.com/swaywm/wlroots/issues/1352

* * *

Breaking changes: some implicit assumptions about `wlr_renderer`'s EGL context no longer hold true. Compositors not using EGL directly shouldn't be affected.

- wlroots' framebuffer no longer is the EGL default framebuffer
- wlroots' framebuffer no longer has a depth attachment