### PR TITLE
Simpler screencopy

### DIFF
--- a/include/wlr/types/wlr_screencopy_v1.h
+++ b/include/wlr/types/wlr_screencopy_v1.h
@@ -52,7 +52,6 @@ struct wlr_screencopy_frame_v1 {
 	struct wl_listener buffer_destroy;
 
 	struct wlr_output *output;
-	struct wl_listener output_precommit;
 	struct wl_listener output_commit;
 	struct wl_listener output_destroy;
 	struct wl_listener output_enable;


### PR DESCRIPTION
This simplifies screencopy by copying pixels to shm in the commit callback rather than the pre-commit callback, so both dmabuf and shm buffers are handled in commit.

Because commit always happens after pre-commit, damage accumulation is also simplified because we no longer need to ascertain whether the damage callback or the frame-copy callback happened first.

Supersedes #2591