### PR TITLE
virtual_pointer: remember current axis for axis events

### DIFF
--- a/types/wlr_virtual_pointer_v1.c
+++ b/types/wlr_virtual_pointer_v1.c
@@ -103,7 +103,8 @@ static void virtual_pointer_axis(struct wl_client *client,
 		return;
 	}
 	struct wlr_input_device *wlr_dev = &pointer->input_device;
-	pointer->axis_valid[axis] = true;
+	pointer->axis = axis;
+	pointer->axis_valid[pointer->axis] = true;
 	pointer->axis_event[pointer->axis].device = wlr_dev;
 	pointer->axis_event[pointer->axis].time_msec = time;
 	pointer->axis_event[pointer->axis].orientation = axis;


### PR DESCRIPTION
Got it! Fixes swaywm/sway#5578.

What looks like a typo in `virtual_pointer_axis` was causing AXIS_HORIZONTAL events to indicate the pointer had two valid events, but it was actually just overwriting the first event leaving the horizontal event blank and crashing sway.