### PR TITLE
examples/screencopy-dmabuf: call strncpy with maxlen - 1

### DIFF
--- a/examples/screencopy-dmabuf.c
+++ b/examples/screencopy-dmabuf.c
@@ -87,7 +87,7 @@ static bool find_render_node(char *node, size_t maxlen) {
 			continue;
 		}
 
-		strncpy(node, dev->nodes[DRM_NODE_RENDER], maxlen);
+		strncpy(node, dev->nodes[DRM_NODE_RENDER], maxlen - 1);
 		node[maxlen - 1] = '\0';
 		r = true;
 		break;


### PR DESCRIPTION
The original code wasn't wrong since we were manually writing a null
byte anyway, but this makes GCC happy.

Closes: https://github.com/swaywm/wlroots/issues/2273