### PR TITLE
backend/x11: re-use pixmaps

### DIFF
--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -82,12 +82,19 @@ static bool output_set_custom_mode(struct wlr_output *wlr_output,
 	return true;
 }
 
+static void destroy_x11_buffer(struct wlr_x11_buffer *buffer);
+
 static void output_destroy(struct wlr_output *wlr_output) {
 	struct wlr_x11_output *output = get_x11_output_from_output(wlr_output);
 	struct wlr_x11_backend *x11 = output->x11;
 
 	wlr_input_device_destroy(&output->pointer_dev);
 	wlr_input_device_destroy(&output->touch_dev);
+
+	struct wlr_x11_buffer *buffer, *buffer_tmp;
+	wl_list_for_each_safe(buffer, buffer_tmp, &output->buffers, link) {
+		destroy_x11_buffer(buffer);
+	}
 
 	wl_list_remove(&output->link);
 	wl_event_source_remove(output->frame_timer);

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -115,6 +115,7 @@ struct wlr_x11_buffer {
 	struct wlr_buffer *buffer;
 	xcb_pixmap_t pixmap;
 	struct wl_list link; // wlr_x11_output::buffers
+	struct wl_listener buffer_destroy;
 };
 
 struct wlr_x11_format {


### PR DESCRIPTION
Instead of re-importing a buffer each time we submit a frame, re-use the
pixmaps if possible.

~~Depends on https://github.com/swaywm/wlroots/pull/2495~~