### PR TITLE
xwayland: disconnect display destroy listener even if xwayland didn't initialize

### DIFF
--- a/xwayland/server.c
+++ b/xwayland/server.c
@@ -150,15 +150,19 @@ static void server_finish_process(struct wlr_xwayland_server *server) {
 }
 
 static void server_finish_display(struct wlr_xwayland_server *server) {
-	if (!server || server->display == -1) {
+	if (!server) {
+		return;
+	}
+
+	wl_list_remove(&server->display_destroy.link);
+
+	if (server->display == -1) {
 		return;
 	}
 
 	safe_close(server->x_fd[0]);
 	safe_close(server->x_fd[1]);
 	server->x_fd[0] = server->x_fd[1] = -1;
-
-	wl_list_remove(&server->display_destroy.link);
 
 	unlink_display_sockets(server->display);
 	server->display = -1;


### PR DESCRIPTION
I got this shutdown crash where Xwayland isn't deinitialized properly. I think the problem might be that Xwayland itself crashes after shutdown has started but fails to restart (since we're already tearing things down).

Anyway, it can be seen that this is a problem: https://github.com/swaywm/wlroots/blob/master/xwayland/server.c#L250

The listener is added, then display sockets are opened, if that fails, `server_finish_display` is called but it is a no-op because of the check in the beginning.