### PR TITLE
Introduce wlr_output_event_commit

### DIFF
--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -163,7 +163,7 @@ struct wlr_output {
 		// Emitted right before commit
 		struct wl_signal precommit; // wlr_output_event_precommit
 		// Emitted right after commit
-		struct wl_signal commit;
+		struct wl_signal commit; // wlr_output_event_commit
 		// Emitted right after the buffer has been presented to the user
 		struct wl_signal present; // wlr_output_event_present
 		struct wl_signal enable;
@@ -196,6 +196,11 @@ struct wlr_output_event_damage {
 struct wlr_output_event_precommit {
 	struct wlr_output *output;
 	struct timespec *when;
+};
+
+struct wlr_output_event_commit {
+	struct wlr_output *output;
+	uint32_t committed; // bitmask of enum wlr_output_state_field
 };
 
 enum wlr_output_present_flag {

--- a/include/wlr/types/wlr_output_power_management_v1.h
+++ b/include/wlr/types/wlr_output_power_management_v1.h
@@ -25,7 +25,7 @@ struct wlr_output_power_v1 {
 	struct wl_list link;
 
 	struct wl_listener output_destroy_listener;
-	struct wl_listener output_enable_listener;
+	struct wl_listener output_commit_listener;
 
 	void *data;
 };

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -581,11 +581,11 @@ bool wlr_output_commit(struct wlr_output *output) {
 	struct timespec now;
 	clock_gettime(CLOCK_MONOTONIC, &now);
 
-	struct wlr_output_event_precommit event = {
+	struct wlr_output_event_precommit pre_event = {
 		.output = output,
 		.when = &now,
 	};
-	wlr_signal_emit_safe(&output->events.precommit, &event);
+	wlr_signal_emit_safe(&output->events.precommit, &pre_event);
 
 	if (!output->impl->commit(output)) {
 		output_state_clear(&output->pending);
@@ -604,7 +604,11 @@ bool wlr_output_commit(struct wlr_output *output) {
 
 	output->commit_seq++;
 
-	wlr_signal_emit_safe(&output->events.commit, output);
+	struct wlr_output_event_commit event = {
+		.output = output,
+		.committed = output->pending.committed,
+	};
+	wlr_signal_emit_safe(&output->events.commit, &event);
 
 	bool scale_updated = output->pending.committed & WLR_OUTPUT_STATE_SCALE;
 	if (scale_updated) {


### PR DESCRIPTION
## output: introduce wlr_output_event_commit
    
This event contains a `committed` bitfield, which allows callers to know
which output fields changed during the commit.
    
This allows users to setup a single atomic commit listener, instead of
setting up one listener for each event (mode, scale, transform, and so
on).
    
References: https://github.com/swaywm/wlroots/issues/2098

## output-power-management-v1: listen to output commit

* * *

Breaking change: the `wlr_output.events.commit` event now has a data argument of type `struct wlr_output_event_commit *` instead of `struct wlr_output *`