### PR TITLE
backend: remove check for _WAYLAND_DISPLAY

### DIFF
--- a/backend/backend.c
+++ b/backend/backend.c
@@ -254,8 +254,7 @@ struct wlr_backend *wlr_backend_autocreate(struct wl_display *display,
 		return backend;
 	}
 
-	if (getenv("WAYLAND_DISPLAY") || getenv("_WAYLAND_DISPLAY") ||
-			getenv("WAYLAND_SOCKET")) {
+	if (getenv("WAYLAND_DISPLAY") || getenv("WAYLAND_SOCKET")) {
 		struct wlr_backend *wl_backend = attempt_wl_backend(display,
 			create_renderer_func);
 		if (!wl_backend) {


### PR DESCRIPTION
I'm not sure what this was used for, but it's not used by libwayland.
Setting _WAYLAND_DISPLAY would result in the Wayland backend being
picked but would ignore the actual value of the env variable.