### PR TITLE
output-management: use same types as wlr_output

### DIFF
--- a/include/wlr/types/wlr_output_management_v1.h
+++ b/include/wlr/types/wlr_output_management_v1.h
@@ -50,12 +50,12 @@ struct wlr_output_head_v1_state {
 	bool enabled;
 	struct wlr_output_mode *mode;
 	struct {
-		int width, height;
-		int refresh;
+		int32_t width, height;
+		int32_t refresh;
 	} custom_mode;
 	int32_t x, y;
 	enum wl_output_transform transform;
-	double scale;
+	float scale;
 };
 
 struct wlr_output_head_v1 {

--- a/types/wlr_output_management_v1.c
+++ b/types/wlr_output_management_v1.c
@@ -240,7 +240,7 @@ static void config_head_handle_set_scale(struct wl_client *client,
 		return;
 	}
 
-	double scale =  wl_fixed_to_double(scale_fixed);
+	float scale =  wl_fixed_to_double(scale_fixed);
 	if (scale <= 0) {
 		wl_resource_post_error(config_head_resource,
 			ZWLR_OUTPUT_CONFIGURATION_HEAD_V1_ERROR_INVALID_SCALE,


### PR DESCRIPTION
This is more correct and also makes things much nicer for languages
that don't allow implicit conversions between these types.