### PR TITLE
Improve DMA-BUF lifetime docs

### DIFF
--- a/include/wlr/types/wlr_buffer.h
+++ b/include/wlr/types/wlr_buffer.h
@@ -69,6 +69,10 @@ void wlr_buffer_unlock(struct wlr_buffer *buffer);
 /**
  * Reads the DMA-BUF attributes of the buffer. If this buffer isn't a DMA-BUF,
  * returns false.
+ *
+ * The returned DMA-BUF attributes are valid for the lifetime of the
+ * wlr_buffer. The caller isn't responsible for cleaning up the DMA-BUF
+ * attributes.
  */
 bool wlr_buffer_get_dmabuf(struct wlr_buffer *buffer,
 	struct wlr_dmabuf_attributes *attribs);

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -385,6 +385,12 @@ size_t wlr_output_get_gamma_size(struct wlr_output *output);
  */
 void wlr_output_set_gamma(struct wlr_output *output, size_t size,
 	const uint16_t *r, const uint16_t *g, const uint16_t *b);
+/**
+ * Exports the output's current back-buffer as a DMA-BUF (ie. the buffer that
+ * will be displayed on next commit).
+ *
+ * The caller is responsible for cleaning up the DMA-BUF attributes.
+ */
 bool wlr_output_export_dmabuf(struct wlr_output *output,
 	struct wlr_dmabuf_attributes *attribs);
 /**


### PR DESCRIPTION
`wlr_buffer_get_dmabuf`'s behaviour avoids exporting the buffer as a DMA-BUF over and over each time we want to import it (e.g. to KMS or EGL).

cc @any1