### PR TITLE
surface: ignore viewport src rect on NULL buffer

### DIFF
--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -147,6 +147,11 @@ static void surface_set_input_region(struct wl_client *client,
  */
 static void surface_state_viewport_src_size(struct wlr_surface_state *state,
 		int *out_width, int *out_height) {
+	if (state->buffer_width == 0 && state->buffer_height == 0) {
+		*out_width = *out_height = 0;
+		return;
+	}
+
 	if (state->viewport.has_src) {
 		*out_width = state->viewport.src.width;
 		*out_height = state->viewport.src.height;


### PR DESCRIPTION
According to the viewporter protocol:

> If the wl_buffer is NULL, the surface has no content and therefore no size.