### PR TITLE
xwayland: do not allow apps to change focus after wlroots request

### DIFF
--- a/include/xwayland/xwm.h
+++ b/include/xwayland/xwm.h
@@ -128,6 +128,7 @@ struct wlr_xwm {
 #if WLR_HAS_XCB_ERRORS
 	xcb_errors_context_t *errors_context;
 #endif
+	unsigned int last_focus_seq;
 
 	struct wl_listener compositor_new_surface;
 	struct wl_listener compositor_destroy;


### PR DESCRIPTION
Resend of #2339 , as @emersion suggested we simply deny requests that are too old. For requests after the latest focus change of wlroots, we allow changing focus between surfaces of the same application, as before.