### PR TITLE
backend/drm: stop force-probing connectors

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1282,8 +1282,8 @@ void scan_drm_connectors(struct wlr_drm_backend *drm) {
 	struct wlr_drm_connector *new_outputs[res->count_connectors + 1];
 
 	for (int i = 0; i < res->count_connectors; ++i) {
-		drmModeConnector *drm_conn = drmModeGetConnector(drm->fd,
-			res->connectors[i]);
+		drmModeConnector *drm_conn =
+			drmModeGetConnectorCurrent(drm->fd, res->connectors[i]);
 		if (!drm_conn) {
 			wlr_log_errno(WLR_ERROR, "Failed to get DRM connector");
 			continue;


### PR DESCRIPTION
After discussing with Pekka and Daniel on #dri-devel, we concluded [1]
that user-space shouldn't need to force-probe connectors. Force-probing
can take some time, so using drmModeGetConnectorCurrent can result in
faster start-up.

Users can manually trigger a force-probe if necessary:

    echo detect | sudo tee /sys/class/drm/card0-DP-1/status

Or just by running a tool like drm_info.

A similar change has been submitted to Weston [2].

[1]: https://lists.freedesktop.org/archives/dri-devel/2020-November/287728.html
[2]: https://gitlab.freedesktop.org/wayland/weston/-/issues/437