### PR TITLE
primary selection: destroy devices before manager 

### DIFF
--- a/types/wlr_gtk_primary_selection.c
+++ b/types/wlr_gtk_primary_selection.c
@@ -452,6 +452,12 @@ static void primary_selection_device_manager_bind(struct wl_client *client,
 static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	struct wlr_gtk_primary_selection_device_manager *manager =
 		wl_container_of(listener, manager, display_destroy);
+
+	struct wlr_gtk_primary_selection_device *device, *tmp;
+	wl_list_for_each_safe(device, tmp, &manager->devices, link) {
+		device_destroy(device);
+	}
+
 	wlr_signal_emit_safe(&manager->events.destroy, manager);
 	wl_list_remove(&manager->display_destroy.link);
 	wl_global_destroy(manager->global);

--- a/types/wlr_primary_selection_v1.c
+++ b/types/wlr_primary_selection_v1.c
@@ -452,6 +452,12 @@ static void primary_selection_device_manager_bind(struct wl_client *client,
 static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	struct wlr_primary_selection_v1_device_manager *manager =
 		wl_container_of(listener, manager, display_destroy);
+
+	struct wlr_primary_selection_v1_device *device, *tmp;
+	wl_list_for_each_safe(device, tmp, &manager->devices, link) {
+		device_destroy(device);
+	}
+
 	wlr_signal_emit_safe(&manager->events.destroy, manager);
 	wl_list_remove(&manager->display_destroy.link);
 	wl_global_destroy(manager->global);


### PR DESCRIPTION
Found thanks to @kennylevinsen's valgrind log:
```
==11666== Invalid write of size 8
==11666==    at 0x4F3173B: wl_list_remove (in /usr/lib64/libwayland-server.so.0.1.0)
==11666==    by 0x48AE988: device_destroy (wlr_primary_selection_v1.c:341)
==11666==    by 0x48AE988: device_handle_seat_destroy (wlr_primary_selection_v1.c:275)
==11666==    by 0x48B84CB: wlr_signal_emit_safe (signal.c:29)
==11666==    by 0x4892E82: wlr_seat_destroy (wlr_seat.c:162)
==11666==    by 0x4892E82: wlr_seat_destroy (wlr_seat.c:157)
==11666==    by 0x4F2C3E4: wl_display_destroy (in /usr/lib64/libwayland-server.so.0.1.0)
==11666==    by 0x41924F: server_fini (server.c:203)
==11666==    by 0x40E9DD: main (main.c:436)
==11666==  Address 0xf436ac0 is 16 bytes inside a block of size 72 free'd
==11666==    at 0x483B9F5: free (vg_replace_malloc.c:538)
==11666==    by 0x4F2C3E4: wl_display_destroy (in /usr/lib64/libwayland-server.so.0.1.0)
==11666==    by 0x41924F: server_fini (server.c:203)
==11666==    by 0x40E9DD: main (main.c:436)
==11666==  Block was alloc'd at
==11666==    at 0x483CAE9: calloc (vg_replace_malloc.c:760)
==11666==    by 0x48AEAF8: wlr_primary_selection_v1_device_manager_create (wlr_primary_selection_v1.c:465)
==11666==    by 0x4190C4: server_init (server.c:150)
==11666==    by 0x40E91A: main (main.c:398)
==11666== 
==11666== Invalid write of size 8
==11666==    at 0x4F3173F: wl_list_remove (in /usr/lib64/libwayland-server.so.0.1.0)
==11666==    by 0x48AE988: device_destroy (wlr_primary_selection_v1.c:341)
==11666==    by 0x48AE988: device_handle_seat_destroy (wlr_primary_selection_v1.c:275)
==11666==    by 0x48B84CB: wlr_signal_emit_safe (signal.c:29)
==11666==    by 0x4892E82: wlr_seat_destroy (wlr_seat.c:162)
==11666==    by 0x4892E82: wlr_seat_destroy (wlr_seat.c:157)
==11666==    by 0x4F2C3E4: wl_display_destroy (in /usr/lib64/libwayland-server.so.0.1.0)
==11666==    by 0x41924F: server_fini (server.c:203)
==11666==    by 0x40E9DD: main (main.c:436)
==11666==  Address 0xf436ab8 is 8 bytes inside a block of size 72 free'd
==11666==    at 0x483B9F5: free (vg_replace_malloc.c:538)
==11666==    by 0x4F2C3E4: wl_display_destroy (in /usr/lib64/libwayland-server.so.0.1.0)
==11666==    by 0x41924F: server_fini (server.c:203)
==11666==    by 0x40E9DD: main (main.c:436)
==11666==  Block was alloc'd at
==11666==    at 0x483CAE9: calloc (vg_replace_malloc.c:760)
==11666==    by 0x48AEAF8: wlr_primary_selection_v1_device_manager_create (wlr_primary_selection_v1.c:465)
==11666==    by 0x4190C4: server_init (server.c:150)
==11666==    by 0x40E91A: main (main.c:398)
==11666== 
```