### PR TITLE
texture: document that functions should not be called while rendering

### DIFF
--- a/include/wlr/render/wlr_texture.h
+++ b/include/wlr/render/wlr_texture.h
@@ -24,6 +24,9 @@ struct wlr_texture {
 /**
  * Create a new texture from raw pixel data. `stride` is in bytes. The returned
  * texture is mutable.
+ *
+ * Should not be called in a rendering block like renderer_begin()/end() or
+ * between attaching a renderer to an output and committing it.
  */
 struct wlr_texture *wlr_texture_from_pixels(struct wlr_renderer *renderer,
 	enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width, uint32_t height,
@@ -32,12 +35,18 @@ struct wlr_texture *wlr_texture_from_pixels(struct wlr_renderer *renderer,
 /**
  * Create a new texture from a wl_drm resource. The returned texture is
  * immutable.
+ *
+ * Should not be called in a rendering block like renderer_begin()/end() or
+ * between attaching a renderer to an output and committing it.
  */
 struct wlr_texture *wlr_texture_from_wl_drm(struct wlr_renderer *renderer,
 	struct wl_resource *data);
 
 /**
  * Create a new texture from a DMA-BUF. The returned texture is immutable.
+ *
+ * Should not be called in a rendering block like renderer_begin()/end() or
+ * between attaching a renderer to an output and committing it.
  */
 struct wlr_texture *wlr_texture_from_dmabuf(struct wlr_renderer *renderer,
 	struct wlr_dmabuf_attributes *attribs);
@@ -58,6 +67,9 @@ bool wlr_texture_is_opaque(struct wlr_texture *texture);
 /**
   * Update a texture with raw pixels. The texture must be mutable, and the input
   * data must have the same pixel format that the texture was created with.
+  *
+  * Should not be called in a rendering block like renderer_begin()/end() or
+  * between attaching a renderer to an output and committing it.
   */
 bool wlr_texture_write_pixels(struct wlr_texture *texture,
 	uint32_t stride, uint32_t width, uint32_t height,


### PR DESCRIPTION
Supersedes: https://github.com/swaywm/wlroots/pull/2438