### PR TITLE
backend/drm: ignore hotplug events while inactive

### DIFF
--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -109,8 +109,11 @@ static void handle_session_active(struct wl_listener *listener, void *data) {
 static void handle_dev_change(struct wl_listener *listener, void *data) {
 	struct wlr_drm_backend *drm = wl_container_of(listener, drm, dev_change);
 
-	wlr_log(WLR_DEBUG, "%s invalidated", drm->name);
+	if (!drm->session->active) {
+		return;
+	}
 
+	wlr_log(WLR_DEBUG, "%s invalidated", drm->name);
 	scan_drm_connectors(drm);
 }
 


### PR DESCRIPTION
When the session is inactive, we can't change the KMS state. Ignore
hotplug events so that compositors don't try to perform a modeset when
a connector is plugged in. We already re-scan connectors when the
session becomes active.

To test, run a wlroots compositor on VT 1, switch to VT 2, unplug a
connector, re-plug it, switch back to VT 1. Without this patch the
screen is black on VT 1.

References: https://github.com/swaywm/wlroots/issues/2370