### PR TITLE
Remove wlr_egl from backends

### DIFF
--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -8,7 +8,6 @@
 #include <wlr/backend/interface.h>
 #include <wlr/backend/session.h>
 #include <wlr/interfaces/wlr_output.h>
-#include <wlr/render/egl.h>
 #include <wlr/types/wlr_list.h>
 #include <wlr/util/log.h>
 #include <xf86drm.h>

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -8,7 +8,6 @@
 #include <string.h>
 #include <unistd.h>
 #include <wayland-util.h>
-#include <wlr/render/egl.h>
 #include <wlr/render/gles2.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_matrix.h>

--- a/backend/headless/backend.c
+++ b/backend/headless/backend.c
@@ -6,7 +6,6 @@
 #include <unistd.h>
 #include <wlr/interfaces/wlr_input_device.h>
 #include <wlr/interfaces/wlr_output.h>
-#include <wlr/render/egl.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/render/gles2.h>
 #include <wlr/util/log.h>

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -206,7 +206,6 @@ static void backend_destroy(struct wlr_backend *backend) {
 	wl_event_source_remove(wl->remote_display_src);
 
 	wlr_renderer_destroy(wl->renderer);
-	wlr_egl_finish(&wl->egl);
 
 	wlr_drm_format_set_finish(&wl->linux_dmabuf_v1_formats);
 
@@ -314,7 +313,7 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display,
 	}
 	wl_event_source_check(wl->remote_display_src);
 
