### PR TITLE
backend/x11: fix DRI3 formats not used

### DIFF
--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -523,7 +523,7 @@ struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
 	}
 
 	const struct wlr_drm_format *dri3_format =
-		wlr_drm_format_set_get(render_formats, x11->x11_format->drm);
+		wlr_drm_format_set_get(&x11->dri3_formats, x11->x11_format->drm);
 	if (dri3_format == NULL) {
 		wlr_log(WLR_ERROR, "X11 server doesn't support DRM format 0x%"PRIX32,
 			x11->x11_format->drm);


### PR DESCRIPTION
We queried DRI3 formats, but we weren't using them. Because of a typo,
only render formats were used.

Fixes: c59aacf94465 ("backend/x11: query modifiers supported by X11 server")
Closes: https://github.com/swaywm/wlroots/issues/2552