### PR TITLE
input/keyboard: send modifiers on first keyboard enter

### DIFF
--- a/types/seat/wlr_seat_keyboard.c
+++ b/types/seat/wlr_seat_keyboard.c
@@ -469,6 +469,9 @@ void seat_client_create_keyboard(struct wlr_seat_client *seat_client,
 		}
 
 		wl_array_release(&keys);
+
+		wlr_seat_keyboard_send_modifiers(seat_client->seat,
+			&keyboard->modifiers);
 	}
 }
 


### PR DESCRIPTION
Will fix Firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=1643991.

Fixes swaywm/sway#5462.