### PR TITLE
backend/headless: use config-less context

### DIFF
--- a/backend/headless/backend.c
+++ b/backend/headless/backend.c
@@ -165,22 +165,12 @@ struct wlr_backend *wlr_headless_backend_create(struct wl_display *display,
 		return NULL;
 	}
 
-	static const EGLint config_attribs[] = {
-		EGL_SURFACE_TYPE, 0,
-		EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
-		EGL_BLUE_SIZE, 1,
-		EGL_GREEN_SIZE, 1,
-		EGL_RED_SIZE, 1,
-		EGL_NONE,
-	};
-
 	if (!create_renderer_func) {
 		create_renderer_func = wlr_renderer_autocreate;
 	}
 
 	struct wlr_renderer *renderer = create_renderer_func(&backend->priv_egl,
-		EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY,
-		(EGLint*)config_attribs, 0);
+		EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY, NULL, 0);
 	if (!renderer) {
 		wlr_log(WLR_ERROR, "Failed to create renderer");
 		free(backend);

--- a/render/egl.c
+++ b/render/egl.c
@@ -319,9 +319,19 @@ bool wlr_egl_init(struct wlr_egl *egl, EGLenum platform, void *remote_display,
 			check_egl_ext(device_exts_str, "EGL_EXT_device_drm");
 	}
 
-	if (!egl_get_config(egl->display, config_attribs, &egl->config, visual_id)) {
-		wlr_log(WLR_ERROR, "Failed to get EGL config");
-		goto error;
+	if (config_attribs != NULL) {
+		if (!egl_get_config(egl->display, config_attribs, &egl->config, visual_id)) {
+			wlr_log(WLR_ERROR, "Failed to get EGL config");
+			goto error;
+		}
+	} else {
+		if (!check_egl_ext(display_exts_str, "EGL_KHR_no_config_context") &&
+				!check_egl_ext(display_exts_str, "EGL_MESA_configless_context")) {
+			wlr_log(WLR_ERROR, "EGL_KHR_no_config_context or "
+				"EGL_MESA_configless_context not supported");
+			goto error;
+		}
+		egl->config = EGL_NO_CONFIG_KHR;
 	}
 
 	wlr_log(WLR_INFO, "Using EGL %d.%d", (int)major, (int)minor);

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -268,7 +268,11 @@ struct wlr_renderer *wlr_renderer_autocreate(struct wlr_egl *egl,
 	memcpy(&all_config_attribs[config_attribs_len], gles2_config_attribs,
 		sizeof(gles2_config_attribs));
 
-	if (!wlr_egl_init(egl, platform, remote_display, all_config_attribs,
+	if (config_attribs != NULL) {
+		config_attribs = all_config_attribs;
+	}
+
+	if (!wlr_egl_init(egl, platform, remote_display, config_attribs,
 			visual_id)) {
 		wlr_log(WLR_ERROR, "Could not initialize EGL");
 		return NULL;


### PR DESCRIPTION
This is preliminary work for https://github.com/swaywm/wlroots/pull/2505.

With `wlr_swapchain`, we stop using `EGLSurface` entirely, so we can skip selecting an `EGLConfig`.