### PR TITLE
backend/drm: avoid uint32_t overflow in mode->clock

### DIFF
--- a/backend/drm/cvt.c
+++ b/backend/drm/cvt.c
@@ -245,11 +245,11 @@ void generate_cvt_mode(drmModeModeInfo *mode, int hdisplay, int vdisplay,
 	}
 
 	/* 15/13. Find pixel clock frequency (kHz for xf86) */
-	mode->clock = mode->htotal * 1000.0 / hperiod;
-	mode->clock -= mode->clock % CVT_CLOCK_STEP;
+	mode->clock = ((uint64_t) mode->htotal) * 1000.0 / hperiod;
+	mode->clock -= ((uint64_t) mode->clock) % CVT_CLOCK_STEP;
 
 	/* 17/15. Find actual Field rate */
-	mode->vrefresh = (1000.0 * ((float) mode->clock)) /
+	mode->vrefresh = (1000.0 * ((double) mode->clock)) /
 		((float) (mode->htotal * mode->vtotal));
 
 	/* 18/16. Find actual vertical frame frequency */

--- a/backend/drm/util.c
+++ b/backend/drm/util.c
@@ -9,7 +9,7 @@
 #include "backend/drm/util.h"
 
 int32_t calculate_refresh_rate(const drmModeModeInfo *mode) {
-	int32_t refresh = (mode->clock * 1000000LL / mode->htotal +
+	int32_t refresh = (((int64_t) mode->clock) * 1000000LL / mode->htotal +
 		mode->vtotal / 2) / mode->vtotal;
 
 	if (mode->flags & DRM_MODE_FLAG_INTERLACE) {


### PR DESCRIPTION
fixes https://github.com/swaywm/wlroots/issues/2449