### PR TITLE
Remove unnecessary wl_display_dispatch calls

### DIFF
--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -279,7 +279,6 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display,
 	}
 
 	wl_registry_add_listener(wl->registry, &registry_listener, wl);
-	wl_display_dispatch(wl->remote_display);
 	wl_display_roundtrip(wl->remote_display);
 
 	if (!wl->compositor) {

--- a/examples/dmabuf-capture.c
+++ b/examples/dmabuf-capture.c
@@ -754,7 +754,6 @@ static int init(struct capture_context *ctx) {
 	wl_registry_add_listener(ctx->registry, &registry_listener, ctx);
 
 	wl_display_roundtrip(ctx->display);
-	wl_display_dispatch(ctx->display);
 
 	if (!ctx->export_manager) {
 		av_log(ctx, AV_LOG_ERROR, "Compositor doesn't support %s!\n",

--- a/examples/foreign-toplevel.c
+++ b/examples/foreign-toplevel.c
@@ -332,7 +332,6 @@ int main(int argc, char **argv) {
 
 	struct wl_registry *registry = wl_display_get_registry(display);
 	wl_registry_add_listener(registry, &registry_listener, NULL);
-	wl_display_dispatch(display);
 	wl_display_roundtrip(display);
 
 	if (toplevel_manager == NULL) {

--- a/examples/gamma-control.c
+++ b/examples/gamma-control.c
@@ -162,7 +162,6 @@ int main(int argc, char *argv[]) {
 
 	struct wl_registry *registry = wl_display_get_registry(display);
 	wl_registry_add_listener(registry, &registry_listener, NULL);
-	wl_display_dispatch(display);
 	wl_display_roundtrip(display);
 
 	if (gamma_control_manager == NULL) {

--- a/examples/idle-inhibit.c
+++ b/examples/idle-inhibit.c
@@ -177,7 +177,6 @@ int main(int argc, char **argv) {
 
 	struct wl_registry *registry = wl_display_get_registry(display);
 	wl_registry_add_listener(registry, &registry_listener, NULL);
-	wl_display_dispatch(display);
 	wl_display_roundtrip(display);
 
 	if (compositor == NULL) {

--- a/examples/idle.c
+++ b/examples/idle.c
@@ -125,7 +125,6 @@ int main(int argc, char *argv[]) {
 
 	struct wl_registry *registry = wl_display_get_registry(display);
 	wl_registry_add_listener(registry, &registry_listener, NULL);
-	wl_display_dispatch(display);
 	wl_display_roundtrip(display);
 	wl_registry_destroy(registry);
 

--- a/examples/input-inhibitor.c
+++ b/examples/input-inhibitor.c
@@ -150,7 +150,6 @@ int main(int argc, char **argv) {
 	struct wl_registry *registry = wl_display_get_registry(display);
 	assert(registry);
 	wl_registry_add_listener(registry, &registry_listener, NULL);
-	wl_display_dispatch(display);
 	wl_display_roundtrip(display);
 	assert(compositor && seat && wm_base && input_inhibit_manager);
 

--- a/examples/input-method-keyboard-grab.c
+++ b/examples/input-method-keyboard-grab.c
@@ -191,7 +191,6 @@ int main(int argc, char **argv) {
 
 	struct wl_registry *registry = wl_display_get_registry(display);
 	wl_registry_add_listener(registry, &registry_listener, NULL);
-	wl_display_dispatch(display);
 	wl_display_roundtrip(display);
 
 	if (input_method_manager == NULL) {

--- a/examples/input-method.c
+++ b/examples/input-method.c
@@ -324,7 +324,6 @@ int main(int argc, char **argv) {
 
 	struct wl_registry *registry = wl_display_get_registry(display);
 	wl_registry_add_listener(registry, &registry_listener, NULL);
-	wl_display_dispatch(display);
 	wl_display_roundtrip(display);
 
 	if (compositor == NULL) {

--- a/examples/keyboard-shortcuts-inhibit.c
+++ b/examples/keyboard-shortcuts-inhibit.c
@@ -209,7 +209,6 @@ int main(int argc, char **argv) {
 
 	struct wl_registry *registry = wl_display_get_registry(display);
 	wl_registry_add_listener(registry, &registry_listener, NULL);
-	wl_display_dispatch(display);
 	wl_display_roundtrip(display);
 
 	if (compositor == NULL) {

--- a/examples/output-power-management.c
+++ b/examples/output-power-management.c
@@ -109,7 +109,6 @@ int main(int argc, char *argv[]) {
 
 	struct wl_registry *registry = wl_display_get_registry(display);
 	wl_registry_add_listener(registry, &registry_listener, NULL);
-	wl_display_dispatch(display);
 	wl_display_roundtrip(display);
 
 	if (output_power_manager == NULL) {

--- a/examples/pointer-constraints.c
+++ b/examples/pointer-constraints.c
@@ -198,7 +198,6 @@ int main(int argc, char **argv) {
 
 	struct wl_registry *registry = wl_display_get_registry(display);
 	wl_registry_add_listener(registry, &registry_listener, NULL);
-	wl_display_dispatch(display);
 	wl_display_roundtrip(display);
 
 	struct wl_region *disjoint_region = wl_compositor_create_region(compositor);

--- a/examples/relative-pointer-unstable-v1.c
+++ b/examples/relative-pointer-unstable-v1.c
@@ -412,7 +412,6 @@ int main(int argc, char **argv) {
 
 	struct wl_registry *registry = wl_display_get_registry(display);
 	wl_registry_add_listener(registry, &registry_listener, NULL);
-	wl_display_dispatch(display);
 	wl_display_roundtrip(display);
 
 	/* Check that all the global interfaces were captured */

--- a/examples/screencopy-dmabuf.c
+++ b/examples/screencopy-dmabuf.c
@@ -315,7 +315,6 @@ int main(int argc, char *argv[]) {
 
 	struct wl_registry *registry = wl_display_get_registry(display);
 	wl_registry_add_listener(registry, &registry_listener, NULL);
-	wl_display_dispatch(display);
 	wl_display_roundtrip(display);
 
 	if (dmabuf == NULL) {

--- a/examples/screencopy.c
+++ b/examples/screencopy.c
@@ -234,7 +234,6 @@ int main(int argc, char *argv[]) {
 
 	struct wl_registry *registry = wl_display_get_registry(display);
 	wl_registry_add_listener(registry, &registry_listener, NULL);
-	wl_display_dispatch(display);
 	wl_display_roundtrip(display);
 
 	if (shm == NULL) {

--- a/examples/text-input.c
+++ b/examples/text-input.c
@@ -344,7 +344,6 @@ int main(int argc, char **argv) {
 
 	struct wl_registry *registry = wl_display_get_registry(display);
 	wl_registry_add_listener(registry, &registry_listener, NULL);
-	wl_display_dispatch(display);
 	wl_display_roundtrip(display);
 
 	if (compositor == NULL) {

--- a/examples/toplevel-decoration.c
+++ b/examples/toplevel-decoration.c
@@ -203,7 +203,6 @@ int main(int argc, char **argv) {
 
 	struct wl_registry *registry = wl_display_get_registry(display);
 	wl_registry_add_listener(registry, &registry_listener, NULL);
-	wl_display_dispatch(display);
 	wl_display_roundtrip(display);
 
 	if (compositor == NULL) {

--- a/examples/virtual-pointer.c
+++ b/examples/virtual-pointer.c
@@ -67,7 +67,6 @@ int main(int argc, char *argv[]) {
 
 	struct wl_registry *registry = wl_display_get_registry(display);
 	wl_registry_add_listener(registry, &registry_listener, NULL);
-	wl_display_dispatch(display);
 	wl_display_roundtrip(display);
 
 	if (pointer_manager == NULL) {
@@ -132,7 +131,6 @@ int main(int argc, char *argv[]) {
 
 	zwlr_virtual_pointer_v1_frame(pointer);
 	zwlr_virtual_pointer_v1_destroy(pointer);
-	wl_display_dispatch(display);
 
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
wl_display_roundtrip already takes care of dispatching the display.