### PR TITLE
backend/drm: stop using GBM flags

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -722,7 +722,7 @@ static bool drm_connector_init_renderer(struct wlr_drm_connector *conn,
 		modifiers = false;
 	}
 
-	if (!drm_plane_init_surface(plane, drm, width, height, format, 0, modifiers) ||
+	if (!drm_plane_init_surface(plane, drm, width, height, format, false, modifiers) ||
 			!drm_connector_pageflip_renderer(conn)) {
 		if (!modifiers) {
 			wlr_log(WLR_ERROR, "Failed to initialize renderer "
@@ -742,7 +742,7 @@ static bool drm_connector_init_renderer(struct wlr_drm_connector *conn,
 		crtc->pending.mode = mode;
 
 		if (!drm_plane_init_surface(plane, drm, width, height, format,
-				0, modifiers)) {
+				false, modifiers)) {
 			return false;
 		}
 		if (!drm_connector_pageflip_renderer(conn)) {
@@ -897,7 +897,7 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 		h = ret ? 64 : h;
 
 		if (!drm_plane_init_surface(plane, drm, w, h,
-				DRM_FORMAT_ARGB8888, GBM_BO_USE_LINEAR, false)) {
+				DRM_FORMAT_ARGB8888, true, false)) {
 			wlr_log(WLR_ERROR, "Cannot allocate cursor resources");
 			return false;
 		}

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -61,7 +61,7 @@ struct gbm_bo *drm_fb_acquire(struct wlr_drm_fb *fb, struct wlr_drm_backend *drm
 
 bool drm_plane_init_surface(struct wlr_drm_plane *plane,
 		struct wlr_drm_backend *drm, int32_t width, uint32_t height,
-		uint32_t format, uint32_t flags, bool with_modifiers);
+		uint32_t format, bool force_linear, bool with_modifiers);
 void drm_plane_finish_surface(struct wlr_drm_plane *plane);
 
 #endif


### PR DESCRIPTION
gbm_bo_create_with_modifiers doesn't take GBM flags, so our
wlr_gbm_allocator interface doesn't either. We were still internally
using GBM flags in the DRM backend, leading to awkward back-and-forth
conversions.

The only flag passed to drm_plane_init_surface was GBM_BO_USE_LINEAR, so
turn that into a bool to make sure other flags can't be passed in.

Move the "force linear" logic out of init_drm_surface, because the
supplied wlr_drm_format should already contain that information.