### PR TITLE
Using %m in `wlr_log` is broken, use `wlr_log_errno` / `perror` instead

### DIFF
--- a/examples/screencopy-dmabuf.c
+++ b/examples/screencopy-dmabuf.c
@@ -297,7 +297,7 @@ int main(int argc, char *argv[]) {
 
 	drm_fd = open(render_node, O_RDWR);
 	if (drm_fd < 0) {
-		fprintf(stderr, "Failed to open drm render node: %m\n");
+		perror("Failed to open drm render node");
 		return EXIT_FAILURE;
 	}
 
@@ -309,7 +309,7 @@ int main(int argc, char *argv[]) {
 
 	struct wl_display *display = wl_display_connect(NULL);
 	if (display == NULL) {
-		fprintf(stderr, "failed to create display: %m\n");
+		perror("failed to create display");
 		return EXIT_FAILURE;
 	}
 
@@ -343,7 +343,7 @@ int main(int argc, char *argv[]) {
 	void *data = gbm_bo_map(buffer.bo, 0, 0, buffer.width, buffer.height,
 			GBM_BO_TRANSFER_READ, &stride, &map_data);
 	if (!data) {
-		fprintf(stderr, "Failed to map gbm bo: %m\n");
+		perror("Failed to map gbm bo");
 		return EXIT_FAILURE;
 	}
 

--- a/examples/screencopy.c
+++ b/examples/screencopy.c
@@ -90,7 +90,7 @@ static struct wl_buffer *create_shm_buffer(enum wl_shm_format fmt,
 
 	void *data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
 	if (data == MAP_FAILED) {
-		fprintf(stderr, "mmap failed: %m\n");
+		perror("mmap failed");
 		close(fd);
 		return NULL;
 	}
@@ -228,7 +228,7 @@ static void write_image(char *filename, enum wl_shm_format wl_fmt, int width,
 int main(int argc, char *argv[]) {
 	struct wl_display * display = wl_display_connect(NULL);
 	if (display == NULL) {
-		fprintf(stderr, "failed to create display: %m\n");
+		perror("failed to create display");
 		return EXIT_FAILURE;
 	}
 

--- a/examples/virtual-pointer.c
+++ b/examples/virtual-pointer.c
@@ -61,7 +61,7 @@ int main(int argc, char *argv[]) {
 	}
 	struct wl_display * display = wl_display_connect(NULL);
 	if (display == NULL) {
-		fprintf(stderr, "failed to create display: %m\n");
+		perror("failed to create display");
 		return EXIT_FAILURE;
 	}
 

--- a/xwayland/selection/outgoing.c
+++ b/xwayland/selection/outgoing.c
@@ -92,7 +92,7 @@ static int xwm_data_source_read(int fd, uint32_t mask, void *data) {
 	size_t available = transfer->source_data.alloc - current;
 	ssize_t len = read(fd, p, available);
 	if (len == -1) {
-		wlr_log(WLR_ERROR, "read error from data source: %m");
+		wlr_log_errno(WLR_ERROR, "read error from data source");
 		goto error_out;
 	}
 
@@ -289,7 +289,7 @@ static void xwm_selection_send_data(struct wlr_xwm_selection *selection,
 
 	int p[2];
 	if (pipe(p) == -1) {
-		wlr_log(WLR_ERROR, "pipe() failed: %m");
+		wlr_log_errno(WLR_ERROR, "pipe() failed");
 		xwm_selection_send_notify(selection->xwm, req, false);
 		return;
 	}


### PR DESCRIPTION
This one was awful to track down, but calls to `wlr_log` with `%m` have
the errno masked by the `isatty` call in `log_stderr`. Switch them to
`wlr_log_errno` instead.

Cue quality "how can `read(2)` POSSIBLY be returning `ENOTTY`??" moments :)

While at it, I replaced the remaining usages of `%m` (in examples/) with
`perror`, since `%m` is a GNU extension.