### PR TITLE
output: take a wlr_buffer in set_cursor

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -676,10 +676,9 @@ static bool drm_connector_init_renderer(struct wlr_drm_connector *conn,
 
 	int width = mode.hdisplay;
 	int height = mode.vdisplay;
-	uint32_t format = DRM_FORMAT_ARGB8888;
 
 	bool modifiers = drm->addfb2_modifiers;
-	if (!drm_plane_init_surface(plane, drm, width, height, format, modifiers) ||
+	if (!drm_plane_init_surface(plane, drm, width, height, modifiers) ||
 			!drm_connector_pageflip_renderer(conn, state)) {
 		if (!modifiers) {
 			wlr_drm_conn_log(conn, WLR_ERROR, "Failed to initialize renderer:"
@@ -694,8 +693,7 @@ static bool drm_connector_init_renderer(struct wlr_drm_connector *conn,
 			"retrying without modifiers");
 		modifiers = false;
 
-		if (!drm_plane_init_surface(plane, drm, width, height, format,
-				modifiers)) {
+		if (!drm_plane_init_surface(plane, drm, width, height, modifiers)) {
 			return false;
 		}
 		if (!drm_connector_pageflip_renderer(conn, state)) {
@@ -860,8 +858,7 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 		ret = drmGetCap(drm->fd, DRM_CAP_CURSOR_HEIGHT, &h);
 		h = ret ? 64 : h;
 
-		if (!drm_plane_init_surface(plane, drm, w, h,
-				DRM_FORMAT_ARGB8888, true)) {
+		if (!drm_plane_init_surface(plane, drm, w, h, true)) {
 			wlr_drm_conn_log(conn, WLR_ERROR, "Cannot allocate cursor resources");
 			return false;
 		}

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -193,7 +193,9 @@ static struct wlr_drm_format *create_linear_format(uint32_t format) {
 
 bool drm_plane_init_surface(struct wlr_drm_plane *plane,
 		struct wlr_drm_backend *drm, int32_t width, uint32_t height,
-		uint32_t format, bool with_modifiers) {
+		bool with_modifiers) {
+	uint32_t format = DRM_FORMAT_ARGB8888;
+
 	if (!wlr_drm_format_set_has(&plane->formats, format, DRM_FORMAT_MOD_INVALID)) {
 		const struct wlr_pixel_format_info *info =
 			drm_get_pixel_format_info(format);

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -62,7 +62,7 @@ void finish_drm_renderer(struct wlr_drm_renderer *renderer) {
 	gbm_device_destroy(renderer->gbm);
 }
 
-static bool init_drm_surface(struct wlr_drm_surface *surf,
+bool init_drm_surface(struct wlr_drm_surface *surf,
 		struct wlr_drm_renderer *renderer, uint32_t width, uint32_t height,
 		const struct wlr_drm_format *drm_format) {
 	if (surf->width == width && surf->height == height) {
@@ -126,7 +126,7 @@ void drm_surface_unset_current(struct wlr_drm_surface *surf) {
 	surf->back_buffer = NULL;
 }
 
-static struct wlr_buffer *drm_surface_blit(struct wlr_drm_surface *surf,
+struct wlr_buffer *drm_surface_blit(struct wlr_drm_surface *surf,
 		struct wlr_buffer *buffer) {
 	struct wlr_renderer *renderer = surf->renderer->wlr_rend;
 
@@ -191,7 +191,7 @@ static struct wlr_drm_format *create_linear_format(uint32_t format) {
 	return fmt;
 }
 
-static struct wlr_drm_format *drm_plane_pick_render_format(
+struct wlr_drm_format *drm_plane_pick_render_format(
 		struct wlr_drm_plane *plane, struct wlr_drm_renderer *renderer) {
 	const struct wlr_drm_format_set *render_formats =
 		wlr_renderer_get_render_formats(renderer->wlr_rend);

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -20,6 +20,7 @@
 #include "render/pixel_format.h"
 #include "render/swapchain.h"
 #include "render/wlr_renderer.h"
+#include "types/wlr_buffer.h"
 #include "util/signal.h"
 
 #include "linux-dmabuf-unstable-v1-client-protocol.h"
@@ -510,6 +511,17 @@ static bool output_set_cursor(struct wlr_output *wlr_output,
 	return true;
 }
 
+static const struct wlr_drm_format_set *output_get_cursor_formats(
+		struct wlr_output *wlr_output, uint32_t buffer_caps) {
+	struct wlr_wl_output *output = get_wl_output_from_output(wlr_output);
+	if (buffer_caps & WLR_BUFFER_CAP_DMABUF) {
+		return &output->backend->linux_dmabuf_v1_formats;
+	} else if (buffer_caps & WLR_BUFFER_CAP_SHM) {
+		return &output->backend->shm_formats;
+	}
+	return NULL;
+}
+
 static void output_destroy(struct wlr_output *wlr_output) {
 	struct wlr_wl_output *output = get_wl_output_from_output(wlr_output);
 	if (output == NULL) {
@@ -569,6 +581,7 @@ static const struct wlr_output_impl output_impl = {
 	.rollback_render = output_rollback_render,
 	.set_cursor = output_set_cursor,
 	.move_cursor = output_move_cursor,
+	.get_cursor_formats = output_get_cursor_formats,
 };
 
 bool wlr_output_is_wl(struct wlr_output *wlr_output) {

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -34,9 +34,10 @@ struct wlr_drm_plane {
 
 	struct wlr_drm_format_set formats;
 
-	// Only used by cursor
+	// Only used by cursor plane
 	bool cursor_enabled;
-	int32_t cursor_hotspot_x, cursor_hotspot_y;
+	int cursor_width, cursor_height;
+	int cursor_hotspot_x, cursor_hotspot_y;
 
 	union wlr_drm_plane_props props;
 };

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -34,11 +34,6 @@ struct wlr_drm_plane {
 
 	struct wlr_drm_format_set formats;
 
-	// Only used by cursor plane
-	bool cursor_enabled;
-	int cursor_width, cursor_height;
-	int cursor_hotspot_x, cursor_hotspot_y;
-
 	union wlr_drm_plane_props props;
 };
 
@@ -123,7 +118,10 @@ struct wlr_drm_connector {
 
 	union wlr_drm_connector_props props;
 
-	int32_t cursor_x, cursor_y;
+	bool cursor_enabled;
+	int cursor_x, cursor_y;
+	int cursor_width, cursor_height;
+	int cursor_hotspot_x, cursor_hotspot_y;
 
 	drmModeCrtc *old_crtc;
 

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -87,6 +87,10 @@ struct wlr_drm_backend {
 
 	struct wlr_drm_renderer renderer;
 	struct wlr_session *session;
+
+	uint64_t cursor_width, cursor_height;
+
+	struct wlr_drm_format_set mgpu_formats;
 };
 
 enum wlr_drm_connector_state {

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -57,7 +57,7 @@ bool drm_surface_render_black_frame(struct wlr_drm_surface *surf);
 
 bool drm_plane_init_surface(struct wlr_drm_plane *plane,
 		struct wlr_drm_backend *drm, int32_t width, uint32_t height,
-		uint32_t format, bool with_modifiers);
+		bool with_modifiers);
 void drm_plane_finish_surface(struct wlr_drm_plane *plane);
 bool drm_plane_lock_surface(struct wlr_drm_plane *plane,
 		struct wlr_drm_backend *drm);

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -43,6 +43,9 @@ bool init_drm_renderer(struct wlr_drm_backend *drm,
 	struct wlr_drm_renderer *renderer);
 void finish_drm_renderer(struct wlr_drm_renderer *renderer);
 
+bool init_drm_surface(struct wlr_drm_surface *surf,
+	struct wlr_drm_renderer *renderer, uint32_t width, uint32_t height,
+	const struct wlr_drm_format *drm_format);
 bool drm_surface_make_current(struct wlr_drm_surface *surf, int *buffer_age);
 void drm_surface_unset_current(struct wlr_drm_surface *surf);
 
@@ -53,8 +56,12 @@ void drm_fb_destroy(struct wlr_drm_fb *fb);
 void drm_fb_clear(struct wlr_drm_fb **fb);
 void drm_fb_move(struct wlr_drm_fb **new, struct wlr_drm_fb **old);
 
+struct wlr_buffer *drm_surface_blit(struct wlr_drm_surface *surf,
+	struct wlr_buffer *buffer);
 bool drm_surface_render_black_frame(struct wlr_drm_surface *surf);
 
+struct wlr_drm_format *drm_plane_pick_render_format(
+		struct wlr_drm_plane *plane, struct wlr_drm_renderer *renderer);
 bool drm_plane_init_surface(struct wlr_drm_plane *plane,
 		struct wlr_drm_backend *drm, int32_t width, uint32_t height,
 		bool with_modifiers);

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -83,9 +83,7 @@ struct wlr_wl_output {
 	struct {
 		struct wlr_wl_pointer *pointer;
 		struct wl_surface *surface;
-		struct wlr_swapchain *swapchain;
 		int32_t hotspot_x, hotspot_y;
-		int32_t width, height;
 	} cursor;
 };
 

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -24,22 +24,15 @@ struct wlr_output_impl {
 	/**
 	 * Set the output cursor plane image.
 	 *
-	 * The parameters describe the image texture, its scale and its transform.
-	 * If the scale and transform doesn't match the output's, the backend is
-	 * responsible for scaling and transforming the texture appropriately.
-	 * If texture is NULL, the cursor should be hidden.
+	 * If buffer is NULL, the cursor should be hidden.
 	 *
 	 * The hotspot indicates the offset that needs to be applied to the
 	 * top-left corner of the image to match the cursor position. In other
 	 * words, the image should be displayed at (x - hotspot_x, y - hotspot_y).
 	 * The hotspot is given in the texture's coordinate space.
-	 *
-	 * If update_texture is true, all parameters need to be taken into account.
-	 * If update_texture is false, only the hotspot is to be updated.
 	 */
-	bool (*set_cursor)(struct wlr_output *output, struct wlr_texture *texture,
-		float scale, enum wl_output_transform transform,
-		int32_t hotspot_x, int32_t hotspot_y, bool update_texture);
+	bool (*set_cursor)(struct wlr_output *output, struct wlr_buffer *buffer,
+		int hotspot_x, int hotspot_y);
 	/**
 	 * Set the output cursor plane position.
 	 *

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -87,6 +87,20 @@ struct wlr_output_impl {
 	 */
 	bool (*export_dmabuf)(struct wlr_output *output,
 		struct wlr_dmabuf_attributes *attribs);
+	/**
+	 * Get the list of formats suitable for the cursor, assuming a buffer with
+	 * the specified capabilities.
+	 *
+	 * If unimplemented, the cursor buffer has no format constraint. If NULL is
+	 * returned, no format is suitable.
+	 */
+	const struct wlr_drm_format_set *(*get_cursor_formats)(
+		struct wlr_output *output, uint32_t buffer_caps);
+	/**
+	 * Get the size suitable for the cursor buffer. Attempts to use a different
+	 * size for the cursor may fail.
+	 */
+	void (*get_cursor_size)(struct wlr_output *output, int *width, int *height);
 };
 
 /**

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -181,6 +181,8 @@ struct wlr_output {
 
 	struct wl_list cursors; // wlr_output_cursor::link
 	struct wlr_output_cursor *hardware_cursor;
+	struct wlr_swapchain *cursor_swapchain;
+	struct wlr_buffer *cursor_front_buffer;
 	int software_cursor_locks; // number of locks forcing software cursors
 
 	struct wl_listener display_destroy;


### PR DESCRIPTION
We want to remove the rendering bits from the backends. To do so, we need to stop feeding them `wlr_texture` for cursors.

Switch to `wlr_buffer`. The common `wlr_output` code is responsible for allocating and rendering cursor textures.

This will also help with [explicit synchronization](https://github.com/swaywm/wlroots/pull/2070).

TODO:

- [x] Fix disappearing cursor when near to output edge on DRM
- [x] Fix output scaling and transform
- [x] Multi-GPU

~~Depends on https://github.com/swaywm/wlroots/pull/2498~~
~~Depends on https://github.com/swaywm/wlroots/pull/2556~~
~~Depends on https://github.com/swaywm/wlroots/pull/2613~~
~~Depends on https://github.com/swaywm/wlroots/pull/2901~~
~~Depends on https://github.com/swaywm/wlroots/pull/2947~~

* * *

Breaking change for backends: `wlr_output_impl.set_cursor` now takes a `wlr_buffer`. Backends should no longer allocate a swapchain for the cursor. Backends can optionally specify cursor buffer format and size restrictions with `get_cursor_formats` and `get_cursor_size`.