### PR TITLE
backend/drm: check drm_surface_make_current return value

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -928,7 +928,9 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 			return false;
 		}
 
-		drm_surface_make_current(&plane->surf, NULL);
+		if (!drm_surface_make_current(&plane->surf, NULL)) {
+			return false;
+		}
 
 		struct wlr_renderer *rend = plane->surf.renderer->wlr_rend;
 


### PR DESCRIPTION
drm_connector_set_cursor wasn't checking the return value of the
drm_surface_make_current call. On failure, this results in a failed
assertion in wlr_renderer_begin (because no rendering context is
current).