### PR TITLE
layer shell: rename popup iterator for consistency

### DIFF
--- a/include/wlr/types/wlr_layer_shell_v1.h
+++ b/include/wlr/types/wlr_layer_shell_v1.h
@@ -138,8 +138,14 @@ struct wlr_layer_surface_v1 *wlr_layer_surface_v1_from_wlr_surface(
 void wlr_layer_surface_v1_for_each_surface(struct wlr_layer_surface_v1 *surface,
 		wlr_surface_iterator_func_t iterator, void *user_data);
 
-/* Calls the iterator function for each popup of this surface */
-void wlr_layer_surface_v1_for_each_popup(struct wlr_layer_surface_v1 *surface,
+/**
+ * Call `iterator` on each popup's surface and popup's subsurface in the
+ * layer surface's tree, with the surfaces's position relative to the root
+ * layer surface. The function is called from root to leaves (in rendering
+ * order).
+ */
+void wlr_layer_surface_v1_for_each_popup_surface(
+		struct wlr_layer_surface_v1 *surface,
 		wlr_surface_iterator_func_t iterator, void *user_data);
 
 /**

--- a/types/wlr_layer_shell_v1.c
+++ b/types/wlr_layer_shell_v1.c
@@ -533,10 +533,10 @@ static void layer_surface_iterator(struct wlr_surface *surface,
 void wlr_layer_surface_v1_for_each_surface(struct wlr_layer_surface_v1 *surface,
 		wlr_surface_iterator_func_t iterator, void *user_data) {
 	wlr_surface_for_each_surface(surface->surface, iterator, user_data);
-	wlr_layer_surface_v1_for_each_popup(surface, iterator, user_data);
+	wlr_layer_surface_v1_for_each_popup_surface(surface, iterator, user_data);
 }
 
-void wlr_layer_surface_v1_for_each_popup(struct wlr_layer_surface_v1 *surface,
+void wlr_layer_surface_v1_for_each_popup_surface(struct wlr_layer_surface_v1 *surface,
 		wlr_surface_iterator_func_t iterator, void *user_data){
 	struct wlr_xdg_popup *popup_state;
 	wl_list_for_each(popup_state, &surface->popups, link) {


### PR DESCRIPTION
This iterates over the subsurfaces of popups as well, so rename it to
match wlr_xdg_surface_for_each_popup_surface().

* * *

Breaking change: `wlr_layer_surface_v1_for_each_popup` has been renamed to `wlr_layer_surface_v1_for_each_popup_surface`.