### PR TITLE
Fix Xwayland restart

### DIFF
--- a/xwayland/server.c
+++ b/xwayland/server.c
@@ -232,8 +232,6 @@ static int xserver_handle_ready(int signal_number, void *data) {
 		.wm_fd = server->wm_fd[0],
 	};
 	wlr_signal_emit_safe(&server->events.ready, &event);
-	/* ready is a one-shot signal, fire and forget */
-	wl_signal_init(&server->events.ready);
 
 	return 1; /* wayland event loop dispatcher's count */
 

--- a/xwayland/xwayland.c
+++ b/xwayland/xwayland.c
@@ -55,8 +55,6 @@ static void handle_server_ready(struct wl_listener *listener, void *data) {
 	}
 
 	wlr_signal_emit_safe(&xwayland->events.ready, NULL);
-	/* ready is a one-shot signal, fire and forget */
-	wl_signal_init(&xwayland->events.ready);
 }
 
 void wlr_xwayland_destroy(struct wlr_xwayland *xwayland) {

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -1312,6 +1312,11 @@ static int x11_event_handler(int fd, uint32_t mask, void *data) {
 	xcb_generic_event_t *event;
 	struct wlr_xwm *xwm = data;
 
+	if ((mask & WL_EVENT_HANGUP) || (mask & WL_EVENT_ERROR)) {
+		xwm_destroy(xwm);
+		return 0;
+	}
+
 	while ((event = xcb_poll_for_event(xwm->xcb_conn))) {
 		count++;
 
@@ -1493,6 +1498,7 @@ void xwm_destroy(struct wlr_xwm *xwm) {
 	wl_list_remove(&xwm->compositor_destroy.link);
 	xcb_disconnect(xwm->xcb_conn);
 
+	xwm->xwayland->xwm = NULL;
 	free(xwm);
 }
 


### PR DESCRIPTION
This fixes two problems on Xwayland restart:

- The xwayland ready signal now fires on restart
- xwm is destroyed instead of leaked

The latter caused compositors to consume all cpu once Xwayland was restarted.

Closes: https://github.com/swaywm/wlroots/issues/2174