### PR TITLE
backend/drm: fix black screens when enabling output

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -356,7 +356,11 @@ static bool drm_crtc_commit(struct wlr_drm_connector *conn, uint32_t flags) {
 static bool drm_crtc_page_flip(struct wlr_drm_connector *conn) {
 	struct wlr_drm_crtc *crtc = conn->crtc;
 
-	if (conn->pageflip_pending) {
+	// wlr_drm_interface.crtc_commit will perform either a non-blocking
+	// page-flip, either a blocking modeset. When performing a blocking modeset
+	// we'll wait for all queued page-flips to complete, so we don't need this
+	// safeguard.
+	if (conn->pageflip_pending && !crtc->pending_modeset) {
 		wlr_log(WLR_ERROR, "Failed to page-flip output '%s': "
 			"a page-flip is already pending", conn->output.name);
 		return false;


### PR DESCRIPTION
This patch fixes this failure:

    01:57:16.642 [ERROR] [backend/drm/drm.c:360] Failed to page-flip output 'eDP-1': a page-flip is already pending
    01:57:16.684 [ERROR] [backend/drm/drm.c:360] Failed to page-flip output 'eDP-1': a page-flip is already pending
    01:57:16.684 [ERROR] [backend/drm/drm.c:732] Failed to initialize renderer on connector 'eDP-1': initial page-flip failed
    01:57:16.684 [ERROR] [backend/drm/drm.c:805] Failed to initialize renderer for plane
    01:57:16.684 [sway/config/output.c:423] Failed to commit output eDP-1

References: https://github.com/swaywm/sway/issues/5101