### PR TITLE
[WIP] Headless export-dmabuf

### DIFF
--- a/include/backend/headless.h
+++ b/include/backend/headless.h
@@ -20,6 +20,14 @@ struct wlr_headless_backend {
 	struct wl_listener renderer_destroy;
 	bool started;
 	GLenum internal_format;
+	int gbm_fd;
+	struct gbm_device *gbm;
+};
+
+struct wlr_headless_bo {
+	struct gbm_bo *bo;
+	GLuint fbo, rbo;
+	EGLImageKHR image;
 };
 
 struct wlr_headless_output {
@@ -28,7 +36,8 @@ struct wlr_headless_output {
 	struct wlr_headless_backend *backend;
 	struct wl_list link;
 
-	GLuint fbo, rbo;
+	struct wlr_headless_bo bo[2];
+	struct wlr_headless_bo *front, *back;
 
 	struct wl_event_source *frame_timer;
 	int frame_delay; // ms

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -18,6 +18,8 @@
 
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
+#include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
 #include <stdbool.h>
 #include <wayland-server-protocol.h>
 #include <wlr/render/wlr_renderer.h>
@@ -67,6 +69,7 @@ struct wlr_renderer_impl {
 	bool (*blit_dmabuf)(struct wlr_renderer *renderer,
 		struct wlr_dmabuf_attributes *dst,
 		struct wlr_dmabuf_attributes *src);
+	GLuint (*renderbuffer_from_image)(EGLImageKHR image);
 };
 
 void wlr_renderer_init(struct wlr_renderer *renderer,

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -10,6 +10,8 @@
 #define WLR_RENDER_WLR_RENDERER_H
 
 #include <stdint.h>
+#include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
 #include <wayland-server-protocol.h>
 #include <wlr/render/egl.h>
 #include <wlr/render/wlr_texture.h>
@@ -129,6 +131,9 @@ bool wlr_renderer_format_supported(struct wlr_renderer *r,
  */
 bool wlr_renderer_init_wl_display(struct wlr_renderer *r,
 	struct wl_display *wl_display);
+
+GLuint wlr_renderer_renderbuffer_from_image(struct wlr_renderer *r,
+	EGLImageKHR image);
 
 /**
  * Destroys this wlr_renderer. Textures must be destroyed separately.

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -360,6 +360,19 @@ static bool gles2_read_pixels(struct wlr_renderer *wlr_renderer,
 	return glGetError() == GL_NO_ERROR;
 }
 
+static GLuint gles2_renderbuffer_from_image(EGLImageKHR image) {
+	if (!gles2_procs.glEGLImageTargetRenderbufferStorageOES) {
+		return 0;
+	}
+
+	GLuint rbo = 0;
+	glGenRenderbuffers(1, &rbo);
+	glBindRenderbuffer(GL_RENDERBUFFER, rbo);
+	gles2_procs.glEGLImageTargetRenderbufferStorageOES(GL_RENDERBUFFER, image);
+	glBindRenderbuffer(GL_RENDERBUFFER, 0);
+	return rbo;
+}
+
 static bool gles2_blit_dmabuf(struct wlr_renderer *wlr_renderer,
 		struct wlr_dmabuf_attributes *dst_attr,
 		struct wlr_dmabuf_attributes *src_attr) {
@@ -538,6 +551,7 @@ static const struct wlr_renderer_impl renderer_impl = {
 	.texture_from_dmabuf = gles2_texture_from_dmabuf,
 	.init_wl_display = gles2_init_wl_display,
 	.blit_dmabuf = gles2_blit_dmabuf,
+	.renderbuffer_from_image = gles2_renderbuffer_from_image,
 };
 
 void push_gles2_marker(const char *file, const char *func) {

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -179,6 +179,14 @@ bool wlr_renderer_blit_dmabuf(struct wlr_renderer *r,
 	return r->impl->blit_dmabuf(r, dst, src);
 }
 
+GLuint wlr_renderer_renderbuffer_from_image(struct wlr_renderer *r,
+		EGLImageKHR image) {
+	if (!r->impl->renderbuffer_from_image) {
+		return false;
+	}
+	return r->impl->renderbuffer_from_image(image);
+}
+
 bool wlr_renderer_format_supported(struct wlr_renderer *r,
 		enum wl_shm_format fmt) {
 	return r->impl->format_supported(r, fmt);


### PR DESCRIPTION
This is very much work in progress, but it does work quite well.

Things I'd like some feedback on:
 * GBM buffer allocation. Would it be better to get the render node from DRM if the renderer belongs to DRM?
 * The way I added `glEGLImageTargetRenderbufferStorageOES` into the backend is rather ugly. Suggestions?
 