### PR TITLE
render: remove EGL config and visual from wlr_renderer_autocreate

### DIFF
--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -31,7 +31,7 @@ bool init_drm_renderer(struct wlr_drm_backend *drm,
 	}
 
 	renderer->wlr_rend = wlr_renderer_autocreate(&renderer->egl,
-		EGL_PLATFORM_GBM_KHR, renderer->gbm, NULL, 0);
+		EGL_PLATFORM_GBM_KHR, renderer->gbm);
 	if (!renderer->wlr_rend) {
 		wlr_log(WLR_ERROR, "Failed to create EGL/WLR renderer");
 		goto error_gbm;

--- a/backend/headless/backend.c
+++ b/backend/headless/backend.c
@@ -207,7 +207,7 @@ struct wlr_backend *wlr_headless_backend_create(struct wl_display *display) {
 	}
 
 	struct wlr_renderer *renderer = wlr_renderer_autocreate(&backend->priv_egl,
-		EGL_PLATFORM_GBM_KHR, gbm_alloc->gbm_device, NULL, 0);
+		EGL_PLATFORM_GBM_KHR, gbm_alloc->gbm_device);
 	if (!renderer) {
 		wlr_log(WLR_ERROR, "Failed to create renderer");
 		goto error_renderer;

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -316,7 +316,7 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display,
 	wl_event_source_check(wl->remote_display_src);
 
 	wl->renderer = wlr_renderer_autocreate(&wl->egl, EGL_PLATFORM_WAYLAND_EXT,
-		wl->remote_display, NULL, 0);
+		wl->remote_display);
 	if (!wl->renderer) {
 		wlr_log(WLR_ERROR, "Could not create renderer");
 		goto error_event;

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -536,7 +536,7 @@ struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
 	x11->allocator = &gbm_alloc->base;
 
 	x11->renderer = wlr_renderer_autocreate(&x11->egl, EGL_PLATFORM_GBM_KHR,
-		gbm_alloc->gbm_device, NULL, 0);
+		gbm_alloc->gbm_device);
 	if (x11->renderer == NULL) {
 		wlr_log(WLR_ERROR, "Failed to create renderer");
 		goto error_event;

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -34,7 +34,7 @@ struct wlr_renderer {
 };
 
 struct wlr_renderer *wlr_renderer_autocreate(struct wlr_egl *egl, EGLenum platform,
-	void *remote_display, EGLint *config_attribs, EGLint visual_id);
+	void *remote_display);
 
 void wlr_renderer_begin(struct wlr_renderer *r, uint32_t width, uint32_t height);
 void wlr_renderer_end(struct wlr_renderer *r);

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -248,36 +248,8 @@ bool wlr_renderer_init_wl_display(struct wlr_renderer *r,
 }
 
 struct wlr_renderer *wlr_renderer_autocreate(struct wlr_egl *egl,
-		EGLenum platform, void *remote_display, EGLint *config_attribs,
-		EGLint visual_id) {
-	// Append GLES2-specific bits to the provided EGL config attributes
-	EGLint gles2_config_attribs[] = {
-		EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
-		EGL_NONE,
-	};
-
-	size_t config_attribs_len = 0; // not including terminating EGL_NONE
-	while (config_attribs != NULL &&
-			config_attribs[config_attribs_len] != EGL_NONE) {
-		++config_attribs_len;
-	}
-
-	size_t all_config_attribs_len = config_attribs_len +
-		sizeof(gles2_config_attribs) / sizeof(gles2_config_attribs[0]);
-	EGLint all_config_attribs[all_config_attribs_len];
-	if (config_attribs_len > 0) {
-		memcpy(all_config_attribs, config_attribs,
-			config_attribs_len * sizeof(EGLint));
-	}
-	memcpy(&all_config_attribs[config_attribs_len], gles2_config_attribs,
-		sizeof(gles2_config_attribs));
-
-	if (config_attribs != NULL) {
-		config_attribs = all_config_attribs;
-	}
-
-	if (!wlr_egl_init(egl, platform, remote_display, config_attribs,
-			visual_id)) {
+		EGLenum platform, void *remote_display) {
+	if (!wlr_egl_init(egl, platform, remote_display, NULL, 0)) {
 		wlr_log(WLR_ERROR, "Could not initialize EGL");
 		return NULL;
 	}


### PR DESCRIPTION
This isn't used anymore by any backend.

Some examples still provide an EGL config to wlr_egl_init, so we can't
drop it yet there.

References: https://github.com/swaywm/wlroots/issues/2563

* * *

Breaking change: `wlr_renderer_autocreate` no longer takes the parameters `EGLint *config_attribs` and `EGLint visual_id`.