### PR TITLE
Export wlr buffer from output backends

### DIFF
--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -148,6 +148,13 @@ static bool output_export_dmabuf(struct wlr_output *wlr_output,
 	return wlr_dmabuf_attributes_copy(attribs, &tmp);
 }
 
+static struct wlr_buffer *output_get_front_buffer(
+		struct wlr_output *wlr_output) {
+	struct wlr_headless_output *output =
+		headless_output_from_output(wlr_output);
+	return output->front_buffer;
+}
+
 static void output_destroy(struct wlr_output *wlr_output) {
 	struct wlr_headless_output *output =
 		headless_output_from_output(wlr_output);
@@ -165,6 +172,7 @@ static const struct wlr_output_impl output_impl = {
 	.commit = output_commit,
 	.rollback_render = output_rollback_render,
 	.export_dmabuf = output_export_dmabuf,
+	.get_front_buffer = output_get_front_buffer,
 };
 
 bool wlr_output_is_headless(struct wlr_output *wlr_output) {

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -341,6 +341,7 @@ static bool output_commit(struct wlr_output *wlr_output) {
 		wl_surface_commit(output->surface);
 
 		wlr_buffer_unlock(output->back_buffer);
+		output->front_buffer = output->back_buffer;
 		output->back_buffer = NULL;
 
 		wlr_swapchain_set_buffer_submitted(output->swapchain, wlr_buffer);
@@ -522,6 +523,14 @@ static bool output_move_cursor(struct wlr_output *_output, int x, int y) {
 	return true;
 }
 
+static struct wlr_buffer *output_get_front_buffer(
+		struct wlr_output *wlr_output) {
+	// TODO: buffer_handle_release might free the front buffer. How do we
+	// fix that?
+	struct wlr_wl_output *output = get_wl_output_from_output(wlr_output);
+	return output->front_buffer;
+}
+
 static const struct wlr_output_impl output_impl = {
 	.destroy = output_destroy,
 	.attach_render = output_attach_render,
@@ -530,6 +539,7 @@ static const struct wlr_output_impl output_impl = {
 	.rollback_render = output_rollback_render,
 	.set_cursor = output_set_cursor,
 	.move_cursor = output_move_cursor,
+	.get_front_buffer = output_get_front_buffer,
 };
 
 bool wlr_output_is_wl(struct wlr_output *wlr_output) {

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -256,6 +256,7 @@ static bool output_commit_buffer(struct wlr_x11_output *output) {
 	}
 
 	wlr_buffer_unlock(output->back_buffer);
+	output->front_buffer = output->back_buffer;
 	output->back_buffer = NULL;
 
 	wlr_swapchain_set_buffer_submitted(output->swapchain, x11_buffer->buffer);
@@ -319,12 +320,21 @@ static void output_rollback_render(struct wlr_output *wlr_output) {
 	wlr_egl_unset_current(&x11->egl);
 }
 
+static struct wlr_buffer *output_get_front_buffer(
+		struct wlr_output *wlr_output) {
+	// TODO: handle_x11_present_event might destroy the front buffer. How
+	// do we deal with that?
+	struct wlr_x11_output *output = get_x11_output_from_output(wlr_output);
+	return output->front_buffer;
+}
+
 static const struct wlr_output_impl output_impl = {
 	.destroy = output_destroy,
 	.attach_render = output_attach_render,
 	.test = output_test,
 	.commit = output_commit,
 	.rollback_render = output_rollback_render,
+	.get_front_buffer = output_get_front_buffer,
 };
 
 struct wlr_output *wlr_x11_output_create(struct wlr_backend *backend) {

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -75,6 +75,7 @@ struct wlr_wl_output {
 	struct wl_list presentation_feedbacks;
 
 	struct wlr_swapchain *swapchain;
+	struct wlr_buffer *front_buffer;
 	struct wlr_buffer *back_buffer;
 
 	uint32_t enter_serial;

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -37,6 +37,7 @@ struct wlr_x11_output {
 	xcb_present_event_t present_event_id;
 
 	struct wlr_swapchain *swapchain;
+	struct wlr_buffer *front_buffer;
 	struct wlr_buffer *back_buffer;
 
 	struct wlr_pointer pointer;

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -14,6 +14,8 @@
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_output.h>
 
+struct wlr_buffer;
+
 /**
  * A backend implementation of wlr_output.
  *
@@ -86,6 +88,10 @@ struct wlr_output_impl {
 	 */
 	bool (*export_dmabuf)(struct wlr_output *output,
 		struct wlr_dmabuf_attributes *attribs);
+        /**
+         * Get the output's current front-buffer as a wlr_buffer.
+         */
+        struct wlr_buffer *(*get_front_buffer)(struct wlr_output *output);
 };
 
 /**

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -405,6 +405,10 @@ void wlr_output_set_gamma(struct wlr_output *output, size_t size,
 bool wlr_output_export_dmabuf(struct wlr_output *output,
 	struct wlr_dmabuf_attributes *attribs);
 /**
+ * Get the output's current front buffer as a wlr_buffer.
+ */
+struct wlr_buffer *wlr_output_get_front_buffer(struct wlr_output *output);
+/**
  * Returns the wlr_output matching the provided wl_output resource. If the
  * resource isn't a wl_output, it aborts. If the resource is inert (because the
  * wlr_output has been destroyed), NULL is returned.

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -762,6 +762,13 @@ bool wlr_output_export_dmabuf(struct wlr_output *output,
 	return output->impl->export_dmabuf(output, attribs);
 }
 
+struct wlr_buffer *wlr_output_get_front_buffer(struct wlr_output *output) {
+	if (!output->impl->get_front_buffer) {
+		return false;
+	}
+	return output->impl->get_front_buffer(output);
+}
+
 void wlr_output_update_needs_frame(struct wlr_output *output) {
 	if (output->needs_frame) {
 		return;

--- a/types/wlr_screencopy_v1.c
+++ b/types/wlr_screencopy_v1.c
@@ -297,12 +297,12 @@ static void frame_handle_output_commit(struct wl_listener *listener,
 	}
 
 	struct wlr_dmabuf_attributes attr = { 0 };
-	bool ok = wlr_output_export_dmabuf(output, &attr);
+	struct wlr_buffer *buffer = wlr_output_get_front_buffer(output);
+	bool ok = buffer && wlr_buffer_get_dmabuf(buffer, &attr);
 	ok = ok && wlr_renderer_blit_dmabuf(renderer,
 		&dma_buffer->attributes, &attr);
 	uint32_t flags = dma_buffer->attributes.flags & WLR_DMABUF_ATTRIBUTES_FLAGS_Y_INVERT ?
 		ZWLR_SCREENCOPY_FRAME_V1_FLAGS_Y_INVERT : 0;
-	wlr_dmabuf_attributes_finish(&attr);
 
 	if (!ok) {
 		zwlr_screencopy_frame_v1_send_failed(frame->resource);
@@ -495,11 +495,11 @@ static struct wlr_screencopy_v1_client *client_from_resource(
 
 static uint32_t get_output_fourcc(struct wlr_output *output) {
 	struct wlr_dmabuf_attributes attr = { 0 };
-	if (!wlr_output_export_dmabuf(output, &attr)) {
+	struct wlr_buffer *buffer = wlr_output_get_front_buffer(output);
+	if (!buffer || !wlr_buffer_get_dmabuf(buffer, &attr)) {
 		return DRM_FORMAT_INVALID;
 	}
 	uint32_t format = attr.format;
-	wlr_dmabuf_attributes_finish(&attr);
 	return format;
 }
 


### PR DESCRIPTION
This implements export-dmabuf and screencopy-dmabuf for all remaining output backends.

It seems that the wayland and x11 backends might delete the front buffer while its in use and I'm not sure what's the best way to fix that. Suggestions are welcome. The simplest solution would be to hold on to it until a new one is committed, but a fancier solution would be a reader reference count on the `wlr_buffer` object, which is probably overkill.