### PR TITLE
examples/fullscreen-shell: stop advertising linux-dmabuf unconditonally

### DIFF
--- a/examples/fullscreen-shell.c
+++ b/examples/fullscreen-shell.c
@@ -10,7 +10,6 @@
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_fullscreen_shell_v1.h>
-#include <wlr/types/wlr_linux_dmabuf_v1.h>
 #include <wlr/types/wlr_matrix.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_output.h>
@@ -209,7 +208,6 @@ int main(int argc, char *argv[]) {
 	wlr_renderer_init_wl_display(server.renderer, server.wl_display);
 
 	wlr_compositor_create(server.wl_display, server.renderer);
-	wlr_linux_dmabuf_v1_create(server.wl_display, server.renderer);
 
 	server.output_layout = wlr_output_layout_create();
 


### PR DESCRIPTION
Remove the wlr_linux_dmabuf_v1_create call. wlr_renderer_init_wl_display
will take care of creating the linux-dmabuf global if the OpenGL
implementation supports it.