### PR TITLE
backend/session: allow wlr_session_find_gpus to return an error

### DIFF
--- a/backend/backend.c
+++ b/backend/backend.c
@@ -152,11 +152,16 @@ static struct wlr_backend *attempt_drm_backend(struct wl_display *display,
 		struct wlr_backend *backend, struct wlr_session *session,
 		wlr_renderer_create_func_t create_renderer_func) {
 	struct wlr_device *gpus[8];
-	size_t num_gpus = wlr_session_find_gpus(session, 8, gpus);
-	struct wlr_backend *primary_drm = NULL;
+	ssize_t num_gpus = wlr_session_find_gpus(session, 8, gpus);
+	if (num_gpus < 0) {
+		wlr_log(WLR_ERROR, "Failed to find GPUs");
+		return NULL;
+	}
+
 	wlr_log(WLR_INFO, "Found %zu GPUs", num_gpus);
 
-	for (size_t i = 0; i < num_gpus; ++i) {
+	struct wlr_backend *primary_drm = NULL;
+	for (size_t i = 0; i < (size_t)num_gpus; ++i) {
 		struct wlr_backend *drm = wlr_drm_backend_create(display, session,
 			gpus[i], primary_drm, create_renderer_func);
 		if (!drm) {

--- a/backend/session/session.c
+++ b/backend/session/session.c
@@ -278,12 +278,12 @@ out_dev:
 	return NULL;
 }
 
-static size_t explicit_find_gpus(struct wlr_session *session,
+static ssize_t explicit_find_gpus(struct wlr_session *session,
 		size_t ret_len, struct wlr_device *ret[static ret_len], const char *str) {
 	char *gpus = strdup(str);
 	if (!gpus) {
 		wlr_log_errno(WLR_ERROR, "Allocation failed");
-		return 0;
+		return -1;
 	}
 
 	size_t i = 0;
@@ -345,7 +345,7 @@ static void find_gpus_handle_add(struct wl_listener *listener, void *data) {
 /* Tries to find the primary GPU by checking for the "boot_vga" attribute.
  * If it's not found, it returns the first valid GPU it finds.
  */
-size_t wlr_session_find_gpus(struct wlr_session *session,
+ssize_t wlr_session_find_gpus(struct wlr_session *session,
 		size_t ret_len, struct wlr_device **ret) {
 	const char *explicit = getenv("WLR_DRM_DEVICES");
 	if (explicit) {

--- a/include/wlr/backend/session.h
+++ b/include/wlr/backend/session.h
@@ -96,7 +96,7 @@ void wlr_session_close_file(struct wlr_session *session,
  */
 bool wlr_session_change_vt(struct wlr_session *session, unsigned vt);
 
-size_t wlr_session_find_gpus(struct wlr_session *session,
+ssize_t wlr_session_find_gpus(struct wlr_session *session,
 	size_t ret_len, struct wlr_device **ret);
 
 #endif


### PR DESCRIPTION
Sometimes wlr_session_find_gpus will encounter an error. This is
different from finding zero GPUs.

On error, wlr_session_find_gpus already returns -1. However, this is
casted to size_t, so callers uncorrectly assume this is a success.

Instead, make wlr_session_find_gpus return a ssize_t and allow callers
to handle the error accordingly.

* * *

Breaking change: `wlr_session_find_gpus` now returns a `ssize_t` instead of a `size_t`.