### PR TITLE
Add some X11 error tracing facilities

### DIFF
--- a/include/xwayland/trace.h
+++ b/include/xwayland/trace.h
@@ -1,0 +1,23 @@
+#ifndef XWAYLAND_TRACE_H
+#define XWAYLAND_TRACE_H
+
+#include <xcb/xcb.h>
+#include <wayland-util.h>
+
+struct wlr_x11_trace {
+	struct wl_list trace_events; // trace_event::link
+};
+
+void wlr_x11_trace_init(struct wlr_x11_trace *trace);
+void wlr_x11_trace_deinit(struct wlr_x11_trace *trace);
+
+void wlr_x11_trace_received_event(struct wlr_x11_trace *trace, xcb_generic_event_t *event);
+void wlr_x11_trace_log_error_trace(struct wlr_x11_trace *trace, uint32_t sequence);
+
+void wlr_x11_trace_trace(struct wlr_x11_trace *trace, unsigned int sequence,
+	const char *file, unsigned int line);
+
+#define WLR_X11_TRACE(trace, conn) \
+	wlr_x11_trace_trace((trace), xcb_no_operation(conn).sequence, __FILE__, __LINE__)
+
+#endif

--- a/include/xwayland/xwm.h
+++ b/include/xwayland/xwm.h
@@ -12,6 +12,7 @@
 #include <xcb/xcb_errors.h>
 #endif
 #include "xwayland/selection.h"
