### PR TITLE
xcursor: add xorg-x11 and cursors path to XCURSORPATH

### DIFF
--- a/xcursor/xcursor.c
+++ b/xcursor/xcursor.c
@@ -618,7 +618,7 @@ XcursorFileLoadImages (FILE *file, int size)
 #endif
 
 #ifndef XCURSORPATH
-#define XCURSORPATH "~/.local/share/icons:~/.icons:/usr/share/icons:/usr/share/pixmaps:"ICONDIR
+#define XCURSORPATH "~/.local/share/icons:~/.icons:/usr/share/icons:/usr/share/pixmaps:~/.cursors:/usr/share/cursors/xorg-x11:"ICONDIR
 #endif
 
 static const char *


### PR DESCRIPTION
This should match default XCURSORPATH, which is used by libwayland-cursor
and other xcursor loading libraries more closely.