### PR TITLE
surface: don't unset width and height in finalize

### DIFF
--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -174,16 +174,16 @@ static void surface_state_finalize(struct wlr_surface *surface,
 		}
 	}
 
-	if (state->buffer_resource != NULL) {
-		if (state->viewport.has_dst) {
+	if (state->viewport.has_dst) {
+		if (state->buffer_width == 0 && state->buffer_height == 0) {
+			state->width = state->height = 0;
+		} else {
 			state->width = state->viewport.dst_width;
 			state->height = state->viewport.dst_height;
-		} else {
-			surface_state_viewport_src_size(state,
-				&state->width, &state->height);
 		}
 	} else {
-		state->width = state->height = 0;
+		surface_state_viewport_src_size(state,
+			&state->width, &state->height);
 	}
 
 	pixman_region32_intersect_rect(&state->surface_damage,


### PR DESCRIPTION
During surface finalization we may not have received a new buffer,
resetting width and height in this case is wrong since we display the
old buffer in this case.