### PR TITLE
Initial support for framebuffer backend

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -16,11 +16,19 @@ sources:
 tasks:
   - setup: |
       cd wlroots
-      meson build -Dauto_features=enabled -Dlogind=disabled -Dlibseat=disabled -Dxcb-errors=disabled
+      meson build \
+        -Dauto_features=enabled \
+        -Dlogind=disabled \
+        -Dlibseat=disabled \
+        -Dxcb-errors=disabled \
+        -Dfbdev-backend=enabled
   - build: |
       cd wlroots
       ninja -C build
   - build-features-disabled: |
       cd wlroots
-      meson build --reconfigure -Dauto_features=disabled
+      meson build \
+        --reconfigure \
+        -Dauto_features=disabled \
+        -Dfbdev-backend=disabled
       ninja -C build

--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -18,8 +18,14 @@ sources:
 tasks:
   - setup: |
       cd wlroots
-      CC=gcc meson build-gcc -Dauto_features=enabled -Dlogind-provider=systemd
-      CC=clang meson build-clang -Dauto_features=enabled -Dlogind-provider=systemd
+      CC=gcc meson build-gcc \
+        -Dauto_features=enabled \
+        -Dlogind-provider=systemd \
+        -Dfbdev-backend=enabled
+      CC=clang meson build-clang \
+        -Dauto_features=enabled \
+        -Dlogind-provider=systemd \
+        -Dfbdev-backend=enabled
   - gcc: |
       cd wlroots/build-gcc
       ninja

