### PR TITLE
Use uint32_t in wlr_renderer_begin signature

### DIFF
--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -35,7 +35,7 @@ struct wlr_renderer {
 struct wlr_renderer *wlr_renderer_autocreate(struct wlr_egl *egl, EGLenum platform,
 	void *remote_display, EGLint *config_attribs, EGLint visual_id);
 
-void wlr_renderer_begin(struct wlr_renderer *r, int width, int height);
+void wlr_renderer_begin(struct wlr_renderer *r, uint32_t width, uint32_t height);
 void wlr_renderer_end(struct wlr_renderer *r);
 void wlr_renderer_clear(struct wlr_renderer *r, const float color[static 4]);
 /**

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -37,7 +37,7 @@ void wlr_renderer_destroy(struct wlr_renderer *r) {
 	}
 }
 
-void wlr_renderer_begin(struct wlr_renderer *r, int width, int height) {
+void wlr_renderer_begin(struct wlr_renderer *r, uint32_t width, uint32_t height) {
 	assert(!r->rendering);
 
 	r->impl->begin(r, width, height);


### PR DESCRIPTION
This matches the signature of wlr_renderer_impl.begin