### PR TITLE
CI builds tinywl

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -21,7 +21,11 @@ tasks:
   - build: |
       cd wlroots
       ninja -C build
+      sudo ninja -C build install
   - build-features-disabled: |
       cd wlroots
       meson build --reconfigure -Dauto_features=disabled
       ninja -C build
+  - tinywl: |
+      cd wlroots/tinywl
+      make

--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -18,11 +18,14 @@ sources:
 tasks:
   - setup: |
       cd wlroots
-      CC=gcc meson build-gcc -Dauto_features=enabled -Dlogind-provider=systemd
+      CC=gcc meson build-gcc -Dauto_features=enabled -Dlogind-provider=systemd --prefix /usr
       CC=clang meson build-clang -Dauto_features=enabled -Dlogind-provider=systemd
   - gcc: |
       cd wlroots/build-gcc
       ninja
+      sudo ninja install
+      cd ../tinywl
+      make
   - clang: |
       cd wlroots/build-clang
       ninja

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -1,29 +1,34 @@
 image: freebsd/latest
 packages:
-- devel/evdev-proto
-- devel/libepoll-shim
-- devel/libudev-devd
-- devel/meson # implies ninja
-- devel/pkgconf
-- graphics/libdrm
-- graphics/mesa-libs
-- graphics/png
-- graphics/wayland
-- graphics/wayland-protocols
-- misc/e2fsprogs-libuuid
-- multimedia/ffmpeg
-- x11/libX11
-- x11/libinput
-- x11/libxcb
-- x11/libxkbcommon
-- x11/pixman
-- x11/xcb-util-errors
-- x11/xcb-util-wm
-- sysutils/seatd
+  - devel/evdev-proto
+  - devel/libepoll-shim
+  - devel/libudev-devd
+  - devel/meson # implies ninja
+  - devel/pkgconf
+  - graphics/libdrm
+  - graphics/mesa-libs
+  - graphics/png
+  - graphics/wayland
+  - graphics/wayland-protocols
+  - misc/e2fsprogs-libuuid
+  - multimedia/ffmpeg
+  - x11/libX11
+  - x11/libinput
+  - x11/libxcb
+  - x11/libxkbcommon
+  - x11/pixman
+  - x11/xcb-util-errors
+  - x11/xcb-util-wm
+  - sysutils/seatd
+  - gmake
 sources:
-- https://github.com/swaywm/wlroots
+  - https://github.com/swaywm/wlroots
 tasks:
-- wlroots: |
-    cd wlroots
-    meson build -Dauto_features=enabled -Dlogind=disabled
-    ninja -C build
+  - wlroots: |
+      cd wlroots
+      meson build -Dauto_features=enabled -Dlogind=disabled
+      ninja -C build
+      sudo ninja -C build install
+  - tinywl: |
+      cd wlroots/tinywl
+      gmake

--- a/tinywl/tinywl.c
+++ b/tinywl/tinywl.c
@@ -841,12 +841,8 @@ int main(int argc, char *argv[]) {
 	/* The backend is a wlroots feature which abstracts the underlying input and
 	 * output hardware. The autocreate option will choose the most suitable
 	 * backend based on the current environment, such as opening an X11 window
-	 * if an X11 server is running. The NULL argument here optionally allows you
-	 * to pass in a custom renderer if wlr_renderer doesn't meet your needs. The
-	 * backend uses the renderer, for example, to fall back to software cursors
-	 * if the backend does not support hardware cursors (some older GPUs
-	 * don't). */
-	server.backend = wlr_backend_autocreate(server.wl_display, NULL);
+	 * if an X11 server is running. */
+	server.backend = wlr_backend_autocreate(server.wl_display);
 
 	/* If we don't provide a renderer, autocreate makes a GLES2 renderer for us.
 	 * The renderer is responsible for defining the various pixel formats it


### PR DESCRIPTION
The ci now builds tinywl, which requires wlroots to be installed first.