### PR TITLE
Maintain correct cursor size on displays with scale factors

### DIFF
--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -1061,8 +1061,8 @@ static void output_cursor_commit(struct wlr_output_cursor *cursor,
 
 	// Some clients commit a cursor surface with a NULL buffer to hide it.
 	cursor->enabled = wlr_surface_has_buffer(surface);
-	cursor->width = surface->current.width * cursor->output->scale;
-	cursor->height = surface->current.height * cursor->output->scale;
+	cursor->width = surface->current.width * surface->current.scale * cursor->output->scale;
+	cursor->height = surface->current.height * surface->current.scale * cursor->output->scale;
 	output_cursor_update_visible(cursor);
 	if (update_hotspot) {
 		cursor->hotspot_x -= surface->current.dx * cursor->output->scale;

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -981,12 +981,10 @@ static void output_cursor_update_visible(struct wlr_output_cursor *cursor) {
 }
 
 static bool output_cursor_attempt_hardware(struct wlr_output_cursor *cursor) {
-	float scale = cursor->output->scale;
 	enum wl_output_transform transform = WL_OUTPUT_TRANSFORM_NORMAL;
 	struct wlr_texture *texture = cursor->texture;
 	if (cursor->surface != NULL) {
 		texture = wlr_surface_get_texture(cursor->surface);
-		scale = cursor->surface->current.scale;
 		transform = cursor->surface->current.transform;
 	}
 
@@ -1002,7 +1000,7 @@ static bool output_cursor_attempt_hardware(struct wlr_output_cursor *cursor) {
 		cursor->output->impl->move_cursor(cursor->output,
 			(int)cursor->x, (int)cursor->y);
 		if (cursor->output->impl->set_cursor(cursor->output, texture,
-				scale, transform, cursor->hotspot_x, cursor->hotspot_y, true)) {
+				1, transform, cursor->hotspot_x, cursor->hotspot_y, true)) {
 			cursor->output->hardware_cursor = cursor;
 			return true;
 		}

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -1021,8 +1021,8 @@ bool wlr_output_cursor_set_image(struct wlr_output_cursor *cursor,
 
 	output_cursor_reset(cursor);
 
-	cursor->width = width;
-	cursor->height = height;
+	cursor->width = width * cursor->output->scale;
+	cursor->height = height * cursor->output->scale;
 	cursor->hotspot_x = hotspot_x;
 	cursor->hotspot_y = hotspot_y;
 	output_cursor_update_visible(cursor);


### PR DESCRIPTION
When using a scale factor on a display, the cursor size was incorrectly handled. With multiple displays and differing scale factors on each display, this caused the cursor size to differ visibly between displays.

For example, I have two 27" monitors side by side. Monitor 1 runs at 2560×1440 with scale 1 and monitor 2 runs at 3840×2160 with scale 1.5. Everything should have the same apparent size on this setup. On monitor 1, everything looks good. On monitor 2:
* in any UI rendered by sway, the cursor appears to be half size.
* in native wayland applications, the cursor appears to be be quarter size.
* on xwayland applications, the cursor appears to be the correct size.

It appears that `cursor->output->impl->set_cursor` [considers the output scale but also divides the dimensions of the cursor by `scale`](https://github.com/swaywm/wlroots/blob/b0144c7ded2b655085eb8e7e9b64908dc9420d60/backend/drm/drm.c#L922-L923). Indeed, everywhere else this function is called in `types/wlr_output.c`, `1` is always passed as `scale`.

Passing `1` in `output_cursor_attempt_hardware` causes the cursor size to be correct in all cases.