### PR TITLE
backend/wayland: fix spurious eglSwapBuffers failures

### DIFF
--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -94,10 +94,8 @@ static const struct wp_presentation_feedback_listener
 static bool output_set_custom_mode(struct wlr_output *wlr_output,
 		int32_t width, int32_t height, int32_t refresh) {
 	struct wlr_wl_output *output = get_wl_output_from_output(wlr_output);
-	wlr_egl_swap_buffers(&output->backend->egl, output->egl_surface, NULL);
 	wl_egl_window_resize(output->egl_window, width, height, 0, 0);
 	wlr_output_update_custom_mode(&output->wlr_output, width, height, 0);
-
 	return true;
 }
 


### PR DESCRIPTION
This was introduced in [1]. However after reverting that PR I still
can't reproduce the bug the PR aimed to fix [2].

Since there's no good explanation why we would need to swap buffers
before resizing, let's just revert the PR.

[1]: https://github.com/swaywm/wlroots/pull/1486
[2]: https://github.com/swaywm/wlroots/issues/1371

Closes: https://github.com/swaywm/wlroots/issues/1768