### PR TITLE
Improve robustness of configure serial handling

### DIFF
--- a/types/wlr_xdg_decoration_v1.c
+++ b/types/wlr_xdg_decoration_v1.c
@@ -111,8 +111,9 @@ static void toplevel_decoration_handle_surface_ack_configure(
 		wl_container_of(listener, decoration, surface_ack_configure);
 	struct wlr_xdg_surface_configure *surface_configure = data;
 
+	// First find the ack'ed configure
 	bool found = false;
-	struct wlr_xdg_toplevel_decoration_v1_configure *configure;
+	struct wlr_xdg_toplevel_decoration_v1_configure *configure, *tmp;
 	wl_list_for_each(configure, &decoration->configure_list, link) {
 		if (configure->surface_configure == surface_configure) {
 			found = true;
@@ -121,6 +122,14 @@ static void toplevel_decoration_handle_surface_ack_configure(
 	}
 	if (!found) {
 		return;
+	}
+	// Then remove old configures from the list
+	wl_list_for_each_safe(configure, tmp, &decoration->configure_list, link) {
+		if (configure->surface_configure == surface_configure) {
+			break;
+		}
+		wl_list_remove(&configure->link);
+		free(configure);
 	}
 
 	decoration->current_mode = configure->mode;

--- a/types/xdg_shell/wlr_xdg_surface.c
+++ b/types/xdg_shell/wlr_xdg_surface.c
@@ -107,16 +107,12 @@ static void xdg_surface_handle_ack_configure(struct wl_client *client,
 		return;
 	}
 
+	// First find the ack'ed configure
 	bool found = false;
 	struct wlr_xdg_surface_configure *configure, *tmp;
-	wl_list_for_each_safe(configure, tmp, &surface->configure_list, link) {
-		if (configure->serial < serial) {
-			wlr_signal_emit_safe(&surface->events.ack_configure, configure);
-			xdg_surface_configure_destroy(configure);
-		} else if (configure->serial == serial) {
+	wl_list_for_each(configure, &surface->configure_list, link) {
+		if (configure->serial == serial) {
 			found = true;
-			break;
-		} else {
 			break;
 		}
 	}
@@ -125,6 +121,14 @@ static void xdg_surface_handle_ack_configure(struct wl_client *client,
 			XDG_WM_BASE_ERROR_INVALID_SURFACE_STATE,
 			"wrong configure serial: %u", serial);
 		return;
+	}
+	// Then remove old configures from the list
+	wl_list_for_each_safe(configure, tmp, &surface->configure_list, link) {
+		if (configure->serial == serial) {
+			break;
+		}
+		wlr_signal_emit_safe(&surface->events.ack_configure, configure);
+		xdg_surface_configure_destroy(configure);
 	}
 
 	switch (surface->role) {

--- a/types/xdg_shell_v6/wlr_xdg_surface_v6.c
+++ b/types/xdg_shell_v6/wlr_xdg_surface_v6.c
@@ -156,15 +156,12 @@ static void xdg_surface_handle_ack_configure(struct wl_client *client,
 		return;
 	}
 
+	// First find the ack'ed configure
 	bool found = false;
 	struct wlr_xdg_surface_v6_configure *configure, *tmp;
-	wl_list_for_each_safe(configure, tmp, &surface->configure_list, link) {
-		if (configure->serial < serial) {
-			xdg_surface_configure_destroy(configure);
-		} else if (configure->serial == serial) {
+	wl_list_for_each(configure, &surface->configure_list, link) {
+		if (configure->serial == serial) {
 			found = true;
-			break;
-		} else {
 			break;
 		}
 	}
@@ -173,6 +170,13 @@ static void xdg_surface_handle_ack_configure(struct wl_client *client,
 			ZXDG_SHELL_V6_ERROR_INVALID_SURFACE_STATE,
 			"wrong configure serial: %u", serial);
 		return;
+	}
+	// Then remove old configures from the list
+	wl_list_for_each_safe(configure, tmp, &surface->configure_list, link) {
+		if (configure->serial == serial) {
+			break;
+		}
+		xdg_surface_configure_destroy(configure);
 	}
 
 	switch (surface->role) {


### PR DESCRIPTION
- Wrapping overflow of the display serial is currently not accounted for in the handling of layer-shell and xdg-shell configure handling.
- Old xdg-decoration configure structs are not currently destroyed on acking a newer configure.