### PR TITLE
wayland: emit relative pointer events only for current pointer

### DIFF
--- a/backend/wayland/seat.c
+++ b/backend/wayland/seat.c
@@ -450,6 +450,9 @@ static void relative_pointer_handle_relative_motion(void *data,
 		wl_fixed_t dy_unaccel) {
 	struct wlr_wl_input_device *input_device = data;
 	struct wlr_input_device *wlr_dev = &input_device->wlr_input_device;
+	if (pointer_get_wl(wlr_dev->pointer) != input_device->backend->current_pointer) {
+		return;
+	}
 
 	uint64_t time_usec = (uint64_t)utime_hi << 32 | utime_lo;
 


### PR DESCRIPTION
As discussed on IRC, without this check, the wayland backend receives the relative motion event once per output, and emits these events on all pointer devices. This can cause confusion in the compositor.