### PR TITLE
backend/drm: refactor wlr_output destruction

### DIFF
--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -33,7 +33,7 @@ static bool atomic_commit(struct atomic *atom,
 	int ret = drmModeAtomicCommit(drm->fd, atom->req, flags, drm);
 	if (ret) {
 		wlr_log_errno(WLR_ERROR, "%s: Atomic %s failed (%s)",
-			conn->output.name,
+			conn->name,
 			(flags & DRM_MODE_ATOMIC_TEST_ONLY) ? "test" : "commit",
 			(flags & DRM_MODE_ATOMIC_ALLOW_MODESET) ? "modeset" : "pageflip");
 		return false;

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -38,7 +38,7 @@ static void backend_destroy(struct wlr_backend *backend) {
 
 	struct wlr_drm_connector *conn, *next;
 	wl_list_for_each_safe(conn, next, &drm->outputs, link) {
-		wlr_output_destroy(&conn->output);
+		destroy_drm_connector(conn);
 	}
 
 	wlr_signal_emit_safe(&backend->events.destroy, backend);

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1087,8 +1087,7 @@ static void realloc_crtcs(struct wlr_drm_backend *drm) {
 		connectors[i] = conn;
 
 		wlr_log(WLR_DEBUG, "  '%s' crtc=%d state=%d desired_enabled=%d",
-			conn->output.name,
-			conn->crtc ? (int)(conn->crtc - drm->crtcs) : -1,
+			conn->name, conn->crtc ? (int)(conn->crtc - drm->crtcs) : -1,
 			conn->state, conn->desired_enabled);
 
 		if (conn->crtc) {
@@ -1146,9 +1145,7 @@ static void realloc_crtcs(struct wlr_drm_backend *drm) {
 		bool prev_enabled = conn->crtc;
 
 		wlr_log(WLR_DEBUG, "  '%s' crtc=%zd state=%d desired_enabled=%d",
-			conn->output.name,
-			connector_match[i],
-			conn->state, conn->desired_enabled);
+			conn->name, connector_match[i], conn->state, conn->desired_enabled);
 
 		// We don't need to change anything.
 		if (prev_enabled && connector_match[i] == conn->crtc - drm->crtcs) {
@@ -1265,7 +1262,7 @@ void scan_drm_connectors(struct wlr_drm_backend *drm) {
 			wlr_conn->state = WLR_DRM_CONN_DISCONNECTED;
 			wlr_conn->id = drm_conn->connector_id;
 
-			snprintf(wlr_conn->output.name, sizeof(wlr_conn->output.name),
+			snprintf(wlr_conn->name, sizeof(wlr_conn->name),
 				"%s-%"PRIu32, conn_get_name(drm_conn->connector_type),
 				drm_conn->connector_type_id);
 
@@ -1274,7 +1271,7 @@ void scan_drm_connectors(struct wlr_drm_backend *drm) {
 			}
 
 			wl_list_insert(drm->outputs.prev, &wlr_conn->link);
-			wlr_log(WLR_INFO, "Found connector '%s'", wlr_conn->output.name);
+			wlr_log(WLR_INFO, "Found connector '%s'", wlr_conn->name);
 		} else {
 			seen[index] = true;
 		}
@@ -1310,9 +1307,12 @@ void scan_drm_connectors(struct wlr_drm_backend *drm) {
 
 		if (wlr_conn->state == WLR_DRM_CONN_DISCONNECTED &&
 				drm_conn->connection == DRM_MODE_CONNECTED) {
-			wlr_log(WLR_INFO, "'%s' connected", wlr_conn->output.name);
+			wlr_log(WLR_INFO, "'%s' connected", wlr_conn->name);
 			wlr_log(WLR_DEBUG, "Current CRTC: %d",
 				wlr_conn->crtc ? (int)wlr_conn->crtc->id : -1);
+
+			strncpy(wlr_conn->output.name, wlr_conn->name,
+				sizeof(wlr_conn->output.name) - 1);
 
 			wlr_conn->output.phys_width = drm_conn->mmWidth;
 			wlr_conn->output.phys_height = drm_conn->mmHeight;
@@ -1379,7 +1379,7 @@ void scan_drm_connectors(struct wlr_drm_backend *drm) {
 		} else if ((wlr_conn->state == WLR_DRM_CONN_CONNECTED ||
 				wlr_conn->state == WLR_DRM_CONN_NEEDS_MODESET) &&
 				drm_conn->connection != DRM_MODE_CONNECTED) {
-			wlr_log(WLR_INFO, "'%s' disconnected", wlr_conn->output.name);
+			wlr_log(WLR_INFO, "'%s' disconnected", wlr_conn->name);
 
 			drm_connector_cleanup(wlr_conn);
 		}
@@ -1400,7 +1400,7 @@ void scan_drm_connectors(struct wlr_drm_backend *drm) {
 			continue;
 		}
 
-		wlr_log(WLR_INFO, "'%s' disappeared", conn->output.name);
+		wlr_log(WLR_INFO, "'%s' disappeared", conn->name);
 		drm_connector_cleanup(conn);
 
 		wlr_output_destroy(&conn->output);

--- a/backend/drm/legacy.c
+++ b/backend/drm/legacy.c
@@ -42,15 +42,14 @@ static bool legacy_crtc_commit(struct wlr_drm_backend *drm,
 			DRM_MODE_DPMS_ON : DRM_MODE_DPMS_OFF;
 		if (drmModeConnectorSetProperty(drm->fd, conn->id, conn->props.dpms,
 				dpms) != 0) {
-			wlr_log_errno(WLR_ERROR, "%s: failed to set DPMS property",
-				conn->output.name);
+			wlr_drm_conn_log_errno(conn, WLR_ERROR,
+				"Failed to set DPMS property");
 			return false;
 		}
 
 		if (drmModeSetCrtc(drm->fd, crtc->id, fb_id, 0, 0,
 				conns, conns_len, mode)) {
-			wlr_log_errno(WLR_ERROR, "%s: failed to set CRTC",
-				conn->output.name);
+			wlr_drm_conn_log_errno(conn, WLR_ERROR, "Failed to set CRTC");
 			return false;
 		}
 	}
@@ -67,16 +66,15 @@ static bool legacy_crtc_commit(struct wlr_drm_backend *drm,
 		if (drmModeObjectSetProperty(drm->fd, crtc->id, DRM_MODE_OBJECT_CRTC,
 				crtc->props.vrr_enabled,
 				output->pending.adaptive_sync_enabled) != 0) {
-			wlr_log_errno(WLR_ERROR,
+			wlr_drm_conn_log_errno(conn, WLR_ERROR,
 				"drmModeObjectSetProperty(VRR_ENABLED) failed");
 			return false;
 		}
 		output->adaptive_sync_status = output->pending.adaptive_sync_enabled ?
 			WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED :
 			WLR_OUTPUT_ADAPTIVE_SYNC_DISABLED;
-		wlr_log(WLR_DEBUG, "VRR %s on connector '%s'",
-			output->pending.adaptive_sync_enabled ? "enabled" : "disabled",
-			output->name);
+		wlr_drm_conn_log(conn, WLR_DEBUG, "VRR %s",
+			output->pending.adaptive_sync_enabled ? "enabled" : "disabled");
 	}
 
 	if (cursor != NULL && drm_connector_is_cursor_visible(conn)) {
@@ -84,29 +82,26 @@ static bool legacy_crtc_commit(struct wlr_drm_backend *drm,
 		struct gbm_bo *cursor_bo =
 			drm_fb_acquire(cursor_fb, drm, &cursor->mgpu_surf);
 		if (!cursor_bo) {
-			wlr_log_errno(WLR_DEBUG, "%s: failed to acquire cursor FB",
-				conn->output.name);
+			wlr_drm_conn_log_errno(conn, WLR_DEBUG,
+				"Failed to acquire cursor FB");
 			return false;
 		}
 
 		if (drmModeSetCursor(drm->fd, crtc->id,
 				gbm_bo_get_handle(cursor_bo).u32,
 				cursor->surf.width, cursor->surf.height)) {
-			wlr_log_errno(WLR_DEBUG, "%s: failed to set hardware cursor",
-				conn->output.name);
+			wlr_drm_conn_log_errno(conn, WLR_DEBUG, "drmModeSetCursor failed");
 			return false;
 		}
 
 		if (drmModeMoveCursor(drm->fd,
 			crtc->id, conn->cursor_x, conn->cursor_y) != 0) {
-			wlr_log_errno(WLR_ERROR, "%s: failed to move cursor",
-				conn->output.name);
+			wlr_drm_conn_log_errno(conn, WLR_ERROR, "drmModeMoveCursor failed");
 			return false;
 		}
 	} else {
 		if (drmModeSetCursor(drm->fd, crtc->id, 0, 0, 0)) {
-			wlr_log_errno(WLR_DEBUG, "%s: failed to unset hardware cursor",
-				conn->output.name);
+			wlr_drm_conn_log_errno(conn, WLR_DEBUG, "drmModeSetCursor failed");
 			return false;
 		}
 	}
@@ -114,7 +109,7 @@ static bool legacy_crtc_commit(struct wlr_drm_backend *drm,
 	if (flags & DRM_MODE_PAGE_FLIP_EVENT) {
 		if (drmModePageFlip(drm->fd, crtc->id, fb_id,
 				DRM_MODE_PAGE_FLIP_EVENT, drm)) {
-			wlr_log_errno(WLR_ERROR, "%s: Failed to page flip", conn->output.name);
+			wlr_drm_conn_log_errno(conn, WLR_ERROR, "drmModePageFlip failed");
 			return false;
 		}
 	}

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -110,9 +110,10 @@ struct wlr_drm_mode {
 };
 
 struct wlr_drm_connector {
-	struct wlr_output output;
+	struct wlr_output output; // only valid if state != DISCONNECTED
 
 	struct wlr_drm_backend *backend;
+	char name[24];
 	enum wlr_drm_connector_state state;
 	struct wlr_output_mode *desired_mode;
 	bool desired_enabled;
@@ -154,5 +155,10 @@ size_t drm_crtc_get_gamma_lut_size(struct wlr_drm_backend *drm,
 	struct wlr_drm_crtc *crtc);
 
 struct wlr_drm_fb *plane_get_next_fb(struct wlr_drm_plane *plane);
+
+#define wlr_drm_conn_log(conn, verb, fmt, ...) \
+	wlr_log(verb, "connector %s: " fmt, conn->output.name, ##__VA_ARGS__)
+#define wlr_drm_conn_log_errno(conn, verb, fmt, ...) \
+	wlr_log_errno(verb, "connector %s: " fmt, conn->output.name, ##__VA_ARGS__)
 
 #endif

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -157,8 +157,8 @@ size_t drm_crtc_get_gamma_lut_size(struct wlr_drm_backend *drm,
 struct wlr_drm_fb *plane_get_next_fb(struct wlr_drm_plane *plane);
 
 #define wlr_drm_conn_log(conn, verb, fmt, ...) \
-	wlr_log(verb, "connector %s: " fmt, conn->output.name, ##__VA_ARGS__)
+	wlr_log(verb, "connector %s: " fmt, conn->name, ##__VA_ARGS__)
 #define wlr_drm_conn_log_errno(conn, verb, fmt, ...) \
-	wlr_log_errno(verb, "connector %s: " fmt, conn->output.name, ##__VA_ARGS__)
+	wlr_log_errno(verb, "connector %s: " fmt, conn->name, ##__VA_ARGS__)
 
 #endif

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -147,6 +147,7 @@ void finish_drm_resources(struct wlr_drm_backend *drm);
 void restore_drm_outputs(struct wlr_drm_backend *drm);
 void scan_drm_connectors(struct wlr_drm_backend *state);
 int handle_drm_event(int fd, uint32_t mask, void *data);
+void destroy_drm_connector(struct wlr_drm_connector *conn);
 bool drm_connector_set_mode(struct wlr_drm_connector *conn,
 	struct wlr_output_mode *mode);
 bool drm_connector_is_cursor_visible(struct wlr_drm_connector *conn);


### PR DESCRIPTION
## backend/drm: add wlr_drm_connector.backend

This allows the DRM code to have direct access to the wlr_drm_backend
without having to go through an upcast via get_drm_backend_from_backend.

## backend/drm: introduce wlr_drm_conn_log

Simplify and unify connector-specific logging with a new
wlr_drm_conn_log macro. This makes it easier to understand which
connector a failure is about, without having to explicitly integrate the
connector name in each log message.

## backend/drm: introduce wlr_drm_connector.name

The DRM backend is a little special when it comes to wlr_outputs: the
wlr_drm_connectors are long-lived and are created even when no screen is
connected.

A wlr_drm_connector only advertises a wlr_output to the compositor when
a screen is connected. As such, most of wlr_output's state is invalid
when the connector is disconnected.

We want to stop using wlr_output state on disconnected connectors.
Introduce wlr_drm_connector.name which is always valid regardless of the
connector status to avoid reading wlr_output.name when disconnected.

## backend/drm: refactor wlr_output destruction 

Instead of hand-rolling our own manual wlr_output cleanup function, rely
on wlr_output_destroy to remove an output from the compositor's state.

References: https://github.com/swaywm/wlroots/pull/2513#issuecomment-739021784