### PR TITLE
backend/drm: re-use FBs

### DIFF
--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -134,7 +134,7 @@ static void set_plane_props(struct atomic *atom, struct wlr_drm_backend *drm,
 	uint32_t id = plane->id;
 	const union wlr_drm_plane_props *props = &plane->props;
 	struct wlr_drm_fb *fb = plane_get_next_fb(plane);
-	if (!fb->id) {
+	if (fb == NULL) {
 		wlr_log(WLR_ERROR, "Failed to acquire FB");
 		goto error;
 	}

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -42,6 +42,11 @@ static void backend_destroy(struct wlr_backend *backend) {
 
 	wlr_signal_emit_safe(&backend->events.destroy, backend);
 
+	struct wlr_drm_fb *fb, *fb_tmp;
+	wl_list_for_each_safe(fb, fb_tmp, &drm->fbs, link) {
+		drm_fb_destroy(fb);
+	}
+
 	wl_list_remove(&drm->display_destroy.link);
 	wl_list_remove(&drm->session_destroy.link);
 	wl_list_remove(&drm->session_active.link);
@@ -147,6 +152,7 @@ struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
 	wlr_backend_init(&drm->backend, &backend_impl);
 
 	drm->session = session;
+	wl_list_init(&drm->fbs);
 	wl_list_init(&drm->outputs);
 
 	drm->dev = dev;

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -630,10 +630,14 @@ static bool drm_connector_export_dmabuf(struct wlr_output *output,
 	struct wlr_drm_backend *drm = conn->backend;
 	struct wlr_drm_crtc *crtc = conn->crtc;
 
+	if (drm->parent) {
+		// We don't keep track of the original buffer on the parent GPU when
+		// using multi-GPU.
+		return false;
+	}
 	if (!drm->session->active) {
 		return false;
 	}
-
 	if (!crtc) {
 		return false;
 	}

--- a/backend/drm/legacy.c
+++ b/backend/drm/legacy.c
@@ -17,7 +17,7 @@ static bool legacy_crtc_commit(struct wlr_drm_backend *drm,
 	uint32_t fb_id = 0;
 	if (crtc->pending.active) {
 		struct wlr_drm_fb *fb = plane_get_next_fb(crtc->primary);
-		if (!fb->id) {
+		if (fb == NULL) {
 			wlr_log(WLR_ERROR, "%s: failed to acquire primary FB",
 				conn->output.name);
 			return false;
@@ -76,7 +76,7 @@ static bool legacy_crtc_commit(struct wlr_drm_backend *drm,
 
 	if (cursor != NULL && drm_connector_is_cursor_visible(conn)) {
 		struct wlr_drm_fb *cursor_fb = plane_get_next_fb(cursor);
-		if (!cursor_fb->bo) {
+		if (cursor_fb == NULL) {
 			wlr_drm_conn_log(conn, WLR_DEBUG, "Failed to acquire cursor FB");
 			return false;
 		}

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -304,7 +304,6 @@ void drm_fb_clear(struct wlr_drm_fb **fb_ptr) {
 	}
 
 	gbm_bo_destroy(fb->bo);
-	wlr_buffer_unlock(fb->local_wlr_buf);
 	wlr_buffer_unlock(fb->wlr_buf);
 	free(fb);
 
@@ -364,18 +363,16 @@ static struct gbm_bo *get_bo_for_dmabuf(struct gbm_device *gbm,
 }
 
 static struct wlr_drm_fb *drm_fb_create(struct wlr_drm_backend *drm,
-		struct wlr_buffer *buf, struct wlr_buffer *local_buf,
-		const struct wlr_drm_format_set *formats) {
+		struct wlr_buffer *buf, const struct wlr_drm_format_set *formats) {
 	struct wlr_drm_fb *fb = calloc(1, sizeof(*fb));
 	if (!fb) {
 		return NULL;
 	}
 
 	fb->wlr_buf = wlr_buffer_lock(buf);
-	fb->local_wlr_buf = wlr_buffer_lock(local_buf);
 
 	struct wlr_dmabuf_attributes attribs;
-	if (!wlr_buffer_get_dmabuf(local_buf, &attribs)) {
+	if (!wlr_buffer_get_dmabuf(buf, &attribs)) {
 		wlr_log(WLR_ERROR, "Failed to get DMA-BUF from buffer");
 		goto error_get_dmabuf;
 	}
@@ -411,7 +408,6 @@ static struct wlr_drm_fb *drm_fb_create(struct wlr_drm_backend *drm,
 error_get_fb_for_bo:
 	gbm_bo_destroy(fb->bo);
 error_get_dmabuf:
-	wlr_buffer_unlock(fb->local_wlr_buf);
 	wlr_buffer_unlock(fb->wlr_buf);
 	free(fb);
 	return NULL;
@@ -432,7 +428,7 @@ bool drm_fb_import(struct wlr_drm_fb **fb_ptr, struct wlr_drm_backend *drm,
 		local_buf = wlr_buffer_lock(buf);
 	}
 
-	struct wlr_drm_fb *fb = drm_fb_create(drm, buf, local_buf, formats);
+	struct wlr_drm_fb *fb = drm_fb_create(drm, local_buf, formats);
 	wlr_buffer_unlock(local_buf);
 	if (!fb) {
 		return false;

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -86,6 +86,7 @@ struct wlr_drm_backend {
 	struct wl_listener session_active;
 	struct wl_listener dev_change;
 
+	struct wl_list fbs; // wlr_drm_fb.link
 	struct wl_list outputs;
 
 	struct wlr_drm_renderer renderer;

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -24,11 +24,11 @@ struct wlr_drm_plane {
 	struct wlr_drm_surface mgpu_surf;
 
 	/* Buffer to be submitted to the kernel on the next page-flip */
-	struct wlr_drm_fb pending_fb;
+	struct wlr_drm_fb *pending_fb;
 	/* Buffer submitted to the kernel, will be presented on next vblank */
-	struct wlr_drm_fb queued_fb;
+	struct wlr_drm_fb *queued_fb;
 	/* Buffer currently displayed on screen */
-	struct wlr_drm_fb current_fb;
+	struct wlr_drm_fb *current_fb;
 
 	struct wlr_drm_format_set formats;
 

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -30,10 +30,9 @@ struct wlr_drm_surface {
 };
 
 struct wlr_drm_fb {
-	struct wlr_buffer *wlr_buf;
+	struct wlr_buffer *wlr_buf; // original buffer
 
-	struct wlr_buffer *mgpu_wlr_buf;
-
+	struct wlr_buffer *local_wlr_buf; // GPU-local buffer
 	struct gbm_bo *bo;
 	uint32_t id;
 };

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -49,7 +49,7 @@ bool drm_fb_lock_surface(struct wlr_drm_fb **fb, struct wlr_drm_backend *drm,
 		struct wlr_drm_surface *surf, struct wlr_drm_surface *mgpu);
 bool drm_fb_import(struct wlr_drm_fb **fb, struct wlr_drm_backend *drm,
 		struct wlr_buffer *buf, struct wlr_drm_surface *mgpu,
-		struct wlr_drm_format_set *set);
+		const struct wlr_drm_format_set *formats);
 
 void drm_fb_clear(struct wlr_drm_fb **fb);
 void drm_fb_move(struct wlr_drm_fb **new, struct wlr_drm_fb **old);

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -31,8 +31,12 @@ struct wlr_drm_surface {
 
 struct wlr_drm_fb {
 	struct wlr_buffer *wlr_buf;
+	struct wl_list link; // wlr_drm_backend.fbs
+
 	struct gbm_bo *bo;
 	uint32_t id;
+
+	struct wl_listener wlr_buf_destroy;
 };
 
 bool init_drm_renderer(struct wlr_drm_backend *drm,
@@ -47,6 +51,7 @@ bool drm_fb_lock_surface(struct wlr_drm_fb **fb, struct wlr_drm_backend *drm,
 bool drm_fb_import(struct wlr_drm_fb **fb, struct wlr_drm_backend *drm,
 		struct wlr_buffer *buf, struct wlr_drm_surface *mgpu,
 		const struct wlr_drm_format_set *formats);
+void drm_fb_destroy(struct wlr_drm_fb *fb);
 
 void drm_fb_clear(struct wlr_drm_fb **fb);
 void drm_fb_move(struct wlr_drm_fb **new, struct wlr_drm_fb **old);

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -45,14 +45,14 @@ void finish_drm_renderer(struct wlr_drm_renderer *renderer);
 bool drm_surface_make_current(struct wlr_drm_surface *surf, int *buffer_age);
 void drm_surface_unset_current(struct wlr_drm_surface *surf);
 
-void drm_fb_clear(struct wlr_drm_fb *fb);
-bool drm_fb_lock_surface(struct wlr_drm_fb *fb, struct wlr_drm_backend *drm,
+bool drm_fb_lock_surface(struct wlr_drm_fb **fb, struct wlr_drm_backend *drm,
 		struct wlr_drm_surface *surf, struct wlr_drm_surface *mgpu);
-bool drm_fb_import(struct wlr_drm_fb *fb, struct wlr_drm_backend *drm,
+bool drm_fb_import(struct wlr_drm_fb **fb, struct wlr_drm_backend *drm,
 		struct wlr_buffer *buf, struct wlr_drm_surface *mgpu,
 		struct wlr_drm_format_set *set);
 
-void drm_fb_move(struct wlr_drm_fb *new, struct wlr_drm_fb *old);
+void drm_fb_clear(struct wlr_drm_fb **fb);
+void drm_fb_move(struct wlr_drm_fb **new, struct wlr_drm_fb **old);
 
 bool drm_surface_render_black_frame(struct wlr_drm_surface *surf);
 

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -30,9 +30,7 @@ struct wlr_drm_surface {
 };
 
 struct wlr_drm_fb {
-	struct wlr_buffer *wlr_buf; // original buffer
-
-	struct wlr_buffer *local_wlr_buf; // GPU-local buffer
+	struct wlr_buffer *wlr_buf;
 	struct gbm_bo *bo;
 	uint32_t id;
 };


### PR DESCRIPTION
Instead of importing buffers to GBM and KMS at each frame, cache them and re-use them while the wlr_buffer is alive.

This is the same as #2538 and #2539 but for the DRM backend.

Closes: https://github.com/swaywm/wlroots/issues/2276