### PR TITLE
foreign-toplevel-management: Report parent toplevel

### DIFF
--- a/include/wlr/types/wlr_foreign_toplevel_management_v1.h
+++ b/include/wlr/types/wlr_foreign_toplevel_management_v1.h
@@ -50,6 +50,7 @@ struct wlr_foreign_toplevel_handle_v1 {
 
 	char *title;
 	char *app_id;
+	struct wlr_foreign_toplevel_handle_v1 *parent;
 	struct wl_list outputs; // wlr_foreign_toplevel_v1_output
 	uint32_t state; // wlr_foreign_toplevel_v1_state
 
@@ -104,6 +105,12 @@ struct wlr_foreign_toplevel_manager_v1 *wlr_foreign_toplevel_manager_v1_create(
 
 struct wlr_foreign_toplevel_handle_v1 *wlr_foreign_toplevel_handle_v1_create(
 	struct wlr_foreign_toplevel_manager_v1 *manager);
+/* Destroy the given toplevel handle, sending the closed event to any
+ * client. Also, if the destroyed toplevel is set as a parent of any
+ * other valid toplevel, clients still holding a handle to both are
+ * sent a parent signal with NULL parent. If this is not desired, the
+ * caller should ensure that any child toplevels are destroyed before
+ * the parent. */
 void wlr_foreign_toplevel_handle_v1_destroy(
 	struct wlr_foreign_toplevel_handle_v1 *toplevel);
 
@@ -125,5 +132,15 @@ void wlr_foreign_toplevel_handle_v1_set_activated(
 	struct wlr_foreign_toplevel_handle_v1 *toplevel, bool activated);
 void wlr_foreign_toplevel_handle_v1_set_fullscreen(
 	struct wlr_foreign_toplevel_handle_v1* toplevel, bool fullscreen);
+
+/* Set the parent of a toplevel. If the parent changed from its previous
+ * value, also sends a parent event to all clients that hold handles to
+ * both toplevel and parent (no message is sent to clients that have
+ * previously destroyed their parent handle). NULL is allowed as the
+ * parent, meaning no parent exists. */
+void wlr_foreign_toplevel_handle_v1_set_parent(
+	struct wlr_foreign_toplevel_handle_v1 *toplevel,
+	struct wlr_foreign_toplevel_handle_v1 *parent);
+
 
 #endif

--- a/protocol/wlr-foreign-toplevel-management-unstable-v1.xml
+++ b/protocol/wlr-foreign-toplevel-management-unstable-v1.xml
@@ -25,7 +25,7 @@
     THIS SOFTWARE.
   </copyright>
 
-  <interface name="zwlr_foreign_toplevel_manager_v1" version="2">
+  <interface name="zwlr_foreign_toplevel_manager_v1" version="3">
     <description summary="list and control opened apps">
       The purpose of this protocol is to enable the creation of taskbars
       and docks by providing them with a list of opened applications and
@@ -68,7 +68,7 @@
     </event>
   </interface>
 
-  <interface name="zwlr_foreign_toplevel_handle_v1" version="2">
+  <interface name="zwlr_foreign_toplevel_handle_v1" version="3">
     <description summary="an opened toplevel">
       A zwlr_foreign_toplevel_handle_v1 object represents an opened toplevel
       window. Each app may have multiple opened toplevels.
@@ -255,5 +255,16 @@
         actually changes, this will be indicated by the state event.
       </description>
     </request>
+
+    <!-- Version 3 additions -->
+
+    <event name="parent" since="3">
+      <description summary="parent change">
+        This event is emitted whenever the parent of the toplevel changes.
+        
+        No event is emitted when the parent handle is destroyed by the client.
+      </description>
+      <arg name="parent" type="object" interface="zwlr_foreign_toplevel_handle_v1" allow-null="true"/>
+    </event>
   </interface>
 </protocol>


### PR DESCRIPTION
This is an implementation for https://github.com/swaywm/wlr-protocols/pull/52

Works together with: https://github.com/dkondor/wayfire/tree/foreign-toplevel-report-parent

Example client: https://github.com/dkondor/cairo-dock-core/tree/wayland_egl

Tested: not displaying child views in the taskbar

Untested: actually grouping together views with the same parent

I'm happy to work on additional test cases if needed.


Potential issues:

- I've added a field storing the parent to the wlr_foreign_toplevel_handle_v1 struct. This is necessary so that foreign_toplevel_manager_bind() can send information about parents to the new client. This breaks ABI though.
- In wlr_foreign_toplevel_handle_v1_destroy(), I've added code to check if the destroyed handle is not stored in the parent field for any other toplevel. I don't really like this solution, since this makes destroying a toplevel handle scale with the number of toplevels managed here (and destroying N toplevels will have a complexity of N^2). Since the number of toplevels is expected to be low, I don't think it is a big problem in practice though. Potential alternatives:
  -- Store the children of a toplevel in a list. I don't like this, since it essentially duplicates functionality that is likely already present in the compositor elsewhere.
  -- Do not do check this and require the caller to ensure that either (1) a parent handle is only destroyed after all child handles; (2) wlr_foreign_toplevel_handle_v1_set_parent() is called with NULL or another parent before destroying the parent handle
- Strangely, I could not find any documentation for wl_resource_find_for_client(), so I used it based on the assumption that it does what I think. I'd be grateful if someone more familiar with these interfaces could confirm that I'm using it correctly.
