### PR TITLE
xwayland: add set_geometry event

### DIFF
--- a/include/wlr/xwayland.h
+++ b/include/wlr/xwayland.h
@@ -198,6 +198,7 @@ struct wlr_xwayland_surface {
 		struct wl_signal set_hints;
 		struct wl_signal set_decorations;
 		struct wl_signal set_override_redirect;
+		struct wl_signal set_geometry;
 		struct wl_signal ping_timeout;
 	} events;
 


### PR DESCRIPTION
This is necessary to react to changes in position of override-redirect views.
Example of where this is necessary is dragging the "Search everywhere" dialog in Android Studio. It configures itself in order to move around the screen, but compositors up to now can only react when the surface is committed. In the meantime, the compositor and the Xserver state is out-of-sync causing jumps of the view because the mouse coordinates are wrong.

See also https://github.com/WayfireWM/wayfire/pull/784