### PR TITLE
xwm: don't iterate output parent in has_parent

### DIFF
--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -470,12 +470,15 @@ static void read_surface_title(struct wlr_xwm *xwm,
 
 static bool has_parent(struct wlr_xwayland_surface *parent,
 		struct wlr_xwayland_surface *child) {
-	while (parent) {
-		if (child == parent) {
+
+	struct wlr_xwayland_surface *search = parent;
+
+	while (search) {
+		if (child == search) {
 			return true;
 		}
 
-		parent = parent->parent;
+		search = search->parent;
 	}
 
 	return false;


### PR DESCRIPTION
Commit 5012121d331c ("xwm: add loop detection for read_surface_parent")
introduced a beviour change, previsously we would correctly setup the
child parent relationship:
```
surface -> surface -> surface -> NULL
   |          ^
   +- parent -+
```
but now, since has_parent iterates on the pointer passe by reference,
our setup looks like this:
```
surface -> surface -> surface -> NULL
   |                     ^
   +------- parent ------+
```
Introduce a local pointer variable in has_parent to fix this issue.