### PR TITLE
backend/drm: remove EGL config

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -712,7 +712,7 @@ static bool drm_connector_init_renderer(struct wlr_drm_connector *conn,
 
 	int width = mode->wlr_mode.width;
 	int height = mode->wlr_mode.height;
-	uint32_t format = drm->renderer.gbm_format;
+	uint32_t format = DRM_FORMAT_ARGB8888;
 
 	bool modifiers = true;
 	const char *no_modifiers = getenv("WLR_DRM_NO_MODIFIERS");

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -30,20 +30,8 @@ bool init_drm_renderer(struct wlr_drm_backend *drm,
 		create_renderer_func = wlr_renderer_autocreate;
 	}
 
-	static EGLint config_attribs[] = {
-		EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
-		EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
-		EGL_RED_SIZE, 1,
-		EGL_GREEN_SIZE, 1,
-		EGL_BLUE_SIZE, 1,
-		EGL_ALPHA_SIZE, 1,
-		EGL_NONE,
-	};
-
-	renderer->gbm_format = GBM_FORMAT_ARGB8888;
 	renderer->wlr_rend = create_renderer_func(&renderer->egl,
-		EGL_PLATFORM_GBM_KHR, renderer->gbm, config_attribs,
-		renderer->gbm_format);
+		EGL_PLATFORM_GBM_KHR, renderer->gbm, NULL, 0);
 	if (!renderer->wlr_rend) {
 		wlr_log(WLR_ERROR, "Failed to create EGL/WLR renderer");
 		goto error_gbm;

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -17,8 +17,6 @@ struct wlr_drm_renderer {
 	struct gbm_device *gbm;
 	struct wlr_egl egl;
 
-	uint32_t gbm_format;
-
 	struct wlr_renderer *wlr_rend;
 	struct wlr_gbm_allocator *allocator;
 };


### PR DESCRIPTION
Since we're using wlr_swapchain, we don't need to provide an EGL config.