### PR TITLE
xwayland/xwm: don't insert surface in list on error

### DIFF
--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -139,7 +139,6 @@ static struct wlr_xwayland_surface *xwayland_surface_create(
 	surface->width = width;
 	surface->height = height;
 	surface->override_redirect = override_redirect;
-	wl_list_insert(&xwm->surfaces, &surface->link);
 	wl_list_init(&surface->children);
 	wl_list_init(&surface->parent_link);
 	wl_signal_init(&surface->events.destroy);
@@ -178,6 +177,8 @@ static struct wlr_xwayland_surface *xwayland_surface_create(
 		wlr_log(WLR_ERROR, "Could not add timer to event loop");
 		return NULL;
 	}
+
+	wl_list_insert(&xwm->surfaces, &surface->link);
 
 	wlr_signal_emit_safe(&xwm->xwayland->events.new_surface, surface);
 


### PR DESCRIPTION
In case wl_event_loop_add_timer errors out, don't insert the free'd
wlr_xwayland_surface in the list.

Closes: https://github.com/swaywm/wlroots/issues/1721