### PR TITLE
Replace wlr_key_state with wl_keyboard_key_state

### DIFF
--- a/backend/libinput/keyboard.c
+++ b/backend/libinput/keyboard.c
@@ -72,10 +72,10 @@ void handle_keyboard_key(struct libinput_event *event,
 		libinput_event_keyboard_get_key_state(kbevent);
 	switch (state) {
 	case LIBINPUT_KEY_STATE_RELEASED:
-		wlr_event.state = WLR_KEY_RELEASED;
+		wlr_event.state = WL_KEYBOARD_KEY_STATE_RELEASED;
 		break;
 	case LIBINPUT_KEY_STATE_PRESSED:
-		wlr_event.state = WLR_KEY_PRESSED;
+		wlr_event.state = WL_KEYBOARD_KEY_STATE_PRESSED;
 		break;
 	}
 	wlr_event.update_state = true;

--- a/backend/wayland/seat.c
+++ b/backend/wayland/seat.c
@@ -209,7 +209,7 @@ static void keyboard_handle_enter(void *data, struct wl_keyboard *wl_keyboard,
 	wl_array_for_each(keycode_ptr, keys) {
 		struct wlr_event_keyboard_key event = {
 			.keycode = *keycode_ptr,
-			.state = WLR_KEY_PRESSED,
+			.state = WL_KEYBOARD_KEY_STATE_PRESSED,
 			.time_msec = time,
 			.update_state = false,
 		};
@@ -232,7 +232,7 @@ static void keyboard_handle_leave(void *data, struct wl_keyboard *wl_keyboard,
 
 		struct wlr_event_keyboard_key event = {
 			.keycode = keycode,
-			.state = WLR_KEY_RELEASED,
+			.state = WL_KEYBOARD_KEY_STATE_RELEASED,
 			.time_msec = time,
 			.update_state = false,
 		};

--- a/backend/x11/input_device.c
+++ b/backend/x11/input_device.c
@@ -4,6 +4,8 @@
 
 #include <linux/input-event-codes.h>
 
+#include <wayland-server-protocol.h>
+
 #include <xcb/xcb.h>
 #include <xcb/xfixes.h>
 #include <xcb/xinput.h>
@@ -18,7 +20,7 @@
 #include "util/signal.h"
 
 static void send_key_event(struct wlr_x11_backend *x11, uint32_t key,
-		enum wlr_key_state st, xcb_timestamp_t time) {
+		enum wl_keyboard_key_state st, xcb_timestamp_t time) {
 	struct wlr_event_keyboard_key ev = {
 		.time_msec = time,
 		.keycode = key,
@@ -123,7 +125,7 @@ void handle_x11_xinput_event(struct wlr_x11_backend *x11,
 
 		wlr_keyboard_notify_modifiers(&x11->keyboard, ev->mods.base,
 			ev->mods.latched, ev->mods.locked, ev->mods.effective);
-		send_key_event(x11, ev->detail - 8, WLR_KEY_PRESSED, ev->time);
+		send_key_event(x11, ev->detail - 8, WL_KEYBOARD_KEY_STATE_PRESSED, ev->time);
 		x11->time = ev->time;
 		break;
 	}
@@ -133,7 +135,7 @@ void handle_x11_xinput_event(struct wlr_x11_backend *x11,
 
 		wlr_keyboard_notify_modifiers(&x11->keyboard, ev->mods.base,
 			ev->mods.latched, ev->mods.locked, ev->mods.effective);
-		send_key_event(x11, ev->detail - 8, WLR_KEY_RELEASED, ev->time);
+		send_key_event(x11, ev->detail - 8, WL_KEYBOARD_KEY_STATE_RELEASED, ev->time);
 		x11->time = ev->time;
 		break;
 	}

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -190,7 +190,7 @@ static void keyboard_key_notify(struct wl_listener *listener, void *data) {
 		// and make this change in pixels/sec^2
 		// Also, key repeat
 		int delta = 75;
-		if (event->state == WLR_KEY_PRESSED) {
+		if (event->state == WL_KEYBOARD_KEY_STATE_PRESSED) {
 			switch (sym) {
 			case XKB_KEY_Left:
 				update_velocities(sample, -delta, 0);

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -140,7 +140,7 @@ static void keyboard_key_notify(struct wl_listener *listener, void *data) {
 		if (sym == XKB_KEY_Escape) {
 			wl_display_terminate(sample->display);
 		}
-		if (event->state == WLR_KEY_PRESSED) {
+		if (event->state == WL_KEYBOARD_KEY_STATE_PRESSED) {
 			switch (sym) {
 			case XKB_KEY_Left:
 				update_velocities(sample, -16, 0);

--- a/include/wlr/types/wlr_keyboard.h
+++ b/include/wlr/types/wlr_keyboard.h
@@ -12,7 +12,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <wayland-server-core.h>
-#include <wayland-server-core.h>
+#include <wayland-server-protocol.h>
 #include <xkbcommon/xkbcommon.h>
 
 #define WLR_LED_COUNT 3
@@ -91,16 +91,11 @@ struct wlr_keyboard {
 	void *data;
 };
 
-enum wlr_key_state {
-	WLR_KEY_RELEASED,
-	WLR_KEY_PRESSED,
-};
-
 struct wlr_event_keyboard_key {
 	uint32_t time_msec;
 	uint32_t keycode;
 	bool update_state; // if backend doesn't update modifiers on its own
-	enum wlr_key_state state;
+	enum wl_keyboard_key_state state;
 };
 
 bool wlr_keyboard_set_keymap(struct wlr_keyboard *kb,

--- a/tinywl/tinywl.c
+++ b/tinywl/tinywl.c
@@ -197,7 +197,7 @@ static void keyboard_handle_key(
 
 	bool handled = false;
 	uint32_t modifiers = wlr_keyboard_get_modifiers(keyboard->device->keyboard);
-	if ((modifiers & WLR_MODIFIER_ALT) && event->state == WLR_KEY_PRESSED) {
+	if ((modifiers & WLR_MODIFIER_ALT) && event->state == WL_KEYBOARD_KEY_STATE_PRESSED) {
 		/* If alt is held down and this button was _pressed_, we attempt to
 		 * process it as a compositor keybinding. */
 		for (int i = 0; i < nsyms; i++) {
@@ -374,7 +374,7 @@ static void process_cursor_resize(struct tinywl_server *server, uint32_t time) {
 	int new_left = server->grab_geobox.x;
 	int new_right = server->grab_geobox.x + server->grab_geobox.width;
 	int new_top = server->grab_geobox.y;
-	int new_bottom = server->grab_geobox.y + server->grab_geobox.height; 
+	int new_bottom = server->grab_geobox.y + server->grab_geobox.height;
 
 	if (server->resize_edges & WLR_EDGE_TOP) {
 		new_top = border_y;

--- a/types/wlr_keyboard.c
+++ b/types/wlr_keyboard.c
@@ -58,11 +58,11 @@ bool keyboard_modifier_update(struct wlr_keyboard *keyboard) {
 
 void keyboard_key_update(struct wlr_keyboard *keyboard,
 		struct wlr_event_keyboard_key *event) {
-	if (event->state == WLR_KEY_PRESSED) {
+	if (event->state == WL_KEYBOARD_KEY_STATE_PRESSED) {
 		set_add(keyboard->keycodes, &keyboard->num_keycodes,
 			WLR_KEYBOARD_KEYS_CAP, event->keycode);
 	}
-	if (event->state == WLR_KEY_RELEASED) {
+	if (event->state == WL_KEYBOARD_KEY_STATE_RELEASED) {
 		set_remove(keyboard->keycodes, &keyboard->num_keycodes,
 			WLR_KEYBOARD_KEYS_CAP, event->keycode);
 	}
@@ -99,7 +99,7 @@ void wlr_keyboard_notify_key(struct wlr_keyboard *keyboard,
 	if (event->update_state) {
 		uint32_t keycode = event->keycode + 8;
 		xkb_state_update_key(keyboard->xkb_state, keycode,
-			event->state == WLR_KEY_PRESSED ? XKB_KEY_DOWN : XKB_KEY_UP);
+			event->state == WL_KEYBOARD_KEY_STATE_PRESSED ? XKB_KEY_DOWN : XKB_KEY_UP);
 	}
 
 	bool updated = keyboard_modifier_update(keyboard);

--- a/types/wlr_keyboard_group.c
+++ b/types/wlr_keyboard_group.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <time.h>
 #include <wayland-server-core.h>
+#include <wayland-server-protocol.h>
 #include <xkbcommon/xkbcommon.h>
 #include "types/wlr_keyboard.h"
 #include "util/signal.h"
@@ -95,11 +96,11 @@ static bool process_key(struct keyboard_group_device *group_device,
 		if (key->keycode != event->keycode) {
 			continue;
 		}
-		if (event->state == WLR_KEY_PRESSED) {
+		if (event->state == WL_KEYBOARD_KEY_STATE_PRESSED) {
 			key->count++;
 			return false;
 		}
-		if (event->state == WLR_KEY_RELEASED) {
+		if (event->state == WL_KEYBOARD_KEY_STATE_RELEASED) {
 			key->count--;
 			if (key->count > 0) {
 				return false;
@@ -110,7 +111,7 @@ static bool process_key(struct keyboard_group_device *group_device,
 		break;
 	}
 
-	if (event->state == WLR_KEY_PRESSED) {
+	if (event->state == WL_KEYBOARD_KEY_STATE_PRESSED) {
 		struct keyboard_group_key *key =
 			calloc(1, sizeof(struct keyboard_group_key));
 		if (!key) {
@@ -199,7 +200,7 @@ static void handle_keyboard_repeat_info(struct wl_listener *listener,
 }
 
 static void refresh_state(struct keyboard_group_device *device,
-		enum wlr_key_state state) {
+		enum wl_keyboard_key_state state) {
 	struct wl_array keys;
 	wl_array_init(&keys);
 
@@ -229,7 +230,7 @@ static void refresh_state(struct keyboard_group_device *device,
 
 	// If there are any unique keys, emit the enter/leave event
 	if (keys.size > 0) {
-		if (state == WLR_KEY_PRESSED) {
+		if (state == WL_KEYBOARD_KEY_STATE_PRESSED) {
 			wlr_signal_emit_safe(&device->keyboard->group->events.enter, &keys);
 		} else {
 			wlr_signal_emit_safe(&device->keyboard->group->events.leave, &keys);
@@ -240,7 +241,7 @@ static void refresh_state(struct keyboard_group_device *device,
 }
 
 static void remove_keyboard_group_device(struct keyboard_group_device *device) {
-	refresh_state(device, WLR_KEY_RELEASED);
+	refresh_state(device, WL_KEYBOARD_KEY_STATE_RELEASED);
 	device->keyboard->group = NULL;
 	wl_list_remove(&device->link);
 	wl_list_remove(&device->key.link);
@@ -312,7 +313,7 @@ bool wlr_keyboard_group_add_keyboard(struct wlr_keyboard_group *group,
 				group_kb->repeat_info.delay);
 	}
 
-	refresh_state(device, WLR_KEY_PRESSED);
+	refresh_state(device, WL_KEYBOARD_KEY_STATE_PRESSED);
 	return true;
 }
 


### PR DESCRIPTION
There's no reason to have duplicate enums.

* * *

Breaking change: `enum wlr_key_state` has been replaced with `enum wl_keyboard_key_state`.