### PR TITLE
wlr_seat: restore NULL behavior for notify_enter

### DIFF
--- a/types/seat/wlr_seat_keyboard.c
+++ b/types/seat/wlr_seat_keyboard.c
@@ -316,10 +316,13 @@ void wlr_seat_keyboard_enter(struct wlr_seat *seat,
 void wlr_seat_keyboard_notify_enter(struct wlr_seat *seat,
 		struct wlr_surface *surface, uint32_t keycodes[], size_t num_keycodes,
 		struct wlr_keyboard_modifiers *modifiers) {
-	// NULL surfaces are prohibited in the grab-compatible API. Use
-	// wlr_seat_keyboard_notify_clear_focus() instead.
-	assert(surface);
 	struct wlr_seat_keyboard_grab *grab = seat->keyboard_state.grab;
+	if (!surface) {
+		// NULL surfaces are prohibited in the grab-compatible API.
+		// Clear focus instead.
+		grab->interface->clear_focus(grab);
+		return;
+	}
 	grab->interface->enter(grab, surface, keycodes, num_keycodes, modifiers);
 }
 

--- a/types/seat/wlr_seat_pointer.c
+++ b/types/seat/wlr_seat_pointer.c
@@ -336,10 +336,13 @@ void wlr_seat_pointer_end_grab(struct wlr_seat *wlr_seat) {
 
 void wlr_seat_pointer_notify_enter(struct wlr_seat *wlr_seat,
 		struct wlr_surface *surface, double sx, double sy) {
-	// NULL surfaces are prohibited in the grab-compatible API. Use
-	// wlr_seat_pointer_notify_clear_focus() instead.
-	assert(surface);
 	struct wlr_seat_pointer_grab *grab = wlr_seat->pointer_state.grab;
+	if (!surface) {
+		// NULL surfaces are prohibited in the grab-compatible API.
+		// Clear focus instead.
+		grab->interface->clear_focus(grab);
+		return;
+	}
 	grab->interface->enter(grab, surface, sx, sy);
 }
 


### PR DESCRIPTION
Unifies the behavior of `wlr_seat_*_notify_enter` with that of `wlr_seat_*_enter` when NULL is passed for the surface parameter.  Provides a non-breaking alternative for the fix in #2217 by using the grab interface.