--- a/backend/fbdev/backend.c
+++ b/backend/fbdev/backend.c
@@ -1,0 +1,187 @@
+#include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <wlr/interfaces/wlr_input_device.h>
+#include <wlr/interfaces/wlr_output.h>
+#include <wlr/render/egl.h>
+#include <wlr/util/log.h>
+#include "backend/fbdev.h"
+#include "util/signal.h"
+
+struct wlr_fbdev_backend *fbdev_backend_from_backend(
+		struct wlr_backend *wlr_backend) {
+	assert(wlr_backend_is_fbdev(wlr_backend));
+	return (struct wlr_fbdev_backend *)wlr_backend;
+}
+
+static bool backend_start(struct wlr_backend *wlr_backend) {
+	struct wlr_fbdev_backend *backend =
+		fbdev_backend_from_backend(wlr_backend);
+	wlr_log(WLR_INFO, "Starting fbdev backend");
+
+	struct wlr_fbdev_output *output;
+	wl_list_for_each(output, &backend->outputs, link) {
+		wl_event_source_timer_update(output->frame_timer, output->frame_delay);
+		wlr_output_update_enabled(&output->wlr_output, true);
+		wlr_signal_emit_safe(&backend->backend.events.new_output,
+			&output->wlr_output);
+	}
+
+	struct wlr_fbdev_input_device *input_device;
+	wl_list_for_each(input_device, &backend->input_devices,
+			wlr_input_device.link) {
+		wlr_signal_emit_safe(&backend->backend.events.new_input,
+			&input_device->wlr_input_device);
+	}
+
+	backend->started = true;
+	return true;
+}
+
+static void backend_destroy(struct wlr_backend *wlr_backend) {
+	struct wlr_fbdev_backend *backend =
+		fbdev_backend_from_backend(wlr_backend);
+	if (!wlr_backend) {
+		return;
+	}
+
+	wl_list_remove(&backend->display_destroy.link);
+	wl_list_remove(&backend->renderer_destroy.link);
+
+	struct wlr_fbdev_output *output, *output_tmp;
+	wl_list_for_each_safe(output, output_tmp, &backend->outputs, link) {
+		wlr_output_destroy(&output->wlr_output);
+	}
+
+	struct wlr_fbdev_input_device *input_device, *input_device_tmp;
+	wl_list_for_each_safe(input_device, input_device_tmp,
+			&backend->input_devices, wlr_input_device.link) {
+		wlr_input_device_destroy(&input_device->wlr_input_device);
+	}
+
+	wlr_signal_emit_safe(&wlr_backend->events.destroy, backend);
+
+	if (backend->egl == &backend->priv_egl) {
+		wlr_renderer_destroy(backend->renderer);
+		wlr_egl_finish(&backend->priv_egl);
+	}
+	wlr_session_close_file(backend->session, backend->fd);
+	free(backend);
+}
+
+static struct wlr_renderer *backend_get_renderer(
+		struct wlr_backend *wlr_backend) {
+	struct wlr_fbdev_backend *backend =
+		fbdev_backend_from_backend(wlr_backend);
+	return backend->renderer;
+}
+
+static const struct wlr_backend_impl backend_impl = {
+	.start = backend_start,
+	.destroy = backend_destroy,
+	.get_renderer = backend_get_renderer,
+};
+
+static void handle_display_destroy(struct wl_listener *listener, void *data) {
+	struct wlr_fbdev_backend *backend =
+		wl_container_of(listener, backend, display_destroy);
+	backend_destroy(&backend->backend);
+}
+
+static void handle_renderer_destroy(struct wl_listener *listener, void *data) {
+	struct wlr_fbdev_backend *backend =
+		wl_container_of(listener, backend, renderer_destroy);
+	backend_destroy(&backend->backend);
+}
+
+static bool backend_init(struct wlr_fbdev_backend *fbdev,
+		struct wl_display *display, struct wlr_session *session,
+		int fbdev_fd, struct wlr_backend *parent,
+		struct wlr_renderer *renderer) {
+	wlr_backend_init(&fbdev->backend, &backend_impl);
+
+	fbdev->display = display;
+	fbdev->session = session;
+	fbdev->fd = fbdev_fd;
+
+	if (parent != NULL) {
+		fbdev->parent = fbdev_backend_from_backend(parent);
+	}
+
+	wl_list_init(&fbdev->outputs);
+	wl_list_init(&fbdev->input_devices);
+
+	fbdev->renderer = renderer;
+	fbdev->egl = wlr_gles2_renderer_get_egl(renderer);
+
+	/* FIXME: hardcoded for now, there is no GL_ARGB4 etc, and translating
+	 * would cost much CPU performance. Devices need to set this in kconfig
+	 * for now. When wlroots has its own swapchain and software rendering,
+	 * we can replace this with the appropriate pixman format like it's
+	 * done in weston. */
+	fbdev->internal_format = GL_RGBA4;
+
+	fbdev->display_destroy.notify = handle_display_destroy;
+	wl_display_add_destroy_listener(display, &fbdev->display_destroy);
+
+	wl_list_init(&fbdev->renderer_destroy.link);
+
+	return true;
+}
+
+struct wlr_backend *wlr_fbdev_backend_create(struct wl_display *display,
+		struct wlr_session *session, int fbdev_fd, struct wlr_backend *parent,
+		wlr_renderer_create_func_t create_renderer_func) {
+	assert(display && session && fbdev_fd >= 0);
+	assert(!parent || wlr_backend_is_fbdev(parent));
+
+	struct fb_fix_screeninfo scr_fix;
+	ioctl(fbdev_fd, FBIOGET_FSCREENINFO, &scr_fix);
+	wlr_log(WLR_INFO, "Initializing fbdev backend for %s", scr_fix.id);
+
+	struct wlr_fbdev_backend *fbdev = calloc(1, sizeof(struct wlr_fbdev_backend));
+	if (!fbdev) {
+		wlr_log(WLR_ERROR, "Failed to allocate wlr_fbdev_backend");
+		return NULL;
+	}
+
+	static const EGLint config_attribs[] = {
+		EGL_SURFACE_TYPE, 0,
+		EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+		EGL_BLUE_SIZE, 1,
+		EGL_GREEN_SIZE, 1,
+		EGL_RED_SIZE, 1,
+		EGL_NONE,
+	};
+
+	if (!create_renderer_func) {
+		create_renderer_func = wlr_renderer_autocreate;
+	}
+
+	struct wlr_renderer *renderer = create_renderer_func(&fbdev->priv_egl,
+		EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY,
+		(EGLint*)config_attribs, 0);
+	if (!renderer) {
+		wlr_log(WLR_ERROR, "Failed to create renderer");
+		free(fbdev);
+		return NULL;
+	}
+
+	if (!backend_init(fbdev, display, session, fbdev_fd, parent, renderer)) {
+		wlr_renderer_destroy(fbdev->renderer);
+		free(fbdev);
+		return NULL;
+	}
+
+	fbdev->renderer_destroy.notify = handle_renderer_destroy;
+	wl_signal_add(&renderer->events.destroy, &fbdev->renderer_destroy);
+
+	return &fbdev->backend;
+}
+
+bool wlr_backend_is_fbdev(struct wlr_backend *backend) {
+	return backend->impl == &backend_impl;
+}

