### PR TITLE
implementation of xdg-foreign protocol

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -7,6 +7,7 @@ packages:
   - mesa-dev
   - meson
   - pixman-dev
+  - util-linux-dev
   - wayland-dev
   - wayland-protocols
   - xcb-util-image-dev

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -10,6 +10,7 @@ packages:
 - graphics/png
 - graphics/wayland
 - graphics/wayland-protocols
+- misc/e2fsprogs-libuuid
 - multimedia/ffmpeg
 - x11/libX11
 - x11/libinput

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Install dependencies:
 * pixman
 * systemd (optional, for logind support)
 * elogind (optional, for logind support on systems without systemd)
+* libuuid (optional, for xdg-foreign support)
 
 If you choose to enable X11 support:
 

--- a/include/meson.build
+++ b/include/meson.build
@@ -10,6 +10,7 @@ endif
 if conf_data.get('WLR_HAS_XDG_FOREIGN', 0) != 1
 	exclude_files += [
     'types/wlr_xdg_foreign_v1.h',
+    'types/wlr_xdg_foreign_v2.h',
     'types/wlr_xdg_foreign_registry.h',
 	]
 endif

--- a/include/meson.build
+++ b/include/meson.build
@@ -9,6 +9,7 @@ if conf_data.get('WLR_HAS_XWAYLAND', 0) != 1
 endif
 if conf_data.get('WLR_HAS_XDG_FOREIGN', 0) != 1
 	exclude_files += [
+    'types/wlr_xdg_foreign_v1.h',
     'types/wlr_xdg_foreign_registry.h',
 	]
 endif

--- a/include/meson.build
+++ b/include/meson.build
@@ -7,6 +7,11 @@ endif
 if conf_data.get('WLR_HAS_XWAYLAND', 0) != 1
 	exclude_files += 'xwayland.h'
 endif
