### PR TITLE
Revert "backend/drm: stop force-probing connectors"

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1282,8 +1282,8 @@ void scan_drm_connectors(struct wlr_drm_backend *drm) {
 	struct wlr_drm_connector *new_outputs[res->count_connectors + 1];
 
 	for (int i = 0; i < res->count_connectors; ++i) {
-		drmModeConnector *drm_conn =
-			drmModeGetConnectorCurrent(drm->fd, res->connectors[i]);
+		drmModeConnector *drm_conn = drmModeGetConnector(drm->fd,
+			res->connectors[i]);
 		if (!drm_conn) {
 			wlr_log_errno(WLR_ERROR, "Failed to get DRM connector");
 			continue;


### PR DESCRIPTION
This reverts commit 713c1661b742f93a7d2167321837c0d99541ca87.

It turns out we do need to force-probe on startup and on hotplug [1].
This is unfortunate, but that's just how the uAPI works. Fixing this
would require patching the kernel.

[1]: https://lists.freedesktop.org/archives/dri-devel/2020-November/289506.html

Closes: https://github.com/swaywm/wlroots/issues/2499

cc @ammen99 