### PR TITLE
types/seat: Clear focus in wlr_seat_destroy()

### DIFF
--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -318,7 +318,8 @@ struct wlr_seat_keyboard_focus_change_event {
  */
 struct wlr_seat *wlr_seat_create(struct wl_display *display, const char *name);
 /**
- * Destroys a wlr_seat and removes its wl_seat global.
+ * Destroys a wlr_seat, removes its wl_seat global and clears focus for all
+ * devices belonging to the seat.
  */
 void wlr_seat_destroy(struct wlr_seat *wlr_seat);
 /**

--- a/types/seat/wlr_seat.c
+++ b/types/seat/wlr_seat.c
@@ -159,6 +159,14 @@ void wlr_seat_destroy(struct wlr_seat *seat) {
 		return;
 	}
 
+	wlr_seat_pointer_clear_focus(seat);
+	wlr_seat_keyboard_clear_focus(seat);
+
+	struct wlr_touch_point *point;
+	wl_list_for_each(point, &seat->touch_state.touch_points, link) {
+		wlr_seat_touch_point_clear_focus(seat, 0, point->touch_id);
+	}
+
 	wlr_signal_emit_safe(&seat->events.destroy, seat);
 
 	wl_list_remove(&seat->display_destroy.link);


### PR DESCRIPTION
This fixes use-after-free in surface destroy signal listeners.