### PR TITLE
render: egl: Use current display to restore NULL context

### DIFF
--- a/render/egl.c
+++ b/render/egl.c
@@ -459,7 +459,20 @@ void wlr_egl_save_context(struct wlr_egl_context *context) {
 }
 
 bool wlr_egl_restore_context(struct wlr_egl_context *context) {
-	return eglMakeCurrent(context->display, context->draw_surface,
+	// If the saved context is a null-context, we must use the current
+	// display instead of the saved display because eglMakeCurrent() can't
+	// handle EGL_NO_DISPLAY.
+	EGLDisplay display = context->display == EGL_NO_DISPLAY ?
+		eglGetCurrentDisplay() : context->display;
+
+	// If the current display is also EGL_NO_DISPLAY, we assume that there
+	// is currently no context set and no action needs to be taken to unset
+	// the context.
+	if (display == EGL_NO_DISPLAY) {
+		return true;
+	}
+
+	return eglMakeCurrent(display, context->draw_surface,
 			context->read_surface, context->context);
 }
 


### PR DESCRIPTION
eglGetCurrentDisplay() returns NULL when there is no context current and
eglMakeCurrent() needs a display argument.

Fixes #2327