### PR TITLE
backend/x11: send more precise output present events

### DIFF
--- a/include/util/time.h
+++ b/include/util/time.h
@@ -14,6 +14,11 @@ uint32_t get_current_time_msec(void);
 int64_t timespec_to_msec(const struct timespec *a);
 
 /**
+ * Convert nanoseconds to a timespec.
+ */
+void timespec_from_nsec(struct timespec *r, int64_t nsec);
+
+/**
  * Subtracts timespec `b` from timespec `a`, and stores the difference in `r`.
  */
 void timespec_sub(struct timespec *r, const struct timespec *a,

--- a/util/time.c
+++ b/util/time.c
@@ -10,6 +10,11 @@ int64_t timespec_to_msec(const struct timespec *a) {
 	return (int64_t)a->tv_sec * 1000 + a->tv_nsec / 1000000;
 }
 
+void timespec_from_nsec(struct timespec *r, int64_t nsec) {
+	r->tv_sec = nsec / NSEC_PER_SEC;
+	r->tv_nsec = nsec % NSEC_PER_SEC;
+}
+
 uint32_t get_current_time_msec(void) {
 	struct timespec now;
 	clock_gettime(CLOCK_MONOTONIC, &now);


### PR DESCRIPTION
Instead of sending dummy output present events, use the X11 Present
extension to send more precise events.