### PR TITLE
examples/pointer: fix wlr_renderer_end call order

### DIFF
--- a/examples/pointer.c
+++ b/examples/pointer.c
@@ -101,8 +101,8 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	wlr_renderer_begin(renderer, wlr_output->width, wlr_output->height);
 	wlr_renderer_clear(renderer, state->clear_color);
 	wlr_output_render_software_cursors(wlr_output, NULL);
-	wlr_output_commit(wlr_output);
 	wlr_renderer_end(renderer);
+	wlr_output_commit(wlr_output);
 }
 
 static void handle_cursor_motion(struct wl_listener *listener, void *data) {


### PR DESCRIPTION
Calling wlr_renderer_end after wlr_output_commit would make an
assertion fail.