+if conf_data.get('WLR_HAS_XDG_FOREIGN', 0) != 1
+	exclude_files += [
+    'types/wlr_xdg_foreign_registry.h',
+	]
+endif
 
 install_subdir('wlr',
 	install_dir: get_option('includedir'),

--- a/include/util/uuid.h
+++ b/include/util/uuid.h
@@ -1,0 +1,8 @@
+#ifndef UTIL_UUID_H
+#define UTIL_UUID_H
+
+#include <stdbool.h>
+
+bool generate_uuid(char out[static 37]);
+
+#endif

--- a/include/wlr/config.h.in
+++ b/include/wlr/config.h.in
@@ -13,4 +13,6 @@
 #mesondefine WLR_HAS_XCB_ERRORS
 #mesondefine WLR_HAS_XCB_ICCCM
 
+#mesondefine WLR_HAS_XDG_FOREIGN
+
 #endif

--- a/include/wlr/types/wlr_xdg_foreign_registry.h
+++ b/include/wlr/types/wlr_xdg_foreign_registry.h
@@ -1,0 +1,75 @@
+/*
+ * This an unstable interface of wlroots. No guarantees are made regarding the
+ * future consistency of this API.
+ */
+#ifndef WLR_USE_UNSTABLE
+#error "Add -DWLR_USE_UNSTABLE to enable unstable wlroots features"
+#endif
+
+#ifndef WLR_TYPES_WLR_XDG_FOREIGN_REGISTRY_H
+#define WLR_TYPES_WLR_XDG_FOREIGN_REGISTRY_H
+
+#include <wayland-server-core.h>
+
+#define WLR_XDG_FOREIGN_HANDLE_SIZE 37
+
+/**
+ * wlr_xdg_foreign_registry is used for storing a list of exported surfaces with
+ * the xdg-foreign family of protocols.
+ *
+ * It can be used to allow interoperability between clients using different
+ * versions of the protocol (if all versions use the same registry).
+ */
+struct wlr_xdg_foreign_registry {
+	struct wl_list exported_surfaces; // struct wlr_xdg_foreign_exported_surface
+
+	struct wl_listener display_destroy;
+	struct {
+		struct wl_signal destroy;
+	} events;
+};
+
+struct wlr_xdg_foreign_exported {
+	struct wl_list link; // wlr_xdg_foreign_registry::exported_surfaces
+	struct wlr_xdg_foreign_registry *registry;
+
+	struct wlr_surface *surface;
+
+	char handle[WLR_XDG_FOREIGN_HANDLE_SIZE];
+
+	struct {
+		struct wl_signal destroy;
+	} events;
+};
+
+/**
+ * Create an empty wlr_xdg_foreign_registry.
+ *
+ * It will be destroyed when the associated display is destroyed.
+ */
+struct wlr_xdg_foreign_registry *wlr_xdg_foreign_registry_create(
+	struct wl_display *display);
+
+/**
+ * Add the given exported surface to the registry and assign it a unique handle.
+ * The caller is responsible for removing the exported surface from the repository
+ * if it is destroyed.
+ *
+ * Returns true if the initialization was successful.
+ */
+bool wlr_xdg_foreign_exported_init(struct wlr_xdg_foreign_exported *surface,
+	struct wlr_xdg_foreign_registry *registry);
+
+/**
+ * Find an exported surface with the given handle, or NULL if such a surface
+ * does not exist.
+ */
+struct wlr_xdg_foreign_exported *wlr_xdg_foreign_registry_find_by_handle(
+	struct wlr_xdg_foreign_registry *registry, const char *handle);
+
+/**
+ * Remove the given surface from the registry it was previously added in.
+ */
+void wlr_xdg_foreign_exported_finish(struct wlr_xdg_foreign_exported *surface);
+
+#endif

--- a/include/wlr/types/wlr_xdg_foreign_v1.h
+++ b/include/wlr/types/wlr_xdg_foreign_v1.h
@@ -1,0 +1,64 @@
+/*
+ * This an unstable interface of wlroots. No guarantees are made regarding the
+ * future consistency of this API.
+ */
+#ifndef WLR_USE_UNSTABLE
+#error "Add -DWLR_USE_UNSTABLE to enable unstable wlroots features"
+#endif
+
+#ifndef WLR_TYPES_WLR_XDG_FOREIGN_V1_H
+#define WLR_TYPES_WLR_XDG_FOREIGN_V1_H
+
+#include <wayland-server-core.h>
+#include <wlr/types/wlr_xdg_foreign_registry.h>
+
+struct wlr_xdg_foreign_v1 {
+	struct {
+		struct wl_global *global;
+		struct wl_list objects; // wlr_xdg_exported_v1::link or wlr_xdg_imported_v1::link
+	} exporter, importer;
+
+	struct wl_listener foreign_registry_destroy;
+	struct wl_listener display_destroy;
+
+	struct wlr_xdg_foreign_registry *registry;
+
+	struct {
+		struct wl_signal destroy;
+	} events;
+
+	void *data;
+};
+
+struct wlr_xdg_exported_v1 {
+	struct wlr_xdg_foreign_exported base;
+
+	struct wl_resource *resource;
+	struct wl_listener xdg_surface_destroy;
+
+	struct wl_list link; // wlr_xdg_foreign_v1::exporter::objects
+};
+
+struct wlr_xdg_imported_v1 {
+	struct wlr_xdg_foreign_exported *exported;
+	struct wl_listener exported_destroyed;
+
+	struct wl_resource *resource;
+	struct wl_list link; // wlr_xdg_foreign_v1::importer::objects
+	struct wl_list children;
+};
+
+struct wlr_xdg_imported_child_v1 {
+	struct wlr_xdg_imported_v1 *imported;
+	struct wlr_surface *surface;
+
+	struct wl_list link; // wlr_xdg_imported_v1::children
+
+	struct wl_listener xdg_surface_unmap;
+	struct wl_listener xdg_toplevel_set_parent;
+};
+
+struct wlr_xdg_foreign_v1 *wlr_xdg_foreign_v1_create(
+		struct wl_display *display, struct wlr_xdg_foreign_registry *registry);
+
+#endif

--- a/include/wlr/types/wlr_xdg_foreign_v2.h
+++ b/include/wlr/types/wlr_xdg_foreign_v2.h
@@ -1,0 +1,64 @@
+/*
+ * This an unstable interface of wlroots. No guarantees are made regarding the
+ * future consistency of this API.
+ */
+#ifndef WLR_USE_UNSTABLE
+#error "Add -DWLR_USE_UNSTABLE to enable unstable wlroots features"
+#endif
+
+#ifndef WLR_TYPES_WLR_XDG_FOREIGN_V2_H
+#define WLR_TYPES_WLR_XDG_FOREIGN_V2_H
+
+#include <wayland-server-core.h>
+#include <wlr/types/wlr_xdg_foreign_registry.h>
+
+struct wlr_xdg_foreign_v2 {
+	struct {
+		struct wl_global *global;
+		struct wl_list objects; // wlr_xdg_exported_v2::link or wlr_xdg_imported_v2::link
+	} exporter, importer;
+
+	struct wl_listener foreign_registry_destroy;
+	struct wl_listener display_destroy;
+
+	struct wlr_xdg_foreign_registry *registry;
+
+	struct {
+		struct wl_signal destroy;
+	} events;
+
+	void *data;
+};
+
+struct wlr_xdg_exported_v2 {
+	struct wlr_xdg_foreign_exported base;
+
+	struct wl_resource *resource;
+	struct wl_listener xdg_surface_destroy;
+
+	struct wl_list link; // wlr_xdg_foreign_v2::exporter::objects
+};
+
+struct wlr_xdg_imported_v2 {
+	struct wlr_xdg_foreign_exported *exported;
+	struct wl_listener exported_destroyed;
+
+	struct wl_resource *resource;
+	struct wl_list link; // wlr_xdg_foreign_v2::importer::objects
+	struct wl_list children;
+};
+
+struct wlr_xdg_imported_child_v2 {
+	struct wlr_xdg_imported_v2 *imported;
+	struct wlr_surface *surface;
+
+	struct wl_list link; // wlr_xdg_imported_v2::children
+
+	struct wl_listener xdg_surface_unmap;
+	struct wl_listener xdg_toplevel_set_parent;
+};
+
+struct wlr_xdg_foreign_v2 *wlr_xdg_foreign_v2_create(
+		struct wl_display *display, struct wlr_xdg_foreign_registry *registry);
+
+#endif

--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -310,6 +310,12 @@ uint32_t wlr_xdg_toplevel_set_tiled(struct wlr_xdg_surface *surface,
 void wlr_xdg_toplevel_send_close(struct wlr_xdg_surface *surface);
 
 /**
+ * Sets the parent of this toplevel. Parent can be NULL.
+ */
+void wlr_xdg_toplevel_set_parent(struct wlr_xdg_surface *surface,
+		struct wlr_xdg_surface *parent);
+
+/**
  * Request that this xdg popup closes.
  **/
 void wlr_xdg_popup_destroy(struct wlr_xdg_surface *surface);

--- a/meson.build
+++ b/meson.build
@@ -87,6 +87,7 @@ conf_data.set10('WLR_HAS_X11_BACKEND', false)
 conf_data.set10('WLR_HAS_XWAYLAND', false)
 conf_data.set10('WLR_HAS_XCB_ERRORS', false)
 conf_data.set10('WLR_HAS_XCB_ICCCM', false)
+conf_data.set10('WLR_HAS_XDG_FOREIGN', false)
 
 # Clang complains about some zeroed initializer lists (= {0}), even though they
 # are valid
@@ -109,8 +110,16 @@ pixman = dependency('pixman-1')
 math = cc.find_library('m')
 rt = cc.find_library('rt')
 
-uuid = dependency('uuid', required: false)
-uuid_create = cc.has_function('uuid_create')
+if not get_option('xdg-foreign').disabled()
+	uuid = dependency('uuid', required: false)
+	uuid_create = cc.has_function('uuid_create')
+	if uuid.found() or uuid_create
+		conf_data.set10('WLR_HAS_XDG_FOREIGN', true)
+	elif get_option('xdg-foreign').enabled()
+		error('Missing dependency uuid and uuid_create function not available ' +
+				'cannot build with xdg-foreign support')
+	endif
+endif
 
 wlr_files = []
 wlr_deps = [
@@ -171,6 +180,7 @@ summary({
 	'x11_backend': conf_data.get('WLR_HAS_X11_BACKEND', 0) == 1,
 	'xcb-icccm': conf_data.get('WLR_HAS_XCB_ICCCM', 0) == 1,
 	'xcb-errors': conf_data.get('WLR_HAS_XCB_ERRORS', 0) == 1,
+	'xdg-foreign': conf_data.get('WLR_HAS_XDG_FOREIGN', 0) == 1,
 }, bool_yn: true)
 
 if get_option('examples')

--- a/meson.build
+++ b/meson.build
@@ -109,6 +109,9 @@ pixman = dependency('pixman-1')
 math = cc.find_library('m')
 rt = cc.find_library('rt')
 
+uuid = dependency('uuid', required: false)
+uuid_create = cc.has_function('uuid_create')
+
 wlr_files = []
 wlr_deps = [
 	wayland_server,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,3 +7,4 @@ option('xwayland', type: 'feature', value: 'auto', yield: true, description: 'En
 option('x11-backend', type: 'feature', value: 'auto', description: 'Enable X11 backend')
 option('examples', type: 'boolean', value: true, description: 'Build example applications')
 option('icon_directory', description: 'Location used to look for cursors (default: ${datadir}/icons)', type: 'string', value: '')
+option('xdg-foreign', type: 'feature', value: 'auto', description: 'Enable xdg-foreign protocol')

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -27,6 +27,7 @@ protocols = {
 	'tablet-unstable-v2': wl_protocol_dir / 'unstable/tablet/tablet-unstable-v2.xml',
 	'text-input-unstable-v3': wl_protocol_dir / 'unstable/text-input/text-input-unstable-v3.xml',
 	'xdg-decoration-unstable-v1': wl_protocol_dir / 'unstable/xdg-decoration/xdg-decoration-unstable-v1.xml',
+	'xdg-foreign-unstable-v1': wl_protocol_dir / 'unstable/xdg-foreign/xdg-foreign-unstable-v1.xml',
 	'xdg-output-unstable-v1': wl_protocol_dir / 'unstable/xdg-output/xdg-output-unstable-v1.xml',
 	# Other protocols
 	'gtk-primary-selection': 'gtk-primary-selection.xml',

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -28,6 +28,7 @@ protocols = {
 	'text-input-unstable-v3': wl_protocol_dir / 'unstable/text-input/text-input-unstable-v3.xml',
 	'xdg-decoration-unstable-v1': wl_protocol_dir / 'unstable/xdg-decoration/xdg-decoration-unstable-v1.xml',
 	'xdg-foreign-unstable-v1': wl_protocol_dir / 'unstable/xdg-foreign/xdg-foreign-unstable-v1.xml',
+	'xdg-foreign-unstable-v2': wl_protocol_dir / 'unstable/xdg-foreign/xdg-foreign-unstable-v2.xml',
 	'xdg-output-unstable-v1': wl_protocol_dir / 'unstable/xdg-output/xdg-output-unstable-v1.xml',
 	# Other protocols
 	'gtk-primary-selection': 'gtk-primary-selection.xml',

--- a/types/meson.build
+++ b/types/meson.build
@@ -66,3 +66,9 @@ wlr_files += files(
 	'wlr_xdg_decoration_v1.c',
 	'wlr_xdg_output_v1.c',
 )
+
+if conf_data.get('WLR_HAS_XDG_FOREIGN', 0) == 1
+	wlr_files += files(
+		'wlr_xdg_foreign_registry.c',
+	)
+endif

--- a/types/meson.build
+++ b/types/meson.build
@@ -70,6 +70,7 @@ wlr_files += files(
 if conf_data.get('WLR_HAS_XDG_FOREIGN', 0) == 1
 	wlr_files += files(
 		'wlr_xdg_foreign_v1.c',
+		'wlr_xdg_foreign_v2.c',
 		'wlr_xdg_foreign_registry.c',
 	)
 endif

--- a/types/meson.build
+++ b/types/meson.build
@@ -69,6 +69,7 @@ wlr_files += files(
 
 if conf_data.get('WLR_HAS_XDG_FOREIGN', 0) == 1
 	wlr_files += files(
+		'wlr_xdg_foreign_v1.c',
 		'wlr_xdg_foreign_registry.c',
 	)
 endif

--- a/types/wlr_xdg_foreign_registry.c
+++ b/types/wlr_xdg_foreign_registry.c
@@ -1,0 +1,73 @@
+#include <wlr/types/wlr_xdg_foreign_registry.h>
+#include "util/signal.h"
+#include "util/uuid.h"
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+bool wlr_xdg_foreign_exported_init(
+		struct wlr_xdg_foreign_exported *exported,
+		struct wlr_xdg_foreign_registry *registry) {
+	do {
+		if (!generate_uuid(exported->handle)) {
+			return false;
+		}
+	} while (wlr_xdg_foreign_registry_find_by_handle(registry, exported->handle) != NULL);
+
+	exported->registry = registry;
+	wl_list_insert(&registry->exported_surfaces, &exported->link);
+
+	wl_signal_init(&exported->events.destroy);
+	return true;
+}
+
+struct wlr_xdg_foreign_exported *wlr_xdg_foreign_registry_find_by_handle(
+		struct wlr_xdg_foreign_registry *registry, const char *handle) {
+	if (handle == NULL || strlen(handle) >= WLR_XDG_FOREIGN_HANDLE_SIZE) {
+		return NULL;
+	}
+
+	struct wlr_xdg_foreign_exported *exported;
+	wl_list_for_each(exported, &registry->exported_surfaces, link) {
+		if (strcmp(handle, exported->handle) == 0) {
+			return exported;
+		}
+	}
+
+	return NULL;
+}
+
+void wlr_xdg_foreign_exported_finish(struct wlr_xdg_foreign_exported *surface) {
+	wlr_signal_emit_safe(&surface->events.destroy, NULL);
+	surface->registry = NULL;
+	wl_list_remove(&surface->link);
+	wl_list_init(&surface->link);
+}
+
+static void foreign_registry_handle_display_destroy(struct wl_listener *listener,
+		void *data) {
+	struct wlr_xdg_foreign_registry *registry =
+		wl_container_of(listener, registry, display_destroy);
+
+	wlr_signal_emit_safe(&registry->events.destroy, NULL);
+
+	// Implementations are supposed to remove all surfaces
+	assert(wl_list_empty(&registry->exported_surfaces));
+	free(registry);
+}
+
+
+struct wlr_xdg_foreign_registry *wlr_xdg_foreign_registry_create(
+		struct wl_display *display) {
+	struct wlr_xdg_foreign_registry *registry = calloc(1, sizeof(*registry));
+	if (!registry) {
+		return NULL;
+	}
+
+	registry->display_destroy.notify = foreign_registry_handle_display_destroy;
+	wl_display_add_destroy_listener(display, &registry->display_destroy);
+
+	wl_list_init(&registry->exported_surfaces);
+	wl_signal_init(&registry->events.destroy);
+	return registry;
+}

--- a/types/wlr_xdg_foreign_v1.c
+++ b/types/wlr_xdg_foreign_v1.c
@@ -1,0 +1,419 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <wlr/types/wlr_xdg_foreign_v1.h>
+#include <wlr/types/wlr_xdg_shell.h>
+#include <wlr/util/log.h>
+#include "util/signal.h"
+#include "xdg-foreign-unstable-v1-protocol.h"
+
+#define FOREIGN_V1_VERSION 1
+
+static const struct zxdg_exported_v1_interface xdg_exported_impl;
+static const struct zxdg_imported_v1_interface xdg_imported_impl;
+static const struct zxdg_exporter_v1_interface xdg_exporter_impl;
+static const struct zxdg_importer_v1_interface xdg_importer_impl;
+
+static struct wlr_xdg_imported_v1 *xdg_imported_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &zxdg_imported_v1_interface,
+		&xdg_imported_impl));
+	return wl_resource_get_user_data(resource);
+}
+
+static void xdg_imported_handle_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+
+static bool verify_is_toplevel(struct wl_resource *client_resource,
+		struct wlr_surface *surface) {
+	if (wlr_surface_is_xdg_surface(surface)) {
+		struct wlr_xdg_surface *xdg_surface =
+			wlr_xdg_surface_from_wlr_surface(surface);
+		if (xdg_surface->role != WLR_XDG_SURFACE_ROLE_TOPLEVEL) {
+			wl_resource_post_error(client_resource, -1,
+					"surface must be an xdg_toplevel");
+			return false;
+		}
+	} else {
+		wl_resource_post_error(client_resource, -1,
+				"surface must be an xdg_surface");
+		return false;
+	}
+	return true;
+}
+
+static void destroy_imported_child(struct wlr_xdg_imported_child_v1 *child) {
+	wl_list_remove(&child->xdg_toplevel_set_parent.link);
+	wl_list_remove(&child->xdg_surface_unmap.link);
+	wl_list_remove(&child->link);
+	free(child);
+}
+
+static void handle_child_xdg_surface_unmap(
+		struct wl_listener *listener, void *data) {
+	struct wlr_xdg_imported_child_v1 *child =
+		wl_container_of(listener, child, xdg_surface_unmap);
+	destroy_imported_child(child);
+}
+
+static void handle_xdg_toplevel_set_parent(
+		struct wl_listener *listener, void *data) {
+	struct wlr_xdg_imported_child_v1 *child =
+		wl_container_of(listener, child, xdg_toplevel_set_parent);
+	destroy_imported_child(child);
+}
+
+static void xdg_imported_handle_set_parent_of(struct wl_client *client,
+		struct wl_resource *resource,
+		struct wl_resource *child_resource) {
+	struct wlr_xdg_imported_v1 *imported =
+		xdg_imported_from_resource(resource);
+	if (imported == NULL) {
+		return;
+	}
+	struct wlr_surface *wlr_surface = imported->exported->surface;
+	struct wlr_surface *wlr_surface_child =
+		wlr_surface_from_resource(child_resource);
+
+	if (!verify_is_toplevel(resource, wlr_surface_child)) {
+		return;
+	}
+	struct wlr_xdg_imported_child_v1 *child;
+	wl_list_for_each(child, &imported->children, link) {
+		if (child->surface == wlr_surface_child) {
+			return;
+		}
+	}
+
+	child = calloc(1, sizeof(struct wlr_xdg_imported_child_v1));
+	if (child == NULL) {
+		wl_client_post_no_memory(client);
+		return;
+	}
+	child->surface = wlr_surface_child;
+	child->xdg_surface_unmap.notify = handle_child_xdg_surface_unmap;
+	child->xdg_toplevel_set_parent.notify = handle_xdg_toplevel_set_parent;
+
+	struct wlr_xdg_surface *surface =
+		wlr_xdg_surface_from_wlr_surface(wlr_surface);
+	struct wlr_xdg_surface *surface_child =
+		wlr_xdg_surface_from_wlr_surface(wlr_surface_child);
+
+	wlr_xdg_toplevel_set_parent(surface_child, surface);
+	wl_signal_add(&surface_child->events.unmap,
+			&child->xdg_surface_unmap);
+	wl_signal_add(&surface_child->toplevel->events.set_parent,
+			&child->xdg_toplevel_set_parent);
+
+	wl_list_insert(&imported->children, &child->link);
+}
+
+static const struct zxdg_imported_v1_interface xdg_imported_impl = {
+	.destroy = xdg_imported_handle_destroy,
+	.set_parent_of = xdg_imported_handle_set_parent_of
+};
+
+static struct wlr_xdg_exported_v1 *xdg_exported_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &zxdg_exported_v1_interface,
+		&xdg_exported_impl));
+	return wl_resource_get_user_data(resource);
+}
+
+static void xdg_exported_handle_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+
+static const struct zxdg_exported_v1_interface xdg_exported_impl = {
+	.destroy = xdg_exported_handle_destroy
+};
+
+static void xdg_exporter_handle_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+
+static struct wlr_xdg_foreign_v1 *xdg_foreign_from_exporter_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &zxdg_exporter_v1_interface,
+		&xdg_exporter_impl));
+	return wl_resource_get_user_data(resource);
+}
+
+static void finish_imported(struct wlr_xdg_imported_v1 *imported) {
+	imported->exported = NULL;
+	struct wlr_xdg_imported_child_v1 *child, *child_tmp;
+	wl_list_for_each_safe(child, child_tmp, &imported->children, link) {
+		struct wlr_xdg_surface *xdg_child =
+			wlr_xdg_surface_from_wlr_surface(child->surface);
+		wlr_xdg_toplevel_set_parent(xdg_child, NULL);
+	}
+
+	wl_list_remove(&imported->exported_destroyed.link);
+	wl_list_init(&imported->exported_destroyed.link);
+
+	wl_list_remove(&imported->link);
+	wl_list_init(&imported->link);
+	free(imported);
+}
+
+static void finish_exported(struct wlr_xdg_exported_v1 *exported) {
+	wlr_xdg_foreign_exported_finish(&exported->base);
+
+	wl_list_remove(&exported->xdg_surface_destroy.link);
+	wl_list_remove(&exported->link);
+	free(exported);
+}
+
+static void xdg_exported_handle_resource_destroy(
+		struct wl_resource *resource) {
+	struct wlr_xdg_exported_v1 *exported =
+		xdg_exported_from_resource(resource);
+
+	if (exported) {
+		finish_exported(exported);
+	}
+}
+
+static void handle_xdg_surface_destroy(
+		struct wl_listener *listener, void *data) {
+	struct wlr_xdg_exported_v1 *exported =
+		wl_container_of(listener, exported, xdg_surface_destroy);
+
+	wl_resource_set_user_data(exported->resource, NULL);
+	finish_exported(exported);
+}
+
+static void xdg_exporter_handle_export(struct wl_client *wl_client,
+		struct wl_resource *client_resource,
+		uint32_t id,
+		struct wl_resource *surface_resource) {
+	struct wlr_xdg_foreign_v1 *foreign =
+		xdg_foreign_from_exporter_resource(client_resource);
+	struct wlr_surface *surface = wlr_surface_from_resource(surface_resource);
+
+	if (!verify_is_toplevel(client_resource, surface)) {
+		return;
+	}
+
+	struct wlr_xdg_exported_v1 *exported =
+		calloc(1, sizeof(struct wlr_xdg_exported_v1));
+	if (exported == NULL) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+
+	if (!wlr_xdg_foreign_exported_init(&exported->base, foreign->registry)) {
+		wl_client_post_no_memory(wl_client);
+		free(exported);
+		return;
+	}
+
+	exported->base.surface = surface;
+	exported->resource = wl_resource_create(wl_client, &zxdg_exported_v1_interface,
+		wl_resource_get_version(client_resource), id);
+	if (exported->resource == NULL) {
+		wlr_xdg_foreign_exported_finish(&exported->base);
+		wl_client_post_no_memory(wl_client);
+		free(exported);
+		return;
+	}
+
+	wl_resource_set_implementation(exported->resource, &xdg_exported_impl,
+			exported, xdg_exported_handle_resource_destroy);
+
+	wl_list_insert(&foreign->exporter.objects, &exported->link);
+
+	zxdg_exported_v1_send_handle(exported->resource, exported->base.handle);
+
+	exported->xdg_surface_destroy.notify = handle_xdg_surface_destroy;
+	struct wlr_xdg_surface *xdg_surface =
+		wlr_xdg_surface_from_wlr_surface(surface);
+	wl_signal_add(&xdg_surface->events.unmap, &exported->xdg_surface_destroy);
+}
+
+static const struct zxdg_exporter_v1_interface xdg_exporter_impl = {
+	.destroy = xdg_exporter_handle_destroy,
+	.export = xdg_exporter_handle_export
+};
+
+static void xdg_exporter_bind(struct wl_client *wl_client, void *data,
+		uint32_t version, uint32_t id) {
+	struct wlr_xdg_foreign_v1 *foreign = data;
+
+	struct wl_resource *exporter_resource =
+		wl_resource_create(wl_client, &zxdg_exporter_v1_interface, version, id);
+	if (exporter_resource == NULL) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+
+	wl_resource_set_implementation(exporter_resource, &xdg_exporter_impl,
+			foreign, NULL);
+}
+
+static struct wlr_xdg_foreign_v1 *xdg_foreign_from_importer_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &zxdg_importer_v1_interface,
+		&xdg_importer_impl));
+	return wl_resource_get_user_data(resource);
+}
+
+static void xdg_importer_handle_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+
+static void xdg_imported_handle_resource_destroy(
+		struct wl_resource *resource) {
+	struct wlr_xdg_imported_v1 *imported = xdg_imported_from_resource(resource);
+	if (!imported) {
+		return;
+	}
+
+	finish_imported(imported);
+}
+
+static void xdg_imported_handle_exported_destroy(struct wl_listener *listener,
+		void *data) {
+	struct wlr_xdg_imported_v1 *imported =
+		wl_container_of(listener, imported, exported_destroyed);
+	zxdg_imported_v1_send_destroyed(imported->resource);
+	finish_imported(imported);
+}
+
+static void xdg_importer_handle_import(struct wl_client *wl_client,
+				struct wl_resource *client_resource,
+				uint32_t id,
+				const char *handle) {
+	struct wlr_xdg_foreign_v1 *foreign =
+		xdg_foreign_from_importer_resource(client_resource);
+
+	struct wlr_xdg_imported_v1 *imported =
+		calloc(1, sizeof(struct wlr_xdg_imported_v1));
+	if (imported == NULL) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+
+	imported->exported = wlr_xdg_foreign_registry_find_by_handle(
+		foreign->registry, handle);
+	imported->resource = wl_resource_create(wl_client, &zxdg_imported_v1_interface,
+			wl_resource_get_version(client_resource), id);
+	if (imported->resource == NULL) {
+		wl_client_post_no_memory(wl_client);
+		free(imported);
+		return;
+	}
+
+	wl_resource_set_implementation(imported->resource, &xdg_imported_impl,
+			imported, xdg_imported_handle_resource_destroy);
+
+	if (imported->exported == NULL) {
+		wl_resource_set_user_data(imported->resource, NULL);
+		zxdg_imported_v1_send_destroyed(imported->resource);
+		free(imported);
+		return;
+	}
+
+	wl_list_init(&imported->children);
+	wl_list_insert(&foreign->importer.objects, &imported->link);
+
+	imported->exported_destroyed.notify = xdg_imported_handle_exported_destroy;
+	wl_signal_add(&imported->exported->events.destroy, &imported->exported_destroyed);
+}
+
+static const struct zxdg_importer_v1_interface xdg_importer_impl = {
+	.destroy = xdg_importer_handle_destroy,
+	.import = xdg_importer_handle_import
+};
+
+static void xdg_importer_bind(struct wl_client *wl_client, void *data,
+		uint32_t version, uint32_t id) {
+	struct wlr_xdg_foreign_v1 *foreign = data;
+
+	struct wl_resource *importer_resource =
+		wl_resource_create(wl_client, &zxdg_importer_v1_interface, version, id);
+
+	if (importer_resource == NULL) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+
+	wl_resource_set_implementation(importer_resource, &xdg_importer_impl,
+			foreign, NULL);
+}
+
+static void xdg_foreign_destroy(struct wlr_xdg_foreign_v1 *foreign) {
+	if (!foreign) {
+		return;
+	}
+
+	wlr_signal_emit_safe(&foreign->events.destroy, NULL);
+	wl_list_remove(&foreign->foreign_registry_destroy.link);
+	wl_list_remove(&foreign->display_destroy.link);
+
+	wl_global_destroy(foreign->exporter.global);
+	wl_global_destroy(foreign->importer.global);
+	free(foreign);
+}
+
+static void handle_display_destroy(struct wl_listener *listener, void *data) {
+	struct wlr_xdg_foreign_v1 *foreign =
+		wl_container_of(listener, foreign, display_destroy);
+	xdg_foreign_destroy(foreign);
+}
+
+static void handle_foreign_registry_destroy(struct wl_listener *listener,
+		void *data) {
+	struct wlr_xdg_foreign_v1 *foreign =
+		wl_container_of(listener, foreign, foreign_registry_destroy);
+	xdg_foreign_destroy(foreign);
+}
+
+struct wlr_xdg_foreign_v1 *wlr_xdg_foreign_v1_create(
+		struct wl_display *display, struct wlr_xdg_foreign_registry *registry) {
+	struct wlr_xdg_foreign_v1 *foreign = calloc(1,
+			sizeof(struct wlr_xdg_foreign_v1));
+	if (!foreign) {
+		return NULL;
+	}
+
+	foreign->exporter.global = wl_global_create(display,
+			&zxdg_exporter_v1_interface,
+			FOREIGN_V1_VERSION, foreign,
+			xdg_exporter_bind);
+	if (!foreign->exporter.global) {
+		free(foreign);
+		return NULL;
+	}
+
+	foreign->importer.global = wl_global_create(display,
+			&zxdg_importer_v1_interface,
+			FOREIGN_V1_VERSION, foreign,
+			xdg_importer_bind);
+	if (!foreign->importer.global) {
+		wl_global_destroy(foreign->exporter.global);
+		free(foreign);
+		return NULL;
+	}
+
+	foreign->registry = registry;
+
+	wl_signal_init(&foreign->events.destroy);
+	wl_list_init(&foreign->exporter.objects);
+	wl_list_init(&foreign->importer.objects);
+
+	foreign->display_destroy.notify = handle_display_destroy;
+	wl_display_add_destroy_listener(display, &foreign->display_destroy);
+
+	foreign->foreign_registry_destroy.notify = handle_foreign_registry_destroy;
+	wl_signal_add(&registry->events.destroy, &foreign->foreign_registry_destroy);
+
+	return foreign;
+}

