### PR TITLE
xwayland: avoid crash on repeated server_finish_display() call

### DIFF
--- a/xwayland/server.c
+++ b/xwayland/server.c
@@ -164,6 +164,7 @@ static void server_finish_display(struct wlr_xwayland_server *server) {
 	}
 
 	wl_list_remove(&server->display_destroy.link);
+	wl_list_init(&server->display_destroy.link);
 
 	if (server->display == -1) {
 		return;


### PR DESCRIPTION
This function may end up being called more than once if the Xwayland
binary does not exist on the system.

Fixes https://github.com/ifreund/river/issues/167