### PR TITLE
xwayland: do not allow apps to change focus after wlroots request

### DIFF
--- a/include/xwayland/xwm.h
+++ b/include/xwayland/xwm.h
@@ -125,6 +125,7 @@ struct wlr_xwm {
 #if WLR_HAS_XCB_ERRORS
 	xcb_errors_context_t *errors_context;
 #endif
+	unsigned int last_focus_seq;
 
 	struct wl_listener compositor_new_surface;
 	struct wl_listener compositor_destroy;


### PR DESCRIPTION
This is an attempt to fix #2324 

@Xyene or someone else who uses JetBrains IDEs: can you check that this does not break #2219?