### PR TITLE
render/egl: remove unused features, introduce create/destroy

### DIFF
--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -116,7 +116,7 @@ bool drm_surface_make_current(struct wlr_drm_surface *surf,
 	}
 
 	struct wlr_egl *egl = wlr_gles2_renderer_get_egl(surf->renderer->wlr_rend);
-	if (!wlr_egl_make_current(egl, EGL_NO_SURFACE, NULL)) {
+	if (!wlr_egl_make_current(egl)) {
 		return false;
 	}
 	if (!wlr_renderer_bind_buffer(surf->renderer->wlr_rend, surf->back_buffer)) {

--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -52,7 +52,7 @@ static bool output_attach_render(struct wlr_output *wlr_output,
 		return false;
 	}
 
-	if (!wlr_egl_make_current(egl, EGL_NO_SURFACE, NULL)) {
+	if (!wlr_egl_make_current(egl)) {
 		return false;
 	}
 	if (!wlr_renderer_bind_buffer(output->backend->renderer,

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -125,7 +125,7 @@ static bool output_attach_render(struct wlr_output *wlr_output,
 		return false;
 	}
 
-	if (!wlr_egl_make_current(egl, EGL_NO_SURFACE, NULL)) {
+	if (!wlr_egl_make_current(egl)) {
 		return false;
 	}
 	if (!wlr_renderer_bind_buffer(output->backend->renderer,
@@ -433,7 +433,7 @@ static bool output_set_cursor(struct wlr_output *wlr_output,
 			return false;
 		}
 
-		if (!wlr_egl_make_current(egl, EGL_NO_SURFACE, NULL)) {
+		if (!wlr_egl_make_current(egl)) {
 			return false;
 		}
 		if (!wlr_renderer_bind_buffer(output->backend->renderer, wlr_buffer)) {

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -106,7 +106,7 @@ static bool output_attach_render(struct wlr_output *wlr_output,
 		return false;
 	}
 
-	if (!wlr_egl_make_current(egl, EGL_NO_SURFACE, NULL)) {
+	if (!wlr_egl_make_current(egl)) {
 		return false;
 	}
 	if (!wlr_renderer_bind_buffer(x11->renderer, output->back_buffer)) {

--- a/examples/idle-inhibit.c
+++ b/examples/idle-inhibit.c
@@ -27,12 +27,12 @@ static struct xdg_wm_base *wm_base = NULL;
 static struct zwp_idle_inhibit_manager_v1 *idle_inhibit_manager = NULL;
 static struct zwp_idle_inhibitor_v1 *idle_inhibitor = NULL;
 
-struct wlr_egl egl;
+struct wlr_egl *egl;
 struct wl_egl_window *egl_window;
 struct wlr_egl_surface *egl_surface;
 
 static void draw(void) {
-	eglMakeCurrent(egl.display, egl_surface, egl_surface, egl.context);
+	eglMakeCurrent(egl->display, egl_surface, egl_surface, egl->context);
 
 	float color[] = {1.0, 1.0, 0.0, 1.0};
 	if (idle_inhibitor) {
@@ -43,7 +43,7 @@ static void draw(void) {
 	glClearColor(color[0], color[1], color[2], 1.0);
 	glClear(GL_COLOR_BUFFER_BIT);
 
-	eglSwapBuffers(egl.display, egl_surface);
+	eglSwapBuffers(egl->display, egl_surface);
 }
 
 static void pointer_handle_button(void *data, struct wl_pointer *pointer, uint32_t serial,
@@ -193,7 +193,7 @@ int main(int argc, char **argv) {
 	}
 
 	EGLint attribs[] = { EGL_NONE };
-	wlr_egl_init(&egl, EGL_PLATFORM_WAYLAND_EXT, display, attribs);
+	egl = wlr_egl_create(EGL_PLATFORM_WAYLAND_EXT, display, attribs);
 
 	struct wl_surface *surface = wl_compositor_create_surface(compositor);
 	struct xdg_surface *xdg_surface =
@@ -214,7 +214,7 @@ int main(int argc, char **argv) {
 	wl_surface_commit(surface);
 
 	egl_window = wl_egl_window_create(surface, width, height);
-	egl_surface = wlr_egl_create_surface(&egl, egl_window);
+	egl_surface = wlr_egl_create_surface(egl, egl_window);
 
 	wl_display_roundtrip(display);
 

--- a/examples/idle-inhibit.c
+++ b/examples/idle-inhibit.c
@@ -193,7 +193,7 @@ int main(int argc, char **argv) {
 	}
 
 	EGLint attribs[] = { EGL_NONE };
-	wlr_egl_init(&egl, EGL_PLATFORM_WAYLAND_EXT, display, attribs, 0);
+	wlr_egl_init(&egl, EGL_PLATFORM_WAYLAND_EXT, display, attribs);
 
 	struct wl_surface *surface = wl_compositor_create_surface(compositor);
 	struct xdg_surface *xdg_surface =

--- a/examples/input-inhibitor.c
+++ b/examples/input-inhibitor.c
@@ -18,12 +18,12 @@ static struct xdg_wm_base *wm_base = NULL;
 static struct zwlr_input_inhibit_manager_v1 *input_inhibit_manager = NULL;
 static struct zwlr_input_inhibitor_v1 *input_inhibitor = NULL;
 
-struct wlr_egl egl;
+struct wlr_egl *egl;
 struct wl_egl_window *egl_window;
 struct wlr_egl_surface *egl_surface;
 
 static void render_frame(void) {
-	eglMakeCurrent(egl.display, egl_surface, egl_surface, egl.context);
+	eglMakeCurrent(egl->display, egl_surface, egl_surface, egl->context);
 
 	glViewport(0, 0, width, height);
 	if (keys) {
@@ -33,7 +33,7 @@ static void render_frame(void) {
 	}
 	glClear(GL_COLOR_BUFFER_BIT);
 
-	eglSwapBuffers(egl.display, egl_surface);
+	eglSwapBuffers(egl->display, egl_surface);
 }
 
 static void xdg_surface_handle_configure(void *data,
@@ -158,7 +158,7 @@ int main(int argc, char **argv) {
 	assert(input_inhibitor);
 
 	EGLint attribs[] = { EGL_NONE };
-	wlr_egl_init(&egl, EGL_PLATFORM_WAYLAND_EXT, display, attribs);
+	egl = wlr_egl_create(EGL_PLATFORM_WAYLAND_EXT, display, attribs);
 
 	struct wl_surface *surface = wl_compositor_create_surface(compositor);
 	assert(surface);
@@ -174,7 +174,7 @@ int main(int argc, char **argv) {
 	wl_surface_commit(surface);
 
 	egl_window = wl_egl_window_create(surface, width, height);
-	egl_surface = wlr_egl_create_surface(&egl, egl_window);
+	egl_surface = wlr_egl_create_surface(egl, egl_window);
 
 	wl_display_roundtrip(display);
 

--- a/examples/input-inhibitor.c
+++ b/examples/input-inhibitor.c
@@ -158,7 +158,7 @@ int main(int argc, char **argv) {
 	assert(input_inhibitor);
 
 	EGLint attribs[] = { EGL_NONE };
-	wlr_egl_init(&egl, EGL_PLATFORM_WAYLAND_EXT, display, attribs, 0);
+	wlr_egl_init(&egl, EGL_PLATFORM_WAYLAND_EXT, display, attribs);
 
 	struct wl_surface *surface = wl_compositor_create_surface(compositor);
 	assert(surface);

--- a/examples/keyboard-shortcuts-inhibit.c
+++ b/examples/keyboard-shortcuts-inhibit.c
@@ -225,7 +225,7 @@ int main(int argc, char **argv) {
 	}
 
 	EGLint attribs[] = { EGL_NONE };
-	wlr_egl_init(&egl, EGL_PLATFORM_WAYLAND_EXT, display, attribs, 0);
+	wlr_egl_init(&egl, EGL_PLATFORM_WAYLAND_EXT, display, attribs);
 
 	struct wl_surface *surface = wl_compositor_create_surface(compositor);
 	struct xdg_surface *xdg_surface =

--- a/examples/keyboard-shortcuts-inhibit.c
+++ b/examples/keyboard-shortcuts-inhibit.c
@@ -33,12 +33,12 @@ static struct zwp_keyboard_shortcuts_inhibitor_v1 *
 	keyboard_shortcuts_inhibitor = NULL;
 static bool active = false;
 
-struct wlr_egl egl;
+struct wlr_egl *egl;
 struct wl_egl_window *egl_window;
 struct wlr_egl_surface *egl_surface;
 
 static void draw(void) {
-	eglMakeCurrent(egl.display, egl_surface, egl_surface, egl.context);
+	eglMakeCurrent(egl->display, egl_surface, egl_surface, egl->context);
 
 	float color[] = {1.0, 1.0, 0.0, 1.0};
 	if (keyboard_shortcuts_inhibitor) {
@@ -49,7 +49,7 @@ static void draw(void) {
 	glClearColor(color[0], color[1], color[2], 1.0);
 	glClear(GL_COLOR_BUFFER_BIT);
 
-	eglSwapBuffers(egl.display, egl_surface);
+	eglSwapBuffers(egl->display, egl_surface);
 }
 
 static void keyboard_shortcuts_inhibit_handle_active(void *data,
@@ -225,7 +225,7 @@ int main(int argc, char **argv) {
 	}
 
 	EGLint attribs[] = { EGL_NONE };
-	wlr_egl_init(&egl, EGL_PLATFORM_WAYLAND_EXT, display, attribs);
+	egl = wlr_egl_create(EGL_PLATFORM_WAYLAND_EXT, display, attribs);
 
 	struct wl_surface *surface = wl_compositor_create_surface(compositor);
 	struct xdg_surface *xdg_surface =
@@ -241,7 +241,7 @@ int main(int argc, char **argv) {
 	wl_surface_commit(surface);
 
 	egl_window = wl_egl_window_create(surface, width, height);
-	egl_surface = wlr_egl_create_surface(&egl, egl_window);
+	egl_surface = wlr_egl_create_surface(egl, egl_window);
 
 	wl_display_roundtrip(display);
 

--- a/examples/layer-shell.c
+++ b/examples/layer-shell.c
@@ -611,7 +611,7 @@ int main(int argc, char **argv) {
 	assert(cursor_surface);
 
 	EGLint attribs[] = { EGL_ALPHA_SIZE, 8, EGL_NONE };
-	wlr_egl_init(&egl, EGL_PLATFORM_WAYLAND_EXT, display, attribs, 0);
+	wlr_egl_init(&egl, EGL_PLATFORM_WAYLAND_EXT, display, attribs);
 
 	wl_surface = wl_compositor_create_surface(compositor);
 	assert(wl_surface);

--- a/examples/pointer-constraints.c
+++ b/examples/pointer-constraints.c
@@ -212,7 +212,7 @@ int main(int argc, char **argv) {
 	regions[REGION_TYPE_JOINT] = joint_region;
 
 	EGLint attribs[] = { EGL_NONE };
-	wlr_egl_init(&egl, EGL_PLATFORM_WAYLAND_EXT, display, attribs, 0);
+	wlr_egl_init(&egl, EGL_PLATFORM_WAYLAND_EXT, display, attribs);
 
 	struct wl_surface *surface = wl_compositor_create_surface(compositor);
 	struct xdg_surface *xdg_surface =

--- a/examples/pointer-constraints.c
+++ b/examples/pointer-constraints.c
@@ -16,7 +16,7 @@ static struct wl_seat *seat = NULL;
 static struct xdg_wm_base *wm_base = NULL;
 static struct zwp_pointer_constraints_v1 *pointer_constraints = NULL;
 
-struct wlr_egl egl;
+struct wlr_egl *egl;
 struct wl_egl_window *egl_window;
 struct wlr_egl_surface *egl_surface;
 struct zwp_locked_pointer_v1* locked_pointer;
@@ -32,7 +32,7 @@ enum {
 struct wl_region *regions[3];
 
 static void draw(void) {
-	eglMakeCurrent(egl.display, egl_surface, egl_surface, egl.context);
+	eglMakeCurrent(egl->display, egl_surface, egl_surface, egl->context);
 
 	float color[] = {1.0, 1.0, 0.0, 1.0};
 
@@ -40,7 +40,7 @@ static void draw(void) {
 	glClearColor(color[0], color[1], color[2], 1.0);
 	glClear(GL_COLOR_BUFFER_BIT);
 
-	eglSwapBuffers(egl.display, egl_surface);
+	eglSwapBuffers(egl->display, egl_surface);
 }
 
 static void pointer_handle_button(void *data, struct wl_pointer *pointer,
@@ -212,7 +212,7 @@ int main(int argc, char **argv) {
 	regions[REGION_TYPE_JOINT] = joint_region;
 
 	EGLint attribs[] = { EGL_NONE };
-	wlr_egl_init(&egl, EGL_PLATFORM_WAYLAND_EXT, display, attribs);
+	egl = wlr_egl_create(EGL_PLATFORM_WAYLAND_EXT, display, attribs);
 
 	struct wl_surface *surface = wl_compositor_create_surface(compositor);
 	struct xdg_surface *xdg_surface =
@@ -241,7 +241,7 @@ int main(int argc, char **argv) {
 	wl_surface_commit(surface);
 
 	egl_window = wl_egl_window_create(surface, width, height);
-	egl_surface = wlr_egl_create_surface(&egl, egl_window);
+	egl_surface = wlr_egl_create_surface(egl, egl_window);
 
 	wl_display_roundtrip(display);
 

--- a/examples/relative-pointer-unstable-v1.c
+++ b/examples/relative-pointer-unstable-v1.c
@@ -444,7 +444,7 @@ int main(int argc, char **argv) {
 	e->width = e->height = 512;
 
 	EGLint attribs[] = { EGL_NONE };
-	wlr_egl_init(e->egl, EGL_PLATFORM_WAYLAND_EXT, display, attribs, 0);
+	wlr_egl_init(e->egl, EGL_PLATFORM_WAYLAND_EXT, display, attribs);
 
 	/* Create the surface and xdg_toplevels, and set listeners */
 

--- a/examples/relative-pointer-unstable-v1.c
+++ b/examples/relative-pointer-unstable-v1.c
@@ -171,7 +171,7 @@ static void xdg_toplevel_handle_configure(void *data,
 static void xdg_toplevel_handle_close(void *data,
 		struct xdg_toplevel *xdg_toplevel) {
 	struct egl_info *e = data;
-	wlr_egl_finish(e->egl);
+	wlr_egl_destroy(e->egl);
 	exit(EXIT_SUCCESS);
 }
 
@@ -440,11 +440,10 @@ int main(int argc, char **argv) {
 	/* Initialize EGL context */
 
 	struct egl_info *e = calloc(1, sizeof(struct egl_info));
-	e->egl = calloc(1, sizeof(struct wlr_egl));
 	e->width = e->height = 512;
 
 	EGLint attribs[] = { EGL_NONE };
-	wlr_egl_init(e->egl, EGL_PLATFORM_WAYLAND_EXT, display, attribs);
+	e->egl = wlr_egl_create(EGL_PLATFORM_WAYLAND_EXT, display, attribs);
 
 	/* Create the surface and xdg_toplevels, and set listeners */
 

--- a/examples/text-input.c
+++ b/examples/text-input.c
@@ -364,7 +364,7 @@ int main(int argc, char **argv) {
 	zwp_text_input_v3_add_listener(text_input, &text_input_listener, NULL);
 
 	EGLint attribs[] = { EGL_NONE };
-	wlr_egl_init(&egl, EGL_PLATFORM_WAYLAND_EXT, display, attribs, 0);
+	wlr_egl_init(&egl, EGL_PLATFORM_WAYLAND_EXT, display, attribs);
 
 	struct wl_surface *surface = wl_compositor_create_surface(compositor);
 	struct xdg_surface *xdg_surface =

--- a/examples/text-input.c
+++ b/examples/text-input.c
@@ -63,12 +63,12 @@ static struct xdg_wm_base *wm_base = NULL;
 static struct zwp_text_input_manager_v3 *text_input_manager = NULL;
 static struct zwp_text_input_v3 *text_input	= NULL;
 
-struct wlr_egl egl;
+struct wlr_egl *egl;
 struct wl_egl_window *egl_window;
 struct wlr_egl_surface *egl_surface;
 
 static void draw(void) {
-	eglMakeCurrent(egl.display, egl_surface, egl_surface, egl.context);
+	eglMakeCurrent(egl->display, egl_surface, egl_surface, egl->context);
 
 	float color[] = {1.0, 1.0, 0.0, 1.0};
 	color[0] = enabled * 1.0;
@@ -78,7 +78,7 @@ static void draw(void) {
 	glClearColor(color[0], color[1], color[2], 1.0);
 	glClear(GL_COLOR_BUFFER_BIT);
 
-	eglSwapBuffers(egl.display, egl_surface);
+	eglSwapBuffers(egl->display, egl_surface);
 }
 
 static size_t utf8_strlen(char *str) {
@@ -364,7 +364,7 @@ int main(int argc, char **argv) {
 	zwp_text_input_v3_add_listener(text_input, &text_input_listener, NULL);
 
 	EGLint attribs[] = { EGL_NONE };
-	wlr_egl_init(&egl, EGL_PLATFORM_WAYLAND_EXT, display, attribs);
+	egl = wlr_egl_create(EGL_PLATFORM_WAYLAND_EXT, display, attribs);
 
 	struct wl_surface *surface = wl_compositor_create_surface(compositor);
 	struct xdg_surface *xdg_surface =
@@ -377,7 +377,7 @@ int main(int argc, char **argv) {
 	wl_surface_commit(surface);
 
 	egl_window = wl_egl_window_create(surface, width, height);
-	egl_surface = wlr_egl_create_surface(&egl, egl_window);
+	egl_surface = wlr_egl_create_surface(egl, egl_window);
 
 	wl_display_roundtrip(display);
 

--- a/examples/toplevel-decoration.c
+++ b/examples/toplevel-decoration.c
@@ -219,7 +219,7 @@ int main(int argc, char **argv) {
 	}
 
 	EGLint attribs[] = { EGL_NONE };
-	wlr_egl_init(&egl, EGL_PLATFORM_WAYLAND_EXT, display, attribs, 0);
+	wlr_egl_init(&egl, EGL_PLATFORM_WAYLAND_EXT, display, attribs);
 
 	struct wl_surface *surface = wl_compositor_create_surface(compositor);
 	struct xdg_surface *xdg_surface =

--- a/examples/toplevel-decoration.c
+++ b/examples/toplevel-decoration.c
@@ -20,7 +20,7 @@ static struct wl_compositor *compositor = NULL;
 static struct xdg_wm_base *wm_base = NULL;
 static struct zxdg_decoration_manager_v1 *decoration_manager = NULL;
 
-struct wlr_egl egl;
+struct wlr_egl *egl;
 struct wl_egl_window *egl_window;
 struct wlr_egl_surface *egl_surface;
 
@@ -53,7 +53,7 @@ static void request_preferred_mode(void) {
 }
 
 static void draw(void) {
-	eglMakeCurrent(egl.display, egl_surface, egl_surface, egl.context);
+	eglMakeCurrent(egl->display, egl_surface, egl_surface, egl->context);
 
 	float color[] = {1.0, 1.0, 0.0, 1.0};
 	if (current_mode == ZXDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE) {
@@ -64,7 +64,7 @@ static void draw(void) {
 	glClearColor(color[0], color[1], color[2], 1.0);
 	glClear(GL_COLOR_BUFFER_BIT);
 
-	eglSwapBuffers(egl.display, egl_surface);
+	eglSwapBuffers(egl->display, egl_surface);
 }
 
 static void xdg_surface_handle_configure(void *data,
@@ -219,7 +219,7 @@ int main(int argc, char **argv) {
 	}
 
 	EGLint attribs[] = { EGL_NONE };
-	wlr_egl_init(&egl, EGL_PLATFORM_WAYLAND_EXT, display, attribs);
+	egl = wlr_egl_create(EGL_PLATFORM_WAYLAND_EXT, display, attribs);
 
 	struct wl_surface *surface = wl_compositor_create_surface(compositor);
 	struct xdg_surface *xdg_surface =
@@ -238,7 +238,7 @@ int main(int argc, char **argv) {
 	wl_surface_commit(surface);
 
 	egl_window = wl_egl_window_create(surface, width, height);
-	egl_surface = wlr_egl_create_surface(&egl, egl_window);
+	egl_surface = wlr_egl_create_surface(egl, egl_window);
 
 	wl_display_roundtrip(display);
 

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -78,21 +78,20 @@ struct wlr_egl {
 	struct wlr_drm_format_set dmabuf_render_formats;
 };
 
-// TODO: Allocate and return a wlr_egl
 /**
  * Initializes an EGL context for the given platform and remote display.
  * Will attempt to load all possibly required api functions.
  *
  * If config_attribs is NULL, the EGL config is not created.
  */
-bool wlr_egl_init(struct wlr_egl *egl, EGLenum platform, void *remote_display,
+struct wlr_egl *wlr_egl_create(EGLenum platform, void *remote_display,
 	const EGLint *config_attribs);
 
 /**
  * Frees all related EGL resources, makes the context not-current and
  * unbinds a bound wayland display.
  */
-void wlr_egl_finish(struct wlr_egl *egl);
+void wlr_egl_destroy(struct wlr_egl *egl);
 
 /**
  * Binds the given display to the EGL instance.

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -89,7 +89,7 @@ struct wlr_egl {
  * If config_attribs is NULL, the EGL config is not created.
  */
 bool wlr_egl_init(struct wlr_egl *egl, EGLenum platform, void *remote_display,
-	const EGLint *config_attribs, EGLint visual_id);
+	const EGLint *config_attribs);
 
 /**
  * Frees all related EGL resources, makes the context not-current and

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -45,7 +45,6 @@ struct wlr_egl {
 	struct {
 		// Display extensions
 		bool bind_wayland_display_wl;
-		bool buffer_age_ext;
 		bool image_base_khr;
 		bool image_dma_buf_export_mesa;
 		bool image_dmabuf_import_ext;
@@ -141,14 +140,12 @@ bool wlr_egl_export_image_to_dmabuf(struct wlr_egl *egl, EGLImageKHR image,
 bool wlr_egl_destroy_image(struct wlr_egl *egl, EGLImageKHR image);
 
 /**
- * Make the EGL context current. The provided surface will be made current
- * unless EGL_NO_SURFACE.
+ * Make the EGL context current.
  *
  * Callers are expected to clear the current context when they are done by
  * calling wlr_egl_unset_current.
  */
-bool wlr_egl_make_current(struct wlr_egl *egl, EGLSurface surface,
-	int *buffer_age);
+bool wlr_egl_make_current(struct wlr_egl *egl);
 
 bool wlr_egl_unset_current(struct wlr_egl *egl);
 

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -37,7 +37,6 @@ struct wlr_egl_context {
 };
 
 struct wlr_egl {
-	EGLenum platform;
 	EGLDisplay display;
 	EGLConfig config; // may be EGL_NO_CONFIG
 	EGLContext context;
@@ -51,7 +50,6 @@ struct wlr_egl {
 		bool image_dma_buf_export_mesa;
 		bool image_dmabuf_import_ext;
 		bool image_dmabuf_import_modifiers_ext;
-		bool swap_buffers_with_damage;
 
 		// Device extensions
 		bool device_drm_ext;
@@ -65,7 +63,6 @@ struct wlr_egl {
 		PFNEGLQUERYWAYLANDBUFFERWL eglQueryWaylandBufferWL;
 		PFNEGLBINDWAYLANDDISPLAYWL eglBindWaylandDisplayWL;
 		PFNEGLUNBINDWAYLANDDISPLAYWL eglUnbindWaylandDisplayWL;
-		PFNEGLSWAPBUFFERSWITHDAMAGEKHRPROC eglSwapBuffersWithDamage; // KHR or EXT
 		PFNEGLQUERYDMABUFFORMATSEXTPROC eglQueryDmaBufFormatsEXT;
 		PFNEGLQUERYDMABUFMODIFIERSEXTPROC eglQueryDmaBufModifiersEXT;
 		PFNEGLEXPORTDMABUFIMAGEQUERYMESAPROC eglExportDMABUFImageQueryMESA;
@@ -169,9 +166,6 @@ void wlr_egl_save_context(struct wlr_egl_context *context);
  * Restore EGL context that was previously saved using wlr_egl_save_current().
  */
 bool wlr_egl_restore_context(struct wlr_egl_context *context);
-
-bool wlr_egl_swap_buffers(struct wlr_egl *egl, EGLSurface surface,
-	pixman_region32_t *damage);
 
 bool wlr_egl_destroy_surface(struct wlr_egl *egl, EGLSurface surface);
 

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -694,9 +694,7 @@ static void gles2_destroy(struct wlr_renderer *wlr_renderer) {
 	}
 
 	wlr_egl_unset_current(renderer->egl);
-
-	wlr_egl_finish(renderer->egl);
-	free(renderer->egl);
+	wlr_egl_destroy(renderer->egl);
 
 	if (renderer->drm_fd >= 0) {
 		close(renderer->drm_fd);

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -41,7 +41,7 @@ static void destroy_buffer(struct wlr_gles2_buffer *buffer) {
 	wl_list_remove(&buffer->link);
 	wl_list_remove(&buffer->buffer_destroy.link);
 
-	wlr_egl_make_current(buffer->renderer->egl, EGL_NO_SURFACE, NULL);
+	wlr_egl_make_current(buffer->renderer->egl);
 
 	push_gles2_debug(buffer->renderer);
 
@@ -575,7 +575,7 @@ static bool gles2_blit_dmabuf(struct wlr_renderer *wlr_renderer,
 		gles2_src_tex->inverted_y = !gles2_src_tex->inverted_y;
 	}
 
-	if (!wlr_egl_make_current(renderer->egl, EGL_NO_SURFACE, NULL)) {
+	if (!wlr_egl_make_current(renderer->egl)) {
 		goto texture_destroy_out;
 	}
 
@@ -673,7 +673,7 @@ struct wlr_egl *wlr_gles2_renderer_get_egl(struct wlr_renderer *wlr_renderer) {
 static void gles2_destroy(struct wlr_renderer *wlr_renderer) {
 	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
 
-	wlr_egl_make_current(renderer->egl, EGL_NO_SURFACE, NULL);
+	wlr_egl_make_current(renderer->egl);
 
 	struct wlr_gles2_buffer *buffer, *buffer_tmp;
 	wl_list_for_each_safe(buffer, buffer_tmp, &renderer->buffers, link) {
@@ -861,7 +861,7 @@ extern const GLchar tex_fragment_src_rgbx[];
 extern const GLchar tex_fragment_src_external[];
 
 struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_egl *egl) {
-	if (!wlr_egl_make_current(egl, EGL_NO_SURFACE, NULL)) {
+	if (!wlr_egl_make_current(egl)) {
 		return NULL;
 	}
 

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -29,7 +29,7 @@ struct wlr_gles2_texture *gles2_get_texture(
 static struct wlr_gles2_texture *get_gles2_texture_in_context(
 		struct wlr_texture *wlr_texture) {
 	struct wlr_gles2_texture *texture = gles2_get_texture(wlr_texture);
-	wlr_egl_make_current(texture->renderer->egl, EGL_NO_SURFACE, NULL);
+	wlr_egl_make_current(texture->renderer->egl);
 	return texture;
 }
 
@@ -138,7 +138,7 @@ struct wlr_texture *gles2_texture_from_pixels(struct wlr_renderer *wlr_renderer,
 		uint32_t height, const void *data) {
 	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
 
-	wlr_egl_make_current(renderer->egl, EGL_NO_SURFACE, NULL);
+	wlr_egl_make_current(renderer->egl);
 
 	const struct wlr_gles2_pixel_format *fmt = get_gles2_format_from_wl(wl_fmt);
 	if (fmt == NULL) {
@@ -180,7 +180,7 @@ struct wlr_texture *gles2_texture_from_wl_drm(struct wlr_renderer *wlr_renderer,
 		struct wl_resource *resource) {
 	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
 
-	wlr_egl_make_current(renderer->egl, EGL_NO_SURFACE, NULL);
+	wlr_egl_make_current(renderer->egl);
 
 	if (!renderer->procs.glEGLImageTargetTexture2DOES) {
 		return NULL;
@@ -245,7 +245,7 @@ struct wlr_texture *gles2_texture_from_dmabuf(struct wlr_renderer *wlr_renderer,
 		struct wlr_dmabuf_attributes *attribs) {
 	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
 
-	wlr_egl_make_current(renderer->egl, EGL_NO_SURFACE, NULL);
+	wlr_egl_make_current(renderer->egl);
 
 	if (!renderer->procs.glEGLImageTargetTexture2DOES) {
 		return NULL;

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -255,7 +255,7 @@ struct wlr_renderer *wlr_renderer_autocreate(EGLenum platform,
 		return NULL;
 	}
 
-	if (!wlr_egl_init(egl, platform, remote_display, NULL, 0)) {
+	if (!wlr_egl_init(egl, platform, remote_display, NULL)) {
 		wlr_log(WLR_ERROR, "Could not initialize EGL");
 		return NULL;
 	}

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -249,25 +249,16 @@ bool wlr_renderer_init_wl_display(struct wlr_renderer *r,
 
 struct wlr_renderer *wlr_renderer_autocreate(EGLenum platform,
 		void *remote_display) {
-	struct wlr_egl *egl = calloc(1, sizeof(*egl));
+	struct wlr_egl *egl = wlr_egl_create(platform, remote_display, NULL);
 	if (egl == NULL) {
-		wlr_log_errno(WLR_ERROR, "Allocation failed");
-		return NULL;
-	}
-
-	if (!wlr_egl_init(egl, platform, remote_display, NULL)) {
 		wlr_log(WLR_ERROR, "Could not initialize EGL");
 		return NULL;
 	}
 
-	/*
-	 * wlr_renderer becomes the owner of the previously wlr_egl, and will
-	 * take care of freeing the allocated memory
-	 * TODO: move the wlr_egl logic to wlr_gles2_renderer
-	 */
 	struct wlr_renderer *renderer = wlr_gles2_renderer_create(egl);
 	if (!renderer) {
-		wlr_egl_finish(egl);
+		wlr_log(WLR_ERROR, "Failed to create GLES2 renderer");
+		wlr_egl_destroy(egl);
 	}
 
 	return renderer;


### PR DESCRIPTION
_See individual commits._

* * *

Breaking changes:

* The `EGLint visual_id` parameter of `wlr_egl_init` has been removed.
* `wlr_egl_swap_buffers` has been removed.
* `wlr_egl_init` and `wlr_egl_finish` have been replaced with `wlr_egl_create` and `wlr_egl_destroy`.
* `wlr_egl_make_current` no longer takes the arguments `EGLSurface surface, int *buffer_age`.