### PR TITLE
backend/drm: fix DPMS on legacy interface

### DIFF
--- a/backend/drm/legacy.c
+++ b/backend/drm/legacy.c
@@ -32,7 +32,7 @@ static bool legacy_crtc_commit(struct wlr_drm_backend *drm,
 		uint32_t *conns = NULL;
 		size_t conns_len = 0;
 		drmModeModeInfo *mode = NULL;
-		if (crtc->pending.mode != NULL) {
+		if (crtc->pending.active) {
 			conns = &conn->id;
 			conns_len = 1;
 			mode = &crtc->pending.mode->drm_mode;


### PR DESCRIPTION
This mirrors what the atomic code does in create_mode_blob.

Closes: https://github.com/swaywm/wlroots/issues/2312