### PR TITLE
xwm: end transfers when the requestor is destroyed

### DIFF
--- a/include/xwayland/selection.h
+++ b/include/xwayland/selection.h
@@ -56,6 +56,8 @@ struct wlr_xwm_selection *xwm_get_selection(struct wlr_xwm *xwm,
 void xwm_send_incr_chunk(struct wlr_xwm_selection_transfer *transfer);
 void xwm_handle_selection_request(struct wlr_xwm *xwm,
 	xcb_selection_request_event_t *req);
+void xwm_handle_selection_destroy_notify(struct wlr_xwm *xwm,
+		xcb_destroy_notify_event_t *event);
 
 void xwm_get_incr_chunk(struct wlr_xwm_selection_transfer *transfer);
 void xwm_handle_selection_notify(struct wlr_xwm *xwm,

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -846,6 +846,7 @@ static void xwm_handle_destroy_notify(struct wlr_xwm *xwm,
 		return;
 	}
 	xwayland_surface_destroy(xsurface);
+	xwm_handle_selection_destroy_notify(xwm, ev);
 }
 
 static void xwm_handle_configure_request(struct wlr_xwm *xwm,


### PR DESCRIPTION
This improves the failure cases when incremental transfers fail to complete successfully for one reason or another. In particular it should vastly improve the failure case seen at https://github.com/swaywm/sway/issues/4007, especially because QXcb uses a special temporary window for its requestor, that gets always destroyed in the case that the error happens.