### PR TITLE
Improve DRM plane matching logic

### DIFF
--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -63,13 +63,6 @@ struct wlr_drm_crtc {
 	struct wlr_drm_plane *primary;
 	struct wlr_drm_plane *cursor;
 
-	/*
-	 * We don't support overlay planes yet, but we keep track of them to
-	 * give to DRM lease clients.
-	 */
-	size_t num_overlays;
-	uint32_t *overlays;
-
 	union wlr_drm_crtc_props props;
 };
 


### PR DESCRIPTION
This is an improved implementation of the plane matching logic when the kernel DRM does not enforce a single CRTC per plane.

This is not a bullet proof implementation but it should work fine for the Raspberry Pi 4 where all CRTCs are possible for all planes. 

Closes: https://github.com/swaywm/wlroots/issues/1943