### PR TITLE
Move primary wlr_swapchain handling out of backends

### DIFF
--- a/backend/headless/backend.c
+++ b/backend/headless/backend.c
@@ -70,8 +70,6 @@ static void backend_destroy(struct wlr_backend *wlr_backend) {
 
 	wlr_backend_finish(wlr_backend);
 
-	free(backend->format);
-
 	close(backend->drm_fd);
 	free(backend);
 }
@@ -145,20 +143,6 @@ static bool backend_init(struct wlr_headless_backend *backend,
 		wlr_log(WLR_ERROR, "Failed to create allocator");
 		return false;
 	}
-
-	const struct wlr_drm_format_set *formats =
-		wlr_renderer_get_render_formats(renderer);
-	if (formats == NULL) {
-		wlr_log(WLR_ERROR, "Failed to get available DMA-BUF formats from renderer");
-		return false;
-	}
-	const struct wlr_drm_format *format =
-		wlr_drm_format_set_get(formats, DRM_FORMAT_XRGB8888);
-	if (format == NULL) {
-		wlr_log(WLR_ERROR, "Renderer doesn't support XRGB8888");
-		return false;
-	}
-	backend->format = wlr_drm_format_dup(format);
 
 	backend->display_destroy.notify = handle_display_destroy;
 	wl_display_add_destroy_listener(display, &backend->display_destroy);

--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -4,10 +4,7 @@
 #include <wlr/interfaces/wlr_output.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/util/log.h>
-#include "backend/backend.h"
 #include "backend/headless.h"
