### PR TITLE
Remove unneeded includes from wlr_input_device.h

### DIFF
--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -2,6 +2,7 @@
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <wlr/interfaces/wlr_output.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/util/log.h>

--- a/backend/libinput/backend.c
+++ b/backend/libinput/backend.c
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <libinput.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <wlr/backend/interface.h>
 #include <wlr/backend/session.h>
 #include <wlr/util/log.h>

--- a/examples/multi-pointer.c
+++ b/examples/multi-pointer.c
@@ -16,6 +16,7 @@
 #include <wlr/types/wlr_list.h>
 #include <wlr/types/wlr_matrix.h>
 #include <wlr/types/wlr_output_layout.h>
+#include <wlr/types/wlr_pointer.h>
 #include <wlr/util/log.h>
 #include <wlr/xcursor.h>
 #include <xkbcommon/xkbcommon.h>

--- a/examples/pointer.c
+++ b/examples/pointer.c
@@ -15,6 +15,9 @@
 #include <wlr/types/wlr_list.h>
 #include <wlr/types/wlr_matrix.h>
 #include <wlr/types/wlr_output_layout.h>
+#include <wlr/types/wlr_pointer.h>
+#include <wlr/types/wlr_tablet_tool.h>
+#include <wlr/types/wlr_touch.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/util/log.h>
 #include <xkbcommon/xkbcommon.h>

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -10,6 +10,7 @@
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_input_device.h>
+#include <wlr/types/wlr_keyboard.h>
 #include <wlr/util/log.h>
 #include <xkbcommon/xkbcommon.h>
 

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -14,6 +14,7 @@
 #include <wlr/types/wlr_matrix.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_input_device.h>
+#include <wlr/types/wlr_keyboard.h>
 #include <wlr/types/wlr_tablet_pad.h>
 #include <wlr/types/wlr_tablet_tool.h>
 #include <wlr/util/log.h>

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -14,7 +14,9 @@
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_list.h>
 #include <wlr/types/wlr_input_device.h>
+#include <wlr/types/wlr_keyboard.h>
 #include <wlr/types/wlr_matrix.h>
+#include <wlr/types/wlr_touch.h>
 #include <wlr/util/log.h>
 #include <xkbcommon/xkbcommon.h>
 #include "cat.h"

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -12,6 +12,7 @@
 #include <wlr/render/egl.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_box.h>
+#include <wlr/types/wlr_pointer.h>
 #include <wlr/render/drm_format_set.h>
 
 struct wlr_wl_backend {

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -10,7 +10,10 @@
 #include <wlr/backend/x11.h>
 #include <wlr/config.h>
 #include <wlr/interfaces/wlr_input_device.h>
+#include <wlr/interfaces/wlr_keyboard.h>
 #include <wlr/interfaces/wlr_output.h>
+#include <wlr/interfaces/wlr_pointer.h>
+#include <wlr/interfaces/wlr_touch.h>
 #include <wlr/render/egl.h>
 #include <wlr/render/wlr_renderer.h>
 

--- a/include/wlr/types/wlr_input_device.h
+++ b/include/wlr/types/wlr_input_device.h
@@ -9,6 +9,8 @@
 #ifndef WLR_TYPES_WLR_INPUT_DEVICE_H
 #define WLR_TYPES_WLR_INPUT_DEVICE_H
 
+#include <wayland-server-core.h>
+
 enum wlr_button_state {
 	WLR_BUTTON_RELEASED,
 	WLR_BUTTON_PRESSED,
@@ -22,14 +24,6 @@ enum wlr_input_device_type {
 	WLR_INPUT_DEVICE_TABLET_PAD,
 	WLR_INPUT_DEVICE_SWITCH,
 };
-
-/* Note: these are circular dependencies */
-#include <wlr/types/wlr_keyboard.h>
-#include <wlr/types/wlr_pointer.h>
-#include <wlr/types/wlr_touch.h>
-#include <wlr/types/wlr_tablet_tool.h>
-#include <wlr/types/wlr_tablet_pad.h>
-#include <wlr/types/wlr_switch.h>
 
 struct wlr_input_device_impl;
 

--- a/include/wlr/types/wlr_pointer.h
+++ b/include/wlr/types/wlr_pointer.h
@@ -11,6 +11,7 @@
 
 #include <stdint.h>
 #include <wayland-server-core.h>
+#include <wayland-server-protocol.h>
 #include <wlr/types/wlr_input_device.h>
 
 struct wlr_pointer_impl;

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -13,6 +13,7 @@
 #include <wayland-server-core.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_keyboard.h>
+#include <wlr/types/wlr_pointer.h>
 #include <wlr/types/wlr_surface.h>
 
 #define WLR_SERIAL_RINGSET_SIZE 128

--- a/types/tablet_v2/wlr_tablet_v2_pad.c
+++ b/types/tablet_v2/wlr_tablet_v2_pad.c
@@ -8,6 +8,7 @@
 #include <types/wlr_tablet_v2.h>
 #include <wayland-util.h>
 #include <wlr/types/wlr_tablet_tool.h>
+#include <wlr/types/wlr_tablet_pad.h>
 #include <wlr/types/wlr_tablet_v2.h>
 #include <wlr/util/log.h>
 

--- a/types/wlr_cursor.c
+++ b/types/wlr_cursor.c
@@ -7,6 +7,9 @@
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_output.h>
+#include <wlr/types/wlr_pointer.h>
+#include <wlr/types/wlr_tablet_tool.h>
+#include <wlr/types/wlr_touch.h>
 #include <wlr/util/log.h>
 #include "util/signal.h"
 


### PR DESCRIPTION
This uncovered many places where we were using things without directly including them.

This allows us to avoid including tablet-unstable-v2 in many of the example compositors.

~~depends on #2469~~

* * *

Breaking change: `wlr/types/wlr_input_device.h` no longer pulls in all device-specific headers.