### PR TITLE
xdg shell: remove wlr_xdg_surface_for_each_popup() 

### DIFF
--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -415,12 +415,4 @@ void wlr_xdg_surface_for_each_popup_surface(struct wlr_xdg_surface *surface,
  */
 uint32_t wlr_xdg_surface_schedule_configure(struct wlr_xdg_surface *surface);
 
-/**
- * Call `iterator` on each popup in the xdg-surface tree, with the popup's
- * position relative to the root xdg-surface. The function is called from root
- * to leaves (in rendering order).
- */
-void wlr_xdg_surface_for_each_popup(struct wlr_xdg_surface *surface,
-	wlr_surface_iterator_func_t iterator, void *user_data);
-
 #endif

--- a/types/xdg_shell/wlr_xdg_surface.c
+++ b/types/xdg_shell/wlr_xdg_surface.c
@@ -626,26 +626,6 @@ static void xdg_surface_iterator(struct wlr_surface *surface,
 		iter_data->user_data);
 }
 
-static void xdg_surface_for_each_popup(struct wlr_xdg_surface *surface,
-		int x, int y, wlr_surface_iterator_func_t iterator, void *user_data) {
-	struct wlr_xdg_popup *popup_state;
-	wl_list_for_each(popup_state, &surface->popups, link) {
-		struct wlr_xdg_surface *popup = popup_state->base;
-		if (!popup->configured) {
-			continue;
-		}
-
-		double popup_sx, popup_sy;
-		xdg_popup_get_position(popup_state, &popup_sx, &popup_sy);
-		iterator(popup->surface, x + popup_sx, y + popup_sy, user_data);
-
-		xdg_surface_for_each_popup(popup,
-			x + popup_sx,
-			y + popup_sy,
-			iterator, user_data);
-	}
-}
-
 static void xdg_surface_for_each_popup_surface(struct wlr_xdg_surface *surface,
 		int x, int y, wlr_surface_iterator_func_t iterator, void *user_data) {
 	struct wlr_xdg_popup *popup_state;
@@ -682,11 +662,6 @@ void wlr_xdg_surface_for_each_surface(struct wlr_xdg_surface *surface,
 void wlr_xdg_surface_for_each_popup_surface(struct wlr_xdg_surface *surface,
 		wlr_surface_iterator_func_t iterator, void *user_data) {
 	xdg_surface_for_each_popup_surface(surface, 0, 0, iterator, user_data);
-}
-
-void wlr_xdg_surface_for_each_popup(struct wlr_xdg_surface *surface,
-		wlr_surface_iterator_func_t iterator, void *user_data) {
-	xdg_surface_for_each_popup(surface, 0, 0, iterator, user_data);
 }
 
 void wlr_xdg_surface_get_geometry(struct wlr_xdg_surface *surface,


### PR DESCRIPTION
~~This function is not well suited to rendering as it does not iterate
over subsurfaces. Therefore, it makes little sense to use the standard
surface iterator function. Introduce an new xdg-popup iterator function
and use that instead.~~

This function is inferior to wlr_xdg_surface_for_each_popup_surface()
for rendering as it does not iterate over subsurfaces. Furthermore,
no compositor known to use this to iterate popups for any purpose other
than rendering. Therefore remove the function which may of course be
reintroduced at a later date if a use-case is found.

* * *

Breaking change: `wlr_xdg_surface_for_each_popup` has been removed, use `wlr_xdg_surface_for_each_popup_surface` instead.