### PR TITLE
xwayland: fix minor typo in debug log

### DIFF
--- a/xwayland/server.c
+++ b/xwayland/server.c
@@ -109,7 +109,7 @@ noreturn static void exec_xwayland(struct wlr_xwayland_server *server) {
 
 	const char *xwayland_path = getenv("WLR_XWAYLAND");
 	if (xwayland_path) {
-		wlr_log(WLR_INFO, "Using Xwayland binary to '%s' due to WLR_XWAYLAND",
+		wlr_log(WLR_INFO, "Using Xwayland binary '%s' due to WLR_XWAYLAND",
 			xwayland_path);
 	} else {
 		xwayland_path = "Xwayland";


### PR DESCRIPTION
This accidentally slipped through 1b0e4c7.