### PR TITLE
Patches to address static analysis warnings

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -800,7 +800,7 @@ bool drm_connector_set_mode(struct wlr_drm_connector *conn,
 		return false;
 	}
 
-	wlr_log(WLR_INFO, "Modesetting '%s' with '%ux%u@%u mHz'",
+	wlr_log(WLR_INFO, "Modesetting '%s' with '%" PRId32 "x%" PRId32 "@%" PRId32 "mHz'",
 		conn->output.name, wlr_mode->width, wlr_mode->height,
 		wlr_mode->refresh);
 

--- a/backend/session/logind.c
+++ b/backend/session/logind.c
@@ -142,7 +142,7 @@ static bool logind_change_vt(struct wlr_session *base, unsigned vt) {
 		"/org/freedesktop/login1/seat/seat0", "org.freedesktop.login1.Seat", "SwitchTo",
 		&error, &msg, "u", (uint32_t)vt);
 	if (ret < 0) {
-		wlr_log(WLR_ERROR, "Failed to change to vt '%d'", vt);
+		wlr_log(WLR_ERROR, "Failed to change to vt '%u'", vt);
 	}
 
 	sd_bus_error_free(&error);

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -97,7 +97,7 @@ static void registry_global(void *data, struct wl_registry *registry,
 		uint32_t name, const char *iface, uint32_t version) {
 	struct wlr_wl_backend *wl = data;
 
-	wlr_log(WLR_DEBUG, "Remote wayland global: %s v%d", iface, version);
+	wlr_log(WLR_DEBUG, "Remote wayland global: %s v%" PRIu32, iface, version);
 
 	if (strcmp(iface, wl_compositor_interface.name) == 0) {
 		wl->compositor = wl_registry_bind(registry, name,

--- a/types/seat/wlr_seat_keyboard.c
+++ b/types/seat/wlr_seat_keyboard.c
@@ -267,7 +267,7 @@ void wlr_seat_keyboard_enter(struct wlr_seat *seat,
 		for (size_t i = 0; i < num_keycodes; ++i) {
 			uint32_t *p = wl_array_add(&keys, sizeof(uint32_t));
 			if (!p) {
-				wlr_log(WLR_ERROR, "Cannot allocate memory, skipping keycode: %d\n",
+				wlr_log(WLR_ERROR, "Cannot allocate memory, skipping keycode: %" PRIu32 "\n",
 					keycodes[i]);
 				continue;
 			}
@@ -449,7 +449,7 @@ void seat_client_create_keyboard(struct wlr_seat_client *seat_client,
 		for (size_t i = 0; i < num_keycodes; ++i) {
 			uint32_t *p = wl_array_add(&keys, sizeof(uint32_t));
 			if (!p) {
-				wlr_log(WLR_ERROR, "Cannot allocate memory, skipping keycode: %d\n",
+				wlr_log(WLR_ERROR, "Cannot allocate memory, skipping keycode: %" PRIu32 "\n",
 					keycodes[i]);
 				continue;
 			}

--- a/types/wlr_compositor.c
+++ b/types/wlr_compositor.c
@@ -39,7 +39,7 @@ static void subcompositor_handle_get_subsurface(struct wl_client *client,
 	if (surface == parent) {
 		wl_resource_post_error(resource,
 			WL_SUBCOMPOSITOR_ERROR_BAD_SURFACE,
-			"%s%d: wl_surface@%d cannot be its own parent",
+			"%s%" PRIu32 ": wl_surface@%" PRIu32 " cannot be its own parent",
 			msg, id, wl_resource_get_id(surface_resource));
 		return;
 	}
@@ -48,7 +48,7 @@ static void subcompositor_handle_get_subsurface(struct wl_client *client,
 			wlr_subsurface_from_wlr_surface(surface) != NULL) {
 		wl_resource_post_error(resource,
 			WL_SUBCOMPOSITOR_ERROR_BAD_SURFACE,
-			"%s%d: wl_surface@%d is already a sub-surface",
+			"%s%" PRIu32 ": wl_surface@%" PRIu32 " is already a sub-surface",
 			msg, id, wl_resource_get_id(surface_resource));
 		return;
 	}
@@ -56,7 +56,7 @@ static void subcompositor_handle_get_subsurface(struct wl_client *client,
 	if (wlr_surface_get_root_surface(parent) == surface) {
 		wl_resource_post_error(resource,
 			WL_SUBCOMPOSITOR_ERROR_BAD_SURFACE,
-			"%s%d: wl_surface@%d is an ancestor of parent",
+			"%s%" PRIu32 ": wl_surface@%" PRIu32 " is an ancestor of parent",
 			msg, id, wl_resource_get_id(surface_resource));
 		return;
 	}

--- a/types/wlr_layer_shell_v1.c
+++ b/types/wlr_layer_shell_v1.c
@@ -74,7 +74,7 @@ static void layer_surface_handle_ack_configure(struct wl_client *client,
 	if (!found) {
 		wl_resource_post_error(resource,
 			ZWLR_LAYER_SURFACE_V1_ERROR_INVALID_SURFACE_STATE,
-			"wrong configure serial: %u", serial);
+			"wrong configure serial: %" PRIu32, serial);
 		return;
 	}
 	// Then remove old configures from the list
@@ -114,7 +114,7 @@ static void layer_surface_handle_set_anchor(struct wl_client *client,
 	if (anchor > max_anchor) {
 		wl_resource_post_error(resource,
 			ZWLR_LAYER_SURFACE_V1_ERROR_INVALID_ANCHOR,
-			"invalid anchor %d", anchor);
+			"invalid anchor %" PRIu32, anchor);
 	}
 	struct wlr_layer_surface_v1 *surface = layer_surface_from_resource(resource);
 
@@ -187,7 +187,7 @@ static void layer_surface_set_layer(struct wl_client *client,
 	if (layer > ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY) {
 		wl_resource_post_error(surface->resource,
 				ZWLR_LAYER_SHELL_V1_ERROR_INVALID_LAYER,
-				"Invalid layer %d", layer);
+				"Invalid layer %" PRIu32, layer);
 		return;
 	}
 	surface->client_pending.layer = layer;
@@ -404,7 +404,7 @@ static void layer_shell_handle_get_layer_surface(struct wl_client *wl_client,
 		free(surface);
 		wl_resource_post_error(client_resource,
 				ZWLR_LAYER_SHELL_V1_ERROR_INVALID_LAYER,
-				"Invalid layer %d", layer);
+				"Invalid layer %" PRIu32, layer);
 		return;
 	}
 	surface->namespace = strdup(namespace);

--- a/types/wlr_linux_dmabuf_v1.c
+++ b/types/wlr_linux_dmabuf_v1.c
@@ -210,7 +210,7 @@ static void params_create_common(struct wl_client *client,
 		if (buffer->attributes.offset[i] > size) {
 			wl_resource_post_error(params_resource,
 				ZWP_LINUX_BUFFER_PARAMS_V1_ERROR_OUT_OF_BOUNDS,
-				"invalid offset %i for plane %d",
+				"invalid offset %" PRIu32 " for plane %d",
 				buffer->attributes.offset[i], i);
 			goto err_out;
 		}
@@ -219,7 +219,7 @@ static void params_create_common(struct wl_client *client,
 				buffer->attributes.stride[i] == 0) {
 			wl_resource_post_error(params_resource,
 				ZWP_LINUX_BUFFER_PARAMS_V1_ERROR_OUT_OF_BOUNDS,
-				"invalid stride %i for plane %d",
+				"invalid stride %" PRIu32 " for plane %d",
 				buffer->attributes.stride[i], i);
 			goto err_out;
 		}

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -712,7 +712,7 @@ bool wlr_surface_set_role(struct wlr_surface *surface,
 	if (surface->role != NULL && surface->role != role) {
 		if (error_resource != NULL) {
 			wl_resource_post_error(error_resource, error_code,
-				"Cannot assign role %s to wl_surface@%d, already has role %s\n",
+				"Cannot assign role %s to wl_surface@%" PRIu32 ", already has role %s\n",
 				role->name, wl_resource_get_id(surface->resource),
 				surface->role->name);
 		}
@@ -720,7 +720,7 @@ bool wlr_surface_set_role(struct wlr_surface *surface,
 	}
 	if (surface->role_data != NULL && surface->role_data != role_data) {
 		wl_resource_post_error(error_resource, error_code,
-			"Cannot reassign role %s to wl_surface@%d,"
+			"Cannot reassign role %s to wl_surface@%" PRIu32 ","
 			"role object still exists", role->name,
 			wl_resource_get_id(surface->resource));
 		return false;
@@ -791,7 +791,7 @@ static void subsurface_handle_place_above(struct wl_client *client,
 	if (!sibling) {
 		wl_resource_post_error(subsurface->resource,
 			WL_SUBSURFACE_ERROR_BAD_SURFACE,
-			"%s: wl_surface@%d is not a parent or sibling",
+			"%s: wl_surface@%" PRIu32 "is not a parent or sibling",
 			"place_above", wl_resource_get_id(sibling_surface->resource));
 		return;
 	}
@@ -818,7 +818,7 @@ static void subsurface_handle_place_below(struct wl_client *client,
 	if (!sibling) {
 		wl_resource_post_error(subsurface->resource,
 			WL_SUBSURFACE_ERROR_BAD_SURFACE,
-			"%s: wl_surface@%d is not a parent or sibling",
+			"%s: wl_surface@%" PRIu32 " is not a parent or sibling",
 			"place_below", wl_resource_get_id(sibling_surface->resource));
 		return;
 	}

--- a/types/wlr_virtual_pointer_v1.c
+++ b/types/wlr_virtual_pointer_v1.c
@@ -94,7 +94,7 @@ static void virtual_pointer_axis(struct wl_client *client,
 	if (axis > WL_POINTER_AXIS_HORIZONTAL_SCROLL) {
 		wl_resource_post_error(resource,
 				ZWLR_VIRTUAL_POINTER_V1_ERROR_INVALID_AXIS,
-				"Invalid enumeration value %d", axis);
+				"Invalid enumeration value %" PRIu32, axis);
 		return;
 	}
 	struct wlr_virtual_pointer_v1 *pointer =
@@ -139,7 +139,7 @@ static void virtual_pointer_axis_source(struct wl_client *client,
 	if (source > WL_POINTER_AXIS_SOURCE_WHEEL_TILT) {
 		wl_resource_post_error(resource,
 				ZWLR_VIRTUAL_POINTER_V1_ERROR_INVALID_AXIS_SOURCE,
-				"Invalid enumeration value %d", source);
+				"Invalid enumeration value %" PRIu32, source);
 		return;
 	}
 	struct wlr_virtual_pointer_v1 *pointer =
@@ -157,7 +157,7 @@ static void virtual_pointer_axis_stop(struct wl_client *client,
 	if (axis > WL_POINTER_AXIS_HORIZONTAL_SCROLL) {
 		wl_resource_post_error(resource,
 				ZWLR_VIRTUAL_POINTER_V1_ERROR_INVALID_AXIS,
-				"Invalid enumeration value %d", axis);
+				"Invalid enumeration value %" PRIu32, axis);
 		return;
 	}
 	struct wlr_virtual_pointer_v1 *pointer =
@@ -181,7 +181,7 @@ static void virtual_pointer_axis_discrete(struct wl_client *client,
 	if (axis > WL_POINTER_AXIS_HORIZONTAL_SCROLL) {
 		wl_resource_post_error(resource,
 				ZWLR_VIRTUAL_POINTER_V1_ERROR_INVALID_AXIS,
-				"Invalid enumeration value %d", axis);
+				"Invalid enumeration value %" PRIu32, axis);
 		return;
 	}
 	struct wlr_virtual_pointer_v1 *pointer =

--- a/xcursor/wlr_xcursor.c
+++ b/xcursor/wlr_xcursor.c
@@ -24,7 +24,7 @@
  */
 
 #define _POSIX_C_SOURCE 200809L
-#include <stdint.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -245,7 +245,7 @@ struct wlr_xcursor_theme *wlr_xcursor_theme_load(const char *name, int size) {
 	for (size_t i = 0; i < theme->cursor_count; ++i) {
 		struct wlr_xcursor *c = theme->cursors[i];
 		struct wlr_xcursor_image *i = c->images[0];
-		wlr_log(WLR_DEBUG, "%s (%u images) %dx%d+%d,%d",
+		wlr_log(WLR_DEBUG, "%s (%u images) %" PRIu32 "x%" PRIu32 "+%" PRIu32 ",%" PRIu32,
 				c->name, c->image_count,
 				i->width, i->height, i->hotspot_x, i->hotspot_y);
 	}

--- a/xwayland/selection/dnd.c
+++ b/xwayland/selection/dnd.c
@@ -192,7 +192,7 @@ int xwm_handle_selection_client_message(struct wlr_xwm *xwm,
 		drag->source->accepted = accepted;
 		wlr_data_source_dnd_action(drag->source, action);
 
-		wlr_log(WLR_DEBUG, "DND_STATUS window=%d accepted=%d action=%d",
+		wlr_log(WLR_DEBUG, "DND_STATUS window=%" PRIu32 " accepted=%d action=%d",
 			target_window, accepted, action);
 		return 1;
 	} else if (ev->type == xwm->atoms[DND_FINISHED]) {
@@ -226,7 +226,7 @@ int xwm_handle_selection_client_message(struct wlr_xwm *xwm,
 			wlr_data_source_dnd_finish(source);
 		}
 
-		wlr_log(WLR_DEBUG, "DND_FINISH window=%d performed=%d action=%d",
+		wlr_log(WLR_DEBUG, "DND_FINISH window=%" PRIu32 " performed=%d action=%d",
 			target_window, performed, action);
 		return 1;
 	} else {

--- a/xwayland/selection/outgoing.c
+++ b/xwayland/selection/outgoing.c
@@ -23,9 +23,9 @@ static void xwm_selection_send_notify(struct wlr_xwm *xwm,
 		.property = success ? req->property : XCB_ATOM_NONE,
 	};
 
-	wlr_log(WLR_DEBUG, "SendEvent destination=%d SelectionNotify(31) time=%d "
-		"requestor=%d selection=%d target=%d property=%d", req->requestor,
-		req->time, req->requestor, req->selection, req->target,
+	wlr_log(WLR_DEBUG, "SendEvent destination=%" PRIu32 " SelectionNotify(31) time=%" PRIu32
+		" requestor=%" PRIu32 " selection=%" PRIu32 " target=%" PRIu32 " property=%" PRIu32,
+		req->requestor, req->time, req->requestor, req->selection, req->target,
 		selection_notify.property);
 	xcb_send_event(xwm->xcb_conn,
 		0, // propagate

--- a/xwayland/xwayland.c
+++ b/xwayland/xwayland.c
@@ -89,7 +89,7 @@ struct wlr_xwayland *wlr_xwayland_create(struct wl_display *wl_display,
 	};
 	xwayland->server = wlr_xwayland_server_create(wl_display, &options);
 	if (xwayland->server == NULL) {
-		free(xwayland->server);
+		free(xwayland);
 		return NULL;
 	}
 

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -386,8 +386,9 @@ static void read_surface_class(struct wlr_xwm *xwm,
 		surface->class = NULL;
 	}
 
-	wlr_log(WLR_DEBUG, "XCB_ATOM_WM_CLASS: %s %s", surface->instance,
-		surface->class);
+	wlr_log(WLR_DEBUG, "XCB_ATOM_WM_CLASS: %s %s",
+		surface->instance ? surface->instance : "(null)",
+		surface->class ? surface->class : "(null)");
 	wlr_signal_emit_safe(&surface->events.set_class, surface);
 }
 
@@ -409,7 +410,8 @@ static void read_surface_role(struct wlr_xwm *xwm,
 		xsurface->role = NULL;
 	}
 
-	wlr_log(WLR_DEBUG, "XCB_ATOM_WM_WINDOW_ROLE: %s", xsurface->role);
+	wlr_log(WLR_DEBUG, "XCB_ATOM_WM_WINDOW_ROLE: %s",
+		xsurface->role ? xsurface->role : "(null)");
 	wlr_signal_emit_safe(&xsurface->events.set_role, xsurface);
 }
 
@@ -437,7 +439,7 @@ static void read_surface_title(struct wlr_xwm *xwm,
 	}
 	xsurface->has_utf8_title = is_utf8;
 
-	wlr_log(WLR_DEBUG, "XCB_ATOM_WM_NAME: %s", xsurface->title);
+	wlr_log(WLR_DEBUG, "XCB_ATOM_WM_NAME: %s", xsurface->title ? xsurface->title : "(null)");
 	wlr_signal_emit_safe(&xsurface->events.set_title, xsurface);
 }
 
@@ -551,7 +553,7 @@ static void read_surface_hints(struct wlr_xwm *xwm,
 		xsurface->hints->input = true;
 	}
 
-	wlr_log(WLR_DEBUG, "WM_HINTS (%d)", reply->value_len);
+	wlr_log(WLR_DEBUG, "WM_HINTS (%" PRIu32 ")", reply->value_len);
 	wlr_signal_emit_safe(&xsurface->events.set_hints, xsurface);
 }
 #else
@@ -603,7 +605,7 @@ static void read_surface_normal_hints(struct wlr_xwm *xwm,
 		xsurface->size_hints->max_height = -1;
 	}
 
-	wlr_log(WLR_DEBUG, "WM_NORMAL_HINTS (%d)", reply->value_len);
+	wlr_log(WLR_DEBUG, "WM_NORMAL_HINTS (%" PRIu32 ")", reply->value_len);
 }
 #else
 static void read_surface_normal_hints(struct wlr_xwm *xwm,
@@ -647,7 +649,7 @@ static void read_surface_motif_hints(struct wlr_xwm *xwm,
 		wlr_signal_emit_safe(&xsurface->events.set_decorations, xsurface);
 	}
 
-	wlr_log(WLR_DEBUG, "MOTIF_WM_HINTS (%d)", reply->value_len);
+	wlr_log(WLR_DEBUG, "MOTIF_WM_HINTS (%" PRIu32 ")", reply->value_len);
 }
 
 static void read_surface_net_wm_state(struct wlr_xwm *xwm,
@@ -718,8 +720,8 @@ static void read_surface_property(struct wlr_xwm *xwm,
 		read_surface_role(xwm, xsurface, reply);
 	} else {
 		char *prop_name = xwm_get_atom_name(xwm, property);
-		wlr_log(WLR_DEBUG, "unhandled X11 property %u (%s) for window %u",
-			property, prop_name, xsurface->window_id);
+		wlr_log(WLR_DEBUG, "unhandled X11 property %" PRIu32 " (%s) for window %" PRIu32,
+			property, prop_name ? prop_name : "(null)", xsurface->window_id);
 		free(prop_name);
 	}
 
@@ -1187,8 +1189,8 @@ static void xwm_handle_wm_protocols_message(struct wlr_xwm *xwm,
 		surface->pinging = false;
 	} else {
 		char *type_name = xwm_get_atom_name(xwm, type);
-		wlr_log(WLR_DEBUG, "unhandled WM_PROTOCOLS client message %u (%s)",
-			type, type_name);
+		wlr_log(WLR_DEBUG, "unhandled WM_PROTOCOLS client message %" PRIu32 " (%s)",
+			type, type_name ? type_name : "(null)");
 		free(type_name);
 	}
 }
@@ -1218,8 +1220,8 @@ static void xwm_handle_client_message(struct wlr_xwm *xwm,
 		xwm_handle_net_active_window_message(xwm, ev);
 	} else if (!xwm_handle_selection_client_message(xwm, ev)) {
 		char *type_name = xwm_get_atom_name(xwm, ev->type);
-		wlr_log(WLR_DEBUG, "unhandled x11 client message %u (%s)", ev->type,
-			type_name);
+		wlr_log(WLR_DEBUG, "unhandled x11 client message %" PRIu32 " (%s)", ev->type,
+			type_name ? type_name : "(null)");
 		free(type_name);
 	}
 }
@@ -1545,7 +1547,7 @@ static void xwm_get_resources(struct wlr_xwm *xwm) {
 	xfixes_reply =
 		xcb_xfixes_query_version_reply(xwm->xcb_conn, xfixes_cookie, NULL);
 
-	wlr_log(WLR_DEBUG, "xfixes version: %d.%d",
+	wlr_log(WLR_DEBUG, "xfixes version: %" PRIu32 ".%" PRIu32,
 		xfixes_reply->major_version, xfixes_reply->minor_version);
 
 	free(xfixes_reply);


### PR DESCRIPTION
Hi!
This is a collection of small patches fixing some warnings reported by PVS-Studio.
Happy to change things if I got the "bug fix" wrong.

I’m not so sure about my fix for 7d1d619 "types/wlr_output: fix pointer to stack variable escaping scope".
 