### PR TITLE
render/gles2: query alpha size from render buffer 

### DIFF
--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -453,8 +453,10 @@ static enum wl_shm_format gles2_preferred_read_format(
 	pop_gles2_debug(renderer);
 
 	EGLint alpha_size = -1;
-	eglGetConfigAttrib(renderer->egl->display, renderer->egl->config,
-		EGL_ALPHA_SIZE, &alpha_size);
+	if (renderer->egl->config != EGL_NO_CONFIG_KHR) {
+		eglGetConfigAttrib(renderer->egl->display, renderer->egl->config,
+			EGL_ALPHA_SIZE, &alpha_size);
+	}
 
 	const struct wlr_gles2_pixel_format *fmt =
 		get_gles2_format_from_gl(gl_format, gl_type, alpha_size > 0);

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -453,7 +453,12 @@ static enum wl_shm_format gles2_preferred_read_format(
 	pop_gles2_debug(renderer);
 
 	EGLint alpha_size = -1;
-	if (renderer->egl->config != EGL_NO_CONFIG_KHR) {
+	if (renderer->current_buffer != NULL) {
+		glBindRenderbuffer(GL_RENDERBUFFER, renderer->current_buffer->rbo);
+		glGetRenderbufferParameteriv(GL_RENDERBUFFER,
+			GL_RENDERBUFFER_ALPHA_SIZE, &alpha_size);
+		glBindRenderbuffer(GL_RENDERBUFFER, 0);
+	} else if (renderer->egl->config != EGL_NO_CONFIG_KHR) {
 		eglGetConfigAttrib(renderer->egl->display, renderer->egl->config,
 			EGL_ALPHA_SIZE, &alpha_size);
 	}


### PR DESCRIPTION
If we don't have an EGL config, don't try to query anything from it.

If we're using a render buffer, query the alpha size from it.

Closes: #2527

cc @any1