### PR TITLE
tablet: add sentinel entry for tablet tool enum

### DIFF
--- a/include/wlr/types/wlr_tablet_tool.h
+++ b/include/wlr/types/wlr_tablet_tool.h
@@ -35,7 +35,8 @@ enum wlr_tablet_tool_type {
 	WLR_TABLET_TOOL_TYPE_LENS,
 	/** A rotary device with positional and rotation data */
 	WLR_TABLET_TOOL_TYPE_TOTEM,
-
+	/** Sentinel enum entry */
+	WLR_TABLET_TOOL_TYPE_LAST,
 };
 
 struct wlr_tablet_tool {

--- a/types/tablet_v2/wlr_tablet_v2_tool.c
+++ b/types/tablet_v2/wlr_tablet_v2_tool.c
@@ -77,6 +77,8 @@ static enum zwp_tablet_tool_v2_type tablet_type_from_wlr_type(
 	case WLR_TABLET_TOOL_TYPE_TOTEM:
 		// missing, see:
 		// https://gitlab.freedesktop.org/wayland/wayland-protocols/-/issues/19
+	case WLR_TABLET_TOOL_TYPE_LAST:
+		// Sentinel, should not be called.
 		abort();
 	}
 	abort(); // unreachable


### PR DESCRIPTION
Required by https://github.com/swaywm/sway/pull/5472; could be worked around but this seems cleanest.

This might be a breaking change if a compositor had a switch based off this enum, and is compiling with `-Wall`.