--- a/backend/fbdev/meson.build
+++ b/backend/fbdev/meson.build
@@ -1,0 +1,10 @@
+if not get_option('fbdev-backend').enabled()
+	conf_data.set10('WLR_HAS_FBDEV_BACKEND', false)
+	subdir_done()
+endif
+
+wlr_files += files(
+	'backend.c',
+	'output.c',
+)
+conf_data.set10('WLR_HAS_FBDEV_BACKEND', true)

--- a/backend/fbdev/output.c
+++ b/backend/fbdev/output.c
@@ -1,0 +1,307 @@
+#include <assert.h>
+#include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
+#include <stdlib.h>
+
+#include <linux/fb.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <wlr/interfaces/wlr_output.h>
+#include <wlr/render/wlr_renderer.h>
+#include <wlr/util/log.h>
+#include "backend/fbdev.h"
+#include "util/signal.h"
+
+static struct wlr_fbdev_output *fbdev_output_from_output(
+		struct wlr_output *wlr_output) {
+	assert(wlr_output_is_fbdev(wlr_output));
+	return (struct wlr_fbdev_output *)wlr_output;
+}
+
+/* Set width, height to 0 to use default resolution */
+static bool create_fbo(struct wlr_fbdev_output *output, uint32_t width, uint32_t height) {
+	if (!wlr_egl_make_current(output->backend->egl, EGL_NO_SURFACE, NULL)) {
+		return false;
+	}
+
+	int fd = output->backend->fd;
+	struct fb_var_screeninfo scr_var;
+	struct fb_fix_screeninfo scr_fix;
+
+	ioctl(fd, FBIOGET_VSCREENINFO, &scr_var);
+	ioctl(fd, FBIOGET_FSCREENINFO, &scr_fix);
+
+	// Change resolution
+	if (width && height) {
+		scr_var.xres = width;
+		scr_var.yres = height;
+		if (ioctl(fd, FBIOPUT_VSCREENINFO, &scr_var) != 0) {
+			wlr_log(WLR_ERROR, "Failed to set resolution %" PRIu32
+				"x%" PRIu32, width, height);
+			return false;
+		}
+	}
+
+	// Map the device into memory
+	size_t fbmem_size;
+	if (scr_var.yres_virtual) {
+		fbmem_size = scr_var.yres_virtual * scr_fix.line_length;
+	} else {
+		fbmem_size = scr_var.yres * scr_fix.line_length;
+	}
+	output->fbmem = mmap(NULL, fbmem_size, PROT_WRITE, MAP_SHARED, fd, 0);
+	if (output->fbmem == MAP_FAILED) {
+		wlr_log(WLR_ERROR, "mmap failed");
+		return false;
+	}
+
+	output->fbmem_size = fbmem_size;
+	output->scr_var = scr_var;
+	output->scr_fix = scr_fix;
+
+	// Initialize GL renderbuffer and GL framebuffer
+	GLuint rbo;
+	glGenRenderbuffers(1, &rbo);
+	glBindRenderbuffer(GL_RENDERBUFFER, rbo);
+	glRenderbufferStorage(GL_RENDERBUFFER, output->backend->internal_format,
+		scr_var.xres, scr_var.yres);
+	glBindRenderbuffer(GL_RENDERBUFFER, 0);
+
+	GLuint fbo;
+	glGenFramebuffers(1, &fbo);
+	glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+		GL_RENDERBUFFER, rbo);
+	GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+	wlr_egl_unset_current(output->backend->egl);
+
+	if (status != GL_FRAMEBUFFER_COMPLETE) {
+		wlr_log(WLR_ERROR, "Failed to create FBO");
+		munmap(output->fbmem, fbmem_size);
+		return false;
+	}
+
+	output->fbo = fbo;
+	output->rbo = rbo;
+	return true;
+}
+
+static void destroy_fbo(struct wlr_fbdev_output *output) {
+	if (!wlr_egl_make_current(output->backend->egl, EGL_NO_SURFACE, NULL)) {
+		return;
+	}
+
+	munmap(output->fbmem, output->fbmem_size);
+
+	glDeleteFramebuffers(1, &output->fbo);
+	glDeleteRenderbuffers(1, &output->rbo);
+
+	wlr_egl_unset_current(output->backend->egl);
+
+	output->fbo = 0;
+	output->rbo = 0;
+}
+
+static bool output_set_custom_mode(struct wlr_output *wlr_output, uint32_t width,
+		uint32_t height, int32_t refresh) {
+	struct wlr_fbdev_output *output =
+		fbdev_output_from_output(wlr_output);
+
+	if (refresh <= 0) {
+		refresh = FBDEV_DEFAULT_REFRESH;
+	}
+
+	destroy_fbo(output);
+	if (!create_fbo(output, width, height)) {
+		wlr_output_destroy(wlr_output);
+		return false;
+	}
+
+	output->frame_delay = 1000000 / refresh;
+
+	wlr_output_update_custom_mode(&output->wlr_output, width, height, refresh);
+	return true;
+}
+
+static bool output_attach_render(struct wlr_output *wlr_output,
+		int *buffer_age) {
+	struct wlr_fbdev_output *output =
+		fbdev_output_from_output(wlr_output);
+
+	if (!wlr_egl_make_current(output->backend->egl, EGL_NO_SURFACE, NULL)) {
+		return false;
+	}
+
+	glBindFramebuffer(GL_FRAMEBUFFER, output->fbo);
+
+	if (buffer_age != NULL) {
+		// HACK: set to 1 instead of 0 to avoid CPU burn
+		// https://github.com/swaywm/wlroots/pull/2410#discussion_r497615821
+		*buffer_age = 1;
+	}
+	return true;
+}
+
+static bool output_test(struct wlr_output *wlr_output) {
+	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_ENABLED) {
+		wlr_log(WLR_DEBUG, "Cannot disable a fbdev output");
+		return false;
+	}
+
+	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_MODE) {
+		assert(wlr_output->pending.mode_type == WLR_OUTPUT_STATE_MODE_CUSTOM);
+	}
+
+	return true;
+}
+
+static bool output_commit(struct wlr_output *wlr_output) {
+	struct wlr_fbdev_output *output =
+		fbdev_output_from_output(wlr_output);
+
+	if (!output_test(wlr_output)) {
+		return false;
+	}
+
+	if (!output->backend->session->active) {
+		return false;
+	}
+
+	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_MODE) {
+		if (!output_set_custom_mode(wlr_output,
+				wlr_output->pending.custom_mode.width,
+				wlr_output->pending.custom_mode.height,
+				wlr_output->pending.custom_mode.refresh)) {
+			return false;
+		}
+	}
+
+	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
+		pixman_box32_t box = wlr_output->pending.damage.extents;
+		int32_t box_width = box.x2 - box.x1;
+
+		if (box_width) {
+			GLint format;
+			GLint type = GL_UNSIGNED_BYTE;
+			glGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_FORMAT, &format);
+			struct fb_var_screeninfo scr_var = output->scr_var;
+			struct fb_fix_screeninfo scr_fix = output->scr_fix;
+			unsigned bytes_per_pixel = (scr_var.bits_per_pixel + 7) / 8;
+
+			wlr_log(WLR_DEBUG, "Updating box at %" PRIu32 "x%" PRIu32
+				" size %" PRIu32 "x%" PRIu32, box.x1, box.y1,
+				box_width, box.y2 - box.y1);
+			for (int y = box.y1; y < box.y2; y++) {
+				glReadPixels(box.x1, scr_var.yres - y - 1,
+					box_width, 1, format, type,
+					output->fbmem
+					+ (scr_var.yoffset + y) * scr_fix.line_length
+					+ (scr_var.xoffset + box.x1) * bytes_per_pixel);
+			}
+		}
+
+		glBindFramebuffer(GL_FRAMEBUFFER, 0);
+		wlr_egl_unset_current(output->backend->egl);
+		wlr_output_send_present(wlr_output, NULL);
+		wl_event_source_timer_update(output->frame_timer, output->frame_delay);
+	}
+
+	return true;
+}
+
+static void output_rollback_render(struct wlr_output *wlr_output) {
+	struct wlr_fbdev_output *output =
+		fbdev_output_from_output(wlr_output);
+	assert(wlr_egl_is_current(output->backend->egl));
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	wlr_egl_unset_current(output->backend->egl);
+}
+
+static void output_destroy(struct wlr_output *wlr_output) {
+	struct wlr_fbdev_output *output =
+		fbdev_output_from_output(wlr_output);
+	wl_list_remove(&output->link);
+	wl_event_source_remove(output->frame_timer);
+	destroy_fbo(output);
+	free(output);
+}
+
+static const struct wlr_output_impl output_impl = {
+	.destroy = output_destroy,
+	.attach_render = output_attach_render,
+	.commit = output_commit,
+	.rollback_render = output_rollback_render,
+};
+
+bool wlr_output_is_fbdev(struct wlr_output *wlr_output) {
+	return wlr_output->impl == &output_impl;
+}
+
+static int signal_frame(void *data) {
+	struct wlr_fbdev_output *output = data;
+	wlr_output_send_frame(&output->wlr_output);
+	return 0;
+}
+
+struct wlr_output *wlr_fbdev_add_output(struct wlr_backend *wlr_backend,
+		uint32_t width, uint32_t height) {
+	struct wlr_fbdev_backend *fbdev = fbdev_backend_from_backend(wlr_backend);
+
+	struct wlr_fbdev_output *output = calloc(1, sizeof(struct wlr_fbdev_output));
+	if (output == NULL) {
+		wlr_log(WLR_ERROR, "Failed to allocate wlr_fbdev_output");
+		return NULL;
+	}
+	output->backend = fbdev;
+	wlr_output_init(&output->wlr_output, &fbdev->backend, &output_impl,
+		fbdev->display);
+	struct wlr_output *wlr_output = &output->wlr_output;
+
+	if (!create_fbo(output, width, height)) {
+		goto error;
+	}
+
+	// Width/height may be 0, but scr_var has the real resolution
+	output_set_custom_mode(wlr_output, output->scr_var.xres,
+		output->scr_var.yres, 0);
+	strncpy(wlr_output->make, "fbdev", sizeof(wlr_output->make));
+	strncpy(wlr_output->model, "fbdev", sizeof(wlr_output->model));
+	snprintf(wlr_output->name, sizeof(wlr_output->name), "FBDEV-%zd",
+		++fbdev->last_output_num);
+
+	char description[128];
+	snprintf(description, sizeof(description),
+		"Framebuffer output %zd (%s)", fbdev->last_output_num,
+		output->scr_fix.id);
+	wlr_output_set_description(wlr_output, description);
+
+	if (!output_attach_render(wlr_output, NULL)) {
+		goto error;
+	}
+
+	wlr_renderer_begin(fbdev->renderer, wlr_output->width, wlr_output->height);
+	wlr_renderer_clear(fbdev->renderer, (float[]){ 1.0, 1.0, 1.0, 1.0 });
+	wlr_renderer_end(fbdev->renderer);
+
+	struct wl_event_loop *ev = wl_display_get_event_loop(fbdev->display);
+	output->frame_timer = wl_event_loop_add_timer(ev, signal_frame, output);
+
+	wl_list_insert(&fbdev->outputs, &output->link);
+
+	if (fbdev->started) {
+		wl_event_source_timer_update(output->frame_timer, output->frame_delay);
+		wlr_output_update_enabled(wlr_output, true);
+		wlr_signal_emit_safe(&fbdev->backend.events.new_output, wlr_output);
+	}
+
+	return wlr_output;
+
+error:
+	wlr_output_destroy(&output->wlr_output);
+	return NULL;
+}

