### PR TITLE
examples/dmabuf-capture: add extra roundtrip for wl_output listener

### DIFF
--- a/examples/dmabuf-capture.c
+++ b/examples/dmabuf-capture.c
@@ -753,6 +753,10 @@ static int init(struct capture_context *ctx) {
 	ctx->registry = wl_display_get_registry(ctx->display);
 	wl_registry_add_listener(ctx->registry, &registry_listener, ctx);
 
+	// First roundtrip to fetch globals
+	wl_display_roundtrip(ctx->display);
+
+	// Second roundtrip to fetch wl_output information
 	wl_display_roundtrip(ctx->display);
 
 	if (!ctx->export_manager) {


### PR DESCRIPTION
This example was relying on wl_display_dispatch being enough to fetch
output information. This worked by chance.

Add an explicit wl_display_roundtrip.

Other examples don't setup wl_output listeners, so they should be fine.

Fixes: 297354f84772 ("Remove unnecessary wl_display_dispatch calls")
Closes: https://github.com/swaywm/wlroots/issues/2386