### PR TITLE
render/egl: recognize EGL_BAD_DEVICE_EXT error

### DIFF
--- a/render/egl.c
+++ b/render/egl.c
@@ -75,6 +75,8 @@ static const char *egl_error_str(EGLint error) {
 		return "EGL_BAD_CURRENT_SURFACE";
 	case EGL_BAD_DISPLAY:
 		return "EGL_BAD_DISPLAY";
+	case EGL_BAD_DEVICE_EXT:
+		return "EGL_BAD_DEVICE_EXT";
 	case EGL_BAD_SURFACE:
 		return "EGL_BAD_SURFACE";
 	case EGL_BAD_MATCH:


### PR DESCRIPTION
This error is generated by various egl functions that handle egl devices, and also potentially by glvnd when dispatching those functions. Printing a human-readable name for it is helpful in debugging issues like #2480.