### PR TITLE
render: add wlr_renderer_get_dmabuf_render_formats

### DIFF
--- a/backend/headless/backend.c
+++ b/backend/headless/backend.c
@@ -13,6 +13,7 @@
 #include "backend/headless.h"
 #include "render/drm_format_set.h"
 #include "render/gbm_allocator.h"
+#include "render/wlr_renderer.h"
 #include "util/signal.h"
 
 struct wlr_headless_backend *headless_backend_from_backend(
@@ -132,12 +133,11 @@ static bool backend_init(struct wlr_headless_backend *backend,
 	backend->allocator = &alloc->base;
 
 	const struct wlr_drm_format_set *formats =
-		wlr_renderer_get_dmabuf_formats(backend->renderer);
+		wlr_renderer_get_dmabuf_render_formats(backend->renderer);
 	if (formats == NULL) {
 		wlr_log(WLR_ERROR, "Failed to get available DMA-BUF formats from renderer");
 		return false;
 	}
-	// TODO: filter modifiers with external_only=false
 	const struct wlr_drm_format *format =
 		wlr_drm_format_set_get(formats, DRM_FORMAT_XRGB8888);
 	if (format == NULL) {

--- a/include/render/wlr_renderer.h
+++ b/include/render/wlr_renderer.h
@@ -4,5 +4,11 @@
 #include <wlr/render/wlr_renderer.h>
 
 bool wlr_renderer_bind_buffer(struct wlr_renderer *r, struct wlr_buffer *buffer);
+/**
+ * Get the DMA-BUF formats supporting rendering usage. Buffers allocated with
+ * a format from this list may be attached via wlr_renderer_bind_buffer.
+ */
+const struct wlr_drm_format_set *wlr_renderer_get_dmabuf_render_formats(
+	struct wlr_renderer *renderer);
 
 #endif

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -79,7 +79,6 @@ struct wlr_egl {
 
 	struct wlr_drm_format_set dmabuf_texture_formats;
 	struct wlr_drm_format_set dmabuf_render_formats;
-	EGLBoolean **external_only_dmabuf_formats;
 };
 
 // TODO: Allocate and return a wlr_egl

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -123,7 +123,7 @@ EGLImageKHR wlr_egl_create_image_from_dmabuf(struct wlr_egl *egl,
 	struct wlr_dmabuf_attributes *attributes, bool *external_only);
 
 /**
- * Get the available dmabuf formats
+ * Get DMA-BUF formats suitable for sampling usage.
  */
 const struct wlr_drm_format_set *wlr_egl_get_dmabuf_formats(struct wlr_egl *egl);
 

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -77,7 +77,7 @@ struct wlr_egl {
 
 	struct wl_display *wl_display;
 
-	struct wlr_drm_format_set dmabuf_formats;
+	struct wlr_drm_format_set dmabuf_texture_formats;
 	struct wlr_drm_format_set dmabuf_render_formats;
 	EGLBoolean **external_only_dmabuf_formats;
 };
@@ -126,7 +126,8 @@ EGLImageKHR wlr_egl_create_image_from_dmabuf(struct wlr_egl *egl,
 /**
  * Get DMA-BUF formats suitable for sampling usage.
  */
-const struct wlr_drm_format_set *wlr_egl_get_dmabuf_formats(struct wlr_egl *egl);
+const struct wlr_drm_format_set *wlr_egl_get_dmabuf_texture_formats(
+	struct wlr_egl *egl);
 /**
  * Get DMA-BUF formats suitable for rendering usage.
  */

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -78,6 +78,7 @@ struct wlr_egl {
 	struct wl_display *wl_display;
 
 	struct wlr_drm_format_set dmabuf_formats;
+	struct wlr_drm_format_set dmabuf_render_formats;
 	EGLBoolean **external_only_dmabuf_formats;
 };
 
@@ -126,6 +127,11 @@ EGLImageKHR wlr_egl_create_image_from_dmabuf(struct wlr_egl *egl,
  * Get DMA-BUF formats suitable for sampling usage.
  */
 const struct wlr_drm_format_set *wlr_egl_get_dmabuf_formats(struct wlr_egl *egl);
+/**
+ * Get DMA-BUF formats suitable for rendering usage.
+ */
+const struct wlr_drm_format_set *wlr_egl_get_dmabuf_render_formats(
+	struct wlr_egl *egl);
 
 bool wlr_egl_export_image_to_dmabuf(struct wlr_egl *egl, EGLImageKHR image,
 	int32_t width, int32_t height, uint32_t flags,

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -50,7 +50,7 @@ struct wlr_renderer_impl {
 		struct wl_resource *resource);
 	void (*wl_drm_buffer_get_size)(struct wlr_renderer *renderer,
 		struct wl_resource *buffer, int *width, int *height);
-	const struct wlr_drm_format_set *(*get_dmabuf_formats)(
+	const struct wlr_drm_format_set *(*get_dmabuf_texture_formats)(
 		struct wlr_renderer *renderer);
 	const struct wlr_drm_format_set *(*get_dmabuf_render_formats)(
 		struct wlr_renderer *renderer);

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -44,7 +44,7 @@ struct wlr_renderer_impl {
 		const float color[static 4], const float matrix[static 9]);
 	void (*render_ellipse_with_matrix)(struct wlr_renderer *renderer,
 		const float color[static 4], const float matrix[static 9]);
-	const enum wl_shm_format *(*formats)(
+	const enum wl_shm_format *(*get_shm_texture_formats)(
 		struct wlr_renderer *renderer, size_t *len);
 	bool (*resource_is_wl_drm_buffer)(struct wlr_renderer *renderer,
 		struct wl_resource *resource);

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -46,8 +46,6 @@ struct wlr_renderer_impl {
 		const float color[static 4], const float matrix[static 9]);
 	const enum wl_shm_format *(*formats)(
 		struct wlr_renderer *renderer, size_t *len);
-	bool (*format_supported)(struct wlr_renderer *renderer,
-		enum wl_shm_format fmt);
 	bool (*resource_is_wl_drm_buffer)(struct wlr_renderer *renderer,
 		struct wl_resource *resource);
 	void (*wl_drm_buffer_get_size)(struct wlr_renderer *renderer,

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -52,6 +52,8 @@ struct wlr_renderer_impl {
 		struct wl_resource *buffer, int *width, int *height);
 	const struct wlr_drm_format_set *(*get_dmabuf_formats)(
 		struct wlr_renderer *renderer);
+	const struct wlr_drm_format_set *(*get_dmabuf_render_formats)(
+		struct wlr_renderer *renderer);
 	enum wl_shm_format (*preferred_read_format)(struct wlr_renderer *renderer);
 	bool (*read_pixels)(struct wlr_renderer *renderer, enum wl_shm_format fmt,
 		uint32_t *flags, uint32_t stride, uint32_t width, uint32_t height,

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -102,7 +102,7 @@ void wlr_renderer_wl_drm_buffer_get_size(struct wlr_renderer *renderer,
  * Get the DMA-BUF formats supporting sampling usage. Buffers allocated with
  * a format from this list may be imported via wlr_texture_from_dmabuf.
  */
-const struct wlr_drm_format_set *wlr_renderer_get_dmabuf_formats(
+const struct wlr_drm_format_set *wlr_renderer_get_dmabuf_texture_formats(
 	struct wlr_renderer *renderer);
 /**
  * Reads out of pixels of the currently bound surface into data. `stride` is in

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -86,8 +86,8 @@ void wlr_render_ellipse_with_matrix(struct wlr_renderer *r,
  * Get the shared-memory formats supporting import usage. Buffers allocated
  * with a format from this list may be imported via wlr_texture_from_pixels.
  */
-const enum wl_shm_format *wlr_renderer_get_formats(struct wlr_renderer *r,
-	size_t *len);
+const enum wl_shm_format *wlr_renderer_get_shm_texture_formats(
+	struct wlr_renderer *r, size_t *len);
 /**
  * Returns true if this wl_buffer is a wl_drm buffer.
  */

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -83,7 +83,8 @@ void wlr_render_ellipse(struct wlr_renderer *r, const struct wlr_box *box,
 void wlr_render_ellipse_with_matrix(struct wlr_renderer *r,
 	const float color[static 4], const float matrix[static 9]);
 /**
- * Returns a list of pixel formats supported by this renderer.
+ * Get the shared-memory formats supporting import usage. Buffers allocated
+ * with a format from this list may be imported via wlr_texture_from_pixels.
  */
 const enum wl_shm_format *wlr_renderer_get_formats(struct wlr_renderer *r,
 	size_t *len);
@@ -98,7 +99,8 @@ bool wlr_renderer_resource_is_wl_drm_buffer(struct wlr_renderer *renderer,
 void wlr_renderer_wl_drm_buffer_get_size(struct wlr_renderer *renderer,
 	struct wl_resource *buffer, int *width, int *height);
 /**
- * Get the available DMA-BUF formats.
+ * Get the DMA-BUF formats supporting sampling usage. Buffers allocated with
+ * a format from this list may be imported via wlr_texture_from_dmabuf.
  */
 const struct wlr_drm_format_set *wlr_renderer_get_dmabuf_formats(
 	struct wlr_renderer *renderer);

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -121,11 +121,6 @@ bool wlr_renderer_read_pixels(struct wlr_renderer *r, enum wl_shm_format fmt,
 bool wlr_renderer_blit_dmabuf(struct wlr_renderer *r,
 	struct wlr_dmabuf_attributes *dst, struct wlr_dmabuf_attributes *src);
 /**
- * Checks if a format is supported.
- */
-bool wlr_renderer_format_supported(struct wlr_renderer *r,
-	enum wl_shm_format fmt);
-/**
  * Creates necessary shm and invokes the initialization of the implementation.
  *
  * Returns false on failure.

--- a/render/egl.c
+++ b/render/egl.c
@@ -158,10 +158,16 @@ static void init_dmabuf_formats(struct wlr_egl *egl) {
 
 		if (modifiers_len == 0) {
 			wlr_drm_format_set_add(&egl->dmabuf_formats, fmt, DRM_FORMAT_MOD_INVALID);
+			wlr_drm_format_set_add(&egl->dmabuf_render_formats, fmt,
+				DRM_FORMAT_MOD_INVALID);
 		}
 
 		for (int j = 0; j < modifiers_len; j++) {
 			wlr_drm_format_set_add(&egl->dmabuf_formats, fmt, modifiers[j]);
+			if (!external_only[j]) {
+				wlr_drm_format_set_add(&egl->dmabuf_render_formats, fmt,
+					modifiers[j]);
+			}
 		}
 
 		free(modifiers);
@@ -397,6 +403,7 @@ void wlr_egl_finish(struct wlr_egl *egl) {
 	}
 	free(egl->external_only_dmabuf_formats);
 
+	wlr_drm_format_set_finish(&egl->dmabuf_render_formats);
 	wlr_drm_format_set_finish(&egl->dmabuf_formats);
 
 	eglMakeCurrent(egl->display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
@@ -807,6 +814,11 @@ static int get_egl_dmabuf_modifiers(struct wlr_egl *egl, int format,
 
 const struct wlr_drm_format_set *wlr_egl_get_dmabuf_formats(struct wlr_egl *egl) {
 	return &egl->dmabuf_formats;
+}
+
+const struct wlr_drm_format_set *wlr_egl_get_dmabuf_render_formats(
+		struct wlr_egl *egl) {
+	return &egl->dmabuf_render_formats;
 }
 
 bool wlr_egl_export_image_to_dmabuf(struct wlr_egl *egl, EGLImageKHR image,

--- a/render/egl.c
+++ b/render/egl.c
@@ -157,13 +157,15 @@ static void init_dmabuf_formats(struct wlr_egl *egl) {
 		}
 
 		if (modifiers_len == 0) {
-			wlr_drm_format_set_add(&egl->dmabuf_formats, fmt, DRM_FORMAT_MOD_INVALID);
+			wlr_drm_format_set_add(&egl->dmabuf_texture_formats, fmt,
+				DRM_FORMAT_MOD_INVALID);
 			wlr_drm_format_set_add(&egl->dmabuf_render_formats, fmt,
 				DRM_FORMAT_MOD_INVALID);
 		}
 
 		for (int j = 0; j < modifiers_len; j++) {
-			wlr_drm_format_set_add(&egl->dmabuf_formats, fmt, modifiers[j]);
+			wlr_drm_format_set_add(&egl->dmabuf_texture_formats, fmt,
+				modifiers[j]);
 			if (!external_only[j]) {
 				wlr_drm_format_set_add(&egl->dmabuf_render_formats, fmt,
 					modifiers[j]);
@@ -398,13 +400,13 @@ void wlr_egl_finish(struct wlr_egl *egl) {
 		return;
 	}
 
-	for (size_t i = 0; i < egl->dmabuf_formats.len; i++) {
+	for (size_t i = 0; i < egl->dmabuf_texture_formats.len; i++) {
 		free(egl->external_only_dmabuf_formats[i]);
 	}
 	free(egl->external_only_dmabuf_formats);
 
 	wlr_drm_format_set_finish(&egl->dmabuf_render_formats);
-	wlr_drm_format_set_finish(&egl->dmabuf_formats);
+	wlr_drm_format_set_finish(&egl->dmabuf_texture_formats);
 
 	eglMakeCurrent(egl->display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
 	if (egl->wl_display) {
@@ -605,8 +607,8 @@ EGLImageKHR wlr_egl_create_image_from_wl_drm(struct wlr_egl *egl,
 
 static bool dmabuf_format_is_external_only(struct wlr_egl *egl,
 		uint32_t format, uint64_t modifier) {
-	for (size_t i = 0; i < egl->dmabuf_formats.len; i++) {
-		struct wlr_drm_format *fmt = egl->dmabuf_formats.formats[i];
+	for (size_t i = 0; i < egl->dmabuf_texture_formats.len; i++) {
+		struct wlr_drm_format *fmt = egl->dmabuf_texture_formats.formats[i];
 		if (fmt->format == format) {
 			if (egl->external_only_dmabuf_formats[i] == NULL) {
 				break;
@@ -812,8 +814,9 @@ static int get_egl_dmabuf_modifiers(struct wlr_egl *egl, int format,
 	return num;
 }
 
-const struct wlr_drm_format_set *wlr_egl_get_dmabuf_formats(struct wlr_egl *egl) {
-	return &egl->dmabuf_formats;
+const struct wlr_drm_format_set *wlr_egl_get_dmabuf_texture_formats(
+		struct wlr_egl *egl) {
+	return &egl->dmabuf_texture_formats;
 }
 
 const struct wlr_drm_format_set *wlr_egl_get_dmabuf_render_formats(

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -401,11 +401,6 @@ static const enum wl_shm_format *gles2_renderer_formats(
 	return get_gles2_wl_formats(len);
 }
 
-static bool gles2_format_supported(struct wlr_renderer *wlr_renderer,
-		enum wl_shm_format wl_fmt) {
-	return get_gles2_format_from_wl(wl_fmt) != NULL;
-}
-
 static bool gles2_resource_is_wl_drm_buffer(struct wlr_renderer *wlr_renderer,
 		struct wl_resource *resource) {
 	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
@@ -705,7 +700,6 @@ static const struct wlr_renderer_impl renderer_impl = {
 	.render_quad_with_matrix = gles2_render_quad_with_matrix,
 	.render_ellipse_with_matrix = gles2_render_ellipse_with_matrix,
 	.formats = gles2_renderer_formats,
-	.format_supported = gles2_format_supported,
 	.resource_is_wl_drm_buffer = gles2_resource_is_wl_drm_buffer,
 	.wl_drm_buffer_get_size = gles2_wl_drm_buffer_get_size,
 	.get_dmabuf_formats = gles2_get_dmabuf_formats,

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -396,7 +396,7 @@ static void gles2_render_ellipse_with_matrix(struct wlr_renderer *wlr_renderer,
 	pop_gles2_debug(renderer);
 }
 
-static const enum wl_shm_format *gles2_renderer_formats(
+static const enum wl_shm_format *gles2_get_shm_texture_formats(
 		struct wlr_renderer *wlr_renderer, size_t *len) {
 	return get_gles2_wl_formats(len);
 }
@@ -705,7 +705,7 @@ static const struct wlr_renderer_impl renderer_impl = {
 	.render_subtexture_with_matrix = gles2_render_subtexture_with_matrix,
 	.render_quad_with_matrix = gles2_render_quad_with_matrix,
 	.render_ellipse_with_matrix = gles2_render_ellipse_with_matrix,
-	.formats = gles2_renderer_formats,
+	.get_shm_texture_formats = gles2_get_shm_texture_formats,
 	.resource_is_wl_drm_buffer = gles2_resource_is_wl_drm_buffer,
 	.wl_drm_buffer_get_size = gles2_wl_drm_buffer_get_size,
 	.get_dmabuf_texture_formats = gles2_get_dmabuf_texture_formats,

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -429,10 +429,10 @@ static void gles2_wl_drm_buffer_get_size(struct wlr_renderer *wlr_renderer,
 		buffer, EGL_HEIGHT, height);
 }
 
-static const struct wlr_drm_format_set *gles2_get_dmabuf_formats(
+static const struct wlr_drm_format_set *gles2_get_dmabuf_texture_formats(
 		struct wlr_renderer *wlr_renderer) {
 	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
-	return wlr_egl_get_dmabuf_formats(renderer->egl);
+	return wlr_egl_get_dmabuf_texture_formats(renderer->egl);
 }
 
 static const struct wlr_drm_format_set *gles2_get_dmabuf_render_formats(
@@ -708,7 +708,7 @@ static const struct wlr_renderer_impl renderer_impl = {
 	.formats = gles2_renderer_formats,
 	.resource_is_wl_drm_buffer = gles2_resource_is_wl_drm_buffer,
 	.wl_drm_buffer_get_size = gles2_wl_drm_buffer_get_size,
-	.get_dmabuf_formats = gles2_get_dmabuf_formats,
+	.get_dmabuf_texture_formats = gles2_get_dmabuf_texture_formats,
 	.get_dmabuf_render_formats = gles2_get_dmabuf_render_formats,
 	.preferred_read_format = gles2_preferred_read_format,
 	.read_pixels = gles2_read_pixels,

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -435,6 +435,12 @@ static const struct wlr_drm_format_set *gles2_get_dmabuf_formats(
 	return wlr_egl_get_dmabuf_formats(renderer->egl);
 }
 
+static const struct wlr_drm_format_set *gles2_get_dmabuf_render_formats(
+		struct wlr_renderer *wlr_renderer) {
+	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
+	return wlr_egl_get_dmabuf_render_formats(renderer->egl);
+}
+
 static enum wl_shm_format gles2_preferred_read_format(
 		struct wlr_renderer *wlr_renderer) {
 	struct wlr_gles2_renderer *renderer =
@@ -703,6 +709,7 @@ static const struct wlr_renderer_impl renderer_impl = {
 	.resource_is_wl_drm_buffer = gles2_resource_is_wl_drm_buffer,
 	.wl_drm_buffer_get_size = gles2_wl_drm_buffer_get_size,
 	.get_dmabuf_formats = gles2_get_dmabuf_formats,
+	.get_dmabuf_render_formats = gles2_get_dmabuf_render_formats,
 	.preferred_read_format = gles2_preferred_read_format,
 	.read_pixels = gles2_read_pixels,
 	.texture_from_pixels = gles2_texture_from_pixels,

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -18,7 +18,6 @@ void wlr_renderer_init(struct wlr_renderer *renderer,
 	assert(impl->render_quad_with_matrix);
 	assert(impl->render_ellipse_with_matrix);
 	assert(impl->formats);
-	assert(impl->format_supported);
 	assert(impl->texture_from_pixels);
 	renderer->impl = impl;
 
@@ -193,11 +192,6 @@ bool wlr_renderer_blit_dmabuf(struct wlr_renderer *r,
 		return false;
 	}
 	return r->impl->blit_dmabuf(r, dst, src);
-}
-
-bool wlr_renderer_format_supported(struct wlr_renderer *r,
-		enum wl_shm_format fmt) {
-	return r->impl->format_supported(r, fmt);
 }
 
 bool wlr_renderer_init_wl_display(struct wlr_renderer *r,

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -173,6 +173,14 @@ const struct wlr_drm_format_set *wlr_renderer_get_dmabuf_formats(
 	return r->impl->get_dmabuf_formats(r);
 }
 
+const struct wlr_drm_format_set *wlr_renderer_get_dmabuf_render_formats(
+		struct wlr_renderer *r) {
+	if (!r->impl->get_dmabuf_render_formats) {
+		return NULL;
+	}
+	return r->impl->get_dmabuf_render_formats(r);
+}
+
 bool wlr_renderer_read_pixels(struct wlr_renderer *r, enum wl_shm_format fmt,
 		uint32_t *flags, uint32_t stride, uint32_t width, uint32_t height,
 		uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y,

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -217,13 +217,22 @@ bool wlr_renderer_init_wl_display(struct wlr_renderer *r,
 		return false;
 	}
 
+	bool argb8888 = false, xrgb8888 = false;
 	for (size_t i = 0; i < len; ++i) {
-		// These formats are already added by default
-		if (formats[i] != WL_SHM_FORMAT_ARGB8888 &&
-				formats[i] != WL_SHM_FORMAT_XRGB8888) {
+		// ARGB8888 and XRGB8888 must be supported and are implicitly
+		// advertised by wl_display_init_shm
+		switch (formats[i]) {
+		case WL_SHM_FORMAT_ARGB8888:
+			argb8888 = true;
+			break;
+		case WL_SHM_FORMAT_XRGB8888:
+			xrgb8888 = true;
+			break;
+		default:
 			wl_display_add_shm_format(wl_display, formats[i]);
 		}
 	}
+	assert(argb8888 && xrgb8888);
 
 	if (r->impl->init_wl_display) {
 		if (!r->impl->init_wl_display(r, wl_display)) {

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -17,7 +17,7 @@ void wlr_renderer_init(struct wlr_renderer *renderer,
 	assert(impl->render_subtexture_with_matrix);
 	assert(impl->render_quad_with_matrix);
 	assert(impl->render_ellipse_with_matrix);
-	assert(impl->formats);
+	assert(impl->get_shm_texture_formats);
 	assert(impl->texture_from_pixels);
 	renderer->impl = impl;
 
@@ -144,9 +144,9 @@ void wlr_render_ellipse_with_matrix(struct wlr_renderer *r,
 	r->impl->render_ellipse_with_matrix(r, color, matrix);
 }
 
-const enum wl_shm_format *wlr_renderer_get_formats(
+const enum wl_shm_format *wlr_renderer_get_shm_texture_formats(
 		struct wlr_renderer *r, size_t *len) {
-	return r->impl->formats(r, len);
+	return r->impl->get_shm_texture_formats(r, len);
 }
 
 bool wlr_renderer_resource_is_wl_drm_buffer(struct wlr_renderer *r,
@@ -210,7 +210,8 @@ bool wlr_renderer_init_wl_display(struct wlr_renderer *r,
 	}
 
 	size_t len;
-	const enum wl_shm_format *formats = wlr_renderer_get_formats(r, &len);
+	const enum wl_shm_format *formats =
+		wlr_renderer_get_shm_texture_formats(r, &len);
 	if (formats == NULL) {
 		wlr_log(WLR_ERROR, "Failed to initialize shm: cannot get formats");
 		return false;

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -165,12 +165,12 @@ void wlr_renderer_wl_drm_buffer_get_size(struct wlr_renderer *r,
 	return r->impl->wl_drm_buffer_get_size(r, buffer, width, height);
 }
 
-const struct wlr_drm_format_set *wlr_renderer_get_dmabuf_formats(
+const struct wlr_drm_format_set *wlr_renderer_get_dmabuf_texture_formats(
 		struct wlr_renderer *r) {
-	if (!r->impl->get_dmabuf_formats) {
+	if (!r->impl->get_dmabuf_texture_formats) {
 		return NULL;
 	}
-	return r->impl->get_dmabuf_formats(r);
+	return r->impl->get_dmabuf_texture_formats(r);
 }
 
 const struct wlr_drm_format_set *wlr_renderer_get_dmabuf_render_formats(

--- a/types/wlr_linux_dmabuf_v1.c
+++ b/types/wlr_linux_dmabuf_v1.c
@@ -389,7 +389,7 @@ static void linux_dmabuf_send_formats(struct wlr_linux_dmabuf_v1 *linux_dmabuf,
 		struct wl_resource *resource, uint32_t version) {
 	uint64_t modifier_invalid = DRM_FORMAT_MOD_INVALID;
 	const struct wlr_drm_format_set *formats =
-		wlr_renderer_get_dmabuf_formats(linux_dmabuf->renderer);
+		wlr_renderer_get_dmabuf_texture_formats(linux_dmabuf->renderer);
 	if (formats == NULL) {
 		return;
 	}


### PR DESCRIPTION
The main motivation for this PR is to ensure we select a format we can render to in the headless backend.

It contains also some breaking changes that clarify what formats advertised by `wlr_renderer` are good for.

* * *

Breaking changes:

* `wlr_egl_get_dmabuf_formats` has been renamed to `wlr_egl_get_dmabuf_texture_formats`
* `wlr_renderer_get_formats` has been renamed to `wlr_renderer_get_shm_texture_formats`
* `wlr_renderer_get_dmabuf_formats` has been renamed to `wlr_renderer_get_dmabuf_texture_formats`
* `wlr_renderer_format_supported` has been removed (instead, use `wlr_renderer_get_shm_texture_formats`)