### PR TITLE
gamma-control-v1: fix use-after-free in gamma_control_handle_set_gamma

### DIFF
--- a/types/wlr_gamma_control_v1.c
+++ b/types/wlr_gamma_control_v1.c
@@ -107,8 +107,8 @@ static void gamma_control_handle_set_gamma(struct wl_client *client,
 
 	wlr_output_set_gamma(gamma_control->output, ramp_size, r, g, b);
 	if (!wlr_output_test(gamma_control->output)) {
-		gamma_control_send_failed(gamma_control);
 		wlr_output_rollback(gamma_control->output);
+		gamma_control_send_failed(gamma_control);
 		goto error_table;
 	}
 	free(table);


### PR DESCRIPTION
gamma_control_send_failed destroys gamma_control.