### PR TITLE
[WIP] add 10bit color support

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -109,11 +109,17 @@ static bool add_plane(struct wlr_drm_backend *drm,
 	for (size_t j = 0; j < drm_plane->count_formats; ++j) {
 		uint32_t fmt = drm_plane->formats[j];
 
-		if (fmt == DRM_FORMAT_XRGB2101010) {
+		if (fmt == DRM_FORMAT_ARGB2101010) {
+			// Prefer formats with 10 bit color
+			// and/or alhpa channel.
+			rgb_format = fmt;
+			break;
+		} else if (fmt == DRM_FORMAT_XRGB2101010) {
 			rgb_format = fmt;
 			break;
 		} else if (fmt == DRM_FORMAT_ARGB8888) {
 			rgb_format = fmt;
+			break;
 		} else if (fmt == DRM_FORMAT_XRGB8888) {
 			rgb_format = fmt;
 		}

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -109,10 +109,11 @@ static bool add_plane(struct wlr_drm_backend *drm,
 	for (size_t j = 0; j < drm_plane->count_formats; ++j) {
 		uint32_t fmt = drm_plane->formats[j];
 
-		if (fmt == DRM_FORMAT_ARGB8888) {
-			// Prefer formats with alpha channel
+		if (fmt == DRM_FORMAT_XRGB2101010) {
 			rgb_format = fmt;
 			break;
+		} else if (fmt == DRM_FORMAT_ARGB8888) {
+			rgb_format = fmt;
 		} else if (fmt == DRM_FORMAT_XRGB8888) {
 			rgb_format = fmt;
 		}

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -35,7 +35,7 @@ bool init_drm_renderer(struct wlr_drm_backend *drm,
 		EGL_NONE,
 	};
 
-	renderer->gbm_format = GBM_FORMAT_ARGB8888;
+	renderer->gbm_format = GBM_FORMAT_ARGB2101010;
 	renderer->wlr_rend = create_renderer_func(&renderer->egl,
 		EGL_PLATFORM_GBM_MESA, renderer->gbm,
 		config_attribs, renderer->gbm_format);

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -34,7 +34,8 @@ bool init_drm_renderer(struct wlr_drm_backend *drm,
 		EGL_ALPHA_SIZE, 1,
 		EGL_NONE,
 	};
-
+	
+	// TODO: allow setting from sway config/args. Have sane default set.
 	renderer->gbm_format = GBM_FORMAT_ARGB2101010;
 	renderer->wlr_rend = create_renderer_func(&renderer->egl,
 		EGL_PLATFORM_GBM_MESA, renderer->gbm,

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -138,6 +138,7 @@ struct wlr_output {
 	bool enabled;
 	float scale;
 	enum wl_output_subpixel subpixel;
+	enum wl_shm_format format;
 	enum wl_output_transform transform;
 	enum wlr_output_adaptive_sync_status adaptive_sync_status;
 
@@ -286,6 +287,12 @@ void wlr_output_set_scale(struct wlr_output *output, float scale);
 void wlr_output_set_subpixel(struct wlr_output *output,
 	enum wl_output_subpixel subpixel);
 void wlr_output_set_description(struct wlr_output *output, const char *desc);
+/**
+ * Set the color format mode for the output.
+ *
+ */
+void wlr_output_set_format(struct wlr_output *output,
+	enum wl_shm_format format);
 /**
  * Schedule a done event.
  *

--- a/render/gles2/pixel_format.c
+++ b/render/gles2/pixel_format.c
@@ -39,9 +39,40 @@ static const struct wlr_gles2_pixel_format formats[] = {
 		.gl_type = GL_UNSIGNED_BYTE,
 		.has_alpha = true,
 	},
+		// 10 bit formats
+	{	
+		.wl_format = WL_SHM_FORMAT_ARGB2101010,
+		.depth = 32,
+		.bpp = 32,
+		.gl_format = GL_BGRA_EXT,
+		.gl_type = GL_UNSIGNED_BYTE,
+		.has_alpha = true,
+	},
+	{
+		.wl_format = WL_SHM_FORMAT_XRGB2101010,
+		.depth = 24,
+		.bpp = 32,
+		.gl_format = GL_BGRA_EXT,
+		.gl_type = GL_UNSIGNED_BYTE,
+		.has_alpha = false,
+	},
+	{
+		.wl_format = WL_SHM_FORMAT_XBGR2101010,
+		.depth = 24,
+		.bpp = 32,
+		.gl_format = GL_RGBA,
+		.gl_type = GL_UNSIGNED_BYTE,
+		.has_alpha = false,
+	},
+	{
+		.wl_format = WL_SHM_FORMAT_ABGR2101010,
+		.depth = 32,
+		.bpp = 32,
+		.gl_format = GL_RGBA,
+		.gl_type = GL_UNSIGNED_BYTE,
+		.has_alpha = true,
+	},
 };
-
-// TODO: more pixel formats
 
 const struct wlr_gles2_pixel_format *get_gles2_format_from_wl(
 		enum wl_shm_format fmt) {

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -267,6 +267,15 @@ void wlr_output_set_subpixel(struct wlr_output *output,
 	wlr_output_schedule_done(output);
 }
 
+void wlr_output_set_format(struct wlr_output *output,
+		enum wl_shm_format format) {
+	if (output->format == format) {
+		return;
+	}
+
+	output->format = format;
+}
+
 void wlr_output_set_description(struct wlr_output *output, const char *desc) {
 	if (output->description != NULL && desc != NULL &&
 			strcmp(output->description, desc) == 0) {


### PR DESCRIPTION
This is an initial pull request to address issue #1378 using @tadeokondrak's patch posted in the issue as a starting point. I've added some of the color formats contained within the `wl_shm_format` enum that are in` /usr/include/wayland-server-protocol.h `. The initial 10bit color formats that have been added seem like a reasonable starting place, given that they look like 10bit versions of the 8bit color formats already being used. In future, adding YCbCr color formats seem like a good addition for TV/HDMI output.

I'm not quite sure if `wlr_output_set_format()` is doing enough when setting the color format. It looks fine, but I don't know if I need to be using `output->pending.format = format;` instead of `output->format = format;`. From what I gather from reading `types/wlr_output.h` and `interfaces/wlr_output.h`, the pending state is used for checking output state changes before committing them. I'm thinking checking before committing the change is possibly desirable in the event someone tries to set 10bit output to an 8bit monitor (and/or using an inadequate video cable). I'm not sure how to check for that at the moment.

Also, I'm not sure if `renderer->gbm_format` should get changed. I'm supposing 8bit color by default is safer than trying to use 10bit color on an 8bit monitor.