### PR TITLE
render: Don't crash on 0 dimensions

### DIFF
--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -99,6 +99,9 @@ bool wlr_render_subtexture_with_matrix(struct wlr_renderer *r,
 
 void wlr_render_rect(struct wlr_renderer *r, const struct wlr_box *box,
 		const float color[static 4], const float projection[static 9]) {
+	if (box->width == 0 || box->height == 0) {
+		return;
+	}
 	assert(box->width > 0 && box->height > 0);
 	float matrix[9];
 	wlr_matrix_project_box(matrix, box, WL_OUTPUT_TRANSFORM_NORMAL, 0,
@@ -115,6 +118,9 @@ void wlr_render_quad_with_matrix(struct wlr_renderer *r,
 
 void wlr_render_ellipse(struct wlr_renderer *r, const struct wlr_box *box,
 		const float color[static 4], const float projection[static 9]) {
+	if (box->width == 0 || box->height == 0) {
+		return;
+	}
 	assert(box->width > 0 && box->height > 0);
 	float matrix[9];
 	wlr_matrix_project_box(matrix, box, WL_OUTPUT_TRANSFORM_NORMAL, 0,


### PR DESCRIPTION
Don't force compositors to check when an empty shape is being renderered.
References #2282. This was motivated by dwl crashing when setting window
borders to 0 (djpohly/dwl#51).