### PR TITLE
backend/wayland: re-use wl_buffers

### DIFF
--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -208,6 +208,11 @@ static void backend_destroy(struct wlr_backend *backend) {
 
 	wlr_drm_format_set_finish(&wl->linux_dmabuf_v1_formats);
 
+	struct wlr_wl_buffer *buffer, *tmp_buffer;
+	wl_list_for_each_safe(buffer, tmp_buffer, &wl->buffers, link) {
+		destroy_wl_buffer(buffer);
+	}
+
 	destroy_wl_seats(wl);
 	if (wl->zxdg_decoration_manager_v1) {
 		zxdg_decoration_manager_v1_destroy(wl->zxdg_decoration_manager_v1);
@@ -268,6 +273,7 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display,
 	wl_list_init(&wl->devices);
 	wl_list_init(&wl->outputs);
 	wl_list_init(&wl->seats);
+	wl_list_init(&wl->buffers);
 
 	wl->remote_display = wl_display_connect(remote);
 	if (!wl->remote_display) {

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -25,9 +25,11 @@ struct wlr_wl_backend {
 	struct wlr_renderer *renderer;
 	struct wlr_drm_format *format;
 	struct wlr_allocator *allocator;
+	struct wl_list buffers; // wlr_wl_buffer.link
 	size_t requested_outputs;
 	size_t last_output_num;
 	struct wl_listener local_display_destroy;
+
 	/* remote state */
 	struct wl_display *remote_display;
 	struct wl_event_source *remote_display_src;
@@ -47,6 +49,9 @@ struct wlr_wl_backend {
 struct wlr_wl_buffer {
 	struct wlr_buffer *buffer;
 	struct wl_buffer *wl_buffer;
+	bool released;
+	struct wl_list link; // wlr_wl_backend.buffers
+	struct wl_listener buffer_destroy;
 };
 
 struct wlr_wl_presentation_feedback {
@@ -130,6 +135,7 @@ struct wlr_wl_input_device *create_wl_input_device(
 	struct wlr_wl_seat *seat, enum wlr_input_device_type type);
 bool create_wl_seat(struct wl_seat *wl_seat, struct wlr_wl_backend *wl);
 void destroy_wl_seats(struct wlr_wl_backend *wl);
+void destroy_wl_buffer(struct wlr_wl_buffer *buffer);
 
 extern const struct wl_seat_listener seat_listener;
 


### PR DESCRIPTION
Instead of re-importing a buffer each time we submit a new frame, re-use
the wl_buffer objects if possible.

~~Depends on https://github.com/swaywm/wlroots/pull/2498~~