### PR TITLE
render: assert sane values for box functions

### DIFF
--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -86,6 +86,7 @@ bool wlr_render_texture_with_matrix(struct wlr_renderer *r,
 
 void wlr_render_rect(struct wlr_renderer *r, const struct wlr_box *box,
 		const float color[static 4], const float projection[static 9]) {
+	assert(box->width > 0 && box->height > 0);
 	float matrix[9];
 	wlr_matrix_project_box(matrix, box, WL_OUTPUT_TRANSFORM_NORMAL, 0,
 		projection);
@@ -101,6 +102,7 @@ void wlr_render_quad_with_matrix(struct wlr_renderer *r,
 
 void wlr_render_ellipse(struct wlr_renderer *r, const struct wlr_box *box,
 		const float color[static 4], const float projection[static 9]) {
+	assert(box->width > 0 && box->height > 0);
 	float matrix[9];
 	wlr_matrix_project_box(matrix, box, WL_OUTPUT_TRANSFORM_NORMAL, 0,
 		projection);


### PR DESCRIPTION
Width and height should always be > 0 for render functions which take a
wlr_box.

References https://github.com/swaywm/wlroots/issues/2281