-	wl->renderer = wlr_renderer_autocreate(&wl->egl, EGL_PLATFORM_WAYLAND_EXT,
+	wl->renderer = wlr_renderer_autocreate(EGL_PLATFORM_WAYLAND_EXT,
 		wl->remote_display);
 	if (!wl->renderer) {
 		wlr_log(WLR_ERROR, "Could not create renderer");

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -14,7 +14,6 @@
 #include <wlr/backend/interface.h>
 #include <wlr/interfaces/wlr_input_device.h>
 #include <wlr/interfaces/wlr_output.h>
-#include <wlr/render/egl.h>
 #include <wlr/render/gles2.h>
 #include <wlr/util/log.h>
 

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -181,7 +181,6 @@ static void backend_destroy(struct wlr_backend *backend) {
 	wl_list_remove(&x11->display_destroy.link);
 
 	wlr_renderer_destroy(x11->renderer);
-	wlr_egl_finish(&x11->egl);
 	wlr_allocator_destroy(x11->allocator);
 	wlr_drm_format_set_finish(&x11->dri3_formats);
 	free(x11->drm_format);
@@ -535,7 +534,7 @@ struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
 	}
 	x11->allocator = &gbm_alloc->base;
 
-	x11->renderer = wlr_renderer_autocreate(&x11->egl, EGL_PLATFORM_GBM_KHR,
+	x11->renderer = wlr_renderer_autocreate(EGL_PLATFORM_GBM_KHR,
 		gbm_alloc->gbm_device);
 	if (x11->renderer == NULL) {
 		wlr_log(WLR_ERROR, "Failed to create renderer");

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -25,7 +25,6 @@
 #include <wlr/interfaces/wlr_input_device.h>
 #include <wlr/interfaces/wlr_keyboard.h>
 #include <wlr/interfaces/wlr_pointer.h>
-#include <wlr/render/egl.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/util/log.h>
 

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -1,7 +1,6 @@
 #ifndef BACKEND_DRM_DRM_H
 #define BACKEND_DRM_DRM_H
 
-#include <EGL/egl.h>
 #include <gbm.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -12,7 +11,6 @@
 #include <wlr/backend/drm.h>
 #include <wlr/backend/session.h>
 #include <wlr/render/drm_format_set.h>
-#include <wlr/render/egl.h>
 #include <xf86drmMode.h>
 #include "iface.h"
 #include "properties.h"

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -1,7 +1,6 @@
 #ifndef BACKEND_DRM_RENDERER_H
 #define BACKEND_DRM_RENDERER_H
 
-#include <EGL/egl.h>
 #include <gbm.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -15,7 +15,6 @@ struct wlr_buffer;
 struct wlr_drm_renderer {
 	struct wlr_drm_backend *backend;
 	struct gbm_device *gbm;
-	struct wlr_egl egl;
 
 	struct wlr_renderer *wlr_rend;
 	struct wlr_gbm_allocator *allocator;

--- a/include/backend/headless.h
+++ b/include/backend/headless.h
@@ -8,8 +8,6 @@
 
 struct wlr_headless_backend {
 	struct wlr_backend backend;
-	struct wlr_egl priv_egl; // may be uninitialized
-	struct wlr_egl *egl;
 	struct wlr_renderer *renderer;
 	struct wlr_allocator *allocator;
 	struct wlr_drm_format *format;
@@ -19,6 +17,7 @@ struct wlr_headless_backend {
 	struct wl_list input_devices;
 	struct wl_listener display_destroy;
 	struct wl_listener renderer_destroy;
+	bool has_parent_renderer;
 	bool started;
 };
 

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -21,7 +21,6 @@ struct wlr_wl_backend {
 	struct wl_display *local_display;
 	struct wl_list devices;
 	struct wl_list outputs;
-	struct wlr_egl egl;
 	struct wlr_renderer *renderer;
 	struct wlr_drm_format *format;
 	struct wlr_allocator *allocator;

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -7,7 +7,6 @@
 #include <wayland-server-core.h>
 
 #include <wlr/backend/wayland.h>
-#include <wlr/render/egl.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_pointer.h>

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -21,7 +21,6 @@
 #include <wlr/interfaces/wlr_pointer.h>
 #include <wlr/interfaces/wlr_touch.h>
 #include <wlr/render/drm_format_set.h>
-#include <wlr/render/egl.h>
 #include <wlr/render/wlr_renderer.h>
 
 #define XCB_EVENT_RESPONSE_TYPE_MASK 0x7f

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -77,7 +77,6 @@ struct wlr_x11_backend {
 	struct wlr_keyboard keyboard;
 	struct wlr_input_device keyboard_dev;
 
-	struct wlr_egl egl;
 	struct wlr_renderer *renderer;
 	struct wlr_drm_format_set dri3_formats;
 	const struct wlr_x11_format *x11_format;

--- a/include/wlr/backend.h
+++ b/include/wlr/backend.h
@@ -11,7 +11,6 @@
 
 #include <wayland-server-core.h>
 #include <wlr/backend/session.h>
-#include <wlr/render/egl.h>
 
 struct wlr_backend_impl;
 

--- a/include/wlr/backend/interface.h
+++ b/include/wlr/backend/interface.h
@@ -12,7 +12,6 @@
 #include <stdbool.h>
 #include <time.h>
 #include <wlr/backend.h>
-#include <wlr/render/egl.h>
 
 struct wlr_backend_impl {
 	bool (*start)(struct wlr_backend *backend);

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -9,18 +9,6 @@
 #ifndef WLR_RENDER_INTERFACE_H
 #define WLR_RENDER_INTERFACE_H
 
-#ifndef MESA_EGL_NO_X11_HEADERS
-#define MESA_EGL_NO_X11_HEADERS
-#endif
-#ifndef EGL_NO_X11
-#define EGL_NO_X11
-#endif
-#ifndef EGL_NO_PLATFORM_SPECIFIC_TYPES
-#define EGL_NO_PLATFORM_SPECIFIC_TYPES
-#endif
-
-#include <EGL/egl.h>
-#include <EGL/eglext.h>
 #include <stdbool.h>
 #include <wayland-server-protocol.h>
 #include <wlr/render/wlr_renderer.h>

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -33,7 +33,7 @@ struct wlr_renderer {
 	} events;
 };
 
-struct wlr_renderer *wlr_renderer_autocreate(struct wlr_egl *egl, EGLenum platform,
+struct wlr_renderer *wlr_renderer_autocreate(EGLenum platform,
 	void *remote_display);
 
 void wlr_renderer_begin(struct wlr_renderer *r, uint32_t width, uint32_t height);

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -674,6 +674,7 @@ static void gles2_destroy(struct wlr_renderer *wlr_renderer) {
 	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
 
 	wlr_egl_make_current(renderer->egl, EGL_NO_SURFACE, NULL);
+	wlr_egl_finish(renderer->egl);
 
 	struct wlr_gles2_buffer *buffer, *buffer_tmp;
 	wl_list_for_each_safe(buffer, buffer_tmp, &renderer->buffers, link) {

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -247,13 +247,24 @@ bool wlr_renderer_init_wl_display(struct wlr_renderer *r,
 	return true;
 }
 
-struct wlr_renderer *wlr_renderer_autocreate(struct wlr_egl *egl,
-		EGLenum platform, void *remote_display) {
+struct wlr_renderer *wlr_renderer_autocreate(EGLenum platform,
+		void *remote_display) {
+	struct wlr_egl *egl = calloc(1, sizeof(*egl));
+	if (egl == NULL) {
+		wlr_log_errno(WLR_ERROR, "Allocation failed");
+		return NULL;
+	}
+
 	if (!wlr_egl_init(egl, platform, remote_display, NULL, 0)) {
 		wlr_log(WLR_ERROR, "Could not initialize EGL");
 		return NULL;
 	}
 
+	/*
+	 * wlr_renderer becomes the owner of the previously wlr_egl, and will
+	 * take care of freeing the allocated memory
+	 * TODO: move the wlr_egl logic to wlr_gles2_renderer
+	 */
 	struct wlr_renderer *renderer = wlr_gles2_renderer_create(egl);
 	if (!renderer) {
 		wlr_egl_finish(egl);


### PR DESCRIPTION
Removes the `wlr_egl` member from various backend to keep it into the `wlr_renderer`. This also removes various includes of the `render/egl.h` header that were made useless by this patch.

References: https://github.com/swaywm/wlroots/issues/2563

* * *

Breaking change: `wlr_renderer_autocreate` no longer takes a `struct wlr_egl *` as parameter.