-#include "render/swapchain.h"
-#include "render/wlr_renderer.h"
 #include "util/signal.h"
 
 static struct wlr_headless_output *headless_output_from_output(
@@ -20,44 +17,14 @@ static bool output_set_custom_mode(struct wlr_output *wlr_output, int32_t width,
 		int32_t height, int32_t refresh) {
 	struct wlr_headless_output *output =
 		headless_output_from_output(wlr_output);
-	struct wlr_allocator *allocator = backend_get_allocator(wlr_output->backend);
 
 	if (refresh <= 0) {
 		refresh = HEADLESS_DEFAULT_REFRESH;
 	}
 
-	wlr_swapchain_destroy(output->swapchain);
-	output->swapchain = wlr_swapchain_create(allocator,
-			width, height, output->backend->format);
-	if (!output->swapchain) {
-		wlr_output_destroy(wlr_output);
-		return false;
-	}
-
 	output->frame_delay = 1000000 / refresh;
 
 	wlr_output_update_custom_mode(&output->wlr_output, width, height, refresh);
-	return true;
-}
-
-static bool output_attach_render(struct wlr_output *wlr_output,
-		int *buffer_age) {
-	struct wlr_headless_output *output =
-		headless_output_from_output(wlr_output);
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(wlr_output->backend);
-
-	wlr_buffer_unlock(output->back_buffer);
-	output->back_buffer = wlr_swapchain_acquire(output->swapchain, buffer_age);
-	if (!output->back_buffer) {
-		wlr_log(WLR_ERROR, "Failed to acquire swapchain buffer");
-		return false;
-	}
-
-	if (!wlr_renderer_bind_buffer(renderer, output->back_buffer)) {
-		wlr_log(WLR_ERROR, "Failed to bind buffer to renderer");
-		return false;
-	}
-
 	return true;
 }
 
@@ -77,7 +44,6 @@ static bool output_test(struct wlr_output *wlr_output) {
 static bool output_commit(struct wlr_output *wlr_output) {
 	struct wlr_headless_output *output =
 		headless_output_from_output(wlr_output);
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(wlr_output->backend);
 
 	if (!output_test(wlr_output)) {
 		return false;
@@ -93,42 +59,16 @@ static bool output_commit(struct wlr_output *wlr_output) {
 	}
 
 	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
-		struct wlr_buffer *buffer = NULL;
-		switch (wlr_output->pending.buffer_type) {
-		case WLR_OUTPUT_STATE_BUFFER_RENDER:
-			assert(output->back_buffer != NULL);
-
-			wlr_renderer_bind_buffer(renderer, NULL);
-
-			buffer = output->back_buffer;
-			output->back_buffer = NULL;
-			break;
-		case WLR_OUTPUT_STATE_BUFFER_SCANOUT:
-			buffer = wlr_buffer_lock(wlr_output->pending.buffer);
-			break;
-		}
-		assert(buffer != NULL);
+		assert(wlr_output->pending.buffer_type ==
+			WLR_OUTPUT_STATE_BUFFER_SCANOUT);
 
 		wlr_buffer_unlock(output->front_buffer);
-		output->front_buffer = buffer;
-
-		wlr_swapchain_set_buffer_submitted(output->swapchain, buffer);
+		output->front_buffer = wlr_buffer_lock(wlr_output->pending.buffer);
 
 		wlr_output_send_present(wlr_output, NULL);
 	}
 
 	return true;
-}
-
-static void output_rollback_render(struct wlr_output *wlr_output) {
-	struct wlr_headless_output *output =
-		headless_output_from_output(wlr_output);
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(wlr_output->backend);
-
-	wlr_renderer_bind_buffer(renderer, NULL);
-
-	wlr_buffer_unlock(output->back_buffer);
-	output->back_buffer = NULL;
 }
 
 static bool output_export_dmabuf(struct wlr_output *wlr_output,
@@ -153,17 +93,13 @@ static void output_destroy(struct wlr_output *wlr_output) {
 		headless_output_from_output(wlr_output);
 	wl_list_remove(&output->link);
 	wl_event_source_remove(output->frame_timer);
-	wlr_swapchain_destroy(output->swapchain);
-	wlr_buffer_unlock(output->back_buffer);
 	wlr_buffer_unlock(output->front_buffer);
 	free(output);
 }
 
 static const struct wlr_output_impl output_impl = {
 	.destroy = output_destroy,
-	.attach_render = output_attach_render,
 	.commit = output_commit,
-	.rollback_render = output_rollback_render,
 	.export_dmabuf = output_export_dmabuf,
 };
 
@@ -182,7 +118,6 @@ struct wlr_output *wlr_headless_add_output(struct wlr_backend *wlr_backend,
 		unsigned int width, unsigned int height) {
 	struct wlr_headless_backend *backend =
 		headless_backend_from_backend(wlr_backend);
-	struct wlr_allocator *allocator = backend_get_allocator(wlr_backend);
 
 	struct wlr_headless_output *output =
 		calloc(1, sizeof(struct wlr_headless_output));
@@ -194,12 +129,6 @@ struct wlr_output *wlr_headless_add_output(struct wlr_backend *wlr_backend,
 	wlr_output_init(&output->wlr_output, &backend->backend, &output_impl,
 		backend->display);
 	struct wlr_output *wlr_output = &output->wlr_output;
-
-	output->swapchain = wlr_swapchain_create(allocator,
-		width, height, backend->format);
-	if (!output->swapchain) {
-		goto error;
-	}
 
 	output_set_custom_mode(wlr_output, width, height, 0);
 	strncpy(wlr_output->make, "headless", sizeof(wlr_output->make));
@@ -224,8 +153,4 @@ struct wlr_output *wlr_headless_add_output(struct wlr_backend *wlr_backend,
 	}
 
 	return wlr_output;
-
-error:
-	wlr_output_destroy(&output->wlr_output);
-	return NULL;
 }

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -452,48 +452,6 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display,
 		goto error_drm_fd;
 	}
 
-	const struct wlr_drm_format_set *remote_formats;
-	if ((allocator->buffer_caps & WLR_BUFFER_CAP_DMABUF) && wl->zwp_linux_dmabuf_v1) {
-		remote_formats = &wl->linux_dmabuf_v1_formats;
-	} else if ((allocator->buffer_caps & WLR_BUFFER_CAP_SHM) && wl->shm) {
-		remote_formats = &wl->shm_formats;
-	}  else {
-		wlr_log(WLR_ERROR,
-				"Failed to get remote formats (DRI3 and SHM unavailable)");
-		goto error_drm_fd;
-	}
-
-	const struct wlr_drm_format_set *render_formats =
-		wlr_renderer_get_render_formats(renderer);
-	if (render_formats == NULL) {
-		wlr_log(WLR_ERROR, "Failed to get available render-capable formats");
-		goto error_drm_fd;
-	}
-
-	uint32_t fmt = DRM_FORMAT_ARGB8888;
-
-	const struct wlr_drm_format *remote_format =
-		wlr_drm_format_set_get(remote_formats, fmt);
-	if (remote_format == NULL) {
-		wlr_log(WLR_ERROR, "Remote compositor doesn't support DRM format "
-			"0x%"PRIX32, fmt);
-		goto error_drm_fd;
-	}
-
-	const struct wlr_drm_format *render_format =
-		wlr_drm_format_set_get(render_formats, fmt);
-	if (render_format == NULL) {
-		wlr_log(WLR_ERROR, "Renderer doesn't support DRM format 0x%"PRIX32, fmt);
-		goto error_drm_fd;
-	}
-
-	wl->format = wlr_drm_format_intersect(remote_format, render_format);
-	if (wl->format == NULL) {
-		wlr_log(WLR_ERROR, "Failed to intersect remote and render modifiers "
-			"for format 0x%"PRIX32, fmt);
-		goto error_drm_fd;
-	}
-
 	wl->local_display_destroy.notify = handle_display_destroy;
 	wl_display_add_destroy_listener(display, &wl->local_display_destroy);
 

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -15,7 +15,6 @@
 #include <wlr/types/wlr_matrix.h>
 #include <wlr/util/log.h>
 
-#include "backend/backend.h"
 #include "backend/wayland.h"
 #include "render/pixel_format.h"
 #include "render/swapchain.h"
@@ -100,40 +99,7 @@ static const struct wp_presentation_feedback_listener
 
 static bool output_set_custom_mode(struct wlr_output *wlr_output,
 		int32_t width, int32_t height, int32_t refresh) {
-	struct wlr_wl_output *output = get_wl_output_from_output(wlr_output);
-	struct wlr_allocator *allocator = backend_get_allocator(wlr_output->backend);
-
-	if (wlr_output->width != width || wlr_output->height != height) {
-		struct wlr_swapchain *swapchain = wlr_swapchain_create(allocator,
-			width, height, output->backend->format);
-		if (swapchain == NULL) {
-			return false;
-		}
-		wlr_swapchain_destroy(output->swapchain);
-		output->swapchain = swapchain;
-	}
-
-	wlr_output_update_custom_mode(&output->wlr_output, width, height, 0);
-	return true;
-}
-
-static bool output_attach_render(struct wlr_output *wlr_output,
-		int *buffer_age) {
-	struct wlr_wl_output *output = get_wl_output_from_output(wlr_output);
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(wlr_output->backend);
-
-	wlr_buffer_unlock(output->back_buffer);
-	output->back_buffer = wlr_swapchain_acquire(output->swapchain, buffer_age);
-	if (!output->back_buffer) {
-		wlr_log(WLR_ERROR, "Failed to acquire swapchain buffer");
-		return false;
-	}
-
-	if (!wlr_renderer_bind_buffer(renderer, output->back_buffer)) {
-		wlr_log(WLR_ERROR, "Failed to bind buffer to renderer");
-		return false;
-	}
-
+	wlr_output_update_custom_mode(wlr_output, width, height, 0);
 	return true;
 }
 
@@ -299,7 +265,6 @@ static bool output_test(struct wlr_output *wlr_output) {
 static bool output_commit(struct wlr_output *wlr_output) {
 	struct wlr_wl_output *output =
 		get_wl_output_from_output(wlr_output);
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(wlr_output->backend);
 
 	if (!output_test(wlr_output)) {
 		return false;
@@ -315,6 +280,9 @@ static bool output_commit(struct wlr_output *wlr_output) {
 	}
 
 	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
+		assert(wlr_output->pending.buffer_type ==
+			WLR_OUTPUT_STATE_BUFFER_SCANOUT);
+
 		struct wp_presentation_feedback *wp_feedback = NULL;
 		if (output->backend->presentation != NULL) {
 			wp_feedback = wp_presentation_feedback(output->backend->presentation,
@@ -334,19 +302,7 @@ static bool output_commit(struct wlr_output *wlr_output) {
 		output->frame_callback = wl_surface_frame(output->surface);
 		wl_callback_add_listener(output->frame_callback, &frame_listener, output);
 
-		struct wlr_buffer *wlr_buffer = NULL;
-		switch (wlr_output->pending.buffer_type) {
-		case WLR_OUTPUT_STATE_BUFFER_RENDER:
-			assert(output->back_buffer != NULL);
-			wlr_buffer = output->back_buffer;
-
-			wlr_renderer_bind_buffer(renderer, NULL);
-			break;
-		case WLR_OUTPUT_STATE_BUFFER_SCANOUT:;
-			wlr_buffer = wlr_output->pending.buffer;
-			break;
-		}
-
+		struct wlr_buffer *wlr_buffer = wlr_output->pending.buffer;
 		struct wlr_wl_buffer *buffer =
 			get_or_create_wl_buffer(output->backend, wlr_buffer);
 		if (buffer == NULL) {
@@ -371,11 +327,6 @@ static bool output_commit(struct wlr_output *wlr_output) {
 
 		wl_surface_commit(output->surface);
 
-		wlr_buffer_unlock(output->back_buffer);
-		output->back_buffer = NULL;
-
-		wlr_swapchain_set_buffer_submitted(output->swapchain, wlr_buffer);
-
 		if (wp_feedback != NULL) {
 			struct wlr_wl_presentation_feedback *feedback =
 				calloc(1, sizeof(*feedback));
@@ -398,11 +349,6 @@ static bool output_commit(struct wlr_output *wlr_output) {
 	wl_display_flush(output->backend->remote_display);
 
 	return true;
-}
-
-static void output_rollback_render(struct wlr_output *wlr_output) {
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(wlr_output->backend);
-	wlr_renderer_bind_buffer(renderer, NULL);
 }
 
 static bool output_set_cursor(struct wlr_output *wlr_output,
@@ -472,8 +418,6 @@ static void output_destroy(struct wlr_output *wlr_output) {
 		presentation_feedback_destroy(feedback);
 	}
 
-	wlr_buffer_unlock(output->back_buffer);
-	wlr_swapchain_destroy(output->swapchain);
 	if (output->zxdg_toplevel_decoration_v1) {
 		zxdg_toplevel_decoration_v1_destroy(output->zxdg_toplevel_decoration_v1);
 	}
@@ -502,10 +446,8 @@ static bool output_move_cursor(struct wlr_output *_output, int x, int y) {
 
 static const struct wlr_output_impl output_impl = {
 	.destroy = output_destroy,
-	.attach_render = output_attach_render,
 	.test = output_test,
 	.commit = output_commit,
-	.rollback_render = output_rollback_render,
 	.set_cursor = output_set_cursor,
 	.move_cursor = output_move_cursor,
 	.get_cursor_formats = output_get_formats,
@@ -625,13 +567,6 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *wlr_backend) {
 	xdg_toplevel_add_listener(output->xdg_toplevel,
 			&xdg_toplevel_listener, output);
 	wl_surface_commit(output->surface);
-
-	struct wlr_allocator *allocator = backend_get_allocator(&backend->backend);
-	output->swapchain = wlr_swapchain_create(allocator,
-		wlr_output->width, wlr_output->height, output->backend->format);
-	if (output->swapchain == NULL) {
-		goto error;
-	}
 
 	wl_display_roundtrip(output->backend->remote_display);
 

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -439,7 +439,7 @@ static bool output_set_cursor(struct wlr_output *wlr_output,
 	return true;
 }
 
-static const struct wlr_drm_format_set *output_get_cursor_formats(
+static const struct wlr_drm_format_set *output_get_formats(
 		struct wlr_output *wlr_output, uint32_t buffer_caps) {
 	struct wlr_wl_output *output = get_wl_output_from_output(wlr_output);
 	if (buffer_caps & WLR_BUFFER_CAP_DMABUF) {
@@ -508,7 +508,8 @@ static const struct wlr_output_impl output_impl = {
 	.rollback_render = output_rollback_render,
 	.set_cursor = output_set_cursor,
 	.move_cursor = output_move_cursor,
-	.get_cursor_formats = output_get_cursor_formats,
+	.get_cursor_formats = output_get_formats,
+	.get_primary_formats = output_get_formats,
 };
 
 bool wlr_output_is_wl(struct wlr_output *wlr_output) {

--- a/include/backend/headless.h
+++ b/include/backend/headless.h
@@ -9,7 +9,6 @@
 struct wlr_headless_backend {
 	struct wlr_backend backend;
 	int drm_fd;
-	struct wlr_drm_format *format;
 	struct wl_display *display;
 	struct wl_list outputs;
 	size_t last_output_num;
@@ -26,8 +25,7 @@ struct wlr_headless_output {
 	struct wlr_headless_backend *backend;
 	struct wl_list link;
 
-	struct wlr_swapchain *swapchain;
-	struct wlr_buffer *back_buffer, *front_buffer;
+	struct wlr_buffer *front_buffer;
 
 	struct wl_event_source *frame_timer;
 	int frame_delay; // ms

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -21,7 +21,6 @@ struct wlr_wl_backend {
 	struct wl_list devices;
 	struct wl_list outputs;
 	int drm_fd;
-	struct wlr_drm_format *format;
 	struct wl_list buffers; // wlr_wl_buffer.link
 	size_t requested_outputs;
 	size_t last_output_num;
@@ -74,9 +73,6 @@ struct wlr_wl_output {
 	struct xdg_toplevel *xdg_toplevel;
 	struct zxdg_toplevel_decoration_v1 *zxdg_toplevel_decoration_v1;
 	struct wl_list presentation_feedbacks;
-
-	struct wlr_swapchain *swapchain;
-	struct wlr_buffer *back_buffer;
 
 	uint32_t enter_serial;
 

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -21,7 +21,6 @@
 #include <wlr/interfaces/wlr_pointer.h>
 #include <wlr/interfaces/wlr_touch.h>
 #include <wlr/render/drm_format_set.h>
-#include <wlr/render/wlr_renderer.h>
 
 #define XCB_EVENT_RESPONSE_TYPE_MASK 0x7f
 
@@ -34,9 +33,6 @@ struct wlr_x11_output {
 
 	xcb_window_t win;
 	xcb_present_event_t present_event_id;
-
-	struct wlr_swapchain *swapchain;
-	struct wlr_buffer *back_buffer;
 
 	struct wlr_pointer pointer;
 	struct wlr_input_device pointer_dev;
@@ -93,7 +89,6 @@ struct wlr_x11_backend {
 	const struct wlr_x11_format *x11_format;
 	struct wlr_drm_format_set primary_dri3_formats;
 	struct wlr_drm_format_set primary_shm_formats;
-	struct wlr_drm_format *drm_format;
 	struct wl_event_source *event_source;
 
 	struct {

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -91,6 +91,8 @@ struct wlr_x11_backend {
 	struct wlr_drm_format_set dri3_formats;
 	struct wlr_drm_format_set shm_formats;
 	const struct wlr_x11_format *x11_format;
+	struct wlr_drm_format_set primary_dri3_formats;
+	struct wlr_drm_format_set primary_shm_formats;
 	struct wlr_drm_format *drm_format;
 	struct wl_event_source *event_source;
 

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -94,6 +94,15 @@ struct wlr_output_impl {
 	 * size for the cursor may fail.
 	 */
 	void (*get_cursor_size)(struct wlr_output *output, int *width, int *height);
+	/**
+	 * Get the list of DMA-BUF formats suitable for the primary buffer,
+	 * assuming a buffer with the specified capabilities.
+	 *
+	 * If unimplemented, the primary buffer has no format constraint. If NULL
+	 * is returned, no format is suitable.
+	 */
+	const struct wlr_drm_format_set *(*get_primary_formats)(
+		struct wlr_output *output, uint32_t buffer_caps);
 };
 
 /**

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -17,8 +17,7 @@
 /**
  * A backend implementation of wlr_output.
  *
- * The functions commit, attach_render and rollback_render are mandatory. Other
- * functions are optional.
+ * The commit function is mandatory. Other functions are optional.
  */
 struct wlr_output_impl {
 	/**

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -185,6 +185,9 @@ struct wlr_output {
 	struct wlr_buffer *cursor_front_buffer;
 	int software_cursor_locks; // number of locks forcing software cursors
 
+	struct wlr_swapchain *swapchain;
+	struct wlr_buffer *back_buffer;
+
 	struct wl_listener display_destroy;
 
 	void *data;

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -1008,7 +1008,8 @@ static void output_cursor_update_visible(struct wlr_output_cursor *cursor) {
 	cursor->visible = visible;
 }
 
-static struct wlr_drm_format *output_pick_cursor_format(struct wlr_output *output) {
+static struct wlr_drm_format *output_pick_format(struct wlr_output *output,
+		const struct wlr_drm_format_set *display_formats) {
 	struct wlr_renderer *renderer = wlr_backend_get_renderer(output->backend);
 	struct wlr_allocator *allocator = backend_get_allocator(output->backend);
 	assert(renderer != NULL && allocator != NULL);
@@ -1020,19 +1021,6 @@ static struct wlr_drm_format *output_pick_cursor_format(struct wlr_output *outpu
 		return NULL;
 	}
 
-	const struct wlr_drm_format_set *display_formats;
-	if (output->impl->get_cursor_formats) {
-		display_formats =
-			output->impl->get_cursor_formats(output, allocator->buffer_caps);
-		if (display_formats == NULL) {
-			wlr_log(WLR_ERROR, "Failed to get display formats");
-			return NULL;
-		}
-	} else {
-		// The backend can display any format
-		display_formats = render_formats;
-	}
-
 	uint32_t fmt = DRM_FORMAT_ARGB8888;
 
 	const struct wlr_drm_format *render_format =
@@ -1042,11 +1030,16 @@ static struct wlr_drm_format *output_pick_cursor_format(struct wlr_output *outpu
 		return NULL;
 	}
 
-	const struct wlr_drm_format *display_format =
-		wlr_drm_format_set_get(display_formats, fmt);
-	if (display_format == NULL) {
-		wlr_log(WLR_DEBUG, "Output doesn't support format 0x%"PRIX32, fmt);
-		return NULL;
+	const struct wlr_drm_format *display_format;
+	if (display_formats != NULL) {
+		display_format = wlr_drm_format_set_get(display_formats, fmt);
+		if (display_format == NULL) {
+			wlr_log(WLR_DEBUG, "Output doesn't support format 0x%"PRIX32, fmt);
+			return NULL;
+		}
+	} else {
+		// The output can display any format
+		display_format = render_format;
 	}
 
 	struct wlr_drm_format *format =
@@ -1058,6 +1051,23 @@ static struct wlr_drm_format *output_pick_cursor_format(struct wlr_output *outpu
 	}
 
 	return format;
+}
+
+static struct wlr_drm_format *output_pick_cursor_format(struct wlr_output *output) {
+	struct wlr_allocator *allocator = backend_get_allocator(output->backend);
+	assert(allocator != NULL);
+
+	const struct wlr_drm_format_set *display_formats = NULL;
+	if (output->impl->get_cursor_formats) {
+		display_formats =
+			output->impl->get_cursor_formats(output, allocator->buffer_caps);
+		if (display_formats == NULL) {
+			wlr_log(WLR_ERROR, "Failed to get cursor display formats");
+			return NULL;
+		}
+	}
+
+	return output_pick_format(output, display_formats);
 }
 
 static struct wlr_buffer *render_cursor_buffer(struct wlr_output_cursor *cursor) {


### PR DESCRIPTION
Move the allocator/renderer-related code out of backends into the common backend/output code for everything related to the primary buffer. This process shouldn't break any compositor.

The DRM backend has not been migrated yet, because it requires more work.

- [x] Allow backends to be created without `get_renderer`
- [x] Allow outputs to be created without `{attach,rollback}_render`
- [x] Create allocator and renderer in `wlr_backend`
- [x] Create swapchain in `wlr_output`
- [x] Add support for the Pixman renderer
- [x] Migrate backends
  - [x] Headless
  - [x] Wayland
  - [x] X11
  - [x] ~~DRM~~ (done separately: https://github.com/swaywm/wlroots/pull/2903)

References: https://github.com/swaywm/wlroots/issues/1352
~~Depends on: https://github.com/swaywm/wlroots/pull/2496~~
~~Depends on: https://github.com/swaywm/wlroots/pull/2498~~
~~Depends on: https://github.com/swaywm/wlroots/pull/2495~~
~~Depends on: https://github.com/swaywm/wlroots/pull/2511~~
~~Depends on: https://github.com/swaywm/wlroots/pull/2507~~
~~Depends on: https://github.com/swaywm/wlroots/pull/2561~~