### PR TITLE
Renderer v6: headless backend

### DIFF
--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -1,65 +1,18 @@
 #include <assert.h>
-#include <GLES2/gl2.h>
-#include <GLES2/gl2ext.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <wlr/interfaces/wlr_output.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/util/log.h>
 #include "backend/headless.h"
+#include "render/swapchain.h"
+#include "render/wlr_renderer.h"
 #include "util/signal.h"
 
 static struct wlr_headless_output *headless_output_from_output(
 		struct wlr_output *wlr_output) {
 	assert(wlr_output_is_headless(wlr_output));
 	return (struct wlr_headless_output *)wlr_output;
-}
-
-static bool create_fbo(struct wlr_headless_output *output,
-		unsigned int width, unsigned int height) {
-	if (!wlr_egl_make_current(output->backend->egl, EGL_NO_SURFACE, NULL)) {
-		return false;
-	}
-
-	GLuint rbo;
-	glGenRenderbuffers(1, &rbo);
-	glBindRenderbuffer(GL_RENDERBUFFER, rbo);
-	glRenderbufferStorage(GL_RENDERBUFFER, output->backend->internal_format,
-		width, height);
-	glBindRenderbuffer(GL_RENDERBUFFER, 0);
-
-	GLuint fbo;
-	glGenFramebuffers(1, &fbo);
-	glBindFramebuffer(GL_FRAMEBUFFER, fbo);
-	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
-		GL_RENDERBUFFER, rbo);
-	GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-	glBindFramebuffer(GL_FRAMEBUFFER, 0);
-
-	wlr_egl_unset_current(output->backend->egl);
-
-	if (status != GL_FRAMEBUFFER_COMPLETE) {
-		wlr_log(WLR_ERROR, "Failed to create FBO");
-		return false;
-	}
-
-	output->fbo = fbo;
-	output->rbo = rbo;
-	return true;
-}
-
-static void destroy_fbo(struct wlr_headless_output *output) {
-	if (!wlr_egl_make_current(output->backend->egl, EGL_NO_SURFACE, NULL)) {
-		return;
-	}
-
-	glDeleteFramebuffers(1, &output->fbo);
-	glDeleteRenderbuffers(1, &output->rbo);
-
-	wlr_egl_unset_current(output->backend->egl);
-
-	output->fbo = 0;
-	output->rbo = 0;
 }
 
 static bool output_set_custom_mode(struct wlr_output *wlr_output, int32_t width,
@@ -71,8 +24,10 @@ static bool output_set_custom_mode(struct wlr_output *wlr_output, int32_t width,
 		refresh = HEADLESS_DEFAULT_REFRESH;
 	}
 
-	destroy_fbo(output);
-	if (!create_fbo(output, width, height)) {
+	wlr_swapchain_destroy(output->swapchain);
+	output->swapchain = wlr_swapchain_create(output->backend->allocator,
+			width, height, output->backend->format);
+	if (!output->swapchain) {
 		wlr_output_destroy(wlr_output);
 		return false;
 	}
@@ -88,15 +43,20 @@ static bool output_attach_render(struct wlr_output *wlr_output,
 	struct wlr_headless_output *output =
 		headless_output_from_output(wlr_output);
 
-	if (!wlr_egl_make_current(output->backend->egl, EGL_NO_SURFACE, NULL)) {
+	wlr_buffer_unlock(output->back_buffer);
+	output->back_buffer = wlr_swapchain_acquire(output->swapchain, buffer_age);
+	if (!output->back_buffer) {
 		return false;
 	}
 
-	glBindFramebuffer(GL_FRAMEBUFFER, output->fbo);
-
-	if (buffer_age != NULL) {
-		*buffer_age = 0; // We only have one buffer
+	if (!wlr_egl_make_current(output->backend->egl, EGL_NO_SURFACE, NULL)) {
+		return false;
 	}
+	if (!wlr_renderer_bind_buffer(output->backend->renderer,
+			output->back_buffer)) {
+		return false;
+	}
+
 	return true;
 }
 
@@ -131,10 +91,18 @@ static bool output_commit(struct wlr_output *wlr_output) {
 	}
 
 	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
-		glBindFramebuffer(GL_FRAMEBUFFER, 0);
+		assert(output->back_buffer != NULL);
+
+		wlr_renderer_bind_buffer(output->backend->renderer, NULL);
 		wlr_egl_unset_current(output->backend->egl);
 
-		// Nothing needs to be done for FBOs
+		wlr_buffer_unlock(output->front_buffer);
+		output->front_buffer = output->back_buffer;
+		output->back_buffer = NULL;
+
+		wlr_swapchain_set_buffer_submitted(output->swapchain,
+			output->front_buffer);
+
 		wlr_output_send_present(wlr_output, NULL);
 	}
 
@@ -145,8 +113,12 @@ static void output_rollback_render(struct wlr_output *wlr_output) {
 	struct wlr_headless_output *output =
 		headless_output_from_output(wlr_output);
 	assert(wlr_egl_is_current(output->backend->egl));
-	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+	wlr_renderer_bind_buffer(output->backend->renderer, NULL);
 	wlr_egl_unset_current(output->backend->egl);
+
+	wlr_buffer_unlock(output->back_buffer);
+	output->back_buffer = NULL;
 }
 
 static void output_destroy(struct wlr_output *wlr_output) {
@@ -154,7 +126,9 @@ static void output_destroy(struct wlr_output *wlr_output) {
 		headless_output_from_output(wlr_output);
 	wl_list_remove(&output->link);
 	wl_event_source_remove(output->frame_timer);
-	destroy_fbo(output);
+	wlr_swapchain_destroy(output->swapchain);
+	wlr_buffer_unlock(output->back_buffer);
+	wlr_buffer_unlock(output->front_buffer);
 	free(output);
 }
 
@@ -192,7 +166,9 @@ struct wlr_output *wlr_headless_add_output(struct wlr_backend *wlr_backend,
 		backend->display);
 	struct wlr_output *wlr_output = &output->wlr_output;
 
-	if (!create_fbo(output, width, height)) {
+	output->swapchain = wlr_swapchain_create(backend->allocator,
+		width, height, backend->format);
+	if (!output->swapchain) {
 		goto error;
 	}
 
@@ -206,14 +182,6 @@ struct wlr_output *wlr_headless_add_output(struct wlr_backend *wlr_backend,
 	snprintf(description, sizeof(description),
 		"Headless output %zd", backend->last_output_num);
 	wlr_output_set_description(wlr_output, description);
-
-	if (!output_attach_render(wlr_output, NULL)) {
-		goto error;
-	}
-
-	wlr_renderer_begin(backend->renderer, wlr_output->width, wlr_output->height);
-	wlr_renderer_clear(backend->renderer, (float[]){ 1.0, 1.0, 1.0, 1.0 });
-	wlr_renderer_end(backend->renderer);
 
 	struct wl_event_loop *ev = wl_display_get_event_loop(backend->display);
 	output->frame_timer = wl_event_loop_add_timer(ev, signal_frame, output);

--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -121,6 +121,23 @@ static void output_rollback_render(struct wlr_output *wlr_output) {
 	output->back_buffer = NULL;
 }
 
+static bool output_export_dmabuf(struct wlr_output *wlr_output,
+		struct wlr_dmabuf_attributes *attribs) {
+	struct wlr_headless_output *output =
+		headless_output_from_output(wlr_output);
+
+	if (!output->front_buffer) {
+		return false;
+	}
+
+	struct wlr_dmabuf_attributes tmp;
+	if (!wlr_buffer_get_dmabuf(output->front_buffer, &tmp)) {
+		return false;
+	}
+
+	return wlr_dmabuf_attributes_copy(attribs, &tmp);
+}
+
 static void output_destroy(struct wlr_output *wlr_output) {
 	struct wlr_headless_output *output =
 		headless_output_from_output(wlr_output);
@@ -137,6 +154,7 @@ static const struct wlr_output_impl output_impl = {
 	.attach_render = output_attach_render,
 	.commit = output_commit,
 	.rollback_render = output_rollback_render,
+	.export_dmabuf = output_export_dmabuf,
 };
 
 bool wlr_output_is_headless(struct wlr_output *wlr_output) {

--- a/include/backend/headless.h
+++ b/include/backend/headless.h
@@ -3,7 +3,6 @@
 
 #include <wlr/backend/headless.h>
 #include <wlr/backend/interface.h>
-#include <wlr/render/gles2.h>
 
 #define HEADLESS_DEFAULT_REFRESH (60 * 1000) // 60 Hz
 
@@ -12,6 +11,8 @@ struct wlr_headless_backend {
 	struct wlr_egl priv_egl; // may be uninitialized
 	struct wlr_egl *egl;
 	struct wlr_renderer *renderer;
+	struct wlr_allocator *allocator;
+	struct wlr_drm_format *format;
 	struct wl_display *display;
 	struct wl_list outputs;
 	size_t last_output_num;
@@ -19,7 +20,6 @@ struct wlr_headless_backend {
 	struct wl_listener display_destroy;
 	struct wl_listener renderer_destroy;
 	bool started;
-	GLenum internal_format;
 };
 
 struct wlr_headless_output {
@@ -28,7 +28,8 @@ struct wlr_headless_output {
 	struct wlr_headless_backend *backend;
 	struct wl_list link;
 
-	GLuint fbo, rbo;
+	struct wlr_swapchain *swapchain;
+	struct wlr_buffer *back_buffer, *front_buffer;
 
 	struct wl_event_source *frame_timer;
 	int frame_delay; // ms

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -35,6 +35,7 @@ struct wlr_gles2_renderer {
 	struct wlr_renderer wlr_renderer;
 
 	struct wlr_egl *egl;
+	int drm_fd;
 
 	const char *exts_str;
 	struct {

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -45,8 +45,10 @@ struct wlr_egl {
 	EGLDisplay display;
 	EGLConfig config;
 	EGLContext context;
+	EGLDeviceEXT device; // may be EGL_NO_DEVICE_EXT
 
 	struct {
+		// Display extensions
 		bool bind_wayland_display_wl;
 		bool buffer_age_ext;
 		bool image_base_khr;
@@ -54,6 +56,9 @@ struct wlr_egl {
 		bool image_dmabuf_import_ext;
 		bool image_dmabuf_import_modifiers_ext;
 		bool swap_buffers_with_damage;
+
+		// Device extensions
+		bool device_drm_ext;
 	} exts;
 
 	struct {
@@ -70,6 +75,8 @@ struct wlr_egl {
 		PFNEGLEXPORTDMABUFIMAGEQUERYMESAPROC eglExportDMABUFImageQueryMESA;
 		PFNEGLEXPORTDMABUFIMAGEMESAPROC eglExportDMABUFImageMESA;
 		PFNEGLDEBUGMESSAGECONTROLKHRPROC eglDebugMessageControlKHR;
+		PFNEGLQUERYDISPLAYATTRIBEXTPROC eglQueryDisplayAttribEXT;
+		PFNEGLQUERYDEVICESTRINGEXTPROC eglQueryDeviceStringEXT;
 	} procs;
 
 	struct wl_display *wl_display;
@@ -163,5 +170,7 @@ bool wlr_egl_swap_buffers(struct wlr_egl *egl, EGLSurface surface,
 	pixman_region32_t *damage);
 
 bool wlr_egl_destroy_surface(struct wlr_egl *egl, EGLSurface surface);
+
+int wlr_egl_dup_drm_fd(struct wlr_egl *egl);
 
 #endif

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -72,6 +72,7 @@ struct wlr_renderer_impl {
 	bool (*blit_dmabuf)(struct wlr_renderer *renderer,
 		struct wlr_dmabuf_attributes *dst,
 		struct wlr_dmabuf_attributes *src);
+	int (*get_drm_fd)(struct wlr_renderer *renderer);
 };
 
 void wlr_renderer_init(struct wlr_renderer *renderer,

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -132,6 +132,13 @@ bool wlr_renderer_init_wl_display(struct wlr_renderer *r,
 	struct wl_display *wl_display);
 
 /**
+ * Obtains the FD of the DRM device used for rendering, or -1 if unavailable.
+ *
+ * The caller doesn't have ownership of the FD, it must not close it.
+ */
+int wlr_renderer_get_drm_fd(struct wlr_renderer *r);
+
+/**
  * Destroys this wlr_renderer. Textures must be destroyed separately.
  */
 void wlr_renderer_destroy(struct wlr_renderer *renderer);

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -269,3 +269,10 @@ struct wlr_renderer *wlr_renderer_autocreate(struct wlr_egl *egl,
 
 	return renderer;
 }
+
+int wlr_renderer_get_drm_fd(struct wlr_renderer *r) {
+	if (!r->impl->get_drm_fd) {
+		return -1;
+	}
+	return r->impl->get_drm_fd(r);
+}


### PR DESCRIPTION
Same as https://github.com/swaywm/wlroots/pull/2240 but for the headless backend. Supersedes https://github.com/swaywm/wlroots/pull/2268.