### PR TITLE
session: Add missing init to direct-freebsd

### DIFF
--- a/backend/session/direct-freebsd.c
+++ b/backend/session/direct-freebsd.c
@@ -18,6 +18,7 @@
 #include <wlr/util/log.h>
 #include <xf86drm.h>
 #include "backend/session/direct-ipc.h"
+#include "backend/session/session.h"
 #include "util/signal.h"
 
 const struct session_impl session_direct;
@@ -274,6 +275,7 @@ static struct wlr_session *direct_session_create(struct wl_display *disp) {
 		return NULL;
 	}
 
+	session_init(&session->base);
 	session->sock = direct_ipc_init(&session->child);
 	if (session->sock == -1) {
 		goto error_session;
@@ -297,6 +299,7 @@ static struct wlr_session *direct_session_create(struct wl_display *disp) {
 
 	snprintf(session->base.seat, sizeof(session->base.seat), "%s", seat);
 	session->base.impl = &session_direct;
+	session->base.active = true;
 	return &session->base;
 
 error_ipc:


### PR DESCRIPTION
bad1e9afa8ea ("session: Add libseat backend") introduced a change to to
how session backends initialize, but failed to update the FreeBSD
specific version of the direct backend accordingly.

Closes: https://github.com/swaywm/wlroots/issues/2376