### PR TITLE
render/egl: print error name

### DIFF
--- a/render/egl.c
+++ b/render/egl.c
@@ -51,11 +51,47 @@ static enum wlr_log_importance egl_log_importance_to_wlr(EGLint type) {
 	}
 }
 
+static const char *egl_error_str(EGLint error) {
+	switch (error) {
+	case EGL_SUCCESS:
+		return "EGL_SUCCESS";
+	case EGL_NOT_INITIALIZED:
+		return "EGL_NOT_INITIALIZED";
+	case EGL_BAD_ACCESS:
+		return "EGL_BAD_ACCESS";
+	case EGL_BAD_ALLOC:
+		return "EGL_BAD_ALLOC";
+	case EGL_BAD_ATTRIBUTE:
+		return "EGL_BAD_ATTRIBUTE";
+	case EGL_BAD_CONTEXT:
+		return "EGL_BAD_CONTEXT";
+	case EGL_BAD_CONFIG:
+		return "EGL_BAD_CONFIG";
+	case EGL_BAD_CURRENT_SURFACE:
+		return "EGL_BAD_CURRENT_SURFACE";
+	case EGL_BAD_DISPLAY:
+		return "EGL_BAD_DISPLAY";
+	case EGL_BAD_SURFACE:
+		return "EGL_BAD_SURFACE";
+	case EGL_BAD_MATCH:
+		return "EGL_BAD_MATCH";
+	case EGL_BAD_PARAMETER:
+		return "EGL_BAD_PARAMETER";
+	case EGL_BAD_NATIVE_PIXMAP:
+		return "EGL_BAD_NATIVE_PIXMAP";
+	case EGL_BAD_NATIVE_WINDOW:
+		return "EGL_BAD_NATIVE_WINDOW";
+	case EGL_CONTEXT_LOST:
+		return "EGL_CONTEXT_LOST";
+	}
+	return "unknown error";
+}
+
 static void egl_log(EGLenum error, const char *command, EGLint msg_type,
 		EGLLabelKHR thread, EGLLabelKHR obj, const char *msg) {
 	_wlr_log(egl_log_importance_to_wlr(msg_type),
-		"[EGL] command: %s, error: 0x%x, message: \"%s\"",
-		command, error, msg);
+		"[EGL] command: %s, error: %s (0x%x), message: \"%s\"",
+		command, egl_error_str(error), error, msg);
 }
 
 static bool check_egl_ext(const char *exts, const char *ext) {


### PR DESCRIPTION
Allows for easier debugging.