### PR TITLE
input/pointer: add functions for modifying pointer state

### DIFF
--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -410,6 +410,19 @@ void wlr_seat_pointer_notify_enter(struct wlr_seat *wlr_seat,
 void wlr_seat_pointer_notify_clear_focus(struct wlr_seat *wlr_seat);
 
 /**
+ * Fetch the current position of the pointer of this seat, in surface-local
+ * coordinates.
+ */
+void wlr_seat_pointer_position(struct wlr_seat *wlr_seat,
+		double *sx, double *sy);
+
+/**
+ * Warp the pointer of this seat to the given surface-local coordinates, without
+ * generating motion events.
+ */
+void wlr_seat_pointer_warp(struct wlr_seat *wlr_seat, double sx, double sy);
+
+/**
  * Notify the seat of motion over the given surface. Pass surface-local
  * coordinates where the pointer motion occurred. Defers to any grab of the
  * pointer.

--- a/types/seat/wlr_seat_pointer.c
+++ b/types/seat/wlr_seat_pointer.c
@@ -199,11 +199,9 @@ void wlr_seat_pointer_enter(struct wlr_seat *wlr_seat,
 	wlr_seat->pointer_state.focused_client = client;
 	wlr_seat->pointer_state.focused_surface = surface;
 	if (surface != NULL) {
-		wlr_seat->pointer_state.sx = sx;
-		wlr_seat->pointer_state.sy = sy;
+		wlr_seat_pointer_warp(wlr_seat, sx, sy);
 	} else {
-		wlr_seat->pointer_state.sx = NAN;
-		wlr_seat->pointer_state.sy = NAN;
+		wlr_seat_pointer_warp(wlr_seat, NAN, NAN);
 	}
 
 	struct wlr_seat_pointer_focus_change_event event = {
@@ -218,6 +216,17 @@ void wlr_seat_pointer_enter(struct wlr_seat *wlr_seat,
 
 void wlr_seat_pointer_clear_focus(struct wlr_seat *wlr_seat) {
 	wlr_seat_pointer_enter(wlr_seat, NULL, 0, 0);
+}
+
+void wlr_seat_pointer_position(struct wlr_seat *wlr_seat,
+		double *sx,double *sy) {
+	*sx = wlr_seat->pointer_state.sx;
+	*sy = wlr_seat->pointer_state.sy;
+}
+
+void wlr_seat_pointer_warp(struct wlr_seat *wlr_seat, double sx, double sy) {
+	wlr_seat->pointer_state.sx = sx;
+	wlr_seat->pointer_state.sy = sy;
 }
 
 void wlr_seat_pointer_send_motion(struct wlr_seat *wlr_seat, uint32_t time,
@@ -241,8 +250,7 @@ void wlr_seat_pointer_send_motion(struct wlr_seat *wlr_seat, uint32_t time,
 			wl_fixed_from_double(sy));
 	}
 
-	wlr_seat->pointer_state.sx = sx;
-	wlr_seat->pointer_state.sy = sy;
+	wlr_seat_pointer_warp(wlr_seat, sx, sy);
 }
 
 uint32_t wlr_seat_pointer_send_button(struct wlr_seat *wlr_seat, uint32_t time,


### PR DESCRIPTION
These allow a compositor to do things like skip motion events on pointer constraint unlock, or not move the pointer during touch emulation.

Refs swaywm/sway#5431, swaywm/sway#5459.

---

Marked as draft until the Sway-side PRs are updated / we decide if this is how we want to do this.