### PR TITLE
xwm: add wlr_xwayland_surface_restack()

### DIFF
--- a/include/wlr/xwayland.h
+++ b/include/wlr/xwayland.h
@@ -252,6 +252,14 @@ void wlr_xwayland_set_cursor(struct wlr_xwayland *wlr_xwayland,
 void wlr_xwayland_surface_activate(struct wlr_xwayland_surface *surface,
 	bool activated);
 
+/**
+ * Restack surface relative to sibling.
+ * If sibling is NULL, then the surface is moved to the top or the bottom
+ * of the stack (depending on the mode).
+ */
+void wlr_xwayland_surface_restack(struct wlr_xwayland_surface *surface,
+	struct wlr_xwayland_surface *sibling, enum xcb_stack_mode_t mode);
+
 void wlr_xwayland_surface_configure(struct wlr_xwayland_surface *surface,
 	int16_t x, int16_t y, uint16_t width, uint16_t height);
 

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -1548,6 +1548,23 @@ void wlr_xwayland_surface_activate(struct wlr_xwayland_surface *xsurface,
 	}
 }
 
+void wlr_xwayland_surface_restack(struct wlr_xwayland_surface *surface,
+		struct wlr_xwayland_surface *sibling, enum xcb_stack_mode_t mode) {
+	struct wlr_xwm *xwm = surface->xwm;
+	uint32_t values[2];
+	size_t idx = 0;
+	uint32_t flags = XCB_CONFIG_WINDOW_STACK_MODE;
+
+	if (sibling != NULL) {
+		values[idx++] = sibling->window_id;
+		flags |= XCB_CONFIG_WINDOW_SIBLING;
+	}
+	values[idx++] = mode;
+
+	xcb_configure_window(xwm->xcb_conn, surface->window_id, flags, values);
+	xcb_flush(xwm->xcb_conn);
+}
+
 void wlr_xwayland_surface_configure(struct wlr_xwayland_surface *xsurface,
 		int16_t x, int16_t y, uint16_t width, uint16_t height) {
 	xsurface->x = x;


### PR DESCRIPTION
This PR adds a simple function for restacking Xwayland surfaces above or below each other.

To allow the most flexibility, this function receives a sibling and a mode argument, like the corresponding X11 configure event does.

EDIT: this is needed because in X11 the surface which gets pointer events is determined by the stacking order. Thus, if a compositor has the concept of always-on-top views or similar, they need to tell the Xserver what the real stacking order is.