### PR TITLE
data-control: Don't send offers to the clients that sent them

### DIFF
--- a/protocol/wlr-data-control-unstable-v1.xml
+++ b/protocol/wlr-data-control-unstable-v1.xml
@@ -108,7 +108,8 @@
         the primary clipboard selections). Immediately following the
         wlr_data_control_device.data_offer event, the new data_offer object
         will send out wlr_data_control_offer.offer events to describe the MIME
-        types it offers.
+        types it offers. Offers will be propagated to other listening clients
+        except for the client that made the offer.
       </description>
       <arg name="id" type="new_id" interface="zwlr_data_control_offer_v1"/>
     </event>

--- a/types/wlr_data_control_v1.c
+++ b/types/wlr_data_control_v1.c
@@ -457,6 +457,17 @@ static void control_send_selection(struct wlr_data_control_device_v1 *device) {
 	}
 
 	device->selection_offer_resource = NULL;
+
+	struct client_data_source *client_source =
+		wl_container_of(source, client_source, source);
+	if (client_source && device->resource) {
+		struct wl_resource *source_resource = client_source->resource;
+		// Don't send the offer back to the client that sent it
+		if (source_resource && wl_resource_get_client(source_resource) ==
+			wl_resource_get_client(device->resource))
+			return;
+	}
+
 	if (source != NULL) {
 		device->selection_offer_resource =
 			create_offer(device, &source->mime_types, false);
@@ -488,6 +499,17 @@ static void control_send_primary_selection(
 	}
 
 	device->primary_selection_offer_resource = NULL;
+
+	struct client_primary_selection_source *client_source =
+		wl_container_of(source, client_source, source);
+	if (client_source && device->resource) {
+		struct wl_resource *source_resource = client_source->resource;
+		// Don't send the offer back to the client that sent it
+		if (source_resource && wl_resource_get_client(source_resource) ==
+			wl_resource_get_client(device->resource))
+			return;
+	}
+
 	if (source != NULL) {
 		device->primary_selection_offer_resource =
 			create_offer(device, &source->mime_types, true);


### PR DESCRIPTION
If a client is listening for offers and sends an offer, it will block forever
when it attempts to receive the offer and read from the file descriptor. This
is because the offer is sent back to the client that sent it. Since the writing
and reading ends are in the same client, it never has a chance to write
(barring methods to work around this problem). Even if the client could read
its own selection, it is pointless to do so.

Here we fix the problem by not making offers back to the client that sent them.
The protocol has been updated to reflect this change.
Closes #2406.