### PR TITLE
backend/wayland: Avoid uninitialized read

### DIFF
--- a/backend/wayland/seat.c
+++ b/backend/wayland/seat.c
@@ -235,11 +235,12 @@ static void keyboard_handle_leave(void *data, struct wl_keyboard *wl_keyboard,
 
 	uint32_t time = get_current_time_msec();
 
-	uint32_t pressed[dev->keyboard->num_keycodes + 1];
+	size_t num_keycodes = dev->keyboard->num_keycodes;
+	uint32_t pressed[num_keycodes + 1];
 	memcpy(pressed, dev->keyboard->keycodes,
-		dev->keyboard->num_keycodes * sizeof(uint32_t));
+		num_keycodes * sizeof(uint32_t));
 
-	for (size_t i = 0; i < sizeof(pressed)/sizeof(pressed[0]); ++i) {
+	for (size_t i = 0; i < num_keycodes; ++i) {
 		uint32_t keycode = pressed[i];
 
 		struct wlr_event_keyboard_key event = {


### PR DESCRIPTION
keyboard_handle_leave would always process 1 keycode more than was
pending, which meant reading uninitialized memory from the "pressed"
array.

Found by valgrind.