### PR TITLE
Mutli-seat support in Wayland backend

### DIFF
--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -164,8 +164,7 @@ static bool backend_start(struct wlr_backend *backend) {
 		}
 
 		if (wl->tablet_manager) {
-			wl_add_tablet_seat(wl->tablet_manager,
-				seat->wl_seat, wl);
+			wl_add_tablet_seat(wl->tablet_manager, seat);
 		}
 	}
 

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -157,8 +157,8 @@ static bool backend_start(struct wlr_backend *backend) {
 
 	wl->started = true;
 
-	struct wlr_wl_seat *seat = wl->seat;
-	if (seat != NULL) {
+	struct wlr_wl_seat *seat;
+	wl_list_for_each(seat, &wl->seats, link) {
 		if (seat->keyboard) {
 			create_wl_keyboard(seat);
 		}
@@ -262,6 +262,7 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display,
 	wl->local_display = display;
 	wl_list_init(&wl->devices);
 	wl_list_init(&wl->outputs);
+	wl_list_init(&wl->seats);
 
 	wl->remote_display = wl_display_connect(remote);
 	if (!wl->remote_display) {

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -160,7 +160,7 @@ static bool backend_start(struct wlr_backend *backend) {
 	struct wlr_wl_seat *seat = wl->seat;
 	if (seat != NULL) {
 		if (seat->keyboard) {
-			create_wl_keyboard(seat->keyboard, wl);
+			create_wl_keyboard(seat);
 		}
 
 		if (wl->tablet_manager) {

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -419,8 +419,10 @@ static void output_destroy(struct wlr_output *wlr_output) {
 }
 
 void update_wl_output_cursor(struct wlr_wl_output *output) {
-	struct wlr_wl_pointer *pointer = output->backend->current_pointer;
-	if (pointer && pointer->output == output && output->enter_serial) {
+	struct wlr_wl_pointer *pointer = output->cursor.pointer;
+	if (pointer) {
+		assert(pointer->output == output);
+		assert(output->enter_serial);
 		wl_pointer_set_cursor(pointer->wl_pointer, output->enter_serial,
 			output->cursor.surface, output->cursor.hotspot_x,
 			output->cursor.hotspot_y);

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -586,8 +586,8 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *wlr_backend) {
 
 	wlr_signal_emit_safe(&backend->backend.events.new_output, wlr_output);
 
-	struct wlr_wl_seat *seat = backend->seat;
-	if (seat != NULL) {
+	struct wlr_wl_seat *seat;
+	wl_list_for_each(seat, &backend->seats, link) {
 		if (seat->pointer) {
 			create_wl_pointer(seat, output);
 		}

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -589,7 +589,7 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *wlr_backend) {
 	struct wlr_wl_seat *seat = backend->seat;
 	if (seat != NULL) {
 		if (seat->pointer) {
-			create_wl_pointer(seat->pointer, output);
+			create_wl_pointer(seat, output);
 		}
 	}
 

--- a/backend/wayland/seat.c
+++ b/backend/wayland/seat.c
@@ -448,7 +448,11 @@ struct wlr_wl_input_device *create_wl_input_device(
 	struct wlr_input_device *wlr_dev = &dev->wlr_input_device;
 
 	unsigned int vendor = 0, product = 0;
-	const char *name = "wayland";
+
+	size_t name_size = 8 + strlen(seat->name) + 1;
+	char name[name_size];
+	(void) snprintf(name, name_size, "wayland-%s", seat->name);
+
 	wlr_input_device_init(wlr_dev, type, &input_device_impl, name, vendor,
 		product);
 	wl_list_insert(&seat->backend->devices, &wlr_dev->link);

--- a/backend/wayland/seat.c
+++ b/backend/wayland/seat.c
@@ -42,7 +42,8 @@ static struct wlr_wl_pointer *output_get_pointer(
 static void pointer_handle_enter(void *data, struct wl_pointer *wl_pointer,
 		uint32_t serial, struct wl_surface *surface, wl_fixed_t sx,
 		wl_fixed_t sy) {
-	struct wlr_wl_backend *backend = data;
+	struct wlr_wl_seat *seat = data;
+	struct wlr_wl_backend *backend = seat->backend;
 	if (surface == NULL) {
 		return;
 	}
@@ -54,8 +55,7 @@ static void pointer_handle_enter(void *data, struct wl_pointer *wl_pointer,
 	struct wlr_wl_pointer *current_pointer = backend->current_pointer;
 	if (current_pointer && current_pointer != pointer) {
 		wlr_log(WLR_INFO, "Ignoring seat %s pointer cursor in favor of seat %s",
-			pointer->input_device->seat->name,
-			current_pointer->input_device->seat->name);
+			seat->name, current_pointer->input_device->seat->name);
 		return;
 	}
 
@@ -66,7 +66,8 @@ static void pointer_handle_enter(void *data, struct wl_pointer *wl_pointer,
 
 static void pointer_handle_leave(void *data, struct wl_pointer *wl_pointer,
 		uint32_t serial, struct wl_surface *surface) {
-	struct wlr_wl_backend *backend = data;
+	struct wlr_wl_seat *seat = data;
+	struct wlr_wl_backend *backend = seat->backend;
 	if (surface == NULL) {
 		return;
 	}
@@ -85,8 +86,8 @@ static void pointer_handle_leave(void *data, struct wl_pointer *wl_pointer,
 
 static void pointer_handle_motion(void *data, struct wl_pointer *wl_pointer,
 		uint32_t time, wl_fixed_t sx, wl_fixed_t sy) {
-	struct wlr_wl_backend *backend = data;
-	struct wlr_wl_pointer *pointer = backend->current_pointer;
+	struct wlr_wl_seat *seat = data;
+	struct wlr_wl_pointer *pointer = seat->backend->current_pointer;
 	if (pointer == NULL) {
 		return;
 	}
@@ -103,8 +104,8 @@ static void pointer_handle_motion(void *data, struct wl_pointer *wl_pointer,
 
 static void pointer_handle_button(void *data, struct wl_pointer *wl_pointer,
 		uint32_t serial, uint32_t time, uint32_t button, uint32_t state) {
-	struct wlr_wl_backend *backend = data;
-	struct wlr_wl_pointer *pointer = backend->current_pointer;
+	struct wlr_wl_seat *seat = data;
+	struct wlr_wl_pointer *pointer = seat->backend->current_pointer;
 	if (pointer == NULL) {
 		return;
 	}
@@ -120,8 +121,8 @@ static void pointer_handle_button(void *data, struct wl_pointer *wl_pointer,
 
 static void pointer_handle_axis(void *data, struct wl_pointer *wl_pointer,
 		uint32_t time, uint32_t axis, wl_fixed_t value) {
-	struct wlr_wl_backend *backend = data;
-	struct wlr_wl_pointer *pointer = backend->current_pointer;
+	struct wlr_wl_seat *seat = data;
+	struct wlr_wl_pointer *pointer = seat->backend->current_pointer;
 	if (pointer == NULL) {
 		return;
 	}
@@ -140,8 +141,8 @@ static void pointer_handle_axis(void *data, struct wl_pointer *wl_pointer,
 }
 
 static void pointer_handle_frame(void *data, struct wl_pointer *wl_pointer) {
-	struct wlr_wl_backend *backend = data;
-	struct wlr_wl_pointer *pointer = backend->current_pointer;
+	struct wlr_wl_seat *seat = data;
+	struct wlr_wl_pointer *pointer = seat->backend->current_pointer;
 	if (pointer == NULL) {
 		return;
 	}
@@ -152,8 +153,8 @@ static void pointer_handle_frame(void *data, struct wl_pointer *wl_pointer) {
 
 static void pointer_handle_axis_source(void *data,
 		struct wl_pointer *wl_pointer, uint32_t axis_source) {
-	struct wlr_wl_backend *backend = data;
-	struct wlr_wl_pointer *pointer = backend->current_pointer;
+	struct wlr_wl_seat *seat = data;
+	struct wlr_wl_pointer *pointer = seat->backend->current_pointer;
 	if (pointer == NULL) {
 		return;
 	}
@@ -163,8 +164,8 @@ static void pointer_handle_axis_source(void *data,
 
 static void pointer_handle_axis_stop(void *data, struct wl_pointer *wl_pointer,
 		uint32_t time, uint32_t axis) {
-	struct wlr_wl_backend *backend = data;
-	struct wlr_wl_pointer *pointer = backend->current_pointer;
+	struct wlr_wl_seat *seat = data;
+	struct wlr_wl_pointer *pointer = seat->backend->current_pointer;
 	if (pointer == NULL) {
 		return;
 	}
@@ -182,8 +183,8 @@ static void pointer_handle_axis_stop(void *data, struct wl_pointer *wl_pointer,
 
 static void pointer_handle_axis_discrete(void *data,
 		struct wl_pointer *wl_pointer, uint32_t axis, int32_t discrete) {
-	struct wlr_wl_backend *backend = data;
-	struct wlr_wl_pointer *pointer = backend->current_pointer;
+	struct wlr_wl_seat *seat = data;
+	struct wlr_wl_pointer *pointer = seat->backend->current_pointer;
 	if (pointer == NULL) {
 		return;
 	}
@@ -685,7 +686,7 @@ void create_wl_pointer(struct wlr_wl_seat *seat, struct wlr_wl_output *output) {
 			&relative_pointer_listener, dev);
 	}
 
-	wl_pointer_add_listener(wl_pointer, &pointer_listener, backend);
+	wl_pointer_add_listener(wl_pointer, &pointer_listener, seat);
 	wlr_signal_emit_safe(&backend->backend.events.new_input, wlr_dev);
 }
 

--- a/backend/wayland/tablet_v2.c
+++ b/backend/wayland/tablet_v2.c
@@ -429,7 +429,8 @@ static void handle_pad_added(void *data,
 		struct zwp_tablet_seat_v2 *zwp_tablet_seat_v2,
 		struct zwp_tablet_pad_v2 *id) {
 	wlr_log(WLR_DEBUG, "New tablet pad");
-	struct wlr_wl_backend *backend = data;
+	struct wlr_wl_seat *seat = data;
+	struct wlr_wl_backend *backend = seat->backend;
 	struct wlr_wl_input_device *dev = create_wl_input_device(
 		backend, WLR_INPUT_DEVICE_TABLET_PAD);
 	if (!dev) {
@@ -889,7 +890,8 @@ static void handle_tab_added(void *data,
 		struct zwp_tablet_seat_v2 *zwp_tablet_seat_v2,
 		struct zwp_tablet_v2 *id) {
 	wlr_log(WLR_DEBUG, "New tablet");
-	struct wlr_wl_backend *backend = data;
+	struct wlr_wl_seat *seat = data;
+	struct wlr_wl_backend *backend = seat->backend;
 	struct wlr_wl_input_device *dev = create_wl_input_device(
 		backend, WLR_INPUT_DEVICE_TABLET_TOOL);
 
@@ -919,18 +921,18 @@ static const struct zwp_tablet_seat_v2_listener tablet_seat_listener = {
 
 struct wlr_wl_tablet_seat *wl_add_tablet_seat(
 		struct zwp_tablet_manager_v2 *manager,
-		struct wl_seat *seat, struct wlr_wl_backend *backend) {
+		struct wlr_wl_seat *seat) {
 	struct wlr_wl_tablet_seat *ret =
 		calloc(1, sizeof(struct wlr_wl_tablet_seat));
 
 	if (!(ret->tablet_seat =
-			zwp_tablet_manager_v2_get_tablet_seat(manager, seat))) {
+			zwp_tablet_manager_v2_get_tablet_seat(manager, seat->wl_seat))) {
 		free(ret);
 		return NULL;
 	}
 
 	zwp_tablet_seat_v2_add_listener(ret->tablet_seat,
-		&tablet_seat_listener, backend);
+		&tablet_seat_listener, seat);
 
 	return ret;
 }

--- a/backend/wayland/tablet_v2.c
+++ b/backend/wayland/tablet_v2.c
@@ -430,9 +430,8 @@ static void handle_pad_added(void *data,
 		struct zwp_tablet_pad_v2 *id) {
 	wlr_log(WLR_DEBUG, "New tablet pad");
 	struct wlr_wl_seat *seat = data;
-	struct wlr_wl_backend *backend = seat->backend;
 	struct wlr_wl_input_device *dev = create_wl_input_device(
-		backend, WLR_INPUT_DEVICE_TABLET_PAD);
+		seat, WLR_INPUT_DEVICE_TABLET_PAD);
 	if (!dev) {
 		/* This leaks a couple of server-sent resource ids. iirc this
 		 * shouldn't ever be a problem, but it isn't exactly nice
@@ -891,9 +890,8 @@ static void handle_tab_added(void *data,
 		struct zwp_tablet_v2 *id) {
 	wlr_log(WLR_DEBUG, "New tablet");
 	struct wlr_wl_seat *seat = data;
-	struct wlr_wl_backend *backend = seat->backend;
 	struct wlr_wl_input_device *dev = create_wl_input_device(
-		backend, WLR_INPUT_DEVICE_TABLET_TOOL);
+		seat, WLR_INPUT_DEVICE_TABLET_TOOL);
 
 	if (!dev) {
 		zwp_tablet_v2_destroy(id);

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -40,7 +40,6 @@ struct wlr_wl_backend {
 	struct zwp_linux_dmabuf_v1 *zwp_linux_dmabuf_v1;
 	struct zwp_relative_pointer_manager_v1 *zwp_relative_pointer_manager_v1;
 	struct wl_list seats; // wlr_wl_seat.link
-	struct wlr_wl_pointer *current_pointer;
 	struct zwp_tablet_manager_v2 *tablet_manager;
 	struct wlr_drm_format_set linux_dmabuf_v1_formats;
 };
@@ -75,6 +74,7 @@ struct wlr_wl_output {
 	uint32_t enter_serial;
 
 	struct {
+		struct wlr_wl_pointer *pointer;
 		struct wl_surface *surface;
 		struct wl_egl_window *egl_window;
 		int32_t hotspot_x, hotspot_y;

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -39,7 +39,7 @@ struct wlr_wl_backend {
 	struct wp_presentation *presentation;
 	struct zwp_linux_dmabuf_v1 *zwp_linux_dmabuf_v1;
 	struct zwp_relative_pointer_manager_v1 *zwp_relative_pointer_manager_v1;
-	struct wlr_wl_seat *seat;
+	struct wl_list seats; // wlr_wl_seat.link
 	struct wlr_wl_pointer *current_pointer;
 	struct zwp_tablet_manager_v2 *tablet_manager;
 	struct wlr_drm_format_set linux_dmabuf_v1_formats;
@@ -109,6 +109,7 @@ struct wlr_wl_pointer {
 struct wlr_wl_seat {
 	struct wl_seat *wl_seat;
 
+	struct wl_list link; // wlr_wl_backend.seats
 	char *name;
 	struct wl_touch *touch;
 	struct wl_pointer *pointer;

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -87,6 +87,7 @@ struct wlr_wl_input_device {
 	uint32_t fingers;
 
 	struct wlr_wl_backend *backend;
+	struct wlr_wl_seat *seat;
 	void *resource;
 };
 
@@ -119,11 +120,11 @@ struct wlr_wl_seat {
 struct wlr_wl_backend *get_wl_backend_from_backend(struct wlr_backend *backend);
 void update_wl_output_cursor(struct wlr_wl_output *output);
 struct wlr_wl_pointer *pointer_get_wl(struct wlr_pointer *wlr_pointer);
-void create_wl_pointer(struct wl_pointer *wl_pointer, struct wlr_wl_output *output);
-void create_wl_keyboard(struct wl_keyboard *wl_keyboard, struct wlr_wl_backend *wl);
-void create_wl_touch(struct wl_touch *wl_touch, struct wlr_wl_backend *wl);
+void create_wl_pointer(struct wlr_wl_seat *seat, struct wlr_wl_output *output);
+void create_wl_keyboard(struct wlr_wl_seat *seat);
+void create_wl_touch(struct wlr_wl_seat *seat);
 struct wlr_wl_input_device *create_wl_input_device(
-	struct wlr_wl_backend *backend, enum wlr_input_device_type type);
+	struct wlr_wl_seat *seat, enum wlr_input_device_type type);
 bool create_wl_seat(struct wl_seat *wl_seat, struct wlr_wl_backend *wl);
 void destroy_wl_seats(struct wlr_wl_backend *wl);
 

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -116,6 +116,7 @@ struct wlr_wl_seat {
 	struct wl_keyboard *keyboard;
 
 	struct wlr_wl_backend *backend;
+	struct wlr_wl_pointer *active_pointer;
 };
 
 struct wlr_wl_backend *get_wl_backend_from_backend(struct wlr_backend *backend);

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -112,6 +112,8 @@ struct wlr_wl_seat {
 	struct wl_touch *touch;
 	struct wl_pointer *pointer;
 	struct wl_keyboard *keyboard;
+
+	struct wlr_wl_backend *backend;
 };
 
 struct wlr_wl_backend *get_wl_backend_from_backend(struct wlr_backend *backend);
@@ -129,6 +131,6 @@ extern const struct wl_seat_listener seat_listener;
 
 struct wlr_wl_tablet_seat *wl_add_tablet_seat(
 		struct zwp_tablet_manager_v2 *manager,
-		struct wl_seat *seat, struct wlr_wl_backend *backend);
+		struct wlr_wl_seat *seat);
 
 #endif


### PR DESCRIPTION
*~~Note  that this PR is based on https://github.com/swaywm/wlroots/pull/2413 `0.11.0`, because latest changes at the moment are crashing my sway test setup https://github.com/swaywm/wlroots/issues/2416.~~*

Intention is to get close to resolving https://github.com/swaywm/wlroots/issues/1499 by getting in one of these:
- ~~exclusive seat per backend (or output)~~.
- ~~muxing pointers/keyboards into virtual ones (same seat)~~
- ~~muxing multiple seats into single virtual one with single/multiple pointer and keyboard~~
- proxying seats as inputs 1:1

Any of those should work for my needs.

Worth to note that as of now we multiple pointers by amount of outputs ~~. Not sure purpose of this.~~ to map absolute coordinates on particular output.

### Progress
* [x] Track multiple seats from outer compositor.
* ~~Switching (`backend->current_pointer`) between seats based on entered/left pointer (for exclusive behavior).~~
* [x] Listen to events from multiple pointers.
* [x] Expose multiple inputs downstream.
* [x] Distinguishable input names to allow seat management in downstream Sway.
* [x] Track down bug triggered by switching VTs.
* [x] Make ~~`current_pointer`~~ *`active_pointer`* be local to `wrl_wl_seat` and point which `wlr_pointer` needs to receive events based on output we entered with host `wl_pointer`.
* [x] Track down bug with clicks/focus propagation in sway-(cage-sway-alacrity)x2 to get two pointers working simulatenously.  
*We were always reporting to `backend->current_pointer`*
* [x] Move `backend->current_pointer` to `wlr_wl_output` since right now it only required there for sending host pointer cursor surface.  
*For me it is still not clear how cursor is set ~~for individual seats since we receive only output in `wlr_output_impl`~~ and how compositor knows if back-end support hardware cursor. For now moved to `output->cursor.pointer` in d6f7dffb547d640041cb2caa892691a8e2d52696 assuming that potentially different outputs might be a different GPUs with own hardware cursors.*

### Testing
Root Sway compositor with two non-empty seats

Checking how seats/inputs are advertised:

*
  ```sh
  cage -s -- wayland-info
  ```
* 
  ```sh
  # dummy-config
  # run: sway -c dummy-config
  exec "swaymsg -t get_inputs; swaymsg -t get_seats; swaymsg exit"
  ```

Checking cursor and events propagation:
```sh
cage -s -D -- wev
cage -s -D -- weston-terminal
```
* Slowly moving through boundaries triggering cursor change to re-size icon before entering output window.
* Check motion events from pointer.

Multi-output: `WLR_WL_OUTPUTS=2` 
Software cursor: `WLR_NO_HARDWARE_CURSORS=1`

#### Goal
Share screen for two people:
```
# inputs
seat seat1 attach {
  # ...
}

# minimal visual split
default_border pixel
hide_edge_borders both

# bootstrap cells
exec cage -s -- alacritty
exec cage -s -- alacritty
```
(from `alacritty` we can spawn `login` or `exec` compositor)

* :heavy_check_mark:  Works for keyboard with input focus following pointer from same seat.  
* :heavy_check_mark: Mouse hover/click and movements do propagate to both windows independently.
* ~~:grey_question: Didn't checked touch/pen events. I have only one digitizing tablet, so can only employ Sway ability to attach same device to both seats in order to check it.~~ Doesn't work regardless of this PR. See https://github.com/swaywm/wlroots/issues/2415 .