### PR TITLE
output: fix dangling renderer context after wlr_output_preferred_read_format

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -586,7 +586,7 @@ static bool drm_connector_commit(struct wlr_output *output) {
 	return true;
 }
 
-static void drm_connector_rollback(struct wlr_output *output) {
+static void drm_connector_rollback_render(struct wlr_output *output) {
 	struct wlr_drm_backend *drm = get_drm_backend_from_backend(output->backend);
 	wlr_egl_unset_current(&drm->renderer.egl);
 }
@@ -1024,7 +1024,7 @@ static const struct wlr_output_impl output_impl = {
 	.attach_render = drm_connector_attach_render,
 	.test = drm_connector_test,
 	.commit = drm_connector_commit,
-	.rollback = drm_connector_rollback,
+	.rollback_render = drm_connector_rollback_render,
 	.get_gamma_size = drm_connector_get_gamma_size,
 	.export_dmabuf = drm_connector_export_dmabuf,
 };

--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -140,13 +140,12 @@ static bool output_commit(struct wlr_output *wlr_output) {
 	return true;
 }
 
-static void output_rollback(struct wlr_output *wlr_output) {
+static void output_rollback_render(struct wlr_output *wlr_output) {
 	struct wlr_headless_output *output =
 		headless_output_from_output(wlr_output);
-	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
-		glBindFramebuffer(GL_FRAMEBUFFER, 0);
-		wlr_egl_unset_current(output->backend->egl);
-	}
+	assert(wlr_egl_is_current(output->backend->egl));
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	wlr_egl_unset_current(output->backend->egl);
 }
 
 static void output_destroy(struct wlr_output *wlr_output) {
@@ -162,7 +161,7 @@ static const struct wlr_output_impl output_impl = {
 	.destroy = output_destroy,
 	.attach_render = output_attach_render,
 	.commit = output_commit,
-	.rollback = output_rollback,
+	.rollback_render = output_rollback_render,
 };
 
 bool wlr_output_is_headless(struct wlr_output *wlr_output) {

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -301,7 +301,7 @@ static bool output_commit(struct wlr_output *wlr_output) {
 	return true;
 }
 
-static void output_rollback(struct wlr_output *wlr_output) {
+static void output_rollback_render(struct wlr_output *wlr_output) {
 	struct wlr_wl_output *output =
 		get_wl_output_from_output(wlr_output);
 	wlr_egl_unset_current(&output->backend->egl);
@@ -436,7 +436,7 @@ static const struct wlr_output_impl output_impl = {
 	.attach_render = output_attach_render,
 	.test = output_test,
 	.commit = output_commit,
-	.rollback = output_rollback,
+	.rollback_render = output_rollback_render,
 	.set_cursor = output_set_cursor,
 	.move_cursor = output_move_cursor,
 };

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -160,7 +160,7 @@ static bool output_commit(struct wlr_output *wlr_output) {
 	return true;
 }
 
-static void output_rollback(struct wlr_output *wlr_output) {
+static void output_rollback_render(struct wlr_output *wlr_output) {
 	struct wlr_x11_output *output = get_x11_output_from_output(wlr_output);
 	wlr_egl_unset_current(&output->x11->egl);
 }
@@ -170,7 +170,7 @@ static const struct wlr_output_impl output_impl = {
 	.attach_render = output_attach_render,
 	.test = output_test,
 	.commit = output_commit,
-	.rollback = output_rollback,
+	.rollback_render = output_rollback_render,
 };
 
 struct wlr_output *wlr_x11_output_create(struct wlr_backend *backend) {

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -23,7 +23,7 @@ struct wlr_output_impl {
 	bool (*attach_render)(struct wlr_output *output, int *buffer_age);
 	bool (*test)(struct wlr_output *output);
 	bool (*commit)(struct wlr_output *output);
-	void (*rollback)(struct wlr_output *output);
+	void (*rollback_render)(struct wlr_output *output);
 	size_t (*get_gamma_size)(struct wlr_output *output);
 	bool (*export_dmabuf)(struct wlr_output *output,
 		struct wlr_dmabuf_attributes *attribs);

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -314,7 +314,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 
 void wlr_output_init(struct wlr_output *output, struct wlr_backend *backend,
 		const struct wlr_output_impl *impl, struct wl_display *display) {
-	assert(impl->attach_render && impl->commit);
+	assert(impl->attach_render && impl->rollback_render && impl->commit);
 	if (impl->set_cursor || impl->move_cursor) {
 		assert(impl->set_cursor && impl->move_cursor);
 	}

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -448,15 +448,16 @@ bool wlr_output_attach_render(struct wlr_output *output, int *buffer_age) {
 
 bool wlr_output_preferred_read_format(struct wlr_output *output,
 		enum wl_shm_format *fmt) {
-	if (!output->impl->attach_render(output, NULL)) {
-		return false;
-	}
-
 	struct wlr_renderer *renderer = wlr_backend_get_renderer(output->backend);
 	if (!renderer->impl->preferred_read_format || !renderer->impl->read_pixels) {
 		return false;
 	}
+
+	if (!output->impl->attach_render(output, NULL)) {
+		return false;
+	}
 	*fmt = renderer->impl->preferred_read_format(renderer);
+	output->impl->rollback_render(output);
 	return true;
 }
 

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -638,11 +638,13 @@ bool wlr_output_commit(struct wlr_output *output) {
 }
 
 void wlr_output_rollback(struct wlr_output *output) {
-	output_state_clear(&output->pending);
-
-	if (output->impl->rollback) {
-		output->impl->rollback(output);
+	if (output->impl->rollback_render &&
+			(output->pending.committed & WLR_OUTPUT_STATE_BUFFER) &&
+			output->pending.buffer_type == WLR_OUTPUT_STATE_BUFFER_RENDER) {
+		output->impl->rollback_render(output);
 	}
+
+	output_state_clear(&output->pending);
 }
 
 void wlr_output_attach_buffer(struct wlr_output *output,


### PR DESCRIPTION
## output: rename impl->rollback to rollback_render

The output backend API is now mostly state-less thanks to the atomic
hooks (commit and test). There is one exception though: attach_render.
This function makes the rendering context current. However sometimes the
compositor might decide not to render after attach_render (e.g. when
there's nothing new to render to the back buffer). Thus
wlr_output_rollback has been introduced to revert the pending state.

Because the output backend API is mostly state-less, the only thing
wlr_output_impl.rollback needs to do is revert the current rendering
context. Rename the function to rollback_render to make this clear. Add
a check in the common wlr_output code to only call rollback_render when
attach_buffer has been previously called.

On the long term, we'll be able to remove attach_render and
rollback_render together.

## output: make rollback_render mandatory

If the output backend provides attach_render, assert it also provides a
way to revert it via rollback_render.

## output: fix dangling renderer context after wlr_output_preferred_read_format

attach_render was called without un-setting the current rendering
context afterwards.

Closes: #2164

* * * 

Breaking change for backends: `wlr_output_impl.rollback` has been renamed to `rollback_render` and now needs to unconditionally unset the renderer context. It'll only be called if `attach_render` has previously been called.

cc @any1