### PR TITLE
Factor out wlr_wl_seat in Wayland backend

### DIFF
--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -586,8 +586,11 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *wlr_backend) {
 
 	wlr_signal_emit_safe(&backend->backend.events.new_output, wlr_output);
 
-	if (backend->pointer != NULL) {
-		create_wl_pointer(backend->pointer, output);
+	struct wlr_wl_seat *seat = backend->seat;
+	if (seat != NULL) {
+		if (seat->pointer) {
+			create_wl_pointer(seat->pointer, output);
+		}
 	}
 
 	return wlr_output;

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -419,8 +419,9 @@ static void output_destroy(struct wlr_output *wlr_output) {
 }
 
 void update_wl_output_cursor(struct wlr_wl_output *output) {
-	if (output->backend->pointer && output->enter_serial) {
-		wl_pointer_set_cursor(output->backend->pointer, output->enter_serial,
+	struct wlr_wl_pointer *pointer = output->backend->current_pointer;
+	if (pointer && pointer->output == output && output->enter_serial) {
+		wl_pointer_set_cursor(pointer->wl_pointer, output->enter_serial,
 			output->cursor.surface, output->cursor.hotspot_x,
 			output->cursor.hotspot_y);
 	}

--- a/backend/wayland/seat.c
+++ b/backend/wayland/seat.c
@@ -48,6 +48,7 @@ static void pointer_handle_enter(void *data, struct wl_pointer *wl_pointer,
 	struct wlr_wl_output *output = wl_surface_get_user_data(surface);
 	assert(output);
 	struct wlr_wl_pointer *pointer = output_get_pointer(output);
+	assert(!backend->current_pointer || backend->current_pointer == pointer);
 
 	output->enter_serial = serial;
 	backend->current_pointer = pointer;

--- a/backend/wayland/seat.c
+++ b/backend/wayland/seat.c
@@ -372,12 +372,49 @@ static struct wlr_wl_input_device *get_wl_input_device_from_input_device(
 	return (struct wlr_wl_input_device *)wlr_dev;
 }
 
+void create_wl_seat(struct wl_seat *wl_seat, struct wlr_wl_backend *wl) {
+	assert(!wl->seat);  // only one seat supported at the moment
+	struct wlr_wl_seat *seat = calloc(1, sizeof(struct wlr_wl_seat));
+	seat->wl_seat = wl_seat;
+	wl->seat = seat;
+	wl_seat_add_listener(wl_seat, &seat_listener, wl);
+}
+
+void destroy_wl_seats(struct wlr_wl_backend *wl) {
+	struct wlr_wl_seat *seat = wl->seat;
+	if (!seat) {
+		return;
+	}
+
+	if (seat->pointer) {
+		wl_pointer_destroy(seat->pointer);
+	}
+	free(seat->name);
+	if (seat->wl_seat) {
+		wl_seat_destroy(seat->wl_seat);
+	}
+	free(seat);
+}
+
+static struct wlr_wl_seat *backend_get_seat(struct wlr_wl_backend *backend, struct wl_seat *wl_seat) {
+	assert(backend->seat && backend->seat->wl_seat == wl_seat);
+	return backend->seat;
+}
+
+static struct wlr_wl_seat *input_device_get_seat(struct wlr_input_device *wlr_dev) {
+	struct wlr_wl_input_device *dev =
+		get_wl_input_device_from_input_device(wlr_dev);
+	assert(dev->backend->seat);
+	return dev->backend->seat;
+}
+
 static void input_device_destroy(struct wlr_input_device *wlr_dev) {
 	struct wlr_wl_input_device *dev =
 		get_wl_input_device_from_input_device(wlr_dev);
 	if (dev->wlr_input_device.type == WLR_INPUT_DEVICE_KEYBOARD) {
-		wl_keyboard_release(dev->backend->keyboard);
-		dev->backend->keyboard = NULL;
+		struct wlr_wl_seat *seat = input_device_get_seat(wlr_dev);
+		wl_keyboard_release(seat->keyboard);
+		seat->keyboard = NULL;
 	}
 	wl_list_remove(&dev->wlr_input_device.link);
 	free(dev);
@@ -678,20 +715,20 @@ void create_wl_touch(struct wl_touch *wl_touch, struct wlr_wl_backend *wl) {
 static void seat_handle_capabilities(void *data, struct wl_seat *wl_seat,
 		enum wl_seat_capability caps) {
 	struct wlr_wl_backend *backend = data;
-	assert(backend->seat == wl_seat);
+	struct wlr_wl_seat *seat = backend_get_seat(backend, wl_seat);
 
-	if ((caps & WL_SEAT_CAPABILITY_POINTER) && backend->pointer == NULL) {
+	if ((caps & WL_SEAT_CAPABILITY_POINTER) && seat->pointer == NULL) {
 		wlr_log(WLR_DEBUG, "seat %p offered pointer", (void *)wl_seat);
 
 		struct wl_pointer *wl_pointer = wl_seat_get_pointer(wl_seat);
-		backend->pointer = wl_pointer;
+		seat->pointer = wl_pointer;
 
 		struct wlr_wl_output *output;
 		wl_list_for_each(output, &backend->outputs, link) {
 			create_wl_pointer(wl_pointer, output);
 		}
 	}
-	if (!(caps & WL_SEAT_CAPABILITY_POINTER) && backend->pointer != NULL) {
+	if (!(caps & WL_SEAT_CAPABILITY_POINTER) && seat->pointer != NULL) {
 		wlr_log(WLR_DEBUG, "seat %p dropped pointer", (void *)wl_seat);
 
 		struct wlr_input_device *device, *tmp;
@@ -701,21 +738,21 @@ static void seat_handle_capabilities(void *data, struct wl_seat *wl_seat,
 			}
 		}
 
-		wl_pointer_release(backend->pointer);
-		backend->pointer = NULL;
+		wl_pointer_release(seat->pointer);
+		seat->pointer = NULL;
 	}
 
-	if ((caps & WL_SEAT_CAPABILITY_KEYBOARD) && backend->keyboard == NULL) {
+	if ((caps & WL_SEAT_CAPABILITY_KEYBOARD) && seat->keyboard == NULL) {
 		wlr_log(WLR_DEBUG, "seat %p offered keyboard", (void *)wl_seat);
 
 		struct wl_keyboard *wl_keyboard = wl_seat_get_keyboard(wl_seat);
-		backend->keyboard = wl_keyboard;
+		seat->keyboard = wl_keyboard;
 
 		if (backend->started) {
 			create_wl_keyboard(wl_keyboard, backend);
 		}
 	}
-	if (!(caps & WL_SEAT_CAPABILITY_KEYBOARD) && backend->keyboard != NULL) {
+	if (!(caps & WL_SEAT_CAPABILITY_KEYBOARD) && seat->keyboard != NULL) {
 		wlr_log(WLR_DEBUG, "seat %p dropped keyboard", (void *)wl_seat);
 
 		struct wlr_input_device *device, *tmp;
@@ -724,18 +761,18 @@ static void seat_handle_capabilities(void *data, struct wl_seat *wl_seat,
 				wlr_input_device_destroy(device);
 			}
 		}
-		assert(backend->keyboard == NULL); // free'ed by input_device_destroy
+		assert(seat->keyboard == NULL); // free'ed by input_device_destroy
 	}
 
-	if ((caps & WL_SEAT_CAPABILITY_TOUCH) && backend->touch == NULL) {
+	if ((caps & WL_SEAT_CAPABILITY_TOUCH) && seat->touch == NULL) {
 		wlr_log(WLR_DEBUG, "seat %p offered touch", (void *)wl_seat);
 
-		backend->touch = wl_seat_get_touch(wl_seat);
+		seat->touch = wl_seat_get_touch(wl_seat);
 		if (backend->started) {
-			create_wl_touch(backend->touch, backend);
+			create_wl_touch(seat->touch, backend);
 		}
 	}
-	if (!(caps & WL_SEAT_CAPABILITY_TOUCH) && backend->touch != NULL) {
+	if (!(caps & WL_SEAT_CAPABILITY_TOUCH) && seat->touch != NULL) {
 		wlr_log(WLR_DEBUG, "seat %p dropped touch", (void *)wl_seat);
 
 		struct wlr_input_device *device, *tmp;
@@ -745,18 +782,17 @@ static void seat_handle_capabilities(void *data, struct wl_seat *wl_seat,
 			}
 		}
 
-		wl_touch_release(backend->touch);
-		backend->touch = NULL;
+		wl_touch_release(seat->touch);
+		seat->touch = NULL;
 	}
 }
 
 static void seat_handle_name(void *data, struct wl_seat *wl_seat,
 		const char *name) {
 	struct wlr_wl_backend *backend = data;
-	assert(backend->seat == wl_seat);
-	// Do we need to check if seatName was previously set for name change?
-	free(backend->seat_name);
-	backend->seat_name = strdup(name);
+	struct wlr_wl_seat *seat = backend_get_seat(backend, wl_seat);
+	free(seat->name);
+	seat->name = strdup(name);
 }
 
 const struct wl_seat_listener seat_listener = {
@@ -765,7 +801,5 @@ const struct wl_seat_listener seat_listener = {
 };
 
 struct wl_seat *wlr_wl_input_device_get_seat(struct wlr_input_device *wlr_dev) {
-	struct wlr_wl_input_device *dev =
-		get_wl_input_device_from_input_device(wlr_dev);
-	return dev->backend->seat;
+	return input_device_get_seat(wlr_dev)->wl_seat;
 }

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -38,13 +38,9 @@ struct wlr_wl_backend {
 	struct wp_presentation *presentation;
 	struct zwp_linux_dmabuf_v1 *zwp_linux_dmabuf_v1;
 	struct zwp_relative_pointer_manager_v1 *zwp_relative_pointer_manager_v1;
-	struct wl_seat *seat;
-	struct wl_touch *touch;
-	struct wl_pointer *pointer;
-	struct wl_keyboard *keyboard;
+	struct wlr_wl_seat *seat;
 	struct wlr_wl_pointer *current_pointer;
 	struct zwp_tablet_manager_v2 *tablet_manager;
-	char *seat_name;
 	struct wlr_drm_format_set linux_dmabuf_v1_formats;
 };
 
@@ -108,6 +104,15 @@ struct wlr_wl_pointer {
 	struct wl_listener output_destroy;
 };
 
+struct wlr_wl_seat {
+	struct wl_seat *wl_seat;
+
+	char *name;
+	struct wl_touch *touch;
+	struct wl_pointer *pointer;
+	struct wl_keyboard *keyboard;
+};
+
 struct wlr_wl_backend *get_wl_backend_from_backend(struct wlr_backend *backend);
 void update_wl_output_cursor(struct wlr_wl_output *output);
 struct wlr_wl_pointer *pointer_get_wl(struct wlr_pointer *wlr_pointer);
@@ -116,6 +121,8 @@ void create_wl_keyboard(struct wl_keyboard *wl_keyboard, struct wlr_wl_backend *
 void create_wl_touch(struct wl_touch *wl_touch, struct wlr_wl_backend *wl);
 struct wlr_wl_input_device *create_wl_input_device(
 	struct wlr_wl_backend *backend, enum wlr_input_device_type type);
+void create_wl_seat(struct wl_seat *wl_seat, struct wlr_wl_backend *wl);
+void destroy_wl_seats(struct wlr_wl_backend *wl);
 
 extern const struct wl_seat_listener seat_listener;
 


### PR DESCRIPTION
~~*Note  that this PR is based on `0.11.0`, because `master` at the moment is crashing my sway for some reason.*~~

#### Change in output to use `current_pointer`

This is just to bring in sync `seat.c` (we propagate events to `current_pointer`) and `output.c`. Though we have at most one pointer at the moment, this may simplify some further work by dropping implicit assumption `assert(!wl->current_pointer || wl->current_pointer->wl_pointer == wl->pointer)` that we already seems to have in `seat.c`.

#### Re-factor managing `seat`/`keyboard`/`pointer` to group them under `wlr_wl_seat`

### Testing
```sh
WLR_WL_OUTPUTS=2 WLR_NO_HARDWARE_CURSORS=1 WLR_BACKENDS=wayland cage -s -D -- weston-terminal
```
Started under Sway (running system `wlroots-0.11.0`) with single seat.