### PR TITLE
backend/drm: handle unplug event

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1053,7 +1053,9 @@ static void dealloc_crtc(struct wlr_drm_connector *conn) {
 	conn->crtc->pending_modeset = true;
 	conn->crtc->pending.active = false;
 	if (!drm_crtc_commit(conn, 0)) {
-		return;
+		// On GPU unplug, disabling the CRTC can fail with EPERM
+		wlr_drm_conn_log(conn, WLR_ERROR, "Failed to disable CRTC %"PRIu32,
+			conn->crtc->id);
 	}
 
 	drm_plane_finish_surface(conn->crtc->primary);

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -86,6 +86,7 @@ struct wlr_drm_backend {
 	struct wl_listener display_destroy;
 	struct wl_listener session_destroy;
 	struct wl_listener session_active;
+	struct wl_listener parent_destroy;
 	struct wl_listener dev_change;
 
 	struct wl_list fbs; // wlr_drm_fb.link

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -88,6 +88,7 @@ struct wlr_drm_backend {
 	struct wl_listener session_active;
 	struct wl_listener parent_destroy;
 	struct wl_listener dev_change;
+	struct wl_listener dev_remove;
 
 	struct wl_list fbs; // wlr_drm_fb.link
 	struct wl_list outputs;

--- a/include/wlr/backend/session.h
+++ b/include/wlr/backend/session.h
@@ -16,6 +16,7 @@ struct wlr_device {
 
 	struct {
 		struct wl_signal change;
+		struct wl_signal remove;
 	} events;
 };
 


### PR DESCRIPTION
This is half of the GPU hotplug work, see https://github.com/swaywm/wlroots/pull/2423.

To test:

```
# MINOR=1 triggers removal for card1
udevadm trigger --verbose --type=devices --action=remove --subsystem-match=drm --property-match="MINOR=1"
```