### PR TITLE
render: define EGL_NO_PLATFORM_SPECIFIC_TYPES

### DIFF
--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -15,6 +15,9 @@
 #ifndef EGL_NO_X11
 #define EGL_NO_X11
 #endif
+#ifndef EGL_NO_PLATFORM_SPECIFIC_TYPES
+#define EGL_NO_PLATFORM_SPECIFIC_TYPES
+#endif
 
 #include <wlr/config.h>
 

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -15,6 +15,9 @@
 #ifndef EGL_NO_X11
 #define EGL_NO_X11
 #endif
+#ifndef EGL_NO_PLATFORM_SPECIFIC_TYPES
+#define EGL_NO_PLATFORM_SPECIFIC_TYPES
+#endif
 
 #include <EGL/egl.h>
 #include <EGL/eglext.h>


### PR DESCRIPTION
This avoids Xlib.h inclusion via EGL headers. See [1] for discussion.

This change is based on a Weston commit [2].

[1]: https://github.com/KhronosGroup/EGL-Registry/pull/111
[2]: https://gitlab.freedesktop.org/wayland/weston/commit/526765ddfdfd