### PR TITLE
wlr-output-management: add missing NULL check

### DIFF
--- a/types/wlr_output_management_v1.c
+++ b/types/wlr_output_management_v1.c
@@ -118,6 +118,9 @@ struct wlr_output_configuration_head_v1 *
 		struct wlr_output_configuration_v1 *config, struct wlr_output *output) {
 	struct wlr_output_configuration_head_v1 *config_head =
 		config_head_create(config, output);
+	if (config_head == NULL) {
+		return NULL;
+	}
 	config_head->state.enabled = output->enabled;
 	config_head->state.mode = output->current_mode;
 	config_head->state.custom_mode.width = output->width;


### PR DESCRIPTION
Handle allocation failure in wlr_output_configuration_head_v1_create