### PR TITLE
session: Don't refuse unprivileged creation of "direct" backend

### DIFF
--- a/backend/session/direct-ipc.c
+++ b/backend/session/direct-ipc.c
@@ -24,16 +24,6 @@
 
 enum { DRM_MAJOR = 226 };
 
-static bool have_permissions(void) {
-#ifdef __linux__
-	if (geteuid() != 0) {
-		wlr_log(WLR_ERROR, "Do not have root privileges; cannot become DRM master");
-		return false;
-	}
-#endif
-	return true;
-}
-
 static void send_msg(int sock, int fd, void *buf, size_t buf_len) {
 	char control[CMSG_SPACE(sizeof(fd))] = {0};
 	struct iovec iovec = { .iov_base = buf, .iov_len = buf_len };
@@ -223,10 +213,6 @@ void direct_ipc_finish(int sock, pid_t pid) {
 }
 
 int direct_ipc_init(pid_t *pid_out) {
-	if (!have_permissions()) {
-		return -1;
-	}
-
 	int sock[2];
 	if (socketpair(AF_UNIX, SOCK_SEQPACKET, 0, sock) < 0) {
 		wlr_log_errno(WLR_ERROR, "Failed to create socket pair");


### PR DESCRIPTION
When starting a compositor that's using the "direct" session backend,
wlroots needs to handle calls to `drmSetMaster()` and `drmDropMaster()`.
As both calls used to require `CAP_SYS_ADMIN`, wlroots thus simply
refused starting in case the process doesn't enjoy evelated privileges.

Permission rules have changed since linux.git commit 45bc3d26c95a (drm:
rework SET_MASTER and DROP_MASTER perm handling, 2020-03-19). As a
result, starting with Linux v5.8, both ioctls will now also succeed if
the process is currently or has been the DRM master. And as the first
process to open render nodes will become the DRM master automatically,
this effectively means that process elevation is not strictly required
in all setups anymore.

So let's drop the `geteuid() != 0` permission check to allow those new
rules to do their magic.