--- a/types/wlr_xdg_foreign_v2.c
+++ b/types/wlr_xdg_foreign_v2.c
@@ -1,0 +1,419 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <wlr/types/wlr_xdg_foreign_v2.h>
+#include <wlr/types/wlr_xdg_shell.h>
+#include <wlr/util/log.h>
+#include "util/signal.h"
+#include "xdg-foreign-unstable-v2-protocol.h"
+
+#define FOREIGN_V2_VERSION 1
+
+static const struct zxdg_exported_v2_interface xdg_exported_impl;
+static const struct zxdg_imported_v2_interface xdg_imported_impl;
+static const struct zxdg_exporter_v2_interface xdg_exporter_impl;
+static const struct zxdg_importer_v2_interface xdg_importer_impl;
+
+static struct wlr_xdg_imported_v2 *xdg_imported_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &zxdg_imported_v2_interface,
+		&xdg_imported_impl));
+	return wl_resource_get_user_data(resource);
+}
+
+static void xdg_imported_handle_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+
+static bool verify_is_toplevel(struct wl_resource *client_resource,
+		struct wlr_surface *surface) {
+	if (wlr_surface_is_xdg_surface(surface)) {
+		struct wlr_xdg_surface *xdg_surface =
+			wlr_xdg_surface_from_wlr_surface(surface);
+		if (xdg_surface->role != WLR_XDG_SURFACE_ROLE_TOPLEVEL) {
+			wl_resource_post_error(client_resource, -1,
+					"surface must be an xdg_toplevel");
+			return false;
+		}
+	} else {
+		wl_resource_post_error(client_resource, -1,
+				"surface must be an xdg_surface");
+		return false;
+	}
+	return true;
+}
+
+static void destroy_imported_child(struct wlr_xdg_imported_child_v2 *child) {
+	wl_list_remove(&child->xdg_toplevel_set_parent.link);
+	wl_list_remove(&child->xdg_surface_unmap.link);
+	wl_list_remove(&child->link);
+	free(child);
+}
+
+static void handle_child_xdg_surface_unmap(
+		struct wl_listener *listener, void *data) {
+	struct wlr_xdg_imported_child_v2 *child =
+		wl_container_of(listener, child, xdg_surface_unmap);
+	destroy_imported_child(child);
+}
+
+static void handle_xdg_toplevel_set_parent(
+		struct wl_listener *listener, void *data) {
+	struct wlr_xdg_imported_child_v2 *child =
+		wl_container_of(listener, child, xdg_toplevel_set_parent);
+	destroy_imported_child(child);
+}
+
+static void xdg_imported_handle_set_parent_of(struct wl_client *client,
+		struct wl_resource *resource,
+		struct wl_resource *child_resource) {
+	struct wlr_xdg_imported_v2 *imported =
+		xdg_imported_from_resource(resource);
+	if (imported == NULL) {
+		return;
+	}
+	struct wlr_surface *wlr_surface = imported->exported->surface;
+	struct wlr_surface *wlr_surface_child =
+		wlr_surface_from_resource(child_resource);
+
+	if (!verify_is_toplevel(resource, wlr_surface_child)) {
+		return;
+	}
+	struct wlr_xdg_imported_child_v2 *child;
+	wl_list_for_each(child, &imported->children, link) {
+		if (child->surface == wlr_surface_child) {
+			return;
+		}
+	}
+
+	child = calloc(1, sizeof(struct wlr_xdg_imported_child_v2));
+	if (child == NULL) {
+		wl_client_post_no_memory(client);
+		return;
+	}
+	child->surface = wlr_surface_child;
+	child->xdg_surface_unmap.notify = handle_child_xdg_surface_unmap;
+	child->xdg_toplevel_set_parent.notify = handle_xdg_toplevel_set_parent;
+
+	struct wlr_xdg_surface *surface =
+		wlr_xdg_surface_from_wlr_surface(wlr_surface);
+	struct wlr_xdg_surface *surface_child =
+		wlr_xdg_surface_from_wlr_surface(wlr_surface_child);
+
+	wlr_xdg_toplevel_set_parent(surface_child, surface);
+	wl_signal_add(&surface_child->events.unmap,
+			&child->xdg_surface_unmap);
+	wl_signal_add(&surface_child->toplevel->events.set_parent,
+			&child->xdg_toplevel_set_parent);
+
+	wl_list_insert(&imported->children, &child->link);
+}
+
+static const struct zxdg_imported_v2_interface xdg_imported_impl = {
+	.destroy = xdg_imported_handle_destroy,
+	.set_parent_of = xdg_imported_handle_set_parent_of
+};
+
+static struct wlr_xdg_exported_v2 *xdg_exported_from_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &zxdg_exported_v2_interface,
+		&xdg_exported_impl));
+	return wl_resource_get_user_data(resource);
+}
+
+static void xdg_exported_handle_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+
+static const struct zxdg_exported_v2_interface xdg_exported_impl = {
+	.destroy = xdg_exported_handle_destroy
+};
+
+static void xdg_exporter_handle_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+
+static struct wlr_xdg_foreign_v2 *xdg_foreign_from_exporter_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &zxdg_exporter_v2_interface,
+		&xdg_exporter_impl));
+	return wl_resource_get_user_data(resource);
+}
+
+static void finish_imported(struct wlr_xdg_imported_v2 *imported) {
+	imported->exported = NULL;
+	struct wlr_xdg_imported_child_v2 *child, *child_tmp;
+	wl_list_for_each_safe(child, child_tmp, &imported->children, link) {
+		struct wlr_xdg_surface *xdg_child =
+			wlr_xdg_surface_from_wlr_surface(child->surface);
+		wlr_xdg_toplevel_set_parent(xdg_child, NULL);
+	}
+
+	wl_list_remove(&imported->exported_destroyed.link);
+	wl_list_init(&imported->exported_destroyed.link);
+
+	wl_list_remove(&imported->link);
+	wl_list_init(&imported->link);
+	free(imported);
+}
+
+static void finish_exported(struct wlr_xdg_exported_v2 *exported) {
+	wlr_xdg_foreign_exported_finish(&exported->base);
+
+	wl_list_remove(&exported->xdg_surface_destroy.link);
+	wl_list_remove(&exported->link);
+	free(exported);
+}
+
+static void xdg_exported_handle_resource_destroy(
+		struct wl_resource *resource) {
+	struct wlr_xdg_exported_v2 *exported =
+		xdg_exported_from_resource(resource);
+
+	if (exported) {
+		finish_exported(exported);
+	}
+}
+
+static void handle_xdg_surface_destroy(
+		struct wl_listener *listener, void *data) {
+	struct wlr_xdg_exported_v2 *exported =
+		wl_container_of(listener, exported, xdg_surface_destroy);
+
+	wl_resource_set_user_data(exported->resource, NULL);
+	finish_exported(exported);
+}
+
+static void xdg_exporter_handle_export(struct wl_client *wl_client,
+		struct wl_resource *client_resource,
+		uint32_t id,
+		struct wl_resource *surface_resource) {
+	struct wlr_xdg_foreign_v2 *foreign =
+		xdg_foreign_from_exporter_resource(client_resource);
+	struct wlr_surface *surface = wlr_surface_from_resource(surface_resource);
+
+	if (!verify_is_toplevel(client_resource, surface)) {
+		return;
+	}
+
+	struct wlr_xdg_exported_v2 *exported =
+		calloc(1, sizeof(struct wlr_xdg_exported_v2));
+	if (exported == NULL) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+
+	if (!wlr_xdg_foreign_exported_init(&exported->base, foreign->registry)) {
+		wl_client_post_no_memory(wl_client);
+		free(exported);
+		return;
+	}
+
+	exported->base.surface = surface;
+	exported->resource = wl_resource_create(wl_client, &zxdg_exported_v2_interface,
+		wl_resource_get_version(client_resource), id);
+	if (exported->resource == NULL) {
+		wlr_xdg_foreign_exported_finish(&exported->base);
+		wl_client_post_no_memory(wl_client);
+		free(exported);
+		return;
+	}
+
+	wl_resource_set_implementation(exported->resource, &xdg_exported_impl,
+			exported, xdg_exported_handle_resource_destroy);
+
+	wl_list_insert(&foreign->exporter.objects, &exported->link);
+
+	zxdg_exported_v2_send_handle(exported->resource, exported->base.handle);
+
+	exported->xdg_surface_destroy.notify = handle_xdg_surface_destroy;
+	struct wlr_xdg_surface *xdg_surface =
+		wlr_xdg_surface_from_wlr_surface(surface);
+	wl_signal_add(&xdg_surface->events.unmap, &exported->xdg_surface_destroy);
+}
+
+static const struct zxdg_exporter_v2_interface xdg_exporter_impl = {
+	.destroy = xdg_exporter_handle_destroy,
+	.export_toplevel = xdg_exporter_handle_export
+};
+
+static void xdg_exporter_bind(struct wl_client *wl_client, void *data,
+		uint32_t version, uint32_t id) {
+	struct wlr_xdg_foreign_v2 *foreign = data;
+
+	struct wl_resource *exporter_resource =
+		wl_resource_create(wl_client, &zxdg_exporter_v2_interface, version, id);
+	if (exporter_resource == NULL) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+
+	wl_resource_set_implementation(exporter_resource, &xdg_exporter_impl,
+			foreign, NULL);
+}
+
+static struct wlr_xdg_foreign_v2 *xdg_foreign_from_importer_resource(
+		struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource, &zxdg_importer_v2_interface,
+		&xdg_importer_impl));
+	return wl_resource_get_user_data(resource);
+}
+
+static void xdg_importer_handle_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+
+static void xdg_imported_handle_resource_destroy(
+		struct wl_resource *resource) {
+	struct wlr_xdg_imported_v2 *imported = xdg_imported_from_resource(resource);
+	if (!imported) {
+		return;
+	}
+
+	finish_imported(imported);
+}
+
+static void xdg_imported_handle_exported_destroy(struct wl_listener *listener,
+		void *data) {
+	struct wlr_xdg_imported_v2 *imported =
+		wl_container_of(listener, imported, exported_destroyed);
+	zxdg_imported_v2_send_destroyed(imported->resource);
+	finish_imported(imported);
+}
+
+static void xdg_importer_handle_import(struct wl_client *wl_client,
+				struct wl_resource *client_resource,
+				uint32_t id,
+				const char *handle) {
+	struct wlr_xdg_foreign_v2 *foreign =
+		xdg_foreign_from_importer_resource(client_resource);
+
+	struct wlr_xdg_imported_v2 *imported =
+		calloc(1, sizeof(struct wlr_xdg_imported_v2));
+	if (imported == NULL) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+
+	imported->exported = wlr_xdg_foreign_registry_find_by_handle(
+		foreign->registry, handle);
+	imported->resource = wl_resource_create(wl_client, &zxdg_imported_v2_interface,
+			wl_resource_get_version(client_resource), id);
+	if (imported->resource == NULL) {
+		wl_client_post_no_memory(wl_client);
+		free(imported);
+		return;
+	}
+
+	wl_resource_set_implementation(imported->resource, &xdg_imported_impl,
+			imported, xdg_imported_handle_resource_destroy);
+
+	if (imported->exported == NULL) {
+		wl_resource_set_user_data(imported->resource, NULL);
+		zxdg_imported_v2_send_destroyed(imported->resource);
+		free(imported);
+		return;
+	}
+
+	wl_list_init(&imported->children);
+	wl_list_insert(&foreign->importer.objects, &imported->link);
+
+	imported->exported_destroyed.notify = xdg_imported_handle_exported_destroy;
+	wl_signal_add(&imported->exported->events.destroy, &imported->exported_destroyed);
+}
+
+static const struct zxdg_importer_v2_interface xdg_importer_impl = {
+	.destroy = xdg_importer_handle_destroy,
+	.import_toplevel = xdg_importer_handle_import
+};
+
+static void xdg_importer_bind(struct wl_client *wl_client, void *data,
+		uint32_t version, uint32_t id) {
+	struct wlr_xdg_foreign_v2 *foreign = data;
+
+	struct wl_resource *importer_resource =
+		wl_resource_create(wl_client, &zxdg_importer_v2_interface, version, id);
+
+	if (importer_resource == NULL) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+
+	wl_resource_set_implementation(importer_resource, &xdg_importer_impl,
+			foreign, NULL);
+}
+
+static void xdg_foreign_destroy(struct wlr_xdg_foreign_v2 *foreign) {
+	if (!foreign) {
+		return;
+	}
+
+	wlr_signal_emit_safe(&foreign->events.destroy, NULL);
+	wl_list_remove(&foreign->foreign_registry_destroy.link);
+	wl_list_remove(&foreign->display_destroy.link);
+
+	wl_global_destroy(foreign->exporter.global);
+	wl_global_destroy(foreign->importer.global);
+	free(foreign);
+}
+
+static void handle_display_destroy(struct wl_listener *listener, void *data) {
+	struct wlr_xdg_foreign_v2 *foreign =
+		wl_container_of(listener, foreign, display_destroy);
+	xdg_foreign_destroy(foreign);
+}
+
+static void handle_foreign_registry_destroy(struct wl_listener *listener,
+		void *data) {
+	struct wlr_xdg_foreign_v2 *foreign =
+		wl_container_of(listener, foreign, foreign_registry_destroy);
+	xdg_foreign_destroy(foreign);
+}
+
+struct wlr_xdg_foreign_v2 *wlr_xdg_foreign_v2_create(
+		struct wl_display *display, struct wlr_xdg_foreign_registry *registry) {
+	struct wlr_xdg_foreign_v2 *foreign = calloc(1,
+			sizeof(struct wlr_xdg_foreign_v2));
+	if (!foreign) {
+		return NULL;
+	}
+
+	foreign->exporter.global = wl_global_create(display,
+			&zxdg_exporter_v2_interface,
+			FOREIGN_V2_VERSION, foreign,
+			xdg_exporter_bind);
+	if (!foreign->exporter.global) {
+		free(foreign);
+		return NULL;
+	}
+
+	foreign->importer.global = wl_global_create(display,
+			&zxdg_importer_v2_interface,
+			FOREIGN_V2_VERSION, foreign,
+			xdg_importer_bind);
+	if (!foreign->importer.global) {
+		wl_global_destroy(foreign->exporter.global);
+		free(foreign);
+		return NULL;
+	}
+
+	foreign->registry = registry;
+
+	wl_signal_init(&foreign->events.destroy);
+	wl_list_init(&foreign->exporter.objects);
+	wl_list_init(&foreign->importer.objects);
+
+	foreign->display_destroy.notify = handle_display_destroy;
+	wl_display_add_destroy_listener(display, &foreign->display_destroy);
+
+	foreign->foreign_registry_destroy.notify = handle_foreign_registry_destroy;
+	wl_signal_add(&registry->events.destroy, &foreign->foreign_registry_destroy);
+
+	return foreign;
+}

