### PR TITLE
WiP: Cursor spy

### DIFF
--- a/examples/cursor-spy.c
+++ b/examples/cursor-spy.c
@@ -1,0 +1,266 @@
+/*
+ * Copyright © 2008 Kristian Høgsberg
+ * Copyright © 2020 Andri Yngvason
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#define _POSIX_C_SOURCE 200112L
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <png.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <assert.h>
+#include <wayland-client-protocol.h>
+#include "cursor-spy-unstable-v1-client-protocol.h"
+
+struct format {
+	enum wl_shm_format wl_format;
+	bool is_bgr;
+};
+
+static struct wl_shm *shm = NULL;
+static struct zext_cursor_spy_manager_v1 *cursor_spy_manager = NULL;
+static struct wl_output *output = NULL;
+
+static struct {
+	struct wl_buffer *wl_buffer;
+	void *data;
+	enum wl_shm_format format;
+	int width, height, stride;
+} buffer;
+bool buffer_copy_done = false;
+
+// wl_shm_format describes little-endian formats, libpng uses big-endian
+// formats (so Wayland's ABGR is libpng's RGBA).
+static const struct format formats[] = {
+	{WL_SHM_FORMAT_XRGB8888, true},
+	{WL_SHM_FORMAT_ARGB8888, true},
+	{WL_SHM_FORMAT_XBGR8888, false},
+	{WL_SHM_FORMAT_ABGR8888, false},
+};
+
+static struct wl_buffer *create_shm_buffer(enum wl_shm_format fmt,
+		int width, int height, int stride, void **data_out) {
+	int size = stride * height;
+
+	const char shm_name[] = "/wlroots-cursor-spy";
+	int fd = shm_open(shm_name, O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
+	if (fd < 0) {
+		fprintf(stderr, "shm_open failed\n");
+		return NULL;
+	}
+	shm_unlink(shm_name);
+
+	int ret;
+	while ((ret = ftruncate(fd, size)) == EINTR) {
+		// No-op
+	}
+	if (ret < 0) {
+		close(fd);
+		fprintf(stderr, "ftruncate failed\n");
+		return NULL;
+	}
+
+	void *data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	if (data == MAP_FAILED) {
+		fprintf(stderr, "mmap failed: %m\n");
+		close(fd);
+		return NULL;
+	}
+
+	struct wl_shm_pool *pool = wl_shm_create_pool(shm, fd, size);
+	close(fd);
+	struct wl_buffer *buffer = wl_shm_pool_create_buffer(pool, 0, width, height,
+		stride, fmt);
+	wl_shm_pool_destroy(pool);
+
+	*data_out = data;
+	return buffer;
+}
+
+static void spy_handle_buffer(void *data,
+		struct zext_cursor_spy_v1 *spy, uint32_t format,
+		uint32_t width, uint32_t height) {
+	buffer.format = format;
+	buffer.width = width;
+	buffer.height = height;
+	buffer.stride = buffer.width * 4;
+
+	// Make sure the buffer is not allocated
+	assert(!buffer.wl_buffer);
+	buffer.wl_buffer = create_shm_buffer(format, width, height,
+			buffer.stride, &buffer.data);
+	if (buffer.wl_buffer == NULL) {
+		fprintf(stderr, "failed to create buffer\n");
+		exit(EXIT_FAILURE);
+	}
+
+	zext_cursor_spy_v1_spy(spy, buffer.wl_buffer, 0);
+}
+
+static void spy_handle_cursor(void* data, struct zext_cursor_spy_v1* spy,
+		uint32_t offset, uint32_t width, uint32_t height,
+		uint32_t hotspot_x, uint32_t hotspot_y) {
+	printf("Got cursor with hotspot %"PRIu32", %"PRIu32"\n", hotspot_x,
+			hotspot_y);
+}
+
+static void spy_handle_done(void *data, struct zext_cursor_spy_v1 *spy,
+		uint32_t seq) {
+	buffer_copy_done = true;
+}
+
+static void spy_handle_failed(void *data,
+		struct zext_cursor_spy_v1 *spy,
+		enum zext_cursor_spy_v1_error error) {
+	// TODO use error
+	fprintf(stderr, "failed to copy cursors\n");
+	exit(EXIT_FAILURE);
+}
+
+static const struct zext_cursor_spy_v1_listener spy_listener = {
+	.buffer = spy_handle_buffer,
+	.cursor = spy_handle_cursor,
+	.done = spy_handle_done,
+	.failed = spy_handle_failed,
+};
+
+static void handle_global(void *data, struct wl_registry *registry,
+		uint32_t name, const char *interface, uint32_t version) {
+	if (strcmp(interface, wl_output_interface.name) == 0 && output == NULL) {
+		output = wl_registry_bind(registry, name, &wl_output_interface, 1);
+	} else if (strcmp(interface, wl_shm_interface.name) == 0) {
+		shm = wl_registry_bind(registry, name, &wl_shm_interface, 1);
+	} else if (strcmp(interface,
+			zext_cursor_spy_manager_v1_interface.name) == 0) {
+		cursor_spy_manager = wl_registry_bind(registry, name,
+			&zext_cursor_spy_manager_v1_interface, 1);
+	}
+}
+
+static void handle_global_remove(void *data, struct wl_registry *registry,
+		uint32_t name) {
+	// Who cares?
+}
+
+static const struct wl_registry_listener registry_listener = {
+	.global = handle_global,
+	.global_remove = handle_global_remove,
+};
+
+static void write_image(char *filename, enum wl_shm_format wl_fmt, int width,
+		int height, int stride, png_bytep data) {
+	const struct format *fmt = NULL;
+	for (size_t i = 0; i < sizeof(formats) / sizeof(formats[0]); ++i) {
+		if (formats[i].wl_format == wl_fmt) {
+			fmt = &formats[i];
+			break;
+		}
+	}
+	if (fmt == NULL) {
+		fprintf(stderr, "unsupported format %"PRIu32"\n", wl_fmt);
+		exit(EXIT_FAILURE);
+	}
+
+	FILE *f = fopen(filename, "wb");
+	if (f == NULL) {
+		fprintf(stderr, "failed to open output file\n");
+		exit(EXIT_FAILURE);
+	}
+
+	png_structp png =
+		png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+	png_infop info = png_create_info_struct(png);
+
+	png_init_io(png, f);
+
+	png_set_IHDR(png, info, width, height, 8, PNG_COLOR_TYPE_RGBA,
+		PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT,
+		PNG_FILTER_TYPE_DEFAULT);
+
+	if (fmt->is_bgr) {
+		png_set_bgr(png);
+	}
+
+	png_write_info(png, info);
+
+	for (size_t i = 0; i < (size_t)height; ++i) {
+		png_bytep row;
+		row = data + i * stride;
+		png_write_row(png, row);
+	}
+
+	png_write_end(png, NULL);
+
+	png_destroy_write_struct(&png, &info);
+
+	fclose(f);
+}
+
+int main(int argc, char *argv[]) {
+	struct wl_display * display = wl_display_connect(NULL);
+	if (display == NULL) {
+		fprintf(stderr, "failed to create display: %m\n");
+		return EXIT_FAILURE;
+	}
+
+	struct wl_registry *registry = wl_display_get_registry(display);
+	wl_registry_add_listener(registry, &registry_listener, NULL);
+	wl_display_dispatch(display);
+	wl_display_roundtrip(display);
+
+	if (shm == NULL) {
+		fprintf(stderr, "compositor is missing wl_shm\n");
+		return EXIT_FAILURE;
+	}
+	if (cursor_spy_manager == NULL) {
+		fprintf(stderr, "compositor doesn't support wlr-cursor-spy-unstable-v1\n");
+		return EXIT_FAILURE;
+	}
+	if (output == NULL) {
+		fprintf(stderr, "no output available\n");
+		return EXIT_FAILURE;
+	}
+
+	struct zext_cursor_spy_v1 *spy =
+		zext_cursor_spy_manager_v1_create_spy(cursor_spy_manager, output);
+	zext_cursor_spy_v1_add_listener(spy, &spy_listener, NULL);
+
+	while (!buffer_copy_done && wl_display_dispatch(display) != -1) {
+		// This space is intentionally left blank
+	}
+
+	write_image("cursor.png", buffer.format, buffer.width, buffer.height,
+			buffer.stride, buffer.data);
+	wl_buffer_destroy(buffer.wl_buffer);
+	munmap(buffer.data, buffer.stride * buffer.height);
+
+	return EXIT_SUCCESS;
+}

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -177,6 +177,11 @@ clients = {
 			'input-method-unstable-v2',
 		],
 	},
+	'cursor-spy': {
+		'src': 'cursor-spy.c',
+		'dep': [libpng, rt],
+		'proto': ['cursor-spy-unstable-v1'],
+	},
 }
 
 foreach name, info : compositors

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -81,6 +81,7 @@ struct wlr_texture_impl {
 	bool (*to_dmabuf)(struct wlr_texture *texture,
 		struct wlr_dmabuf_attributes *attribs);
 	void (*destroy)(struct wlr_texture *texture);
+	bool (*read_pixels)(struct wlr_texture *texture, void *pixels);
 };
 
 void wlr_texture_init(struct wlr_texture *texture,

--- a/include/wlr/render/wlr_texture.h
+++ b/include/wlr/render/wlr_texture.h
@@ -64,6 +64,12 @@ bool wlr_texture_write_pixels(struct wlr_texture *texture,
 	uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y,
 	const void *data);
 
+/**
+ * Read pixels from texture. Pixel buffer must be big enough to accommodate the
+ * pixels.
+ */
+bool wlr_texture_read_pixels(struct wlr_texture *texture, void *pixels);
+
 bool wlr_texture_to_dmabuf(struct wlr_texture *texture,
 	struct wlr_dmabuf_attributes *attribs);
 

