### PR TITLE
backend/wayland: use wlr_swapchain

### DIFF
--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -582,6 +582,7 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *wlr_backend) {
 			NULL)) {
 		goto error;
 	}
+	wlr_output->frame_pending = true;
 
 	wl_list_insert(&backend->outputs, &output->link);
 	wlr_output_update_enabled(wlr_output, true);

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,4 +1,5 @@
 threads = dependency('threads')
+wayland_egl = dependency('wayland-egl')
 wayland_cursor = dependency('wayland-cursor')
 libpng = dependency('libpng', required: false, disabler: true)
 # These versions correspond to ffmpeg 4.0
@@ -54,7 +55,7 @@ clients = {
 	},
 	'idle-inhibit': {
 		'src': 'idle-inhibit.c',
-		'dep': wlroots,
+		'dep': [wayland_egl, wlroots],
 		'proto': [
 			'idle-inhibit-unstable-v1',
 			'xdg-shell',
@@ -62,7 +63,7 @@ clients = {
 	},
 	'keyboard-shortcuts-inhibit': {
 		'src': 'keyboard-shortcuts-inhibit.c',
-		'dep': [wayland_cursor, wlroots],
+		'dep': [wayland_egl, wayland_cursor, wlroots],
 		'proto': [
 			'keyboard-shortcuts-inhibit-unstable-v1',
 			'xdg-shell',
@@ -70,7 +71,7 @@ clients = {
 	},
 	'layer-shell': {
 		'src': 'layer-shell.c',
-		'dep': [wayland_cursor, wlroots],
+		'dep': [wayland_egl, wayland_cursor, wlroots],
 		'proto': [
 			'wlr-layer-shell-unstable-v1',
 			'xdg-shell',
@@ -78,7 +79,7 @@ clients = {
 	},
 	'input-inhibitor': {
 		'src': 'input-inhibitor.c',
-		'dep': [wayland_cursor, wlroots],
+		'dep': [wayland_egl, wayland_cursor, wlroots],
 		'proto': [
 			'wlr-input-inhibitor-unstable-v1',
 			'xdg-shell',
@@ -96,7 +97,7 @@ clients = {
 	},
 	'pointer-constraints': {
 		'src': 'pointer-constraints.c',
-		'dep': wlroots,
+		'dep': [wayland_egl, wlroots],
 		'proto': [
 			'pointer-constraints-unstable-v1',
 			'xdg-shell',
@@ -104,7 +105,7 @@ clients = {
 	},
 	'relative-pointer': {
 		'src': 'relative-pointer-unstable-v1.c',
-		'dep': wlroots,
+		'dep': [wayland_egl, wlroots],
 		'proto': [
 			'pointer-constraints-unstable-v1',
 			'relative-pointer-unstable-v1',
@@ -137,7 +138,7 @@ clients = {
 	},
 	'toplevel-decoration': {
 		'src': 'toplevel-decoration.c',
-		'dep': wlroots,
+		'dep': [wayland_egl, wlroots],
 		'proto': [
 			'xdg-decoration-unstable-v1',
 			'xdg-shell',
@@ -145,7 +146,7 @@ clients = {
 	},
 	'input-method': {
 		'src': 'input-method.c',
-		'dep': libepoll,
+		'dep': [wayland_egl, libepoll],
 		'proto': [
 			'input-method-unstable-v2',
 			'text-input-unstable-v3',
@@ -154,7 +155,7 @@ clients = {
 	},
 	'text-input': {
 		'src': 'text-input.c',
-		'dep': [wayland_cursor, wlroots],
+		'dep': [wayland_egl, wayland_cursor, wlroots],
 		'proto': [
 			'text-input-unstable-v3',
 			'xdg-shell',

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -25,6 +25,8 @@ struct wlr_wl_backend {
 	struct wl_list outputs;
 	struct wlr_egl egl;
 	struct wlr_renderer *renderer;
+	struct wlr_drm_format *format;
+	struct wlr_allocator *allocator;
 	size_t requested_outputs;
 	size_t last_output_num;
 	struct wl_listener local_display_destroy;
@@ -67,9 +69,10 @@ struct wlr_wl_output {
 	struct xdg_surface *xdg_surface;
 	struct xdg_toplevel *xdg_toplevel;
 	struct zxdg_toplevel_decoration_v1 *zxdg_toplevel_decoration_v1;
-	struct wl_egl_window *egl_window;
-	EGLSurface egl_surface;
 	struct wl_list presentation_feedbacks;
+
+	struct wlr_swapchain *swapchain;
+	struct wlr_buffer *back_buffer;
 
 	uint32_t enter_serial;
 

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -4,9 +4,7 @@
 #include <stdbool.h>
 
 #include <wayland-client.h>
-#include <wayland-egl.h>
 #include <wayland-server-core.h>
-#include <wayland-util.h>
 
 #include <wlr/backend/wayland.h>
 #include <wlr/render/egl.h>
@@ -79,7 +77,7 @@ struct wlr_wl_output {
 	struct {
 		struct wlr_wl_pointer *pointer;
 		struct wl_surface *surface;
-		struct wl_egl_window *egl_window;
+		struct wlr_swapchain *swapchain;
 		int32_t hotspot_x, hotspot_y;
 		int32_t width, height;
 	} cursor;

--- a/meson.build
+++ b/meson.build
@@ -97,7 +97,6 @@ endif
 
 wayland_server = dependency('wayland-server', version: '>=1.18')
 wayland_client = dependency('wayland-client')
-wayland_egl = dependency('wayland-egl')
 wayland_protos = dependency('wayland-protocols', version: '>=1.17')
 egl = dependency('egl')
 glesv2 = dependency('glesv2')
@@ -114,7 +113,6 @@ wlr_files = []
 wlr_deps = [
 	wayland_server,
 	wayland_client,
-	wayland_egl,
 	wayland_protos,
 	egl,
 	glesv2,

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -358,8 +358,6 @@ void wlr_output_init(struct wlr_output *output, struct wlr_backend *backend,
 
 	output->display_destroy.notify = handle_display_destroy;
 	wl_display_add_destroy_listener(display, &output->display_destroy);
-
-	output->frame_pending = true;
 }
 
 void wlr_output_destroy(struct wlr_output *output) {


### PR DESCRIPTION
~~Depends on #2496~~

TODO:

- [x] Use `wlr_swapchain` for main surface
- [x] Use `wlr_swapchain` for cursor surface
- [x] Intersect linux-dmabuf-v1 formats with render formats

Future work:

- Don't create a `wl_buffer` on each commit -- cache them (https://github.com/swaywm/wlroots/pull/2538)
- Use linux-dmabuf hints to get render FD

References: #1352