### PR TITLE
util: fix uuid support for freebsd

### DIFF
--- a/util/uuid.c
+++ b/util/uuid.c
@@ -9,6 +9,7 @@ bool generate_uuid(char out[static 37]) {
 	return true;
 }
 #else
+#include <assert.h>
 #include <string.h>
 #include <stdlib.h>
 
@@ -26,7 +27,7 @@ bool generate_uuid(char out[static 37]) {
 	}
 
 	assert(strlen(str) + 1 == 37);
-	memcpy(out, str, sizeof(out));
+	memcpy(out, str, 37);
 	free(str);
 	return true;
 }


### PR DESCRIPTION
Fixes:
```
  FAILED: subprojects/wlroots/libwlroots.so.7.p/util_uuid.c.o
  cc -Isubprojects/wlroots/libwlroots.so.7.p -Isubprojects/wlroots -I../subprojects/wlroots -Isubprojects/wlroots/include -I../subprojects/wlroots/include -Isubprojects/wlroots/protocol -I../subprojects/wlroots/protocol -I/usr/local/include -I/usr/local/include/libepoll-shim -I/usr/local/include/libdrm -I/usr/local/include/pixman-1 -Xclang -fcolor-diagnostics -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -std=c11 -g -DWLR_USE_UNSTABLE -Wundef -Wmissing-include-dirs -Wold-style-definition -Wpointer-arith -Winit-self -Wstrict-prototypes -Wendif-labels -Wstrict-aliasing=2 -Woverflow -Wmissing-prototypes -Wno-missing-braces -Wno-missing-field-initializers -Wno-unused-parameter '-DWLR_REL_SRC_DIR="../subprojects/wlroots/"' -Wno-missing-field-initializers -Wno-missing-braces -DHAS_LIBUUID=0 '-DICONDIR="/usr/local/share/icons"' -fPIC -pthread -D_THREAD_SAFE -MD -MQ subprojects/wlroots/libwlroots.so.7.p/util_uuid.c.o -MF subprojects/wlroots/libwlroots.so.7.p/util_uuid.c.o.d -o subprojects/wlroots/libwlroots.so.7.p/util_uuid.c.o -c ../subprojects/wlroots/util/uuid.c
  ../subprojects/wlroots/util/uuid.c:28:2: error: implicit declaration of function 'assert' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
          assert(strlen(str) + 1 == 37);
          ^
  ../subprojects/wlroots/util/uuid.c:28:2: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
  ../subprojects/wlroots/util/uuid.c:29:25: error: sizeof on array function parameter will return size of 'char *' instead of 'char [static 37]' [-Werror,-Wsizeof-array-argument]
          memcpy(out, str, sizeof(out));
                                 ^
  ../subprojects/wlroots/util/uuid.c:15:25: note: declared here
  bool generate_uuid(char out[static 37]) {
                          ^
  ../subprojects/wlroots/util/uuid.c:29:26: error: 'memcpy' call operates on objects of type 'char' while the size is based on a different type 'char *' [-Werror,-Wsizeof-pointer-memaccess]
          memcpy(out, str, sizeof(out));
                 ~~~              ^~~
  ../subprojects/wlroots/util/uuid.c:29:26: note: did you mean to provide an explicit length?
          memcpy(out, str, sizeof(out));
```
Fixes #2616