### PR TITLE
backend/drm: avoid gcc stringop-truncation warning

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1317,8 +1317,8 @@ void scan_drm_connectors(struct wlr_drm_backend *drm) {
 			wlr_output_init(&wlr_conn->output, &drm->backend, &output_impl,
 				drm->display);
 
-			strncpy(wlr_conn->output.name, wlr_conn->name,
-				sizeof(wlr_conn->output.name) - 1);
+			memcpy(wlr_conn->output.name, wlr_conn->name,
+				sizeof(wlr_conn->output.name));
 
 			wlr_conn->output.phys_width = drm_conn->mmWidth;
 			wlr_conn->output.phys_height = drm_conn->mmHeight;


### PR DESCRIPTION
fixes #2559 

Maybe worth noting that the -1 might not be necessary in the first place – since wlr_conn->name field is filled by snprintf I believe it is guaranteed to be null-terminated.

EDIT: dropped the -1