### PR TITLE
Remove wlr_create_renderer_func_t

### DIFF
--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -128,8 +128,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 
 struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
 		struct wlr_session *session, struct wlr_device *dev,
-		struct wlr_backend *parent,
-		wlr_renderer_create_func_t create_renderer_func) {
+		struct wlr_backend *parent) {
 	assert(display && session && dev);
 	assert(!parent || wlr_backend_is_drm(parent));
 
@@ -179,7 +178,7 @@ struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
 		goto error_event;
 	}
 
-	if (!init_drm_renderer(drm, &drm->renderer, create_renderer_func)) {
+	if (!init_drm_renderer(drm, &drm->renderer)) {
 		wlr_log(WLR_ERROR, "Failed to initialize renderer");
 		goto error_event;
 	}

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -21,7 +21,7 @@
 #include "render/wlr_renderer.h"
 
 bool init_drm_renderer(struct wlr_drm_backend *drm,
-		struct wlr_drm_renderer *renderer, wlr_renderer_create_func_t create_renderer_func) {
+		struct wlr_drm_renderer *renderer) {
 	renderer->backend = drm;
 
 	renderer->gbm = gbm_create_device(drm->fd);
@@ -30,11 +30,7 @@ bool init_drm_renderer(struct wlr_drm_backend *drm,
 		return false;
 	}
 
-	if (!create_renderer_func) {
-		create_renderer_func = wlr_renderer_autocreate;
-	}
-
-	renderer->wlr_rend = create_renderer_func(&renderer->egl,
+	renderer->wlr_rend = wlr_renderer_autocreate(&renderer->egl,
 		EGL_PLATFORM_GBM_KHR, renderer->gbm, NULL, 0);
 	if (!renderer->wlr_rend) {
 		wlr_log(WLR_ERROR, "Failed to create EGL/WLR renderer");

--- a/backend/headless/backend.c
+++ b/backend/headless/backend.c
@@ -184,8 +184,7 @@ out:
 	return fd;
 }
 
-struct wlr_backend *wlr_headless_backend_create(struct wl_display *display,
-		wlr_renderer_create_func_t create_renderer_func) {
+struct wlr_backend *wlr_headless_backend_create(struct wl_display *display) {
 	wlr_log(WLR_INFO, "Creating headless backend");
 
 	int drm_fd = open_drm_render_node();
@@ -207,11 +206,7 @@ struct wlr_backend *wlr_headless_backend_create(struct wl_display *display,
 		goto error_backend;
 	}
 
-	if (!create_renderer_func) {
-		create_renderer_func = wlr_renderer_autocreate;
-	}
-
-	struct wlr_renderer *renderer = create_renderer_func(&backend->priv_egl,
+	struct wlr_renderer *renderer = wlr_renderer_autocreate(&backend->priv_egl,
 		EGL_PLATFORM_GBM_KHR, gbm_alloc->gbm_device, NULL, 0);
 	if (!renderer) {
 		wlr_log(WLR_ERROR, "Failed to create renderer");

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -260,7 +260,7 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 }
 
 struct wlr_backend *wlr_wl_backend_create(struct wl_display *display,
-		const char *remote, wlr_renderer_create_func_t create_renderer_func) {
+		const char *remote) {
 	wlr_log(WLR_INFO, "Creating wayland backend");
 
 	struct wlr_wl_backend *wl = calloc(1, sizeof(*wl));
@@ -315,11 +315,7 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display,
 	}
 	wl_event_source_check(wl->remote_display_src);
 
-	if (!create_renderer_func) {
-		create_renderer_func = wlr_renderer_autocreate;
-	}
-
-	wl->renderer = create_renderer_func(&wl->egl, EGL_PLATFORM_WAYLAND_EXT,
+	wl->renderer = wlr_renderer_autocreate(&wl->egl, EGL_PLATFORM_WAYLAND_EXT,
 		wl->remote_display, NULL, 0);
 	if (!wl->renderer) {
 		wlr_log(WLR_ERROR, "Could not create renderer");

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -322,8 +322,7 @@ static bool query_dri3_formats(struct wlr_x11_backend *x11) {
 }
 
 struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
-		const char *x11_display,
-		wlr_renderer_create_func_t create_renderer_func) {
+		const char *x11_display) {
 	struct wlr_x11_backend *x11 = calloc(1, sizeof(*x11));
 	if (!x11) {
 		return NULL;
@@ -512,11 +511,7 @@ struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
 	}
 	x11->allocator = &gbm_alloc->base;
 
-	if (!create_renderer_func) {
-		create_renderer_func = wlr_renderer_autocreate;
-	}
-
-	x11->renderer = create_renderer_func(&x11->egl, EGL_PLATFORM_GBM_KHR,
+	x11->renderer = wlr_renderer_autocreate(&x11->egl, EGL_PLATFORM_GBM_KHR,
 		gbm_alloc->gbm_device, NULL, 0);
 	if (x11->renderer == NULL) {
 		wlr_log(WLR_ERROR, "Failed to create renderer");

--- a/examples/fullscreen-shell.c
+++ b/examples/fullscreen-shell.c
@@ -203,7 +203,7 @@ int main(int argc, char *argv[]) {
 
 	struct fullscreen_server server = {0};
 	server.wl_display = wl_display_create();
-	server.backend = wlr_backend_autocreate(server.wl_display, NULL);
+	server.backend = wlr_backend_autocreate(server.wl_display);
 	server.renderer = wlr_backend_get_renderer(server.backend);
 	wlr_renderer_init_wl_display(server.renderer, server.wl_display);
 

--- a/examples/multi-pointer.c
+++ b/examples/multi-pointer.c
@@ -271,7 +271,7 @@ int main(int argc, char *argv[]) {
 		.clear_color = { 0.25f, 0.25f, 0.25f, 1 },
 		.display = display,
 	};
-	struct wlr_backend *wlr = wlr_backend_autocreate(display, NULL);
+	struct wlr_backend *wlr = wlr_backend_autocreate(display);
 	if (!wlr) {
 		exit(1);
 	}

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -267,7 +267,7 @@ int main(int argc, char *argv[]) {
 	state.layout = wlr_output_layout_create();
 	clock_gettime(CLOCK_MONOTONIC, &state.ts_last);
 
-	struct wlr_backend *wlr = wlr_backend_autocreate(display, NULL);
+	struct wlr_backend *wlr = wlr_backend_autocreate(display);
 	if (!wlr) {
 		exit(1);
 	}

--- a/examples/pointer.c
+++ b/examples/pointer.c
@@ -333,7 +333,7 @@ int main(int argc, char *argv[]) {
 		.display = display
 	};
 
-	struct wlr_backend *wlr = wlr_backend_autocreate(display, NULL);
+	struct wlr_backend *wlr = wlr_backend_autocreate(display);
 	if (!wlr) {
 		exit(1);
 	}

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -241,7 +241,7 @@ int main(int argc, char *argv[]) {
 	};
 	wl_list_init(&state.outputs);
 
-	struct wlr_backend *wlr = wlr_backend_autocreate(display, NULL);
+	struct wlr_backend *wlr = wlr_backend_autocreate(display);
 	if (!wlr) {
 		exit(1);
 	}

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -173,7 +173,7 @@ int main(void) {
 		.last_frame = { 0 },
 		.display = display
 	};
-	struct wlr_backend *backend = wlr_backend_autocreate(display, NULL);
+	struct wlr_backend *backend = wlr_backend_autocreate(display);
 	if (!backend) {
 		exit(1);
 	}

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -356,7 +356,7 @@ int main(int argc, char *argv[]) {
 	};
 	wl_list_init(&state.tablet_pads);
 	wl_list_init(&state.tablet_tools);
-	struct wlr_backend *wlr = wlr_backend_autocreate(display, NULL);
+	struct wlr_backend *wlr = wlr_backend_autocreate(display);
 	if (!wlr) {
 		exit(1);
 	}

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -249,7 +249,7 @@ int main(int argc, char *argv[]) {
 	wl_list_init(&state.touch_points);
 	wl_list_init(&state.touch);
 
-	struct wlr_backend *wlr = wlr_backend_autocreate(display, NULL);
+	struct wlr_backend *wlr = wlr_backend_autocreate(display);
 	if (!wlr) {
 		exit(1);
 	}

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -41,7 +41,7 @@ struct wlr_drm_fb {
 };
 
 bool init_drm_renderer(struct wlr_drm_backend *drm,
-	struct wlr_drm_renderer *renderer, wlr_renderer_create_func_t create_render);
+	struct wlr_drm_renderer *renderer);
 void finish_drm_renderer(struct wlr_drm_renderer *renderer);
 
 bool drm_surface_make_current(struct wlr_drm_surface *surf, int *buffer_age);

--- a/include/wlr/backend.h
+++ b/include/wlr/backend.h
@@ -28,20 +28,12 @@ struct wlr_backend {
 	} events;
 };
 
-typedef struct wlr_renderer *(*wlr_renderer_create_func_t)(struct wlr_egl *egl, EGLenum platform,
-	void *remote_display, EGLint *config_attribs, EGLint visual_id);
 /**
  * Automatically initializes the most suitable backend given the environment.
  * Will always return a multibackend. The backend is created but not started.
  * Returns NULL on failure.
- *
- * The compositor can request to initialize the backend's renderer by setting
- * the create_render_func. The callback must initialize the given wlr_egl and
- * return a valid wlr_renderer, or NULL if it has failed to initiaze it.
- * Pass NULL as create_renderer_func to use the backend's default renderer.
  */
-struct wlr_backend *wlr_backend_autocreate(struct wl_display *display,
-	wlr_renderer_create_func_t create_renderer_func);
+struct wlr_backend *wlr_backend_autocreate(struct wl_display *display);
 /**
  * Start the backend. This may signal new_input or new_output immediately, but
  * may also wait until the display's event loop begins. Returns false on

--- a/include/wlr/backend/drm.h
+++ b/include/wlr/backend/drm.h
@@ -23,8 +23,7 @@
  */
 struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
 	struct wlr_session *session, struct wlr_device *dev,
-	struct wlr_backend *parent,
-	wlr_renderer_create_func_t create_renderer_func);
+	struct wlr_backend *parent);
 
 bool wlr_backend_is_drm(struct wlr_backend *backend);
 bool wlr_output_is_drm(struct wlr_output *output);

--- a/include/wlr/backend/headless.h
+++ b/include/wlr/backend/headless.h
@@ -17,8 +17,7 @@
  * Creates a headless backend. A headless backend has no outputs or inputs by
  * default.
  */
-struct wlr_backend *wlr_headless_backend_create(struct wl_display *display,
-	wlr_renderer_create_func_t create_renderer_func);
+struct wlr_backend *wlr_headless_backend_create(struct wl_display *display);
 /**
  * Creates a headless backend with an existing renderer.
  */

--- a/include/wlr/backend/wayland.h
+++ b/include/wlr/backend/wayland.h
@@ -16,7 +16,7 @@
  * default)
  */
 struct wlr_backend *wlr_wl_backend_create(struct wl_display *display,
-		const char *remote, wlr_renderer_create_func_t create_renderer_func);
+		const char *remote);
 
 /**
  * Returns the remote wl_display used by the Wayland backend.

--- a/include/wlr/backend/x11.h
+++ b/include/wlr/backend/x11.h
@@ -17,7 +17,7 @@
  * to NULL for the default behaviour of XOpenDisplay.
  */
 struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
-	const char *x11_display, wlr_renderer_create_func_t create_renderer_func);
+	const char *x11_display);
 
 /**
  * Adds a new output to this backend. You may remove outputs by destroying them.


### PR DESCRIPTION
This callback allowed compositors to customize the EGL config used by
the renderer. However with renderer v6 EGL configs aren't used anymore.
Instead, buffers are allocated via GBM and GL FBOs are rendered to. So
customizing the EGL config is a no-op.

cc @ammen99 

* * *

Breaking changes:

* `wlr_backend_autocreate`, `wlr_drm_backend_create`, `wlr_headless_backend_create`, `wlr_wl_backend_create`, `wlr_x11_backend_create` no longer take a `wlr_renderer_create_func_t` parameter.
* The `wlr_renderer_create_func_t` type has been removed.