--- a/types/xdg_shell/wlr_xdg_toplevel.c
+++ b/types/xdg_shell/wlr_xdg_toplevel.c
@@ -194,16 +194,14 @@ struct wlr_xdg_surface *wlr_xdg_surface_from_toplevel_resource(
 	return wl_resource_get_user_data(resource);
 }
 
-static void set_parent(struct wlr_xdg_surface *surface,
-		struct wlr_xdg_surface *parent);
-
 static void handle_parent_unmap(struct wl_listener *listener, void *data) {
 	struct wlr_xdg_toplevel *toplevel =
 		wl_container_of(listener, toplevel, parent_unmap);
-	set_parent(toplevel->base, toplevel->parent->toplevel->parent);
+	wlr_xdg_toplevel_set_parent(toplevel->base,
+			toplevel->parent->toplevel->parent);
 }
 
-static void set_parent(struct wlr_xdg_surface *surface,
+void wlr_xdg_toplevel_set_parent(struct wlr_xdg_surface *surface,
 		struct wlr_xdg_surface *parent) {
 	assert(surface->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL);
 	assert(!parent || parent->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL);
@@ -232,7 +230,7 @@ static void xdg_toplevel_handle_set_parent(struct wl_client *client,
 		parent = wlr_xdg_surface_from_toplevel_resource(parent_resource);
 	}
 
-	set_parent(surface, parent);
+	wlr_xdg_toplevel_set_parent(surface, parent);
 }
 
 static void xdg_toplevel_handle_set_title(struct wl_client *client,

--- a/util/meson.build
+++ b/util/meson.build
@@ -7,3 +7,11 @@ wlr_files += files(
 	'signal.c',
 	'time.c',
 )
+
+if uuid.found()
+	wlr_deps += uuid
+	add_project_arguments('-DHAS_LIBUUID=1', language: 'c')
+else
+	add_project_arguments('-DHAS_LIBUUID=0', language: 'c')
+endif
+wlr_files += files('uuid.c')

--- a/util/meson.build
+++ b/util/meson.build
@@ -8,10 +8,13 @@ wlr_files += files(
 	'time.c',
 )
 
-if uuid.found()
-	wlr_deps += uuid
-	add_project_arguments('-DHAS_LIBUUID=1', language: 'c')
-else
-	add_project_arguments('-DHAS_LIBUUID=0', language: 'c')
+
+if conf_data.get('WLR_HAS_XDG_FOREIGN', 0) == 1
+	if uuid.found()
+		wlr_deps += uuid
+		add_project_arguments('-DHAS_LIBUUID=1', language: 'c')
+	else
+		add_project_arguments('-DHAS_LIBUUID=0', language: 'c')
+	endif
+	wlr_files += files('uuid.c')
 endif
-wlr_files += files('uuid.c')

--- a/util/uuid.c
+++ b/util/uuid.c
@@ -1,0 +1,33 @@
+#include <uuid.h>
+#include "util/uuid.h"
+
+#if HAS_LIBUUID
+bool generate_uuid(char out[static 37]) {
+	uuid_t uuid;
+	uuid_generate_random(uuid);
+	uuid_unparse(uuid, out);
+	return true;
+}
+#else
+#include <string.h>
+#include <stdlib.h>
+
+bool generate_uuid(char out[static 37]) {
+	uuid_t uuid;
+	uint32_t status;
+	uuid_create(&uuid, &status);
+	if (status != uuid_s_ok) {
+		return false;
+	}
+	char *str;
+	uuid_to_string(&uuid, &str, &status);
+	if (status != uuid_s_ok) {
+		return false;
+	}
+
+	assert(strlen(str) + 1 == 37);
+	memcpy(out, str, sizeof(out));
+	free(str);
+	return true;
+}
+#endif


### PR DESCRIPTION
Supersedes #1841 (for now only rebased) and thus fixes #1702 

TODO:

- [x] Make xdg-foreign v1 and v2 share resources (as discussed in https://github.com/swaywm/wlroots/pull/1841#issuecomment-721125163)