--- a/include/wlr/types/wlr_cursor_spy_v1.h
+++ b/include/wlr/types/wlr_cursor_spy_v1.h
@@ -1,0 +1,45 @@
+/*
+ * This an unstable interface of wlroots. No guarantees are made regarding the
+ * future consistency of this API.
+ */
+#ifndef WLR_USE_UNSTABLE
+#error "Add -DWLR_USE_UNSTABLE to enable unstable wlroots features"
+#endif
+
+#ifndef WLR_TYPES_WLR_CURSOR_SPY_V1_H
+#define WLR_TYPES_WLR_CURSOR_SPY_V1_H
+
+#include <stdbool.h>
+#include <wayland-server-core.h>
+#include <wlr/types/wlr_box.h>
+
+struct wlr_cursor_spy_manager_v1 {
+	struct wl_global *global;
+
+	struct wl_listener display_destroy;
+
+	struct {
+		struct wl_signal destroy;
+	} events;
+
+	void *data;
+};
+
+struct wlr_cursor_spy_v1 {
+	struct wl_resource *resource;
+
+	enum wl_shm_format format;
+	int stride;
+
+	struct wl_shm_buffer *buffer;
+
+	struct wlr_output *output;
+	struct wl_listener output_destroy;
+
+	void *data;
+};
+
+struct wlr_cursor_spy_manager_v1 *wlr_cursor_spy_manager_v1_create(
+	struct wl_display *display);
+
+#endif

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -151,6 +151,10 @@ struct wlr_output {
 	// Commit sequence number. Incremented on each commit, may overflow.
 	uint32_t commit_seq;
 
+	// Cursor commit sequence number. Incremented on each cursor commit, may
+	// overflow.
+	uint32_t cursor_commit_seq;
+
 	struct {
 		// Request to render a frame
 		struct wl_signal frame;

--- a/protocol/cursor-spy-unstable-v1.xml
+++ b/protocol/cursor-spy-unstable-v1.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="cursor_spy_unstable_v1">
+  <copyright>
+    Copyright © 2020 Andri Yngvason
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="spy on cursors">
+    This protocol allows a client to receive a list of all cursors on a specific
+    output, including but not limited to the image and hot spot.
+  </description>
+
+  <interface name="zext_cursor_spy_manager_v1" version="1">
+    <description summary="manager to inform clients and begin spying">
+      This object is a manager which offers requests to start spying on cursors.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        All objects created by the manager will still remain valid, until their
+        appropriate destroy request has been called.
+      </description>
+    </request>
+
+    <request name="create_spy">
+      <description summary="get a new spy object for a specific output">
+        Start spying on cursors on the specified output.
+      </description>
+      <arg name="spy" type="new_id" interface="zext_cursor_spy_v1"/>
+      <arg name="output" type="object" interface="wl_output"/>
+    </request>
+  </interface>
+
+  <interface name="zext_cursor_spy_v1" version="1">
+    <description summary="a spy for requesting and receiving cursors">
+      This object is used for requesting and receiving cursors.
+    </description>
+
+    <enum name="error">
+      <entry name="invalid_buffer" value="0"
+        summary="buffer attributes are invalid"/>
+      <entry name="invalid_output" value="1"
+        summary="supplied output is invalid"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the spy">
+        This closes and cleans up the spy object.
+      </description>
+    </request>
+
+    <event name="buffer">
+      <description summary="wl_shm buffer information">
+        Provides information about wl_shm buffer parameters that need to be used
+        for this spy. This event is sent once after the spy is created and when
+        the buffer needs to be resized following a spy request.
+
+        The stride of the buffer must be large enough to contain on pixel row of
+        the minimum width.
+      </description>
+      <arg name="format" type="uint" enum="wl_shm.format"
+        summary="buffer format"/>
+      <arg name="min_width" type="uint" summary="minimum buffer width"/>
+      <arg name="min_height" type="uint" summary="minimum buffer height"/>
+    </event>
+
+    <event name="cursor">
+      <description summary="cursor info">
+        Provides information about a cursor. The compositor may place the
+        cursor image anywhere inside the supplied buffer and the client must
+        read it from the offset as specified by the offset argument.
+      </description>
+      <arg name="offset" type="uint"
+        summary="offset of the cursor image in the buffer"/>
+      <arg name="width" type="uint" summary="width of the cursor image"/>
+      <arg name="height" type="uint" summary="height of the cursor image"/>
+      <arg name="hotspot_x" type="uint" summary="hotspot x coordinates"/>
+      <arg name="hotspot_y" type="uint" summary="hotspot y coordinates"/>
+    </event>
+
+    <event name="done">
+      <description summary="end of cursor grabbing">
+        This event is emitted once at the end of a response to a spy request.
+      </description>
+      <arg name="seq" type="uint" summary="sequence number"/>
+    </event>
+
+    <event name="failed">
+      <description summary="cursor grabbing failed">
+        This event is emitted upon failure.
+      </description>
+      <arg name="error" type="uint" enum="error" summary="reason of failure"/>
+    </event>
+
+    <request name="spy">
+      <description summary="start spying">
+        Grabs all cursors and places them into the supplied buffer. When
+        grabbing is done, a cursor event is emitted for each cursor. When
+        all cursors have been handled, the done event is emitted.
+
+        If the buffer is too small, a buffer event will be emitted. When this
+        happens, the client must resize the buffer and retry the spy request.
+
+        The last_seq argument should be set to the last sequence number received
+        from the done event. If no cursor changes have happened since the last
+        time, the compositor will send the done event immediately without
+        sending any cursors.
+
+        If the request fails, the failed event is emitted and no more events
+        will be emitted until the next request.
+      </description>
+      <arg name="buffer" type="object" interface="wl_buffer"/>
+      <arg name="last_seq" type="uint" summary="sequence number"/>
+    </request>
+  </interface>
+</protocol>

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -45,6 +45,7 @@ protocols = {
 	'wlr-output-power-management-unstable-v1': 'wlr-output-power-management-unstable-v1.xml',
 	'wlr-screencopy-unstable-v1': 'wlr-screencopy-unstable-v1.xml',
 	'wlr-virtual-pointer-unstable-v1': 'wlr-virtual-pointer-unstable-v1.xml',
+	'cursor-spy-unstable-v1': 'cursor-spy-unstable-v1.xml',
 }
 
 protocols_code = {}

--- a/render/egl.c
+++ b/render/egl.c
@@ -459,7 +459,9 @@ void wlr_egl_save_context(struct wlr_egl_context *context) {
 }
 
 bool wlr_egl_restore_context(struct wlr_egl_context *context) {
-	return eglMakeCurrent(context->display, context->draw_surface,
+	EGLDisplay display = context->display ?
+		context->display : eglGetCurrentDisplay();
+	return eglMakeCurrent(display, context->draw_surface,
 			context->read_surface, context->context);
 }
 

--- a/render/wlr_texture.c
+++ b/render/wlr_texture.c
@@ -66,6 +66,14 @@ bool wlr_texture_write_pixels(struct wlr_texture *texture,
 		src_x, src_y, dst_x, dst_y, data);
 }
 
+bool wlr_texture_read_pixels(struct wlr_texture *texture,
+		void *pixels) {
+	if (!texture->impl->read_pixels) {
+		return false;
+	}
+	return texture->impl->read_pixels(texture, pixels);
+}
+
 bool wlr_texture_to_dmabuf(struct wlr_texture *texture,
 		struct wlr_dmabuf_attributes *attribs) {
 	if (!texture->impl->to_dmabuf) {

--- a/types/meson.build
+++ b/types/meson.build
@@ -70,4 +70,5 @@ wlr_files += files(
 	'wlr_xcursor_manager.c',
 	'wlr_xdg_decoration_v1.c',
 	'wlr_xdg_output_v1.c',
+	'wlr_cursor_spy_v1.c',
 )

--- a/types/wlr_cursor_spy_v1.c
+++ b/types/wlr_cursor_spy_v1.c
@@ -1,0 +1,298 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <wlr/types/wlr_output.h>
+#include <wlr/types/wlr_cursor_spy_v1.h>
+#include <wlr/types/wlr_surface.h>
+#include <wlr/render/wlr_texture.h>
+#include <wlr/util/log.h>
+#include "cursor-spy-unstable-v1-protocol.h"
+#include "util/signal.h"
+
+#define CURSOR_SPY_MANAGER_VERSION 1
+#define PREFERRED_FORMAT WL_SHM_FORMAT_ARGB8888
+
+static const struct zext_cursor_spy_manager_v1_interface cursor_spy_manager_impl;
+static const struct zext_cursor_spy_v1_interface cursor_spy_impl;
+
+static struct wlr_cursor_spy_manager_v1 *cursor_spy_manager_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource,
+			&zext_cursor_spy_manager_v1_interface,
+			&cursor_spy_manager_impl));
+	return wl_resource_get_user_data(resource);
+}
+
+static struct wlr_cursor_spy_v1 *cursor_spy_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource,
+			&zext_cursor_spy_v1_interface, &cursor_spy_impl));
+	return wl_resource_get_user_data(resource);
+}
+
+static void cursor_spy_destroy(struct wlr_cursor_spy_v1 *spy)
+{
+	if (!spy) {
+		return;
+	}
+
+	wl_list_remove(&spy->output_destroy.link);
+	wl_resource_set_user_data(spy->resource, NULL);
+	free(spy);
+}
+
+static void cursor_spy_handle_resource_destroy(struct wl_resource *resource) {
+	struct wlr_cursor_spy_v1 *spy = cursor_spy_from_resource(resource);
+	cursor_spy_destroy(spy);
+}
+
+static void handle_cursor_spy_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+
+// Cursor image are stacked on top of each other
+static void calculate_buffer_dimensions(struct wlr_output *output,
+		uint32_t *width, uint32_t *height) {
+	*width = 0;
+	*height = 0;
+
+	struct wlr_output_cursor *cursor;
+	wl_list_for_each(cursor, &output->cursors, link) {
+		if (!cursor->enabled || !cursor->visible) {
+			continue;
+		}
+
+		if (cursor->width > *width) {
+			*width = cursor->width;
+		}
+
+		*height += cursor->height;
+	}
+}
+
+static bool send_buffer_info(struct wl_client *client,
+		struct wlr_cursor_spy_v1 *spy, uint32_t width,
+		uint32_t height) {
+	enum wl_shm_format format = PREFERRED_FORMAT;
+	zext_cursor_spy_v1_send_buffer(spy->resource, format, width, height);
+	return true;
+}
+
+static void emit_cursor_event(struct wl_client *client,
+		struct wlr_cursor_spy_v1 *spy, struct wl_shm_buffer *buffer,
+		struct wlr_output_cursor *cursor, uint32_t *y_index) {
+	uint32_t y = *y_index;
+	*y_index += cursor->height;
+
+	uint8_t *scratchpad = calloc(1, cursor->width * cursor->height * 4);
+	if (!scratchpad) {
+		wl_client_post_no_memory(client);
+		return;
+	}
+
+	// TODO: This assert fails
+	//assert(!(cursor->texture && cursor->surface));
+
+	struct wlr_texture *texture = NULL;
+	if (cursor->surface) {
+		texture = wlr_surface_get_texture(cursor->surface);
+	} else if (cursor->texture) {
+		texture = cursor->texture;
+	} else {
+		abort();
+	}
+
+	uint8_t *pixels = wl_shm_buffer_get_data(buffer);
+	uint32_t stride = wl_shm_buffer_get_stride(buffer);
+
+	// TODO: Convert to preferred format if the formats don't match
+	wlr_texture_read_pixels(texture, scratchpad);
+
+	for (uint32_t row = 0; row < cursor->height; ++row) {
+		memcpy(&pixels[(row + y) * stride],
+				&scratchpad[row * cursor->width * 4],
+				cursor->width * 4);
+	}
+
+	zext_cursor_spy_v1_send_cursor(spy->resource, y * stride, cursor->width,
+			cursor->height, cursor->hotspot_x, cursor->hotspot_y);
+}
+
+static void handle_cursor_spy_spy(struct wl_client *client,
+		struct wl_resource *spy_resource,
+		struct wl_resource *buffer_resource, uint32_t seq) {
+	struct wlr_cursor_spy_v1 *spy = cursor_spy_from_resource(spy_resource);
+	struct wl_shm_buffer *buffer = wl_shm_buffer_get(buffer_resource);
+
+	if (!spy) {
+		return;
+	}
+
+	if (!buffer) {
+		zext_cursor_spy_v1_send_failed(spy->resource,
+				ZEXT_CURSOR_SPY_V1_ERROR_INVALID_BUFFER);
+		return;
+	}
+
+	struct wlr_output *output = spy->output;
+
+	if (seq == output->cursor_commit_seq) {
+		goto done;
+	}
+
+	uint32_t min_width, min_height;
+	calculate_buffer_dimensions(spy->output, &min_width, &min_height);
+
+	uint32_t width = wl_shm_buffer_get_width(buffer);
+	uint32_t height = wl_shm_buffer_get_height(buffer);
+	uint32_t stride = wl_shm_buffer_get_stride(buffer);
+	enum wl_shm_format format = wl_shm_buffer_get_format(buffer);
+
+	if (width < min_width || height < min_height ||
+			format != PREFERRED_FORMAT || stride < width * 4) {
+		send_buffer_info(client, spy, min_width, min_height);
+		return;
+	}
+
+	uint32_t y_index = 0;
+	struct wlr_output_cursor *cursor;
+	wl_list_for_each(cursor, &output->cursors, link) {
+		if (cursor->enabled && cursor->visible) {
+			emit_cursor_event(client, spy, buffer, cursor,
+					&y_index);
+		}
+	}
+
+done:
+	zext_cursor_spy_v1_send_done(spy->resource, output->cursor_commit_seq);
+}
+
+static const struct zext_cursor_spy_v1_interface cursor_spy_impl = {
+	.spy = handle_cursor_spy_spy,
+	.destroy = handle_cursor_spy_destroy,
+};
+
+static void spy_handle_output_destroy(struct wl_listener *listener,
+		void *data) {
+	struct wlr_cursor_spy_v1 *spy =
+		wl_container_of(listener, spy, output_destroy);
+	zext_cursor_spy_v1_send_failed(spy->resource,
+			ZEXT_CURSOR_SPY_V1_ERROR_INVALID_OUTPUT);
+	wl_resource_set_user_data(spy->resource, NULL);
+	free(spy);
+}
+
+static void create_spy(struct wl_client *client,
+		struct wlr_cursor_spy_manager_v1 *manager, uint32_t id,
+		struct wlr_output *output) {
+	struct wlr_cursor_spy_v1 *spy =
+		calloc(1, sizeof(struct wlr_cursor_spy_v1));
+	if (!spy) {
+		wl_client_post_no_memory(client);
+		return;
+	}
+
+	spy->output = output;
+	spy->resource = wl_resource_create(client,
+			&zext_cursor_spy_v1_interface,
+			CURSOR_SPY_MANAGER_VERSION, id);
+	if (!spy->resource) {
+		wl_client_post_no_memory(client);
+		goto failure;
+	}
+
+	wl_resource_set_implementation(spy->resource, &cursor_spy_impl,
+			spy, cursor_spy_handle_resource_destroy);
+
+	if (!output || !output->enabled) {
+		zext_cursor_spy_v1_send_failed(spy->resource,
+				ZEXT_CURSOR_SPY_V1_ERROR_INVALID_OUTPUT);
+		goto output_failure;
+	}
+
+	uint32_t width, height;
+	calculate_buffer_dimensions(output, &width, &height);
+	if (!send_buffer_info(client, spy, width, height)) {
+		zext_cursor_spy_v1_send_failed(spy->resource,
+				ZEXT_CURSOR_SPY_V1_ERROR_INVALID_OUTPUT);
+		goto buffer_failure;
+	}
+
+	wl_signal_add(&output->events.destroy, &spy->output_destroy);
+	spy->output_destroy.notify = spy_handle_output_destroy;
+
+	return;
+buffer_failure:
+output_failure:
+	wl_resource_set_user_data(spy->resource, NULL);
+failure:
+	free(spy);
+}
+
+static void manager_handle_create_spy(struct wl_client *wl_client,
+		struct wl_resource *manager_resource, uint32_t id,
+		struct wl_resource *output_resource) {
+	struct wlr_cursor_spy_manager_v1 *manager =
+		cursor_spy_manager_from_resource(manager_resource);
+	struct wlr_output *output = wlr_output_from_resource(output_resource);
+	create_spy(wl_client, manager, id, output);
+};
+
+static void manager_handle_destroy(struct wl_client *wl_client,
+		struct wl_resource *manager_resource) {
+	wl_resource_destroy(manager_resource);
+}
+
+static const struct zext_cursor_spy_manager_v1_interface
+		cursor_spy_manager_impl = {
+	.create_spy = manager_handle_create_spy,
+	.destroy = manager_handle_destroy,
+};
+
+static void manager_bind(struct wl_client *wl_client, void *data,
+		uint32_t version, uint32_t id) {
+	struct wlr_cursor_spy_manager_v1 *manager = data;
+
+	struct wl_resource *resource = wl_resource_create(wl_client,
+		&zext_cursor_spy_manager_v1_interface, version, id);
+	if (resource == NULL) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+
+	wl_resource_set_implementation(resource, &cursor_spy_manager_impl,
+			manager, NULL);
+}
+
+static void handle_display_destroy(struct wl_listener *listener, void *data) {
+	struct wlr_cursor_spy_manager_v1 *manager =
+		wl_container_of(listener, manager, display_destroy);
+	wlr_signal_emit_safe(&manager->events.destroy, manager);
+	wl_list_remove(&manager->display_destroy.link);
+	wl_global_destroy(manager->global);
+	free(manager);
+}
+
+struct wlr_cursor_spy_manager_v1 *wlr_cursor_spy_manager_v1_create(
+		struct wl_display *display) {
+	struct wlr_cursor_spy_manager_v1 *manager =
+		calloc(1, sizeof(struct wlr_cursor_spy_manager_v1));
+	if (manager == NULL) {
+		return NULL;
+	}
+
+	manager->global = wl_global_create(display,
+		&zext_cursor_spy_manager_v1_interface,
+		CURSOR_SPY_MANAGER_VERSION, manager, manager_bind);
+	if (manager->global == NULL) {
+		free(manager);
+		return NULL;
+	}
+
+	wl_signal_init(&manager->events.destroy);
+
+	manager->display_destroy.notify = handle_display_destroy;
+	wl_display_add_destroy_listener(display, &manager->display_destroy);
+
+	return manager;
+}

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -325,6 +325,7 @@ void wlr_output_init(struct wlr_output *output, struct wlr_backend *backend,
 	output->transform = WL_OUTPUT_TRANSFORM_NORMAL;
 	output->scale = 1;
 	output->commit_seq = 0;
+	output->cursor_commit_seq = 0;
 	wl_list_init(&output->cursors);
 	wl_list_init(&output->resources);
 	wl_signal_init(&output->events.frame);
@@ -1046,6 +1047,8 @@ bool wlr_output_cursor_set_image(struct wlr_output_cursor *cursor,
 
 static void output_cursor_commit(struct wlr_output_cursor *cursor,
 		bool update_hotspot) {
+	cursor->output->cursor_commit_seq++;
+
 	if (cursor->output->hardware_cursor != cursor) {
 		output_cursor_damage_whole(cursor);
 	}


### PR DESCRIPTION
This implements a protocol for spying on cursors on a given output. This is needed for implementing client side cursor rendering in VNC. See https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst#cursor-pseudo-encoding

This feature significantly improves user experience on high latency VNC.

This implementation currently assumes that the pixel format read from cursor textures is ARGB8888. This will be fixed later, I just want some feedback on the protocol.

wayland-protocols MR is here: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/39