--- a/backend/meson.build
+++ b/backend/meson.build
@@ -1,6 +1,7 @@
 wlr_files += files('backend.c')
 
 subdir('drm')
+subdir('fbdev')
 subdir('headless')
 subdir('libinput')
 subdir('multi')

--- a/backend/session/logind.c
+++ b/backend/session/logind.c
@@ -24,7 +24,7 @@
 	#include <elogind/sd-login.h>
 #endif
 
-enum { DRM_MAJOR = 226 };
+enum { DRM_MAJOR = 226, FB_MAJOR= 29 };
 
 const struct session_impl session_logind;
 
@@ -43,6 +43,7 @@ struct logind_session {
 	// if so, the session will be (de)activated with the drm fd,
 	// otherwise with the dbus PropertiesChanged on "active" signal
 	bool has_drm;
+	bool has_fb;
 };
 
 static struct logind_session *logind_session_from_session(
@@ -68,6 +69,14 @@ static int logind_take_device(struct wlr_session *base, const char *path) {
 	if (major(st.st_rdev) == DRM_MAJOR) {
 		session->has_drm = true;
 	}
+#if WLR_HAS_FBDEV_BACKEND
+	if (major(st.st_rdev) == FB_MAJOR) {
+		session->has_fb = true;
+		// logind will answer with 'No such device', so open it
+		// directly.
+		return open(path, O_RDWR);
+	}
+#endif
 
 	ret = sd_bus_call_method(session->bus, "org.freedesktop.login1",
 		session->path, "org.freedesktop.login1.Session", "TakeDevice",
@@ -501,8 +510,8 @@ static int seat_properties_changed(sd_bus_message *msg, void *userdata,
 	struct logind_session *session = userdata;
 	int ret = 0;
 
-	// if we have a drm fd we don't depend on this
-	if (session->has_drm) {
+	// if we have a drm/framebuffer fd we don't depend on this
+	if (session->has_drm || session->has_fb) {
 		return 0;
 	}
 

--- a/backend/session/session.c
+++ b/backend/session/session.c
@@ -16,6 +16,12 @@
 #include "backend/session/session.h"
 #include "util/signal.h"
 
+#if WLR_HAS_FBDEV_BACKEND
+#include <linux/fb.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#endif
+
 extern const struct session_impl session_libseat;
 extern const struct session_impl session_logind;
 extern const struct session_impl session_direct;
@@ -262,6 +268,42 @@ out_fd:
 	return -1;
 }
 
+#if WLR_HAS_FBDEV_BACKEND
+static int open_if_fbdev(struct wlr_session *restrict session,
+		const char *restrict path) {
+	if (!path) {
+		return -1;
+	}
+
+	int fd = wlr_session_open_file(session, path);
+	if (fd < 0) {
+		return -1;
+	}
+
+	struct fb_fix_screeninfo scr_fix;
+	if (ioctl(fd, FBIOGET_FSCREENINFO, &scr_fix) == -1) {
+		wlr_log(WLR_ERROR, "%s: FBIOGET_FSCREENINFO failed", path);
+		goto out_fd;
+	}
+
+	// Skip fbdevs that can't be opened with mmap (as seen on a Nexus 4
+	// downstream kernel)
+	size_t fbmem_size = 1;
+	unsigned char *fbmem = mmap(NULL, fbmem_size, PROT_WRITE, MAP_SHARED, fd, 0);
+	if (fbmem == MAP_FAILED) {
+		wlr_log(WLR_ERROR, "%s: mmap failed", path);
+		goto out_fd;
+	}
+
+	munmap(fbmem, fbmem_size);
+	return fd;
+
+out_fd:
+	wlr_session_close_file(session, fd);
+	return -1;
+}
+#endif
+
 static size_t find_devs_explicit(struct wlr_session *session,
 		size_t ret_len, int ret[static ret_len], const char *str,
 		int (*open_if_dev)(struct wlr_session *restrict session,
@@ -383,3 +425,11 @@ size_t wlr_session_find_gpus(struct wlr_session *session,
 	return find_devs(session, ret_len, ret, "WLR_DRM_DEVICES",
 			"drm", "card[0-9]*", open_if_kms, "DRM");
 }
+
+#if WLR_HAS_FBDEV_BACKEND
+size_t wlr_session_find_fbdevs(struct wlr_session *session,
+		size_t ret_len, int *ret) {
+	return find_devs(session, ret_len, ret, "WLR_FBDEV_DEVICES",
+			 "graphics", "fb[0-9]*", open_if_fbdev, "fbdev");
+}
+#endif

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -3,7 +3,7 @@ wlroots reads these environment variables
 # wlroots specific
 
 * *WLR_BACKENDS*: comma-separated list of backends to use (available backends:
-  libinput, drm, wayland, x11, headless, noop)
+  libinput, drm, wayland, x11, headless, noop, fbdev)
 * *WLR_NO_HARDWARE_CURSORS*: set to 1 to use software cursors instead of
   hardware cursors
 * *WLR_SESSION*: specifies the wlr\_session to be used (available sessions:
@@ -19,6 +19,12 @@ wlroots reads these environment variables
   mode setting
 * *WLR_DRM_NO_MODIFIERS*: set to 1 to always allocate planes without modifiers,
   this can fix certain modeset failures because of bandwidth restrictions.
+
+## fbdev backend
+
+* *WLR_FBDEV_DEVICES*: specifies the framebuffer devices (as colon separated
+  list) instead of auto probing them. The first existing device in this list is
+  considered the primary framebuffer device.
 
 ## Headless backend
 

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -8,6 +8,8 @@ wlroots reads these environment variables
   hardware cursors
 * *WLR_SESSION*: specifies the wlr\_session to be used (available sessions:
   logind/systemd, direct)
+* *WLR_SESSION_LOGIND_NO_WAIT_CAN_GRAPHICAL*: do not wait for 'CanGraphical'
+  from logind/systemd (needed for fbdev)
 * *WLR_DIRECT_TTY*: specifies the tty to be used (instead of using /dev/tty)
 
 ## DRM backend

--- a/include/backend/fbdev.h
+++ b/include/backend/fbdev.h
@@ -1,0 +1,59 @@
+#ifndef BACKEND_FBDEV_H
+#define BACKEND_FBDEV_H
+
+#include <wlr/backend/fbdev.h>
+#include <wlr/backend/interface.h>
+#include <wlr/render/gles2.h>
+#include <linux/fb.h>
+
+#define FBDEV_DEFAULT_REFRESH (60 * 1000) // 60 Hz
+
+struct wlr_fbdev_backend {
+	struct wlr_backend backend;
+
+	struct wlr_fbdev_backend *parent;
+
+	struct wlr_egl priv_egl; // may be uninitialized
+	struct wlr_egl *egl;
+	struct wlr_renderer *renderer;
+	struct wl_display *display;
+	struct wl_list outputs;
+	size_t last_output_num;
+	struct wl_list input_devices;
+	struct wl_listener display_destroy;
+	struct wl_listener renderer_destroy;
+	bool started;
+	GLenum internal_format;
+
+	int fd;
+	struct wlr_session *session;
+};
+
+struct wlr_fbdev_output {
+	struct wlr_output wlr_output;
+
+	struct wlr_fbdev_backend *backend;
+	struct wl_list link;
+
+	GLuint fbo, rbo;
+
+	struct wl_event_source *frame_timer;
+	int frame_delay; // ms
+
+	size_t fbmem_size;
+	unsigned char *fbmem;
+
+	struct fb_var_screeninfo scr_var;
+	struct fb_fix_screeninfo scr_fix;
+};
+
+struct wlr_fbdev_input_device {
+	struct wlr_input_device wlr_input_device;
+
+	struct wlr_fbdev_backend *backend;
+};
+
+struct wlr_fbdev_backend *fbdev_backend_from_backend(
+	struct wlr_backend *wlr_backend);
+
+#endif

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,6 +1,9 @@
 subdir('wlr')
 
 exclude_files = ['meson.build', 'config.h.in', 'version.h.in']
+if conf_data.get('WLR_HAS_FBDEV_BACKEND', 0) != 1
+	exclude_files += 'backend/fbdev.h'
+endif
 if conf_data.get('WLR_HAS_X11_BACKEND', 0) != 1
 	exclude_files += 'backend/x11.h'
 endif

--- a/include/wlr/backend/fbdev.h
+++ b/include/wlr/backend/fbdev.h
@@ -1,0 +1,26 @@
+/*
+ * This an unstable interface of wlroots. No guarantees are made regarding the
+ * future consistency of this API.
+ */
+#ifndef WLR_USE_UNSTABLE
+#error "Add -DWLR_USE_UNSTABLE to enable unstable wlroots features"
+#endif
+
+#ifndef WLR_BACKEND_FBDEV_H
+#define WLR_BACKEND_FBDEV_H
+
+#include <wlr/backend.h>
+#include <wlr/types/wlr_input_device.h>
+#include <wlr/types/wlr_output.h>
+
+struct wlr_backend *wlr_fbdev_backend_create(struct wl_display *display,
+	struct wlr_session *session, int fbdev_fd, struct wlr_backend *parent,
+	wlr_renderer_create_func_t create_renderer_func);
+
+struct wlr_output *wlr_fbdev_add_output(struct wlr_backend *backend,
+	unsigned int width, unsigned int height);
+
+bool wlr_backend_is_fbdev(struct wlr_backend *backend);
+bool wlr_output_is_fbdev(struct wlr_output *output);
+
+#endif

--- a/include/wlr/backend/session.h
+++ b/include/wlr/backend/session.h
@@ -90,5 +90,7 @@ bool wlr_session_change_vt(struct wlr_session *session, unsigned vt);
 
 size_t wlr_session_find_gpus(struct wlr_session *session,
 	size_t ret_len, int *ret);
+size_t wlr_session_find_fbdevs(struct wlr_session *session,
+	size_t ret_len, int *ret);
 
 #endif

--- a/include/wlr/config.h.in
+++ b/include/wlr/config.h.in
@@ -10,6 +10,7 @@
 
 #mesondefine WLR_HAS_LIBSEAT
 
+#mesondefine WLR_HAS_FBDEV_BACKEND
 #mesondefine WLR_HAS_X11_BACKEND
 
 #mesondefine WLR_HAS_XWAYLAND

--- a/meson.build
+++ b/meson.build
@@ -179,6 +179,7 @@ summary({
 	'elogind': conf_data.get('WLR_HAS_ELOGIND', 0),
 	'libseat': conf_data.get('WLR_HAS_LIBSEAT', 0),
 	'xwayland': conf_data.get('WLR_HAS_XWAYLAND', 0),
+	'fbdev_backend': conf_data.get('WLR_HAS_FBDEV_BACKEND', 0),
 	'x11_backend': conf_data.get('WLR_HAS_X11_BACKEND', 0),
 	'xcb-icccm': conf_data.get('WLR_HAS_XCB_ICCCM', 0),
 	'xcb-errors': conf_data.get('WLR_HAS_XCB_ERRORS', 0),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,5 +5,6 @@ option('xcb-errors', type: 'feature', value: 'auto', description: 'Use xcb-error
 option('xcb-icccm', type: 'feature', value: 'auto', description: 'Use xcb-icccm util library')
 option('xwayland', type: 'feature', value: 'auto', yield: true, description: 'Enable support for X11 applications')
 option('x11-backend', type: 'feature', value: 'auto', description: 'Enable X11 backend')
+option('fbdev-backend', type: 'feature', value: 'disabled', description: 'Enable framebuffer backend')
 option('examples', type: 'boolean', value: true, description: 'Build example applications')
 option('icon_directory', description: 'Location used to look for cursors (default: ${datadir}/icons)', type: 'string', value: '')


### PR DESCRIPTION
Allow running modern wlroots based compositors on downstream kernels of old Android phones/tablets. In theory, this makes [over a billion](https://www.which.co.uk/news/2020/03/more-than-one-billion-android-devices-at-risk-of-malware-threats/) devices with hopelessly outdated Android stacks useful again: after swapping out the userspace with postmarketOS + wlroots, they can at least be used for raspberry-pi-with-touchscreen like projects.

It would be best to run mainline Linux on those devices, then run wlroots on DRM instead of framebuffer. We are following this approach in postmarketOS too, but it's too time consuming to be done for more than a small percentage out of the countless Android devices in existence.

Since modern setups won't need this, I've made it opt-in (`-Dfbdev-backend=enabled`). If somebody is worried about who would maintain this upstream in wlroots: the postmarketOS community and I would be happy to make sure that this keeps on working and gets improved.

### Demo
I've tested this on both the Samsung Galaxy SII and Google Nexus 4 and made a video of the latter running Sway and Phosh, with gnome-chess and the kgx terminal app:
https://postmarketos.org/static/video/2020-09/wlroots-fbdev-lg-mako.webm

If somebody wants to try it on their phone, see these notes:
https://wiki.postmarketos.org/wiki/User:Ollieparanoid/Run_wlroots_with_fbdev

### Beyond this PR
Improvements for future patches, that seem to be out of scope for this initial version:
* Use renderer v6 (#2240, #2374) after related patches are merged and the pixman software renderer (#2399) is implemented. This should improve performance, as GL+swrast would not be needed anymore. Furthermore, this will make more framebuffer formats possible. (Right now it's hardcoded to RGBA4, see the related comment in the patch.)
* `wlr_backend_autocreate()`: if no DRM devices were found, fall back to fbdev (I've tried this, but after failing to create the DRM backend, the session/wlr_backend can't be reused. So this probably needs further refactoring?)
* Implement dmabuf extension to make [casa](https://git.sr.ht/~sircmpwn/casa) work

### Questions
* Should the fbdev backend be decoupled from the logind session? Logind will answer with "No such device" when requesting `/dev/fb0` etc. With the current version, `logind_take_device` just calls `open` instead of asking logind, if it is a framebuffer device.
* Anything I'm missing, regarding performance optimizations or otherwise?