### PR TITLE
xdg_shell: simplify wlr_xdg_toplevel_state

### DIFF
--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -106,12 +106,6 @@ struct wlr_xdg_toplevel_state {
 	uint32_t width, height;
 	uint32_t max_width, max_height;
 	uint32_t min_width, min_height;
-
-	// Since the fullscreen request may be made before the toplevel's surface
-	// is mapped, this is used to store the requested fullscreen output (if
-	// any) for wlr_xdg_toplevel::client_pending.
-	struct wlr_output *fullscreen_output;
-	struct wl_listener fullscreen_output_destroy;
 };
 
 struct wlr_xdg_toplevel {
@@ -125,6 +119,12 @@ struct wlr_xdg_toplevel {
 	struct wlr_xdg_toplevel_state client_pending;
 	struct wlr_xdg_toplevel_state server_pending;
 	struct wlr_xdg_toplevel_state current;
+
+	// Since the fullscreen request may be made before the toplevel's surface
+	// is mapped, this is used to store the requested fullscreen output if
+	// any. This is part of the client's pending state.
+	struct wlr_output *requested_fullscreen_output;
+	struct wl_listener requested_fullscreen_output_destroy;
 
 	char *title;
 	char *app_id;

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -113,12 +113,6 @@ struct wlr_xdg_toplevel_v6_state {
 	uint32_t width, height;
 	uint32_t max_width, max_height;
 	uint32_t min_width, min_height;
-
-	// Since the fullscreen request may be made before the toplevel's surface
-	// is mapped, this is used to store the requested fullscreen output (if
-	// any) for wlr_xdg_toplevel_v6::client_pending.
-	struct wlr_output *fullscreen_output;
-	struct wl_listener fullscreen_output_destroy;
 };
 
 /**
@@ -140,6 +134,12 @@ struct wlr_xdg_toplevel_v6 {
 	struct wlr_xdg_toplevel_v6_state client_pending;
 	struct wlr_xdg_toplevel_v6_state server_pending;
 	struct wlr_xdg_toplevel_v6_state current;
+
+	// Since the fullscreen request may be made before the toplevel's surface
+	// is mapped, this is used to store the requested fullscreen output if
+	// any. This is part of the client's pending state.
+	struct wlr_output *requested_fullscreen_output;
+	struct wl_listener requested_fullscreen_output_destroy;
 
 	char *title;
 	char *app_id;

--- a/types/xdg_shell/wlr_xdg_surface.c
+++ b/types/xdg_shell/wlr_xdg_surface.c
@@ -484,10 +484,9 @@ void reset_xdg_surface(struct wlr_xdg_surface *xdg_surface) {
 		wl_resource_set_user_data(xdg_surface->toplevel->resource, NULL);
 		xdg_surface->toplevel->resource = NULL;
 
-		if (xdg_surface->toplevel->client_pending.fullscreen_output) {
-			struct wlr_xdg_toplevel_state *client_pending =
-				&xdg_surface->toplevel->client_pending;
-			wl_list_remove(&client_pending->fullscreen_output_destroy.link);
+		if (xdg_surface->toplevel->requested_fullscreen_output) {
+			struct wlr_xdg_toplevel *toplevel = xdg_surface->toplevel;
+			wl_list_remove(&toplevel->requested_fullscreen_output_destroy.link);
 		}
 		free(xdg_surface->toplevel);
 		xdg_surface->toplevel = NULL;

--- a/types/xdg_shell/wlr_xdg_toplevel.c
+++ b/types/xdg_shell/wlr_xdg_toplevel.c
@@ -404,25 +404,26 @@ static void xdg_toplevel_handle_unset_maximized(struct wl_client *client,
 
 static void handle_fullscreen_output_destroy(struct wl_listener *listener,
 		void *data) {
-	struct wlr_xdg_toplevel_state *state =
-		wl_container_of(listener, state, fullscreen_output_destroy);
-	state->fullscreen_output = NULL;
-	wl_list_remove(&state->fullscreen_output_destroy.link);
+	struct wlr_xdg_toplevel *toplevel =
+		wl_container_of(listener, toplevel, requested_fullscreen_output_destroy);
+	toplevel->requested_fullscreen_output = NULL;
+	wl_list_remove(&toplevel->requested_fullscreen_output_destroy.link);
 }
 
 static void store_fullscreen_pending(struct wlr_xdg_surface *surface,
 		bool fullscreen, struct wlr_output *output) {
-	struct wlr_xdg_toplevel_state *state = &surface->toplevel->client_pending;
+	struct wlr_xdg_toplevel *toplevel = surface->toplevel;
+	struct wlr_xdg_toplevel_state *state = &toplevel->client_pending;
 	state->fullscreen = fullscreen;
-	if (state->fullscreen_output) {
-		wl_list_remove(&state->fullscreen_output_destroy.link);
+	if (toplevel->requested_fullscreen_output) {
+		wl_list_remove(&toplevel->requested_fullscreen_output_destroy.link);
 	}
-	state->fullscreen_output = output;
-	if (state->fullscreen_output) {
-		state->fullscreen_output_destroy.notify =
+	toplevel->requested_fullscreen_output = output;
+	if (toplevel->requested_fullscreen_output) {
+		toplevel->requested_fullscreen_output_destroy.notify =
 			handle_fullscreen_output_destroy;
-		wl_signal_add(&state->fullscreen_output->events.destroy,
-				&state->fullscreen_output_destroy);
+		wl_signal_add(&toplevel->requested_fullscreen_output->events.destroy,
+			&toplevel->requested_fullscreen_output_destroy);
 	}
 }
 


### PR DESCRIPTION
the fullscreen_output and fullscreen_output_destroy fields were only
used if the state was wlr_xdg_toplevel::client_pending. Moving these
fields to wlr_xdg_toplevel reduces confusion and simplifies the code.