### PR TITLE
Implement logind session SetType method to change session type to wayland

### DIFF
--- a/backend/session/logind.c
+++ b/backend/session/logind.c
@@ -257,12 +257,16 @@ static bool set_type(struct logind_session *session) {
 	sd_bus_error_free(&error);
 	sd_bus_message_unref(msg);
 
+	if (ret < 0) {
+		return false;
+	}
+
 	ret = setenv("XDG_SESSION_TYPE", "wayland", 1);
 	if (ret < 0) {
 		wlr_log(WLR_ERROR, "Failed to set XDG_SESSION_TYPE for session");
+		return false;
 	}
-
-	return ret >= 0;
+	return true;
 }
 
 static void release_control(struct logind_session *session) {

--- a/backend/session/logind.c
+++ b/backend/session/logind.c
@@ -250,12 +250,18 @@ static bool set_type(struct logind_session *session) {
 		session->path, "org.freedesktop.login1.Session", "SetType",
 		&error, &msg, "s", "wayland");
 	if (ret < 0) {
-		wlr_log(WLR_ERROR, "Failed to set session type for session: %s",
+		wlr_log(WLR_ERROR, "Failed to set logind session type for session: %s",
 			error.message);
 	}
 
 	sd_bus_error_free(&error);
 	sd_bus_message_unref(msg);
+
+	ret = setenv("XDG_SESSION_TYPE", "wayland", 1);
+	if (ret < 0) {
+		wlr_log(WLR_ERROR, "Failed to set XDG_SESSION_TYPE for session");
+	}
+
 	return ret >= 0;
 }
 


### PR DESCRIPTION
Sets systemd-logind session type to `wayland` so that systemd recognises a graphical session is running. Needed for logind idle inhibition to work. Relies on the logind session `SetType` command which is not yet released (in systemd master, tagged for v246).

Relevant systemd PR here - https://github.com/systemd/systemd/pull/14925

Will close #2144.