### PR TITLE
noop: listen to display destroy and destroy the backend

### DIFF
--- a/include/backend/noop.h
+++ b/include/backend/noop.h
@@ -10,6 +10,8 @@ struct wlr_noop_backend {
 	struct wl_list outputs;
 	size_t last_output_num;
 	bool started;
+
+	struct wl_listener display_destroy;
 };
 
 struct wlr_noop_output {


### PR DESCRIPTION
Not sure if this is needed, but I guess it is a good idea, since most objects which are related to the display are destroyed when it is destroyed?
