### PR TITLE
output-management-v1: add head identifying information

### DIFF
--- a/protocol/wlr-output-management-unstable-v1.xml
+++ b/protocol/wlr-output-management-unstable-v1.xml
@@ -39,7 +39,7 @@
     interface version number is reset.
   </description>
 
-  <interface name="zwlr_output_manager_v1" version="1">
+  <interface name="zwlr_output_manager_v1" version="2">
     <description summary="output device configuration manager">
       This interface is a manager that allows reading and writing the current
       output device configuration.
@@ -125,7 +125,7 @@
     </event>
   </interface>
 
-  <interface name="zwlr_output_head_v1" version="1">
+  <interface name="zwlr_output_head_v1" version="2">
     <description summary="output device">
       A head is an output device. The difference between a wl_output object and
       a head is that heads are advertised even if they are turned off. A head
@@ -257,9 +257,80 @@
         resources associated with it.
       </description>
     </event>
+
+    <!-- Version 2 additions -->
+    <event name="make" since="2">
+      <description summary="head manufacturer">
+        This event describes the manufacturer of the head.
+
+        This must report the same make as the wl_output interface does in its
+        geometry event.
+
+        Together with the model and serial_number events the purpose is to
+        allow clients to recognize heads from previous sessions and for example
+        load head-specific configurations back.
+
+        It is not guaranteed this event will be ever sent. A reason for that
+        can be that the compositor does not have information about the make of
+        the head or the definition of a make is not sensible in the current
+        setup, for example in a virtual session. Clients can still try to
+        identify the head by available information from other events but should
+        be aware that there is an increased risk of false positives.
+
+        It is not recommended to display the make string in UI to users. For
+        that the string provided by the description event should be preferred.
+      </description>
+      <arg name="make" type="string"/>
+    </event>
+
+    <event name="model" since="2">
+      <description summary="head model">
+        This event describes the model of the head.
+
+        This must report the same model as the wl_output interface does in its
+        geometry event.
+
+        Together with the make and serial_number events the purpose is to
+        allow clients to recognize heads from previous sessions and for example
+        load head-specific configurations back.
+
+        It is not guaranteed this event will be ever sent. A reason for that
+        can be that the compositor does not have information about the model of
+        the head or the definition of a model is not sensible in the current
+        setup, for example in a virtual session. Clients can still try to
+        identify the head by available information from other events but should
+        be aware that there is an increased risk of false positives.
+
+        It is not recommended to display the model string in UI to users. For
+        that the string provided by the description event should be preferred.
+      </description>
+      <arg name="model" type="string"/>
+    </event>
+
+    <event name="serial_number" since="2">
+      <description summary="head serial number">
+        This event describes the serial number of the head.
+
+        Together with the make and model events the purpose is to allow clients
+        to recognize heads from previous sessions and for example load head-
+        specific configurations back.
+
+        It is not guaranteed this event will be ever sent. A reason for that
+        can be that the compositor does not have information about the serial
+        number of the head or the definition of a serial number is not sensible
+        in the current setup. Clients can still try to identify the head by
+        available information from other events but should be aware that there
+        is an increased risk of false positives.
+
+        It is not recommended to display the serial_number string in UI to
+        users. For that the string provided by the description event should be
+        preferred.
+      </description>
+      <arg name="serial_number" type="string"/>
+    </event>
   </interface>
 
-  <interface name="zwlr_output_mode_v1" version="1">
+  <interface name="zwlr_output_mode_v1" version="2">
     <description summary="output mode">
       This object describes an output mode.
 
@@ -305,7 +376,7 @@
     </event>
   </interface>
 
-  <interface name="zwlr_output_configuration_v1" version="1">
+  <interface name="zwlr_output_configuration_v1" version="2">
     <description summary="output configuration">
       This object is used by the client to describe a full output configuration.
 
@@ -423,7 +494,7 @@
     </request>
   </interface>
 
-  <interface name="zwlr_output_configuration_head_v1" version="1">
+  <interface name="zwlr_output_configuration_head_v1" version="2">
     <description summary="head configuration">
       This object is used by the client to update a single head's configuration.
 

--- a/types/wlr_output_management_v1.c
+++ b/types/wlr_output_management_v1.c
@@ -6,7 +6,7 @@
 #include "util/signal.h"
 #include "wlr-output-management-unstable-v1-protocol.h"
 
-#define OUTPUT_MANAGER_VERSION 1
+#define OUTPUT_MANAGER_VERSION 2
 
 enum {
 	HEAD_STATE_ENABLED = 1 << 0,
@@ -759,6 +759,16 @@ static void manager_send_head(struct wlr_output_manager_v1 *manager,
 	if (output->phys_width > 0 && output->phys_height > 0) {
 		zwlr_output_head_v1_send_physical_size(head_resource,
 			output->phys_width, output->phys_height);
+	}
+
+	if (version >= ZWLR_OUTPUT_HEAD_V1_MAKE_SINCE_VERSION && output->make[0] != '\0') {
+		zwlr_output_head_v1_send_make(head_resource, output->make);
+	}
+	if (version >= ZWLR_OUTPUT_HEAD_V1_MODEL_SINCE_VERSION && output->model[0] != '\0') {
+		zwlr_output_head_v1_send_model(head_resource, output->model);
+	}
+	if (version >= ZWLR_OUTPUT_HEAD_V1_SERIAL_NUMBER_SINCE_VERSION && output->serial[0] != '\0') {
+		zwlr_output_head_v1_send_serial_number(head_resource, output->serial);
 	}
 
 	struct wlr_output_mode *mode;


### PR DESCRIPTION
Add events to zwlr_output_head_v1 for make, model and serial number of a display. This allows clients to identify displays from previous compositor sessions and reload accordingly configurations that were saved previously.

I have an example implementation with:
* Generic Wayland client library: https://gitlab.com/kwinft/wrapland/-/merge_requests/75
* Output management client library: https://gitlab.com/kwinft/disman/-/merge_requests/9
* KDisplay client: https://gitlab.com/kwinft/kdisplay/-/merge_requests/6

![screenshot](https://user-images.githubusercontent.com/9366064/92121798-fbc7be80-edfa-11ea-929a-bcf07ac73a16.jpg)

The form in which the client combines this information to recognize the display again is unspecified and depends on how permissive it is.

For example in case of Disman I use a string `<make>:<model>:<serial_number>:<name>` which I then MD5-hash and hex convert for the name of the output configuration files.

I also use the name in there because I only want to load a configuration when the display is connected to the same connector (displays can have different capabilities on different connectors).