### PR TITLE
render/gles2: remove gles2_procs global

### DIFF
--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -79,7 +79,7 @@ struct wlr_gles2_renderer {
 
 struct wlr_gles2_texture {
 	struct wlr_texture wlr_texture;
-	struct wlr_egl *egl;
+	struct wlr_gles2_renderer *renderer;
 
 	// Basically:
 	//   GL_TEXTURE_2D == mutable

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -14,17 +14,6 @@
 #include <wlr/render/wlr_texture.h>
 #include <wlr/util/log.h>
 
-struct wlr_gles2_procs {
-	PFNGLEGLIMAGETARGETTEXTURE2DOESPROC glEGLImageTargetTexture2DOES;
-	PFNGLDEBUGMESSAGECALLBACKKHRPROC glDebugMessageCallbackKHR;
-	PFNGLDEBUGMESSAGECONTROLKHRPROC glDebugMessageControlKHR;
-	PFNGLPOPDEBUGGROUPKHRPROC glPopDebugGroupKHR;
-	PFNGLPUSHDEBUGGROUPKHRPROC glPushDebugGroupKHR;
-	PFNGLEGLIMAGETARGETRENDERBUFFERSTORAGEOESPROC glEGLImageTargetRenderbufferStorageOES;
-};
-
-extern struct wlr_gles2_procs gles2_procs;
-
 struct wlr_gles2_pixel_format {
 	enum wl_shm_format wl_format;
 	GLint gl_format, gl_type;
@@ -54,6 +43,15 @@ struct wlr_gles2_renderer {
 		bool egl_image_external_oes;
 		bool egl_image_oes;
 	} exts;
+
+	struct {
+		PFNGLEGLIMAGETARGETTEXTURE2DOESPROC glEGLImageTargetTexture2DOES;
+		PFNGLDEBUGMESSAGECALLBACKKHRPROC glDebugMessageCallbackKHR;
+		PFNGLDEBUGMESSAGECONTROLKHRPROC glDebugMessageControlKHR;
+		PFNGLPOPDEBUGGROUPKHRPROC glPopDebugGroupKHR;
+		PFNGLPUSHDEBUGGROUPKHRPROC glPushDebugGroupKHR;
+		PFNGLEGLIMAGETARGETRENDERBUFFERSTORAGEOESPROC glEGLImageTargetRenderbufferStorageOES;
+	} procs;
 
 	struct {
 		struct {

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -115,9 +115,9 @@ struct wlr_texture *gles2_texture_from_wl_drm(struct wlr_renderer *wlr_renderer,
 struct wlr_texture *gles2_texture_from_dmabuf(struct wlr_renderer *wlr_renderer,
 	struct wlr_dmabuf_attributes *attribs);
 
-void push_gles2_marker(const char *file, const char *func);
-void pop_gles2_marker(void);
-#define PUSH_GLES2_DEBUG push_gles2_marker(_WLR_FILENAME, __func__)
-#define POP_GLES2_DEBUG pop_gles2_marker()
+void push_gles2_debug_(struct wlr_gles2_renderer *renderer,
+	const char *file, const char *func);
+#define push_gles2_debug(renderer) push_gles2_debug_(renderer, _WLR_FILENAME, __func__)
+void pop_gles2_debug(struct wlr_gles2_renderer *renderer);
 
 #endif

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -102,8 +102,18 @@ const struct wlr_gles2_pixel_format *get_gles2_format_from_gl(
 	GLint gl_format, GLint gl_type, bool alpha);
 const enum wl_shm_format *get_gles2_wl_formats(size_t *len);
 
+struct wlr_gles2_renderer *gles2_get_renderer(
+	struct wlr_renderer *wlr_renderer);
 struct wlr_gles2_texture *gles2_get_texture(
 	struct wlr_texture *wlr_texture);
+
+struct wlr_texture *gles2_texture_from_pixels(struct wlr_renderer *wlr_renderer,
+	enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width, uint32_t height,
+	const void *data);
+struct wlr_texture *gles2_texture_from_wl_drm(struct wlr_renderer *wlr_renderer,
+	struct wl_resource *data);
+struct wlr_texture *gles2_texture_from_dmabuf(struct wlr_renderer *wlr_renderer,
+	struct wlr_dmabuf_attributes *attribs);
 
 void push_gles2_marker(const char *file, const char *func);
 void pop_gles2_marker(void);

--- a/include/wlr/render/gles2.h
+++ b/include/wlr/render/gles2.h
@@ -21,14 +21,6 @@ struct wlr_egl *wlr_gles2_renderer_get_egl(struct wlr_renderer *renderer);
 bool wlr_gles2_renderer_check_ext(struct wlr_renderer *renderer,
 	const char *ext);
 
-struct wlr_texture *wlr_gles2_texture_from_pixels(struct wlr_egl *egl,
-	enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width, uint32_t height,
-	const void *data);
-struct wlr_texture *wlr_gles2_texture_from_wl_drm(struct wlr_egl *egl,
-	struct wl_resource *data);
-struct wlr_texture *wlr_gles2_texture_from_dmabuf(struct wlr_egl *egl,
-	struct wlr_dmabuf_attributes *attribs);
-
 struct wlr_gles2_texture_attribs {
 	GLenum target; /* either GL_TEXTURE_2D or GL_TEXTURE_EXTERNAL_OES */
 	GLuint tex;

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -25,7 +25,7 @@ struct wlr_gles2_procs gles2_procs = {0};
 
 static const struct wlr_renderer_impl renderer_impl;
 
-static struct wlr_gles2_renderer *gles2_get_renderer(
+struct wlr_gles2_renderer *gles2_get_renderer(
 		struct wlr_renderer *wlr_renderer) {
 	assert(wlr_renderer->impl == &renderer_impl);
 	return (struct wlr_gles2_renderer *)wlr_renderer;
@@ -440,27 +440,6 @@ texture_destroy_out:
 restore_context_out:
 	wlr_egl_restore_context(&old_context);
 	return r;
-}
-
-static struct wlr_texture *gles2_texture_from_pixels(
-		struct wlr_renderer *wlr_renderer, enum wl_shm_format wl_fmt,
-		uint32_t stride, uint32_t width, uint32_t height, const void *data) {
-	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
-	return wlr_gles2_texture_from_pixels(renderer->egl, wl_fmt, stride, width,
-		height, data);
-}
-
-static struct wlr_texture *gles2_texture_from_wl_drm(
-		struct wlr_renderer *wlr_renderer, struct wl_resource *data) {
-	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
-	return wlr_gles2_texture_from_wl_drm(renderer->egl, data);
-}
-
-static struct wlr_texture *gles2_texture_from_dmabuf(
-		struct wlr_renderer *wlr_renderer,
-		struct wlr_dmabuf_attributes *attribs) {
-	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
-	return wlr_gles2_texture_from_dmabuf(renderer->egl, attribs);
 }
 
 static bool gles2_init_wl_display(struct wlr_renderer *wlr_renderer,

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -134,9 +134,12 @@ static const struct wlr_texture_impl texture_impl = {
 	.destroy = gles2_texture_destroy,
 };
 
-struct wlr_texture *wlr_gles2_texture_from_pixels(struct wlr_egl *egl,
+struct wlr_texture *gles2_texture_from_pixels(struct wlr_renderer *wlr_renderer,
 		enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width,
 		uint32_t height, const void *data) {
+	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
+	struct wlr_egl *egl = renderer->egl;
+
 	wlr_egl_make_current(egl, EGL_NO_SURFACE, NULL);
 
 	const struct wlr_gles2_pixel_format *fmt = get_gles2_format_from_wl(wl_fmt);
@@ -175,8 +178,11 @@ struct wlr_texture *wlr_gles2_texture_from_pixels(struct wlr_egl *egl,
 	return &texture->wlr_texture;
 }
 
-struct wlr_texture *wlr_gles2_texture_from_wl_drm(struct wlr_egl *egl,
+struct wlr_texture *gles2_texture_from_wl_drm(struct wlr_renderer *wlr_renderer,
 		struct wl_resource *resource) {
+	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
+	struct wlr_egl *egl = renderer->egl;
+
 	wlr_egl_make_current(egl, EGL_NO_SURFACE, NULL);
 
 	if (!gles2_procs.glEGLImageTargetTexture2DOES) {
@@ -238,8 +244,11 @@ struct wlr_texture *wlr_gles2_texture_from_wl_drm(struct wlr_egl *egl,
 	return &texture->wlr_texture;
 }
 
-struct wlr_texture *wlr_gles2_texture_from_dmabuf(struct wlr_egl *egl,
+struct wlr_texture *gles2_texture_from_dmabuf(struct wlr_renderer *wlr_renderer,
 		struct wlr_dmabuf_attributes *attribs) {
+	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
+	struct wlr_egl *egl = renderer->egl;
+
 	wlr_egl_make_current(egl, EGL_NO_SURFACE, NULL);
 
 	if (!gles2_procs.glEGLImageTargetTexture2DOES) {

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -56,7 +56,7 @@ static bool gles2_texture_write_pixels(struct wlr_texture *wlr_texture,
 	assert(fmt);
 
 	// TODO: what if the unpack subimage extension isn't supported?
-	PUSH_GLES2_DEBUG;
+	push_gles2_debug(texture->renderer);
 
 	glBindTexture(GL_TEXTURE_2D, texture->tex);
 
@@ -73,7 +73,7 @@ static bool gles2_texture_write_pixels(struct wlr_texture *wlr_texture,
 
 	glBindTexture(GL_TEXTURE_2D, 0);
 
-	POP_GLES2_DEBUG;
+	pop_gles2_debug(texture->renderer);
 
 	wlr_egl_unset_current(texture->renderer->egl);
 	return true;
@@ -115,12 +115,12 @@ static void gles2_texture_destroy(struct wlr_texture *wlr_texture) {
 	struct wlr_gles2_texture *texture =
 		get_gles2_texture_in_context(wlr_texture);
 
-	PUSH_GLES2_DEBUG;
+	push_gles2_debug(texture->renderer);
 
 	glDeleteTextures(1, &texture->tex);
 	wlr_egl_destroy_image(texture->renderer->egl, texture->image);
 
-	POP_GLES2_DEBUG;
+	pop_gles2_debug(texture->renderer);
 
 	wlr_egl_unset_current(texture->renderer->egl);
 
@@ -159,7 +159,7 @@ struct wlr_texture *gles2_texture_from_pixels(struct wlr_renderer *wlr_renderer,
 	texture->has_alpha = fmt->has_alpha;
 	texture->wl_format = fmt->wl_format;
 
-	PUSH_GLES2_DEBUG;
+	push_gles2_debug(renderer);
 
 	glGenTextures(1, &texture->tex);
 	glBindTexture(GL_TEXTURE_2D, texture->tex);
@@ -171,7 +171,7 @@ struct wlr_texture *gles2_texture_from_pixels(struct wlr_renderer *wlr_renderer,
 
 	glBindTexture(GL_TEXTURE_2D, 0);
 
-	POP_GLES2_DEBUG;
+	pop_gles2_debug(renderer);
 
 	wlr_egl_unset_current(renderer->egl);
 	return &texture->wlr_texture;
@@ -228,7 +228,7 @@ struct wlr_texture *gles2_texture_from_wl_drm(struct wlr_renderer *wlr_renderer,
 
 	texture->target = GL_TEXTURE_EXTERNAL_OES;
 
-	PUSH_GLES2_DEBUG;
+	push_gles2_debug(renderer);
 
 	glGenTextures(1, &texture->tex);
 	glBindTexture(GL_TEXTURE_EXTERNAL_OES, texture->tex);
@@ -236,7 +236,7 @@ struct wlr_texture *gles2_texture_from_wl_drm(struct wlr_renderer *wlr_renderer,
 		texture->image);
 	glBindTexture(GL_TEXTURE_EXTERNAL_OES, 0);
 
-	POP_GLES2_DEBUG;
+	pop_gles2_debug(renderer);
 
 	wlr_egl_unset_current(renderer->egl);
 	return &texture->wlr_texture;
@@ -295,14 +295,14 @@ struct wlr_texture *gles2_texture_from_dmabuf(struct wlr_renderer *wlr_renderer,
 
 	texture->target = external_only ? GL_TEXTURE_EXTERNAL_OES : GL_TEXTURE_2D;
 
-	PUSH_GLES2_DEBUG;
+	push_gles2_debug(renderer);
 
 	glGenTextures(1, &texture->tex);
 	glBindTexture(texture->target, texture->tex);
 	gles2_procs.glEGLImageTargetTexture2DOES(texture->target, texture->image);
 	glBindTexture(texture->target, 0);
 
-	POP_GLES2_DEBUG;
+	pop_gles2_debug(renderer);
 
 	wlr_egl_unset_current(renderer->egl);
 	return &texture->wlr_texture;

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -183,7 +183,7 @@ struct wlr_texture *gles2_texture_from_wl_drm(struct wlr_renderer *wlr_renderer,
 
 	wlr_egl_make_current(renderer->egl, EGL_NO_SURFACE, NULL);
 
-	if (!gles2_procs.glEGLImageTargetTexture2DOES) {
+	if (!renderer->procs.glEGLImageTargetTexture2DOES) {
 		return NULL;
 	}
 
@@ -232,7 +232,7 @@ struct wlr_texture *gles2_texture_from_wl_drm(struct wlr_renderer *wlr_renderer,
 
 	glGenTextures(1, &texture->tex);
 	glBindTexture(GL_TEXTURE_EXTERNAL_OES, texture->tex);
-	gles2_procs.glEGLImageTargetTexture2DOES(GL_TEXTURE_EXTERNAL_OES,
+	renderer->procs.glEGLImageTargetTexture2DOES(GL_TEXTURE_EXTERNAL_OES,
 		texture->image);
 	glBindTexture(GL_TEXTURE_EXTERNAL_OES, 0);
 
@@ -248,7 +248,7 @@ struct wlr_texture *gles2_texture_from_dmabuf(struct wlr_renderer *wlr_renderer,
 
 	wlr_egl_make_current(renderer->egl, EGL_NO_SURFACE, NULL);
 
-	if (!gles2_procs.glEGLImageTargetTexture2DOES) {
+	if (!renderer->procs.glEGLImageTargetTexture2DOES) {
 		return NULL;
 	}
 
@@ -299,7 +299,7 @@ struct wlr_texture *gles2_texture_from_dmabuf(struct wlr_renderer *wlr_renderer,
 
 	glGenTextures(1, &texture->tex);
 	glBindTexture(texture->target, texture->tex);
-	gles2_procs.glEGLImageTargetTexture2DOES(texture->target, texture->image);
+	renderer->procs.glEGLImageTargetTexture2DOES(texture->target, texture->image);
 	glBindTexture(texture->target, 0);
 
 	pop_gles2_debug(renderer);


### PR DESCRIPTION
_See individual commits._

* * *

Breaking change: the `wlr_gles2_texture_from_*` family of functions are no longer public API.