### PR TITLE
backend/session: misc. refactoring, replace CanGraphical with udev

### DIFF
--- a/backend/backend.c
+++ b/backend/backend.c
@@ -151,7 +151,7 @@ static struct wlr_backend *attempt_noop_backend(struct wl_display *display) {
 static struct wlr_backend *attempt_drm_backend(struct wl_display *display,
 		struct wlr_backend *backend, struct wlr_session *session,
 		wlr_renderer_create_func_t create_renderer_func) {
-	int gpus[8];
+	struct wlr_device *gpus[8];
 	size_t num_gpus = wlr_session_find_gpus(session, 8, gpus);
 	struct wlr_backend *primary_drm = NULL;
 	wlr_log(WLR_INFO, "Found %zu GPUs", num_gpus);
@@ -160,7 +160,7 @@ static struct wlr_backend *attempt_drm_backend(struct wl_display *display,
 		struct wlr_backend *drm = wlr_drm_backend_create(display, session,
 			gpus[i], primary_drm, create_renderer_func);
 		if (!drm) {
-			wlr_log(WLR_ERROR, "Failed to open DRM device %d", gpus[i]);
+			wlr_log(WLR_ERROR, "Failed to create DRM backend");
 			continue;
 		}
 

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -85,7 +85,7 @@ bool wlr_backend_is_drm(struct wlr_backend *b) {
 static void session_signal(struct wl_listener *listener, void *data) {
 	struct wlr_drm_backend *drm =
 		wl_container_of(listener, drm, session_signal);
-	struct wlr_session *session = data;
+	struct wlr_session *session = drm->session;
 
 	if (session->active) {
 		wlr_log(WLR_INFO, "DRM fd resumed");
@@ -170,7 +170,7 @@ struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
 	}
 
 	drm->session_signal.notify = session_signal;
-	wl_signal_add(&session->session_signal, &drm->session_signal);
+	wl_signal_add(&session->events.active, &drm->session_signal);
 
 	if (!check_drm_features(drm)) {
 		goto error_event;

--- a/backend/libinput/backend.c
+++ b/backend/libinput/backend.c
@@ -16,12 +16,27 @@ static struct wlr_libinput_backend *get_libinput_backend_from_backend(
 static int libinput_open_restricted(const char *path,
 		int flags, void *_backend) {
 	struct wlr_libinput_backend *backend = _backend;
-	return wlr_session_open_file(backend->session, path);
+	struct wlr_device *dev = wlr_session_open_file(backend->session, path);
+	if (dev == NULL) {
+		return -1;
+	}
+	return dev->fd;
 }
 
 static void libinput_close_restricted(int fd, void *_backend) {
 	struct wlr_libinput_backend *backend = _backend;
-	wlr_session_close_file(backend->session, fd);
+
+	struct wlr_device *dev;
+	bool found = false;
+	wl_list_for_each(dev, &backend->session->devices, link) {
+		if (dev->fd == fd) {
+			found = true;
+			break;
+		}
+	}
+	if (found) {
+		wlr_session_close_file(backend->session, dev);
+	}
 }
 
 static const struct libinput_interface libinput_impl = {

--- a/backend/libinput/backend.c
+++ b/backend/libinput/backend.c
@@ -174,7 +174,7 @@ bool wlr_backend_is_libinput(struct wlr_backend *b) {
 static void session_signal(struct wl_listener *listener, void *data) {
 	struct wlr_libinput_backend *backend =
 		wl_container_of(listener, backend, session_signal);
-	struct wlr_session *session = data;
+	struct wlr_session *session = backend->session;
 
 	if (!backend->libinput_context) {
 		return;
@@ -218,7 +218,7 @@ struct wlr_backend *wlr_libinput_backend_create(struct wl_display *display,
 	backend->display = display;
 
 	backend->session_signal.notify = session_signal;
-	wl_signal_add(&session->session_signal, &backend->session_signal);
+	wl_signal_add(&session->events.active, &backend->session_signal);
 
 	backend->session_destroy.notify = handle_session_destroy;
 	wl_signal_add(&session->events.destroy, &backend->session_destroy);

--- a/backend/session/direct-freebsd.c
+++ b/backend/session/direct-freebsd.c
@@ -115,7 +115,7 @@ static int vt_handler(int signo, void *data) {
 
 	if (session->base.active) {
 		session->base.active = false;
-		wlr_signal_emit_safe(&session->base.session_signal, session);
+		wlr_signal_emit_safe(&session->base.events.active, NULL);
 
 		wl_list_for_each(dev, &session->base.devices, link) {
 			if (ioctl(dev->fd, DRM_IOCTL_VERSION, &dv) == 0) {
@@ -134,7 +134,7 @@ static int vt_handler(int signo, void *data) {
 		}
 
 		session->base.active = true;
-		wlr_signal_emit_safe(&session->base.session_signal, session);
+		wlr_signal_emit_safe(&session->base.events.active, NULL);
 	}
 
 	return 1;

--- a/backend/session/direct.c
+++ b/backend/session/direct.c
@@ -126,7 +126,7 @@ static int vt_handler(int signo, void *data) {
 
 	if (session->base.active) {
 		session->base.active = false;
-		wlr_signal_emit_safe(&session->base.session_signal, session);
+		wlr_signal_emit_safe(&session->base.events.active, NULL);
 
 		struct wlr_device *dev;
 		wl_list_for_each(dev, &session->base.devices, link) {
@@ -149,7 +149,7 @@ static int vt_handler(int signo, void *data) {
 		}
 
 		session->base.active = true;
-		wlr_signal_emit_safe(&session->base.session_signal, session);
+		wlr_signal_emit_safe(&session->base.events.active, NULL);
 	}
 
 	return 1;

--- a/backend/session/libseat.c
+++ b/backend/session/libseat.c
@@ -35,13 +35,13 @@ struct libseat_session {
 static void handle_enable_seat(struct libseat *seat, void *data) {
 	struct libseat_session *session = data;
 	session->base.active = true;
-	wlr_signal_emit_safe(&session->base.session_signal, session);
+	wlr_signal_emit_safe(&session->base.events.active, NULL);
 }
 
 static void handle_disable_seat(struct libseat *seat, void *data) {
 	struct libseat_session *session = data;
 	session->base.active = false;
-	wlr_signal_emit_safe(&session->base.session_signal, session);
+	wlr_signal_emit_safe(&session->base.events.active, NULL);
 	libseat_disable_seat(session->seat);
 }
 

--- a/backend/session/logind.c
+++ b/backend/session/logind.c
@@ -36,9 +36,7 @@ struct logind_session {
 
 	char *id;
 	char *path;
-	char *seat_path;
 
-	bool can_graphical;
 	// specifies whether a drm device was taken
 	// if so, the session will be (de)activated with the drm fd,
 	// otherwise with the dbus PropertiesChanged on "active" signal
@@ -179,34 +177,6 @@ out:
 	return ret >= 0;
 }
 
-static bool find_seat_path(struct logind_session *session) {
-	int ret;
-	sd_bus_message *msg = NULL;
-	sd_bus_error error = SD_BUS_ERROR_NULL;
-
-	ret = sd_bus_call_method(session->bus, "org.freedesktop.login1",
-			"/org/freedesktop/login1", "org.freedesktop.login1.Manager",
-			"GetSeat", &error, &msg, "s", session->base.seat);
-	if (ret < 0) {
-		wlr_log(WLR_ERROR, "Failed to get seat path: %s", error.message);
-		goto out;
-	}
-
-	const char *path;
-	ret = sd_bus_message_read(msg, "o", &path);
-	if (ret < 0) {
-		wlr_log(WLR_ERROR, "Could not parse seat path: %s", error.message);
-		goto out;
-	}
-	session->seat_path = strdup(path);
-
-out:
-	sd_bus_error_free(&error);
-	sd_bus_message_unref(msg);
-
-	return ret >= 0;
-}
-
 static bool session_activate(struct logind_session *session) {
 	int ret;
 	sd_bus_message *msg = NULL;
@@ -294,7 +264,6 @@ static void logind_session_destroy(struct wlr_session *base) {
 	sd_bus_unref(session->bus);
 	free(session->id);
 	free(session->path);
-	free(session->seat_path);
 	free(session);
 }
 
@@ -496,95 +465,6 @@ error:
 	return 0;
 }
 
-static int seat_properties_changed(sd_bus_message *msg, void *userdata,
-		sd_bus_error *ret_error) {
-	struct logind_session *session = userdata;
-	int ret = 0;
-
-	// if we have a drm fd we don't depend on this
-	if (session->has_drm) {
-		return 0;
-	}
-
-	// PropertiesChanged arg 1: interface
-	const char *interface;
-	ret = sd_bus_message_read_basic(msg, 's', &interface); // skip path
-	if (ret < 0) {
-		goto error;
-	}
-
-	if (strcmp(interface, "org.freedesktop.login1.Seat") != 0) {
-		// not interesting for us; ignore
-		wlr_log(WLR_DEBUG, "ignoring PropertiesChanged from %s", interface);
-		return 0;
-	}
-
-	// PropertiesChanged arg 2: changed properties with values
-	ret = sd_bus_message_enter_container(msg, 'a', "{sv}");
-	if (ret < 0) {
-		goto error;
-	}
-
-	const char *s;
-	while ((ret = sd_bus_message_enter_container(msg, 'e', "sv")) > 0) {
-		ret = sd_bus_message_read_basic(msg, 's', &s);
-		if (ret < 0) {
-			goto error;
-		}
-
-		if (strcmp(s, "CanGraphical") == 0) {
-			int ret;
-			ret = sd_bus_message_enter_container(msg, 'v', "b");
-			if (ret < 0) {
-				goto error;
-			}
-
-			ret = sd_bus_message_read_basic(msg, 'b', &session->can_graphical);
-			if (ret < 0) {
-				goto error;
-			}
-
-			return 0;
-		} else {
-			sd_bus_message_skip(msg, "{sv}");
-		}
-
-		ret = sd_bus_message_exit_container(msg);
-		if (ret < 0) {
-			goto error;
-		}
-	}
-
-	if (ret < 0) {
-		goto error;
-	}
-
-	ret = sd_bus_message_exit_container(msg);
-	if (ret < 0) {
-		goto error;
-	}
-
-	// PropertiesChanged arg 3: changed properties without values
-	sd_bus_message_enter_container(msg, 'a', "s");
-	while ((ret = sd_bus_message_read_basic(msg, 's', &s)) > 0) {
-		if (strcmp(s, "CanGraphical") == 0) {
-			session->can_graphical = sd_seat_can_graphical(session->base.seat);
-			return 0;
-		}
-	}
-
-	if (ret < 0) {
-		goto error;
-	}
-
-	return 0;
-
-error:
-	wlr_log(WLR_ERROR, "Failed to parse D-Bus PropertiesChanged: %s",
-		strerror(-ret));
-	return 0;
-}
-
 static bool add_signal_matches(struct logind_session *session) {
 	static const char *logind = "org.freedesktop.login1";
 	static const char *logind_path = "/org/freedesktop/login1";
@@ -617,14 +497,6 @@ static bool add_signal_matches(struct logind_session *session) {
 	ret = sd_bus_match_signal(session->bus, NULL, logind, session->path,
 		property_interface, "PropertiesChanged",
 		session_properties_changed, session);
-	if (ret < 0) {
-		wlr_log(WLR_ERROR, "Failed to add D-Bus match: %s", strerror(-ret));
-		return false;
-	}
-
-	ret = sd_bus_match_signal(session->bus, NULL, logind, session->seat_path,
-		property_interface, "PropertiesChanged",
-		seat_properties_changed, session);
 	if (ret < 0) {
 		wlr_log(WLR_ERROR, "Failed to add D-Bus match: %s", strerror(-ret));
 		return false;
@@ -811,12 +683,6 @@ static struct wlr_session *logind_session_create(struct wl_display *disp) {
 		goto error;
 	}
 
-	if (!find_seat_path(session)) {
-		sd_bus_unref(session->bus);
-		free(session->path);
-		goto error;
-	}
-
 	if (!add_signal_matches(session)) {
 		goto error_bus;
 	}
@@ -833,21 +699,6 @@ static struct wlr_session *logind_session_create(struct wl_display *disp) {
 		goto error_bus;
 	}
 
-	// Check for CanGraphical first
-	session->can_graphical = sd_seat_can_graphical(session->base.seat);
-	if (!session->can_graphical) {
-		wlr_log(WLR_INFO, "Waiting for 'CanGraphical' on seat %s", session->base.seat);
-	}
-
-	while (!session->can_graphical) {
-		ret = wl_event_loop_dispatch(event_loop, -1);
-		if (ret < 0) {
-			wlr_log(WLR_ERROR, "Polling error waiting for 'CanGraphical' on seat %s",
-				session->base.seat);
-			goto error_bus;
-		}
-	}
-
 	set_type(session);
 
 	wlr_log(WLR_INFO, "Successfully loaded logind session");
@@ -860,7 +711,6 @@ static struct wlr_session *logind_session_create(struct wl_display *disp) {
 error_bus:
 	sd_bus_unref(session->bus);
 	free(session->path);
-	free(session->seat_path);
 
 error:
 	free(session->id);

--- a/backend/session/logind.c
+++ b/backend/session/logind.c
@@ -306,7 +306,7 @@ static int pause_device(sd_bus_message *msg, void *userdata,
 	if (major == DRM_MAJOR && strcmp(type, "gone") != 0) {
 		assert(session->has_drm);
 		session->base.active = false;
-		wlr_signal_emit_safe(&session->base.session_signal, session);
+		wlr_signal_emit_safe(&session->base.events.active, NULL);
 	}
 
 	if (strcmp(type, "pause") == 0) {
@@ -348,7 +348,7 @@ static int resume_device(sd_bus_message *msg, void *userdata,
 
 		if (!session->base.active) {
 			session->base.active = true;
-			wlr_signal_emit_safe(&session->base.session_signal, session);
+			wlr_signal_emit_safe(&session->base.events.active, NULL);
 		}
 	}
 
@@ -407,7 +407,7 @@ static int session_properties_changed(sd_bus_message *msg, void *userdata,
 
 			if (session->base.active != active) {
 				session->base.active = active;
-				wlr_signal_emit_safe(&session->base.session_signal, session);
+				wlr_signal_emit_safe(&session->base.events.active, NULL);
 			}
 			return 0;
 		} else {
@@ -447,7 +447,7 @@ static int session_properties_changed(sd_bus_message *msg, void *userdata,
 
 			if (session->base.active != active) {
 				session->base.active = active;
-				wlr_signal_emit_safe(&session->base.session_signal, session);
+				wlr_signal_emit_safe(&session->base.events.active, NULL);
 			}
 			return 0;
 		}

--- a/backend/session/logind.c
+++ b/backend/session/logind.c
@@ -569,6 +569,8 @@ static bool get_display_session(char **session_id) {
 	char *xdg_session_id = getenv("XDG_SESSION_ID");
 
 	if (xdg_session_id) {
+		wlr_log(WLR_INFO, "Selecting session from XDG_SESSION_ID: %s", xdg_session_id);
+
 		// This just checks whether the supplied session ID is valid
 		if (sd_session_is_active(xdg_session_id) < 0) {
 			wlr_log(WLR_ERROR, "Invalid XDG_SESSION_ID: '%s'", xdg_session_id);

--- a/backend/session/session.c
+++ b/backend/session/session.c
@@ -101,7 +101,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 }
 
 void session_init(struct wlr_session *session) {
-	wl_signal_init(&session->session_signal);
+	wl_signal_init(&session->events.active);
 	wl_signal_init(&session->events.add_drm_card);
 	wl_signal_init(&session->events.destroy);
 	wl_list_init(&session->devices);

--- a/backend/session/session.c
+++ b/backend/session/session.c
@@ -7,6 +7,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <time.h>
 #include <wayland-server-core.h>
 #include <wlr/backend/session.h>
 #include <wlr/backend/session/interface.h>
@@ -16,6 +17,8 @@
 #include <xf86drmMode.h>
 #include "backend/session/session.h"
 #include "util/signal.h"
+
+#define WAIT_GPU_TIMEOUT 10000 // ms
 
 extern const struct session_impl session_libseat;
 extern const struct session_impl session_logind;
@@ -322,6 +325,12 @@ static struct udev_enumerate *enumerate_drm_cards(struct udev *udev) {
 	return en;
 }
 
+static uint64_t get_current_time_ms(void) {
+	struct timespec ts = {0};
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (uint64_t)ts.tv_sec * 1000 + (uint64_t)ts.tv_nsec / 1000000;
+}
+
 struct find_gpus_add_handler {
 	bool added;
 	struct wl_listener listener;
@@ -356,16 +365,24 @@ size_t wlr_session_find_gpus(struct wlr_session *session,
 		handler.listener.notify = find_gpus_handle_add;
 		wl_signal_add(&session->events.add_drm_card, &handler.listener);
 
+		uint64_t started_at = get_current_time_ms();
+		uint64_t timeout = WAIT_GPU_TIMEOUT;
 		struct wl_event_loop *event_loop =
 			wl_display_get_event_loop(session->display);
 		while (!handler.added) {
-			int ret = wl_event_loop_dispatch(event_loop, -1);
+			int ret = wl_event_loop_dispatch(event_loop, (int)timeout);
 			if (ret < 0) {
 				wlr_log_errno(WLR_ERROR, "Failed to wait for DRM card device: "
 					"wl_event_loop_dispatch failed");
 				udev_enumerate_unref(en);
 				return -1;
 			}
+
+			uint64_t now = get_current_time_ms();
+			if (now >= started_at + WAIT_GPU_TIMEOUT) {
+				break;
+			}
+			timeout = started_at + WAIT_GPU_TIMEOUT - now;
 		}
 
 		wl_list_remove(&handler.listener.link);

--- a/backend/session/session.c
+++ b/backend/session/session.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <unistd.h>
 #include <wayland-server-core.h>
 #include <wlr/backend/session.h>
 #include <wlr/backend/session/interface.h>
@@ -195,7 +196,8 @@ int wlr_session_open_file(struct wlr_session *session, const char *path) {
 
 error:
 	free(dev);
-	return fd;
+	close(fd);
+	return -1;
 }
 
 static struct wlr_device *find_device(struct wlr_session *session, int fd) {

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -82,6 +82,7 @@ struct wlr_drm_backend {
 	bool addfb2_modifiers;
 
 	int fd;
+	struct wlr_device *dev;
 
 	size_t num_crtcs;
 	struct wlr_drm_crtc *crtcs;

--- a/include/wlr/backend/drm.h
+++ b/include/wlr/backend/drm.h
@@ -22,7 +22,8 @@
  * a DRM backend, other kinds of backends raise SIGABRT).
  */
 struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
-	struct wlr_session *session, int gpu_fd, struct wlr_backend *parent,
+	struct wlr_session *session, struct wlr_device *dev,
+	struct wlr_backend *parent,
 	wlr_renderer_create_func_t create_renderer_func);
 
 bool wlr_backend_is_drm(struct wlr_backend *backend);

--- a/include/wlr/backend/session.h
+++ b/include/wlr/backend/session.h
@@ -40,6 +40,7 @@ struct wlr_session {
 
 	struct wl_list devices;
 
+	struct wl_display *display;
 	struct wl_listener display_destroy;
 
 	struct {

--- a/include/wlr/backend/session.h
+++ b/include/wlr/backend/session.h
@@ -11,9 +11,11 @@ struct session_impl;
 struct wlr_device {
 	int fd;
 	dev_t dev;
-	struct wl_signal signal;
-
 	struct wl_list link;
+
+	struct {
+		struct wl_signal change;
+	} events;
 };
 
 struct wlr_session {
@@ -74,21 +76,21 @@ void wlr_session_destroy(struct wlr_session *session);
  *
  * Returns -errno on error.
  */
-int wlr_session_open_file(struct wlr_session *session, const char *path);
+struct wlr_device *wlr_session_open_file(struct wlr_session *session,
+	const char *path);
 
 /*
  * Closes a file previously opened with wlr_session_open_file.
  */
-void wlr_session_close_file(struct wlr_session *session, int fd);
+void wlr_session_close_file(struct wlr_session *session,
+	struct wlr_device *device);
 
-void wlr_session_signal_add(struct wlr_session *session, int fd,
-	struct wl_listener *listener);
 /*
  * Changes the virtual terminal.
  */
 bool wlr_session_change_vt(struct wlr_session *session, unsigned vt);
 
 size_t wlr_session_find_gpus(struct wlr_session *session,
-	size_t ret_len, int *ret);
+	size_t ret_len, struct wlr_device **ret);
 
 #endif

--- a/include/wlr/backend/session.h
+++ b/include/wlr/backend/session.h
@@ -24,7 +24,6 @@ struct wlr_session {
 	 * Signal for when the session becomes active/inactive.
 	 * It's called when we swap virtual terminal.
 	 */
-	struct wl_signal session_signal;
 	bool active;
 
 	/*
@@ -44,6 +43,7 @@ struct wlr_session {
 	struct wl_listener display_destroy;
 
 	struct {
+		struct wl_signal active;
 		struct wl_signal add_drm_card; // struct wlr_session_add_event
 		struct wl_signal destroy;
 	} events;

--- a/include/wlr/backend/session.h
+++ b/include/wlr/backend/session.h
@@ -43,8 +43,13 @@ struct wlr_session {
 	struct wl_listener display_destroy;
 
 	struct {
+		struct wl_signal add_drm_card; // struct wlr_session_add_event
 		struct wl_signal destroy;
 	} events;
+};
+
+struct wlr_session_add_event {
+	const char *path;
 };
 
 /*


### PR DESCRIPTION
_See individual commits._

This PR refactors `wlr_session` to prepare support for GPU hotplug. cc @neon64 

- The session API doesn't deal with FDs anymore, `wlr_device` is used instead. This allows callers to directly listen on `wlr_device` events. This will be useful for a future "remove" event.
- A new `add_drm_card` event is introduced. It's used to replace the logind-specific `CanGraphical` property.
- Signals are renamed and moved into an embedded `events` struct, for consistency with the rest of wlroots.

* * *

Breaking changes:

* `wlr_drm_backend_create` takes a `wlr_device` instead of a DRM FD
* `wlr_device.signal` has been replaced by `wlr_device.events.change`
* `wlr_session.session_signal` has been replaced by `wlr_session.events.active`
* `wlr_session_open_file` and `wlr_session_close_file` now take a `wlr_device` instead of a FD
* `wlr_session_find_gpus` now fills an array of `wlr_device` pointers instead of an array of FDs