+#include "xwayland/trace.h"
 
 /* This is in xcb/xcb_event.h, but pulling xcb-util just for a constant
  * others redefine anyway is meh
@@ -98,6 +99,7 @@ struct wlr_xwm {
 	struct wlr_xwayland *xwayland;
 	struct wl_event_source *event_source;
 	struct wlr_seat *seat;
+	struct wlr_x11_trace trace;
 	uint32_t ping_timeout;
 
 	xcb_atom_t atoms[ATOM_LAST];

--- a/xwayland/meson.build
+++ b/xwayland/meson.build
@@ -56,6 +56,7 @@ wlr_files += files(
 	'selection/selection.c',
 	'server.c',
 	'sockets.c',
+	'trace.c',
 	'xwayland.c',
 	'xwm.c',
 )

--- a/xwayland/trace.c
+++ b/xwayland/trace.c
@@ -1,0 +1,77 @@
+#include "xwayland/trace.h"
+#include <stdlib.h>
+#include <wlr/util/log.h>
+
+struct trace_event {
+	const char *file;
+	unsigned int line;
+	unsigned int sequence;
+	struct wl_list link;
+};
+
+static void trace_event_free(struct trace_event *event) {
+	wl_list_remove(&event->link);
+	free(event);
+}
+
+void wlr_x11_trace_init(struct wlr_x11_trace *trace) {
+	wl_list_init(&trace->trace_events);
+}
+
+void wlr_x11_trace_deinit(struct wlr_x11_trace *trace) {
+	struct trace_event *event, *next;
+	wl_list_for_each_safe(event, next, &trace->trace_events, link) {
+		trace_event_free(event);
+	}
+}
+
+void wlr_x11_trace_trace(struct wlr_x11_trace *trace, unsigned int sequence,
+	const char *file, unsigned int line) {
+	struct trace_event *event = malloc(sizeof(*event));
+	if (event == NULL) {
+		return;
+	}
+
+	event->file = file;
+	event->line = line;
+	event->sequence = sequence;
+
+	wl_list_insert(trace->trace_events.prev, &event->link);
+}
+
+// Remove entries from the event queue which are no longer needed.
+//
+// This removes all but one event with an older sequence number than the given
+// event.
+void wlr_x11_trace_received_event(struct wlr_x11_trace *trace, xcb_generic_event_t *event) {
+	struct trace_event *entry, *next, *prev = NULL;
+	wl_list_for_each_safe(entry, next, &trace->trace_events, link) {
+		if (prev) {
+			if (entry->sequence >= event->full_sequence) {
+				break;
+			}
+			trace_event_free(prev);
+		}
+		prev = entry;
+	}
+}
+
+void wlr_x11_trace_log_error_trace(struct wlr_x11_trace *trace, uint32_t sequence) {
+	struct trace_event *entry, *prev = NULL;
+	wl_list_for_each(entry, &trace->trace_events, link) {
+		if (entry->sequence >= sequence) {
+			if (prev) {
+				wlr_log(WLR_ERROR, "X11 error happened somewhere after %s:%d",
+						prev->file, prev->line);
+			}
+			wlr_log(WLR_ERROR, "X11 error happened somewhere before %s:%d",
+					entry->file, entry->line);
+			return;
+		}
+		prev = entry;
+	}
+	if (prev) {
+		wlr_log(WLR_ERROR, "X11 error happened somewhere after %s:%d",
+				prev->file, prev->line);
+	}
+}

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -1372,11 +1372,11 @@ static void xwm_handle_focus_in(struct wlr_xwm *xwm,
 	}
 }
 
-static void xwm_handle_xcb_error(struct wlr_xwm *xwm, xcb_value_error_t *ev) {
+static void xwm_handle_xcb_error(struct wlr_xwm *xwm, xcb_generic_error_t *ev) {
 #if WLR_HAS_XCB_ERRORS
 	const char *major_name =
 		xcb_errors_get_name_for_major_code(xwm->errors_context,
-			ev->major_opcode);
+			ev->major_code);
 	if (!major_name) {
 		wlr_log(WLR_DEBUG, "xcb error happened, but could not get major name");
 		goto log_raw;
@@ -1384,7 +1384,7 @@ static void xwm_handle_xcb_error(struct wlr_xwm *xwm, xcb_value_error_t *ev) {
 
 	const char *minor_name =
 		xcb_errors_get_name_for_minor_code(xwm->errors_context,
-			ev->major_opcode, ev->minor_opcode);
+			ev->major_code, ev->minor_code);
 
 	const char *extension;
 	const char *error_name =
@@ -1398,15 +1398,15 @@ static void xwm_handle_xcb_error(struct wlr_xwm *xwm, xcb_value_error_t *ev) {
 	wlr_log(WLR_ERROR, "xcb error: op %s (%s), code %s (%s), sequence %"PRIu16", value %"PRIu32,
 		major_name, minor_name ? minor_name : "no minor",
 		error_name, extension ? extension : "no extension",
-		ev->sequence, ev->bad_value);
+		ev->sequence, ev->resource_id);
 
 	return;
 log_raw:
 #endif
 	wlr_log(WLR_ERROR,
 		"xcb error: op %"PRIu8":%"PRIu16", code %"PRIu8", sequence %"PRIu16", value %"PRIu32,
-		ev->major_opcode, ev->minor_opcode, ev->error_code,
-		ev->sequence, ev->bad_value);
+		ev->major_code, ev->minor_code, ev->error_code,
+		ev->sequence, ev->resource_id);
 
 }
 
@@ -1486,7 +1486,7 @@ static int x11_event_handler(int fd, uint32_t mask, void *data) {
 			xwm_handle_focus_in(xwm, (xcb_focus_in_event_t *)event);
 			break;
 		case 0:
-			xwm_handle_xcb_error(xwm, (xcb_value_error_t *)event);
+			xwm_handle_xcb_error(xwm, (xcb_generic_error_t *)event);
 			break;
 		default:
 			xwm_handle_unhandled_event(xwm, event);

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -125,6 +125,8 @@ static struct wlr_xwayland_surface *xwayland_surface_create(
 		return NULL;
 	}
 
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
+
 	xcb_get_geometry_cookie_t geometry_cookie =
 		xcb_get_geometry(xwm->xcb_conn, window_id);
 
@@ -187,19 +189,25 @@ static struct wlr_xwayland_surface *xwayland_surface_create(
 
 	wlr_signal_emit_safe(&xwm->xwayland->events.new_surface, surface);
 
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
+
 	return surface;
 }
 
 static void xwm_set_net_active_window(struct wlr_xwm *xwm,
 		xcb_window_t window) {
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 	xcb_change_property(xwm->xcb_conn, XCB_PROP_MODE_REPLACE,
 			xwm->screen->root, xwm->atoms[NET_ACTIVE_WINDOW],
 			xwm->atoms[WINDOW], 32, 1, &window);
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 }
 
 static void xwm_send_wm_message(struct wlr_xwayland_surface *surface,
 		xcb_client_message_data_t *data, uint32_t event_mask) {
 	struct wlr_xwm *xwm = surface->xwm;
+
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 
 	xcb_client_message_event_t event = {
 		.response_type = XCB_CLIENT_MESSAGE,
@@ -215,6 +223,7 @@ static void xwm_send_wm_message(struct wlr_xwayland_surface *surface,
 		surface->window_id,
 		event_mask,
 		(const char *)&event);
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 	xcb_flush(xwm->xcb_conn);
 }
 
@@ -235,9 +244,11 @@ static void xwm_set_net_client_list(struct wlr_xwm *xwm) {
 		}
 	}
 
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 	xcb_change_property(xwm->xcb_conn, XCB_PROP_MODE_REPLACE,
 			xwm->screen->root, xwm->atoms[NET_CLIENT_LIST],
 			XCB_ATOM_WINDOW, 32, mapped_surfaces, windows);
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 }
 
 static void xsurface_set_net_wm_state(struct wlr_xwayland_surface *xsurface);
@@ -245,6 +256,8 @@ static void xsurface_set_net_wm_state(struct wlr_xwayland_surface *xsurface);
 static void xwm_set_focus_window(struct wlr_xwm *xwm,
 		struct wlr_xwayland_surface *xsurface) {
 	struct wlr_xwayland_surface *unfocus_surface = xwm->focus_surface;
+
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 
 	// We handle cases where focus_surface == xsurface because we
 	// want to be able to deny FocusIn events.
@@ -287,6 +300,7 @@ static void xwm_set_focus_window(struct wlr_xwm *xwm,
 		XCB_CONFIG_WINDOW_STACK_MODE, values);
 
 	xsurface_set_net_wm_state(xsurface);
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 }
 
 static void xwm_surface_activate(struct wlr_xwm *xwm,
@@ -309,6 +323,8 @@ static void xwm_surface_activate(struct wlr_xwm *xwm,
 
 static void xsurface_set_net_wm_state(struct wlr_xwayland_surface *xsurface) {
 	struct wlr_xwm *xwm = xsurface->xwm;
+
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 
 	uint32_t property[6];
 	size_t i = 0;
@@ -339,6 +355,8 @@ static void xsurface_set_net_wm_state(struct wlr_xwayland_surface *xsurface) {
 		XCB_ATOM_ATOM,
 		32, // format
 		i, property);
+
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 }
 
 static void xsurface_unmap(struct wlr_xwayland_surface *surface);
@@ -966,6 +984,7 @@ static void xsurface_set_wm_state(struct wlr_xwayland_surface *xsurface,
 	struct wlr_xwm *xwm = xsurface->xwm;
 	uint32_t property[] = { state, XCB_WINDOW_NONE };
 
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 	xcb_change_property(xwm->xcb_conn,
 		XCB_PROP_MODE_REPLACE,
 		xsurface->window_id,
@@ -973,6 +992,7 @@ static void xsurface_set_wm_state(struct wlr_xwayland_surface *xsurface,
 		xwm->atoms[WM_STATE],
 		32, // format
 		sizeof(property) / sizeof(property[0]), property);
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 }
 
 static void xwm_handle_map_request(struct wlr_xwm *xwm,
@@ -983,6 +1003,8 @@ static void xwm_handle_map_request(struct wlr_xwm *xwm,
 		return;
 	}
 
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
+
 	xsurface_set_wm_state(xsurface, ICCCM_NORMAL_STATE);
 	xsurface_set_net_wm_state(xsurface);
 
@@ -992,6 +1014,8 @@ static void xwm_handle_map_request(struct wlr_xwm *xwm,
 			XCB_CONFIG_WINDOW_STACK_MODE, values);
 
 	xcb_map_window(xwm->xcb_conn, ev->window);
+
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 }
 
 static void xwm_handle_map_notify(struct wlr_xwm *xwm,
@@ -1559,6 +1583,8 @@ void wlr_xwayland_surface_restack(struct wlr_xwayland_surface *surface,
 	size_t idx = 0;
 	uint32_t flags = XCB_CONFIG_WINDOW_STACK_MODE;
 
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
+
 	if (sibling != NULL) {
 		values[idx++] = sibling->window_id;
 		flags |= XCB_CONFIG_WINDOW_SIBLING;
@@ -1566,6 +1592,7 @@ void wlr_xwayland_surface_restack(struct wlr_xwayland_surface *surface,
 	values[idx++] = mode;
 
 	xcb_configure_window(xwm->xcb_conn, surface->window_id, flags, values);
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 	xcb_flush(xwm->xcb_conn);
 }
 
@@ -1577,16 +1604,20 @@ void wlr_xwayland_surface_configure(struct wlr_xwayland_surface *xsurface,
 	xsurface->height = height;
 
 	struct wlr_xwm *xwm = xsurface->xwm;
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 	uint32_t mask = XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y |
 		XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT |
 		XCB_CONFIG_WINDOW_BORDER_WIDTH;
 	uint32_t values[] = {x, y, width, height, 0};
 	xcb_configure_window(xwm->xcb_conn, xsurface->window_id, mask, values);
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 	xcb_flush(xwm->xcb_conn);
 }
 
 void wlr_xwayland_surface_close(struct wlr_xwayland_surface *xsurface) {
 	struct wlr_xwm *xwm = xsurface->xwm;
+
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 
 	bool supports_delete = false;
 	for (size_t i = 0; i < xsurface->protocols_len; i++) {
@@ -1605,6 +1636,7 @@ void wlr_xwayland_surface_close(struct wlr_xwayland_surface *xsurface) {
 		xcb_kill_client(xwm->xcb_conn, xsurface->window_id);
 		xcb_flush(xwm->xcb_conn);
 	}
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 }
 
 void xwm_destroy(struct wlr_xwm *xwm) {
@@ -1646,6 +1678,8 @@ void xwm_destroy(struct wlr_xwm *xwm) {
 }
 
 static void xwm_get_resources(struct wlr_xwm *xwm) {
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
+
 	xcb_prefetch_extension_data(xwm->xcb_conn, &xcb_xfixes_id);
 	xcb_prefetch_extension_data(xwm->xcb_conn, &xcb_composite_id);
 
@@ -1691,10 +1725,13 @@ static void xwm_get_resources(struct wlr_xwm *xwm) {
 		xfixes_reply->major_version, xfixes_reply->minor_version);
 
 	free(xfixes_reply);
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 }
 
 static void xwm_create_wm_window(struct wlr_xwm *xwm) {
 	static const char name[] = "wlroots wm";
+
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 
 	xwm->window = xcb_generate_id(xwm->xcb_conn);
 
@@ -1742,6 +1779,8 @@ static void xwm_create_wm_window(struct wlr_xwm *xwm) {
 		xwm->window,
 		xwm->atoms[NET_WM_CM_S0],
 		XCB_CURRENT_TIME);
+
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 }
 
 // TODO use me to support 32 bit color somehow
@@ -1749,6 +1788,8 @@ static void xwm_get_visual_and_colormap(struct wlr_xwm *xwm) {
 	xcb_depth_iterator_t d_iter;
 	xcb_visualtype_iterator_t vt_iter;
 	xcb_visualtype_t *visualtype;
+
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 
 	d_iter = xcb_screen_allowed_depths_iterator(xwm->screen);
 	visualtype = NULL;
@@ -1774,6 +1815,7 @@ static void xwm_get_visual_and_colormap(struct wlr_xwm *xwm) {
 		xwm->colormap,
 		xwm->screen->root,
 		xwm->visual_id);
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 }
 
 static void xwm_get_render_format(struct wlr_xwm *xwm) {
@@ -1809,6 +1851,7 @@ static void xwm_get_render_format(struct wlr_xwm *xwm) {
 
 void xwm_set_cursor(struct wlr_xwm *xwm, const uint8_t *pixels, uint32_t stride,
 		uint32_t width, uint32_t height, int32_t hotspot_x, int32_t hotspot_y) {
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 	if (!xwm->render_format_id) {
 		wlr_log(WLR_ERROR, "Cannot set xwm cursor: no render format available");
 		return;
@@ -1844,6 +1887,7 @@ void xwm_set_cursor(struct wlr_xwm *xwm, const uint8_t *pixels, uint32_t stride,
 	xcb_change_window_attributes(xwm->xcb_conn, xwm->screen->root,
 		XCB_CW_CURSOR, values);
 	xcb_flush(xwm->xcb_conn);
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 }
 
 struct wlr_xwm *xwm_create(struct wlr_xwayland *xwayland, int wm_fd) {
@@ -1866,6 +1910,8 @@ struct wlr_xwm *xwm_create(struct wlr_xwayland *xwayland, int wm_fd) {
 		free(xwm);
 		return NULL;
 	}
+
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 
 #if WLR_HAS_XCB_ERRORS
 	if (xcb_errors_context_new(xwm->xcb_conn, &xwm->errors_context)) {
@@ -1939,6 +1985,7 @@ struct wlr_xwm *xwm_create(struct wlr_xwayland *xwayland, int wm_fd) {
 
 	xwm_create_wm_window(xwm);
 
+	WLR_X11_TRACE(&xwm->trace, xwm->xcb_conn);
 	xcb_flush(xwm->xcb_conn);
 
 	return xwm;


### PR DESCRIPTION
This PR adds some infrastructure to better pinpoint where an X11 error was caused.

As an example, causing an X11 error on purpose like this:
```diff
diff --git a/xwayland/xwm.c b/xwayland/xwm.c
index bb7a4759..0f604f0a 100644
--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -168,6 +168,7 @@ static struct wlr_xwayland_surface *xwayland_surface_create(
 	wl_signal_init(&surface->events.ping_timeout);
 	wl_signal_init(&surface->events.set_geometry);
 
+	xcb_change_window_attributes(xwm->xcb_conn, 1234, 0, NULL);
 	xcb_get_geometry_reply_t *geometry_reply =
 		xcb_get_geometry_reply(xwm->xcb_conn, geometry_cookie, NULL);
 	if (geometry_reply != NULL) {
```
produces the following output:
```
00:00:02.140 [wlr] [xwayland/xwm.c:1432] xcb error: op 2:0, code 3, sequence 111, value 1234
00:00:02.140 [wlr] [xwayland/trace.c:64] X11 error happened somewhere after xwayland/xwm.c:128
00:00:02.140 [wlr] [xwayland/trace.c:67] X11 error happened somewhere before xwayland/xwm.c:193
```
Future work on this:
- [ ] Make this a compile time option so that it can be turned off when not needed. Dunno if this is necessary and I didn't want to start the bikeshedding with an own name for the option, so this is up to you.
- [ ] Do something similar for `backend/x11`. Since this is best done by sharing code between `xwayland` and the backend, which is not done so far, I did not want to do this just yet. I'd be happy if someone who knows what they are doing does this as a follow-up PR.