### PR TITLE
backend/x11: create per-window present event contexts

### DIFF
--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -564,8 +564,6 @@ struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
 	}
 #endif
 
-	x11->present_event_id = xcb_generate_id(x11->xcb);
-
 	wlr_input_device_init(&x11->keyboard_dev, WLR_INPUT_DEVICE_KEYBOARD,
 		&input_device_impl, "X11 keyboard", 0, 0);
 	wlr_keyboard_init(&x11->keyboard, &keyboard_impl);

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -86,6 +86,8 @@ static void output_destroy(struct wlr_output *wlr_output) {
 	wl_list_remove(&output->link);
 	wlr_buffer_unlock(output->back_buffer);
 	wlr_swapchain_destroy(output->swapchain);
+	// A zero event mask deletes the event context
+	xcb_present_select_input(x11->xcb, output->present_event_id, output->win, 0);
 	xcb_destroy_window(x11->xcb, output->win);
 	xcb_flush(x11->xcb);
 	free(output);
@@ -398,7 +400,8 @@ struct wlr_output *wlr_x11_output_create(struct wlr_backend *backend) {
 
 	uint32_t present_mask = XCB_PRESENT_EVENT_MASK_IDLE_NOTIFY |
 		XCB_PRESENT_EVENT_MASK_COMPLETE_NOTIFY;
-	xcb_present_select_input(x11->xcb, x11->present_event_id, output->win,
+	output->present_event_id = xcb_generate_id(x11->xcb);
+	xcb_present_select_input(x11->xcb, output->present_event_id, output->win,
 		present_mask);
 
 	xcb_change_property(x11->xcb, XCB_PROP_MODE_REPLACE, output->win,

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -34,6 +34,7 @@ struct wlr_x11_output {
 	struct wl_list link; // wlr_x11_backend::outputs
 
 	xcb_window_t win;
+	xcb_present_event_t present_event_id;
 
 	struct wlr_swapchain *swapchain;
 	struct wlr_buffer *back_buffer;
@@ -68,7 +69,6 @@ struct wlr_x11_backend {
 	xcb_depth_t *depth;
 	xcb_visualid_t visualid;
 	xcb_colormap_t colormap;
-	xcb_present_event_t present_event_id;
 
 	size_t requested_outputs;
 	size_t last_output_num;


### PR DESCRIPTION
The Present protocol states:

> An event context is associated with a specific window; using an existing
> event context with a different window generates a Match error.

Instead of a global event context, use a per-window event context to fix
this error:

    [backend/x11/backend.c:608] X11 error: op Present (SelectInput), code Match (no extension), sequence 63, value 4194307

Closes: https://github.com/swaywm/wlroots/issues/2577