### PR TITLE
Minor fixes in Wayland backend seat and input device handling alloc errors

### DIFF
--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -105,7 +105,9 @@ static void registry_global(void *data, struct wl_registry *registry,
 	} else if (strcmp(iface, wl_seat_interface.name) == 0) {
 		struct wl_seat *wl_seat = wl_registry_bind(registry, name,
 			&wl_seat_interface, 5);
-		create_wl_seat(wl_seat, wl);
+		if (!create_wl_seat(wl_seat, wl)) {
+			wl_seat_destroy(wl_seat);
+		}
 	} else if (strcmp(iface, xdg_wm_base_interface.name) == 0) {
 		wl->xdg_wm_base = wl_registry_bind(registry, name,
 			&xdg_wm_base_interface, 1);

--- a/backend/wayland/seat.c
+++ b/backend/wayland/seat.c
@@ -372,12 +372,17 @@ static struct wlr_wl_input_device *get_wl_input_device_from_input_device(
 	return (struct wlr_wl_input_device *)wlr_dev;
 }
 
-void create_wl_seat(struct wl_seat *wl_seat, struct wlr_wl_backend *wl) {
+bool create_wl_seat(struct wl_seat *wl_seat, struct wlr_wl_backend *wl) {
 	assert(!wl->seat);  // only one seat supported at the moment
 	struct wlr_wl_seat *seat = calloc(1, sizeof(struct wlr_wl_seat));
+	if (!seat) {
+		wlr_log_errno(WLR_ERROR, "Allocation failed");
+		return false;
+	}
 	seat->wl_seat = wl_seat;
 	wl->seat = seat;
 	wl_seat_add_listener(wl_seat, &seat_listener, wl);
+	return true;
 }
 
 void destroy_wl_seats(struct wlr_wl_backend *wl) {

--- a/backend/wayland/seat.c
+++ b/backend/wayland/seat.c
@@ -391,8 +391,15 @@ void destroy_wl_seats(struct wlr_wl_backend *wl) {
 		return;
 	}
 
+	if (seat->touch) {
+		wl_touch_destroy(seat->touch);
+	}
 	if (seat->pointer) {
 		wl_pointer_destroy(seat->pointer);
+	}
+	if (seat->keyboard && !wl->started) {
+		// early termination will not be handled by input_device_destroy
+		wl_keyboard_destroy(seat->keyboard);
 	}
 	free(seat->name);
 	if (seat->wl_seat) {

--- a/backend/wayland/seat.c
+++ b/backend/wayland/seat.c
@@ -636,9 +636,6 @@ void create_wl_pointer(struct wl_pointer *wl_pointer, struct wlr_wl_output *outp
 	pointer->wl_pointer = wl_pointer;
 	pointer->output = output;
 
-	wl_signal_add(&output->wlr_output.events.destroy, &pointer->output_destroy);
-	pointer->output_destroy.notify = pointer_handle_output_destroy;
-
 	struct wlr_wl_input_device *dev =
 		create_wl_input_device(backend, WLR_INPUT_DEVICE_POINTER);
 	if (dev == NULL) {
@@ -647,6 +644,9 @@ void create_wl_pointer(struct wl_pointer *wl_pointer, struct wlr_wl_output *outp
 		return;
 	}
 	pointer->input_device = dev;
+
+	wl_signal_add(&output->wlr_output.events.destroy, &pointer->output_destroy);
+	pointer->output_destroy.notify = pointer_handle_output_destroy;
 
 	wlr_dev = &dev->wlr_input_device;
 	wlr_dev->pointer = &pointer->wlr_pointer;
@@ -686,7 +686,7 @@ void create_wl_keyboard(struct wl_keyboard *wl_keyboard, struct wlr_wl_backend *
 	wlr_dev->keyboard = calloc(1, sizeof(*wlr_dev->keyboard));
 	if (!wlr_dev->keyboard) {
 		wlr_log_errno(WLR_ERROR, "Allocation failed");
-		free(dev);
+		wlr_input_device_destroy(wlr_dev);
 		return;
 	}
 	wlr_keyboard_init(wlr_dev->keyboard, NULL);
@@ -707,7 +707,7 @@ void create_wl_touch(struct wl_touch *wl_touch, struct wlr_wl_backend *wl) {
 	wlr_dev->touch = calloc(1, sizeof(*wlr_dev->touch));
 	if (!wlr_dev->touch) {
 		wlr_log_errno(WLR_ERROR, "Allocation failed");
-		free(dev);
+		wlr_input_device_destroy(wlr_dev);
 		return;
 	}
 	wlr_touch_init(wlr_dev->touch, NULL);

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -121,7 +121,7 @@ void create_wl_keyboard(struct wl_keyboard *wl_keyboard, struct wlr_wl_backend *
 void create_wl_touch(struct wl_touch *wl_touch, struct wlr_wl_backend *wl);
 struct wlr_wl_input_device *create_wl_input_device(
 	struct wlr_wl_backend *backend, enum wlr_input_device_type type);
-void create_wl_seat(struct wl_seat *wl_seat, struct wlr_wl_backend *wl);
+bool create_wl_seat(struct wl_seat *wl_seat, struct wlr_wl_backend *wl);
 void destroy_wl_seats(struct wlr_wl_backend *wl);
 
 extern const struct wl_seat_listener seat_listener;


### PR DESCRIPTION
This is partially follow on comments for https://github.com/swaywm/wlroots/pull/2413 and https://github.com/swaywm/wlroots/pull/2435 .

Note that releasing `wl_keyboard` is managed by `wlr_wl_keyboard` created in association 1:1 most of the time. With one exception when back-end is not yet started.