### PR TITLE
Fix undefined behavior in xcursor

### DIFF
--- a/include/xcursor/xcursor.h
+++ b/include/xcursor/xcursor.h
@@ -26,8 +26,10 @@
 #ifndef XCURSOR_H
 #define XCURSOR_H
 
-typedef int		XcursorBool;
-typedef unsigned int	XcursorUInt;
+#include <stdint.h>
+
+typedef int XcursorBool;
+typedef uint32_t XcursorUInt;
 
 typedef XcursorUInt	XcursorDim;
 typedef XcursorUInt	XcursorPixel;

--- a/xcursor/xcursor.c
+++ b/xcursor/xcursor.c
@@ -285,11 +285,12 @@ _XcursorReadUInt (XcursorFile *file, XcursorUInt *u)
         return XcursorFalse;
 
     if ((*file->read) (file, bytes, 4) != 4)
-	return XcursorFalse;
-    *u = ((bytes[0] << 0) |
-	  (bytes[1] << 8) |
-	  (bytes[2] << 16) |
-	  (bytes[3] << 24));
+        return XcursorFalse;
+
+    *u = ((XcursorUInt)(bytes[0]) << 0) |
+         ((XcursorUInt)(bytes[1]) << 8) |
+         ((XcursorUInt)(bytes[2]) << 16) |
+         ((XcursorUInt)(bytes[3]) << 24);
     return XcursorTrue;
 }
 


### PR DESCRIPTION
Copied from the two commit messages:

Use fixed size integer type
This type is meant to be 4 bytes large as seen in _XcursorReadUInt which
always reads 4 bytes. An unsigned int is often 4 bytes large but this
isnt' guaranteed so it is cleaner to use the exact type we want.

Fix undefined behavior
Without the casts the bytes accesses get converted to int. but int is
not guaranteed to be 4 bytes large. Even when it is 4 bytes large
`bytes[3] << 24` does not fit because int is signed.
