### PR TITLE
backend/drm: Check if output is enabled before sending frame event

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1523,7 +1523,7 @@ static void page_flip_handler(int fd, unsigned seq,
 	};
 	wlr_output_send_present(&conn->output, &present_event);
 
-	if (drm->session->active) {
+	if (drm->session->active && conn->output.enabled) {
 		wlr_output_send_frame(&conn->output);
 	}
 }


### PR DESCRIPTION
This is my first contribution to wlroots so I'm not quite sure if this is the right place to fix the bug.
But since it is only a one line change it should be easy to review.

When an output is disabled one last pageflip will happen to disable it.
Since the output is disabled we don't want to send frame events anymore.
Currently one last event is send after the output is disabled (and the disable is committed ofc).