### PR TITLE
render/gbm_allocator: add support for gbm_bo_get_fd_for_plane

### DIFF
--- a/render/gbm_allocator.c
+++ b/render/gbm_allocator.c
@@ -35,12 +35,14 @@ static bool export_gbm_bo(struct gbm_bo *bo,
 	int i;
 	int32_t handle = -1;
 	for (i = 0; i < attribs.n_planes; ++i) {
+#if HAS_GBM_BO_GET_FD_FOR_PLANE
+		attribs.fd[i] = gbm_bo_get_fd_for_plane(bo, i);
+		(void)handle;
+#else
 		// GBM is lacking a function to get a FD for a given plane. Instead,
 		// check all planes have the same handle. We can't use
 		// drmPrimeHandleToFD because that messes up handle ref'counting in
 		// the user-space driver.
-		// TODO: use gbm_bo_get_plane_fd when it lands, see
-		// https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/5442
 		union gbm_bo_handle plane_handle = gbm_bo_get_handle_for_plane(bo, i);
 		if (plane_handle.s32 < 0) {
 			wlr_log(WLR_ERROR, "gbm_bo_get_handle_for_plane failed");
@@ -55,6 +57,8 @@ static bool export_gbm_bo(struct gbm_bo *bo,
 		}
 
 		attribs.fd[i] = gbm_bo_get_fd(bo);
+#endif
+
 		if (attribs.fd[i] < 0) {
 			wlr_log(WLR_ERROR, "gbm_bo_get_fd failed");
 			goto error_fd;

--- a/render/meson.build
+++ b/render/meson.build
@@ -18,6 +18,9 @@ wlr_files += files(
 	'drm_dumb_allocator.c',
 )
 
+has = cc.has_function('gbm_bo_get_fd_for_plane', dependencies: [gbm])
+add_project_arguments('-DHAS_GBM_BO_GET_FD_FOR_PLANE=@0@'.format(has.to_int()), language: 'c')
+
 egl = dependency('egl', required: 'gles2' in renderers)
 if egl.found()
 	wlr_deps += egl


### PR DESCRIPTION
This ensures we get the right FD for multi-planar buffers.

Depends on [1].

[1]: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/5442