### PR TITLE
xwayland: introduce WLR_XWAYLAND for specifying which Xwayland to use

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -9,6 +9,8 @@ wlroots reads these environment variables
 * *WLR_SESSION*: specifies the wlr\_session to be used (available sessions:
   logind/systemd, direct)
 * *WLR_DIRECT_TTY*: specifies the tty to be used (instead of using /dev/tty)
+* *WLR_XWAYLAND*: specifies the path to an Xwayland binary to be used (instead
+  of following shell search semantics for "Xwayland")
 
 ## DRM backend
 

--- a/xwayland/server.c
+++ b/xwayland/server.c
@@ -107,8 +107,16 @@ noreturn static void exec_xwayland(struct wlr_xwayland_server *server) {
 		dup2(devnull, STDERR_FILENO);
 	}
 
+	const char *xwayland_path = getenv("WLR_XWAYLAND");
+	if (xwayland_path) {
+		wlr_log(WLR_INFO, "Using Xwayland binary to '%s' due to WLR_XWAYLAND",
+			xwayland_path);
+	} else {
+		xwayland_path = "Xwayland";
+	}
+
 	// This returns if and only if the call fails
-	execvp("Xwayland", argv);
+	execvp(xwayland_path, argv);
 
 	wlr_log_errno(WLR_ERROR, "failed to exec Xwayland");
 	close(devnull);


### PR DESCRIPTION
When debugging Xwayland-related issues, a common first step in debugging
has been to ask the reporter to move their real Xwayland to
/usr/bin/Xwayland.bin, and create a shell script starting Xwayland with
extra arguments under the original /usr/bin/Xwayland location.

Introducing a `WLR_XWAYLAND` environment variable makes this less
invasive, by allowing the user to swap out Xwayland without resorting to
global system changes (or source patches).