### PR TITLE
backend/drm: fix stack overflow in dealloc_crtc

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1052,7 +1052,12 @@ static void dealloc_crtc(struct wlr_drm_connector *conn) {
 	wlr_log(WLR_DEBUG, "De-allocating CRTC %zu for output '%s'",
 		conn->crtc - drm->crtcs, conn->output.name);
 
-	drm_connector_set_mode(conn, NULL);
+	conn->crtc->pending_modeset = true;
+	conn->crtc->pending.active = false;
+	if (!drm_crtc_commit(conn, 0)) {
+		return;
+	}
+
 	drm_plane_finish_surface(conn->crtc->primary);
 	drm_plane_finish_surface(conn->crtc->cursor);
 	if (conn->crtc->cursor != NULL) {


### PR DESCRIPTION
Call drm_crtc_commit directly instead of calling drm_connector_set_mode.
This restores the previous behaviour where conn_enable was called [1].

[1]: https://github.com/swaywm/wlroots/blob/0c7c562482575cacaecadcd7913ef25aeb21711f/backend/drm/drm.c#L1093

Closes: https://github.com/swaywm/wlroots/issues/2253