### PR TITLE
backend/drm: simplify wlr_drm_fb handling

### DIFF
--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -135,12 +135,7 @@ static void set_plane_props(struct atomic *atom, struct wlr_drm_backend *drm,
 	uint32_t id = plane->id;
 	const union wlr_drm_plane_props *props = &plane->props;
 	struct wlr_drm_fb *fb = plane_get_next_fb(plane);
-	struct gbm_bo *bo = drm_fb_acquire(fb, drm, &plane->mgpu_surf);
-	if (!bo) {
-		goto error;
-	}
-
-	uint32_t fb_id = get_fb_for_bo(bo, drm->addfb2_modifiers);
+	uint32_t fb_id = drm_fb_acquire(fb, drm, &plane->mgpu_surf);
 	if (!fb_id) {
 		goto error;
 	}

--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -135,8 +135,8 @@ static void set_plane_props(struct atomic *atom, struct wlr_drm_backend *drm,
 	uint32_t id = plane->id;
 	const union wlr_drm_plane_props *props = &plane->props;
 	struct wlr_drm_fb *fb = plane_get_next_fb(plane);
-	uint32_t fb_id = drm_fb_acquire(fb, drm, &plane->mgpu_surf);
-	if (!fb_id) {
+	if (!fb->id) {
+		wlr_log(WLR_ERROR, "Failed to acquire FB");
 		goto error;
 	}
 
@@ -147,7 +147,7 @@ static void set_plane_props(struct atomic *atom, struct wlr_drm_backend *drm,
 	atomic_add(atom, id, props->src_h, (uint64_t)plane->surf.height << 16);
 	atomic_add(atom, id, props->crtc_w, plane->surf.width);
 	atomic_add(atom, id, props->crtc_h, plane->surf.height);
-	atomic_add(atom, id, props->fb_id, fb_id);
+	atomic_add(atom, id, props->fb_id, fb->id);
 	atomic_add(atom, id, props->crtc_id, crtc_id);
 	atomic_add(atom, id, props->crtc_x, (uint64_t)x);
 	atomic_add(atom, id, props->crtc_y, (uint64_t)y);

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -641,14 +641,21 @@ static bool drm_connector_export_dmabuf(struct wlr_output *output,
 	}
 
 	struct wlr_drm_fb *fb = &crtc->primary->queued_fb;
-	if (fb->bo == NULL) {
+	if (fb->wlr_buf == NULL) {
 		fb = &crtc->primary->current_fb;
 	}
-	if (fb->bo == NULL) {
+	if (fb->wlr_buf == NULL) {
 		return false;
 	}
 
-	return export_drm_bo(fb->bo, attribs);
+	// export_dmabuf gives ownership of the DMA-BUF to the caller, so we need
+	// to dup it
+	struct wlr_dmabuf_attributes buf_attribs = {0};
+	if (!wlr_buffer_get_dmabuf(fb->wlr_buf, &buf_attribs)) {
+		return false;
+	}
+
+	return wlr_dmabuf_attributes_copy(attribs, &buf_attribs);
 }
 
 struct wlr_drm_fb *plane_get_next_fb(struct wlr_drm_plane *plane) {

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -492,7 +492,8 @@ static bool drm_connector_commit_buffer(struct wlr_output *output) {
 	assert(output->pending.committed & WLR_OUTPUT_STATE_BUFFER);
 	switch (output->pending.buffer_type) {
 	case WLR_OUTPUT_STATE_BUFFER_RENDER:
-		if (!drm_fb_lock_surface(&plane->pending_fb, &plane->surf)) {
+		if (!drm_fb_lock_surface(&plane->pending_fb, drm, &plane->surf,
+				&plane->mgpu_surf)) {
 			wlr_drm_conn_log(conn, WLR_ERROR, "drm_fb_lock_surface failed");
 			return false;
 		}
@@ -502,7 +503,7 @@ static bool drm_connector_commit_buffer(struct wlr_output *output) {
 		if (!test_buffer(conn, output->pending.buffer)) {
 			return false;
 		}
-		if (!drm_fb_import_wlr(&plane->pending_fb, &drm->renderer, buffer,
+		if (!drm_fb_import(&plane->pending_fb, drm, buffer, NULL,
 				&crtc->primary->formats)) {
 			return false;
 		}
@@ -669,6 +670,7 @@ struct wlr_drm_fb *plane_get_next_fb(struct wlr_drm_plane *plane) {
 }
 
 static bool drm_connector_pageflip_renderer(struct wlr_drm_connector *conn) {
+	struct wlr_drm_backend *drm = conn->backend;
 	struct wlr_drm_crtc *crtc = conn->crtc;
 	if (!crtc) {
 		wlr_drm_conn_log(conn, WLR_ERROR, "Page-flip failed: no CRTC");
@@ -681,7 +683,8 @@ static bool drm_connector_pageflip_renderer(struct wlr_drm_connector *conn) {
 		if (!drm_surface_render_black_frame(&plane->surf)) {
 			return false;
 		}
-		if (!drm_fb_lock_surface(&plane->pending_fb, &plane->surf)) {
+		if (!drm_fb_lock_surface(&plane->pending_fb, drm, &plane->surf,
+				&plane->mgpu_surf)) {
 			return false;
 		}
 	}
@@ -957,7 +960,8 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 		wlr_render_texture_with_matrix(rend, texture, matrix, 1.0);
 		wlr_renderer_end(rend);
 
-		if (!drm_fb_lock_surface(&plane->pending_fb, &plane->surf)) {
+		if (!drm_fb_lock_surface(&plane->pending_fb, drm, &plane->surf,
+				&plane->mgpu_surf)) {
 			return false;
 		}
 

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -146,6 +146,12 @@ static struct wlr_buffer *drm_surface_blit(struct wlr_drm_surface *surf,
 		struct wlr_buffer *buffer) {
 	struct wlr_renderer *renderer = surf->renderer->wlr_rend;
 
+	if (surf->width != (uint32_t)buffer->width ||
+			surf->height != (uint32_t)buffer->height) {
+		wlr_log(WLR_ERROR, "Surface size doesn't match buffer size");
+		return NULL;
+	}
+
 	struct wlr_dmabuf_attributes attribs = {0};
 	if (!wlr_buffer_get_dmabuf(buffer, &attribs)) {
 		return NULL;

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -141,34 +141,6 @@ void drm_surface_unset_current(struct wlr_drm_surface *surf) {
 	surf->back_buffer = NULL;
 }
 
-bool export_drm_bo(struct gbm_bo *bo, struct wlr_dmabuf_attributes *attribs) {
-	memset(attribs, 0, sizeof(struct wlr_dmabuf_attributes));
-
-	attribs->n_planes = gbm_bo_get_plane_count(bo);
-	if (attribs->n_planes > WLR_DMABUF_MAX_PLANES) {
-		return false;
-	}
-
-	attribs->width = gbm_bo_get_width(bo);
-	attribs->height = gbm_bo_get_height(bo);
-	attribs->format = gbm_bo_get_format(bo);
-	attribs->modifier = gbm_bo_get_modifier(bo);
-
-	for (int i = 0; i < attribs->n_planes; ++i) {
-		attribs->offset[i] = gbm_bo_get_offset(bo, i);
-		attribs->stride[i] = gbm_bo_get_stride_for_plane(bo, i);
-		attribs->fd[i] = gbm_bo_get_fd(bo);
-		if (attribs->fd[i] < 0) {
-			for (int j = 0; j < i; ++j) {
-				close(attribs->fd[j]);
-			}
-			return false;
-		}
-	}
-
-	return true;
-}
-
 void drm_plane_finish_surface(struct wlr_drm_plane *plane) {
 	if (!plane) {
 		return;

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -38,6 +38,8 @@ struct wlr_drm_fb {
 	struct wlr_drm_surface *mgpu_surf;
 	struct gbm_bo *mgpu_bo;
 	struct wlr_buffer *mgpu_wlr_buf;
+
+	uint32_t id;
 };
 
 bool init_drm_renderer(struct wlr_drm_backend *drm,
@@ -55,7 +57,7 @@ bool drm_fb_import_wlr(struct wlr_drm_fb *fb, struct wlr_drm_renderer *renderer,
 void drm_fb_move(struct wlr_drm_fb *new, struct wlr_drm_fb *old);
 
 bool drm_surface_render_black_frame(struct wlr_drm_surface *surf);
-struct gbm_bo *drm_fb_acquire(struct wlr_drm_fb *fb, struct wlr_drm_backend *drm,
+uint32_t drm_fb_acquire(struct wlr_drm_fb *fb, struct wlr_drm_backend *drm,
 		struct wlr_drm_surface *mgpu);
 
 bool drm_plane_init_surface(struct wlr_drm_plane *plane,

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -13,7 +13,7 @@ struct wlr_drm_plane;
 struct wlr_buffer;
 
 struct wlr_drm_renderer {
-	int fd;
+	struct wlr_drm_backend *backend;
 	struct gbm_device *gbm;
 	struct wlr_egl egl;
 
@@ -32,13 +32,11 @@ struct wlr_drm_surface {
 };
 
 struct wlr_drm_fb {
-	struct gbm_bo *bo;
 	struct wlr_buffer *wlr_buf;
 
-	struct wlr_drm_surface *mgpu_surf;
-	struct gbm_bo *mgpu_bo;
 	struct wlr_buffer *mgpu_wlr_buf;
 
+	struct gbm_bo *bo;
 	uint32_t id;
 };
 
@@ -50,15 +48,15 @@ bool drm_surface_make_current(struct wlr_drm_surface *surf, int *buffer_age);
 void drm_surface_unset_current(struct wlr_drm_surface *surf);
 
 void drm_fb_clear(struct wlr_drm_fb *fb);
-bool drm_fb_lock_surface(struct wlr_drm_fb *fb, struct wlr_drm_surface *surf);
-bool drm_fb_import_wlr(struct wlr_drm_fb *fb, struct wlr_drm_renderer *renderer,
-		struct wlr_buffer *buf, struct wlr_drm_format_set *set);
+bool drm_fb_lock_surface(struct wlr_drm_fb *fb, struct wlr_drm_backend *drm,
+		struct wlr_drm_surface *surf, struct wlr_drm_surface *mgpu);
+bool drm_fb_import(struct wlr_drm_fb *fb, struct wlr_drm_backend *drm,
+		struct wlr_buffer *buf, struct wlr_drm_surface *mgpu,
+		struct wlr_drm_format_set *set);
 
 void drm_fb_move(struct wlr_drm_fb *new, struct wlr_drm_fb *old);
 
 bool drm_surface_render_black_frame(struct wlr_drm_surface *surf);
-uint32_t drm_fb_acquire(struct wlr_drm_fb *fb, struct wlr_drm_backend *drm,
-		struct wlr_drm_surface *mgpu);
 
 bool drm_plane_init_surface(struct wlr_drm_plane *plane,
 		struct wlr_drm_backend *drm, int32_t width, uint32_t height,

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -46,7 +46,6 @@ void finish_drm_renderer(struct wlr_drm_renderer *renderer);
 
 bool drm_surface_make_current(struct wlr_drm_surface *surf, int *buffer_age);
 void drm_surface_unset_current(struct wlr_drm_surface *surf);
-bool export_drm_bo(struct gbm_bo *bo, struct wlr_dmabuf_attributes *attribs);
 
 void drm_fb_clear(struct wlr_drm_fb *fb);
 bool drm_fb_lock_surface(struct wlr_drm_fb *fb, struct wlr_drm_surface *surf);


### PR DESCRIPTION
Try to remove as much of the `wlr_drm_fb` complexity as possible:

- Import to GBM and to KMS at the same time. Stop doing any kind of import in the legacy/atomic commit hooks.
- Only import to GBM on the scanout device. Stop needlessly importing to GBM on the render device.
- Remove unused mgpu renderer field.
- Stop stuffing things in `gbm_bo` user data field.
- Avoid using GBM for `export_dmabuf`. Instead, directly use `wlr_buffer_get_dmabuf` and drop `export_drm_bo`.

_See individual commits._

* * *

Tested:

- [x] Basic startup, multi-screen
- [x] DPMS, modesetting
- [x] Multi-GPU