### PR TITLE
Always schedule configure on maximize and fullscreen requests

### DIFF
--- a/types/xdg_shell/wlr_xdg_toplevel.c
+++ b/types/xdg_shell/wlr_xdg_toplevel.c
@@ -581,7 +581,7 @@ uint32_t wlr_xdg_toplevel_set_maximized(struct wlr_xdg_surface *surface,
 	assert(surface->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL);
 	surface->toplevel->server_pending.maximized = maximized;
 
-	return schedule_xdg_surface_configure(surface);
+	return wlr_xdg_surface_schedule_configure(surface);
 }
 
 uint32_t wlr_xdg_toplevel_set_fullscreen(struct wlr_xdg_surface *surface,
@@ -589,7 +589,7 @@ uint32_t wlr_xdg_toplevel_set_fullscreen(struct wlr_xdg_surface *surface,
 	assert(surface->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL);
 	surface->toplevel->server_pending.fullscreen = fullscreen;
 
-	return schedule_xdg_surface_configure(surface);
+	return wlr_xdg_surface_schedule_configure(surface);
 }
 
 uint32_t wlr_xdg_toplevel_set_resizing(struct wlr_xdg_surface *surface,


### PR DESCRIPTION
This is my approach for fixing #2330. The idea is that compositors already implement handlers that call these functions (probably), so wlroots should do the "right thing" and always schedule a configure event even if the compositor decided not to change the window state.

If a compositor like sway doesn't care about maximize requests, it still needs to implement a stub handler that calls set_maximized to indicate it is done considering the request.