### PR TITLE
xdg_positioner: remove unused field

### DIFF
--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -48,8 +48,6 @@ struct wlr_xdg_client {
 };
 
 struct wlr_xdg_positioner {
-	struct wl_resource *resource;
-
 	struct wlr_box anchor_rect;
 	enum xdg_positioner_anchor anchor;
 	enum xdg_positioner_gravity gravity;


### PR DESCRIPTION
The resource field of wlr_xdg_positioner is never initialized or
accessed within wlroots. The wl_resource for this interface is stored
in the wlr_xdg_positioner_resource struct.