### PR TITLE
backend/drm: add support for suggested output position prop

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1221,6 +1221,94 @@ static uint32_t get_possible_crtcs(int fd, drmModeRes *res,
 
 static void disconnect_drm_connector(struct wlr_drm_connector *conn);
 
+static bool update_modes(drmModeConnector *drm_conn,
+		struct wlr_drm_connector *wlr_conn) {
+	bool changes_made = false;
+
+	struct wlr_output_mode *previous_mode, *tmp_mode;
+	wl_list_for_each_safe(previous_mode, tmp_mode, &wlr_conn->output.modes, link) {
+
+		struct wlr_drm_mode *previous_drm_mode = (struct wlr_drm_mode *) previous_mode;
+		bool matched = false;
+
+		for (int j = 0; j < drm_conn->count_modes; ++j) {
+			if (memcmp(&previous_drm_mode->drm_mode, &drm_conn->modes[j],
+					sizeof(previous_drm_mode->drm_mode)) == 0) {
+				matched = true;
+				continue;
+			}
+		}
+
+		if (matched) {
+			continue;
+		}
+
+		if (!changes_made) {
+			changes_made = true;
+			wlr_log(WLR_INFO, "Removed modes:");
+		}
+
+		wlr_log(WLR_INFO, "  %"PRId32"x%"PRId32"@%"PRId32" %s",
+			previous_drm_mode->wlr_mode.width,
+			previous_drm_mode->wlr_mode.height,
+			previous_drm_mode->wlr_mode.refresh,
+			previous_drm_mode->wlr_mode.preferred ? "(preferred)" : "");
+
+		wl_list_remove(&previous_drm_mode->wlr_mode.link);
+		free(previous_drm_mode);
+	}
+
+	if (drm_conn->count_modes > wl_list_length(&wlr_conn->output.modes)) {
+		wlr_log(WLR_INFO, "New modes:");
+
+		for (int i = 0; i < drm_conn->count_modes; ++i) {
+			if (drm_conn->modes[i].flags & DRM_MODE_FLAG_INTERLACE) {
+				continue;
+			}
+
+			struct wlr_output_mode *existing_mode;
+			bool matched = false;
+			wl_list_for_each(existing_mode, &wlr_conn->output.modes, link) {
+				struct wlr_drm_mode *existing_drm_mode =
+					(struct wlr_drm_mode *) existing_mode;
+				if (memcmp(&drm_conn->modes[i], &existing_drm_mode->drm_mode,
+						sizeof(drm_conn->modes[i])) == 0) {
+					matched = true;
+					continue;
+				}
+			}
+
+			if (matched) {
+				continue;
+			}
+
+			struct wlr_drm_mode *mode = calloc(1, sizeof(*mode));
+			if (!mode) {
+				wlr_log_errno(WLR_ERROR, "Allocation failed");
+				continue;
+			}
+
+			mode->drm_mode = drm_conn->modes[i];
+			mode->wlr_mode.width = mode->drm_mode.hdisplay;
+			mode->wlr_mode.height = mode->drm_mode.vdisplay;
+			mode->wlr_mode.refresh = calculate_refresh_rate(&mode->drm_mode);
+			if (mode->drm_mode.type & DRM_MODE_TYPE_PREFERRED) {
+				mode->wlr_mode.preferred = true;
+			}
+
+			wlr_log(WLR_INFO, "  %"PRId32"x%"PRId32"@%"PRId32" %s",
+				mode->wlr_mode.width, mode->wlr_mode.height,
+				mode->wlr_mode.refresh,
+				mode->wlr_mode.preferred ? "(preferred)" : "");
+
+			changes_made = true;
+			wl_list_insert(&wlr_conn->output.modes, &mode->wlr_mode.link);
+		}
+	}
+
+	return changes_made;
+}
+
 void scan_drm_connectors(struct wlr_drm_backend *drm) {
 	/*
 	 * This GPU is not really a modesetting device.
@@ -1322,6 +1410,15 @@ void scan_drm_connectors(struct wlr_drm_backend *drm) {
 			}
 		}
 
+		if ((wlr_conn->state == WLR_DRM_CONN_CONNECTED
+				|| wlr_conn->state == WLR_DRM_CONN_NEEDS_MODESET) &&
+				drm_conn->connection == DRM_MODE_CONNECTED) {
+			wlr_log(WLR_INFO, "Scanning '%s' for changed modes", wlr_conn->name);
+			if (update_modes(drm_conn, wlr_conn)) {
+				wlr_output_update_available_modes(&wlr_conn->output);
+			}
+		}
+
 		if (wlr_conn->state == WLR_DRM_CONN_DISCONNECTED &&
 				drm_conn->connection == DRM_MODE_CONNECTED) {
 			wlr_log(WLR_INFO, "'%s' connected", wlr_conn->name);
@@ -1354,35 +1451,7 @@ void scan_drm_connectors(struct wlr_drm_backend *drm) {
 				output->make, output->model, output->serial, output->name);
 			wlr_output_set_description(output, description);
 
-			wlr_log(WLR_INFO, "Detected modes:");
-
-			for (int i = 0; i < drm_conn->count_modes; ++i) {
-				struct wlr_drm_mode *mode = calloc(1, sizeof(*mode));
-				if (!mode) {
-					wlr_log_errno(WLR_ERROR, "Allocation failed");
-					continue;
-				}
-
-				if (drm_conn->modes[i].flags & DRM_MODE_FLAG_INTERLACE) {
-					free(mode);
-					continue;
-				}
-
-				mode->drm_mode = drm_conn->modes[i];
-				mode->wlr_mode.width = mode->drm_mode.hdisplay;
-				mode->wlr_mode.height = mode->drm_mode.vdisplay;
-				mode->wlr_mode.refresh = calculate_refresh_rate(&mode->drm_mode);
-				if (mode->drm_mode.type & DRM_MODE_TYPE_PREFERRED) {
-					mode->wlr_mode.preferred = true;
-				}
-
-				wlr_log(WLR_INFO, "  %"PRId32"x%"PRId32"@%"PRId32" %s",
-					mode->wlr_mode.width, mode->wlr_mode.height,
-					mode->wlr_mode.refresh,
-					mode->wlr_mode.preferred ? "(preferred)" : "");
-
-				wl_list_insert(&wlr_conn->output.modes, &mode->wlr_mode.link);
-			}
+			update_modes(drm_conn, wlr_conn);
 
 			wlr_conn->possible_crtcs = get_possible_crtcs(drm->fd, res, drm_conn);
 			if (wlr_conn->possible_crtcs == 0) {

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1255,7 +1255,13 @@ static bool update_modes(drmModeConnector *drm_conn,
 			previous_drm_mode->wlr_mode.preferred ? "(preferred)" : "");
 
 		wl_list_remove(&previous_drm_mode->wlr_mode.link);
-		free(previous_drm_mode);
+
+		// Free the removed mode unless it is the current or pending mode
+		if (previous_mode != wlr_conn->output.current_mode &&
+				!(wlr_conn->output.pending.committed & WLR_OUTPUT_STATE_MODE &&
+				previous_mode != wlr_conn->output.pending.mode)) {
+			free(previous_drm_mode);
+		}
 	}
 
 	if (drm_conn->count_modes > wl_list_length(&wlr_conn->output.modes)) {

--- a/backend/drm/properties.c
+++ b/backend/drm/properties.c
@@ -25,6 +25,8 @@ static const struct prop_info connector_info[] = {
 	{ "PATH", INDEX(path) },
 	{ "link-status", INDEX(link_status) },
 	{ "vrr_capable", INDEX(vrr_capable) },
+	{ "suggested X", INDEX(suggested_x) },
+	{ "suggested Y", INDEX(suggested_y) },
 #undef INDEX
 };
 

--- a/include/backend/drm/properties.h
+++ b/include/backend/drm/properties.h
@@ -17,6 +17,8 @@ union wlr_drm_connector_props {
 		uint32_t link_status; // not guaranteed to exist
 		uint32_t path;
 		uint32_t vrr_capable; // not guaranteed to exist
+		uint32_t suggested_x;
+		uint32_t suggested_y;
 
 		// atomic-modesetting only
 

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -110,6 +110,13 @@ void wlr_output_update_mode(struct wlr_output *output,
 void wlr_output_update_custom_mode(struct wlr_output *output, int32_t width,
 	int32_t height, int32_t refresh);
 /**
+ * Update the output available modes.
+ *
+ * The backend must call this function when the available modes are updated
+ * to notify compositors about the change.
+ */
+void wlr_output_update_available_modes(struct wlr_output *output);
+/**
  * Update the current output status.
  *
  * The backend must call this function when the status is updated to notify

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -117,6 +117,13 @@ void wlr_output_update_custom_mode(struct wlr_output *output, int32_t width,
  */
 void wlr_output_update_available_modes(struct wlr_output *output);
 /**
+ * Update the output suggested position.
+ *
+ * The backend must call this function when the suggested position is updated
+ * to notify compositors about the change.
+ */
+void wlr_output_update_suggested_position (struct wlr_output *output);
+/**
  * Update the current output status.
  *
  * The backend must call this function when the status is updated to notify

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -170,6 +170,7 @@ struct wlr_output {
 		struct wl_signal bind; // wlr_output_event_bind
 		struct wl_signal enable;
 		struct wl_signal mode;
+		struct wl_signal available_modes;
 		struct wl_signal scale;
 		struct wl_signal transform;
 		struct wl_signal description;

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -128,6 +128,7 @@ struct wlr_output {
 	char model[16];
 	char serial[16];
 	int32_t phys_width, phys_height; // mm
+	int32_t suggested_x, suggested_y;
 
 	// Note: some backends may have zero modes
 	struct wl_list modes; // wlr_output_mode::link
@@ -171,6 +172,7 @@ struct wlr_output {
 		struct wl_signal enable;
 		struct wl_signal mode;
 		struct wl_signal available_modes;
+		struct wl_signal suggested_position;
 		struct wl_signal scale;
 		struct wl_signal transform;
 		struct wl_signal description;

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -226,6 +226,10 @@ void wlr_output_update_custom_mode(struct wlr_output *output, int32_t width,
 	wlr_signal_emit_safe(&output->events.mode, output);
 }
 
+void wlr_output_update_available_modes(struct wlr_output *output) {
+	wlr_signal_emit_safe(&output->events.available_modes, output);
+}
+
 void wlr_output_set_transform(struct wlr_output *output,
 		enum wl_output_transform transform) {
 	if (output->transform == transform) {
@@ -343,6 +347,7 @@ void wlr_output_init(struct wlr_output *output, struct wlr_backend *backend,
 	wl_signal_init(&output->events.bind);
 	wl_signal_init(&output->events.enable);
 	wl_signal_init(&output->events.mode);
+	wl_signal_init(&output->events.available_modes);
 	wl_signal_init(&output->events.scale);
 	wl_signal_init(&output->events.transform);
 	wl_signal_init(&output->events.description);

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -263,6 +263,10 @@ void wlr_output_update_available_modes(struct wlr_output *output) {
 	wlr_signal_emit_safe(&output->events.available_modes, output);
 }
 
+void wlr_output_update_suggested_position (struct wlr_output *output) {
+	wlr_signal_emit_safe(&output->events.suggested_position, output);
+}
+
 void wlr_output_set_transform(struct wlr_output *output,
 		enum wl_output_transform transform) {
 	if (output->transform == transform) {
@@ -381,6 +385,7 @@ void wlr_output_init(struct wlr_output *output, struct wlr_backend *backend,
 	wl_signal_init(&output->events.enable);
 	wl_signal_init(&output->events.mode);
 	wl_signal_init(&output->events.available_modes);
+	wl_signal_init(&output->events.suggested_position);
 	wl_signal_init(&output->events.scale);
 	wl_signal_init(&output->events.transform);
 	wl_signal_init(&output->events.description);


### PR DESCRIPTION
Depends on and includes commits from https://github.com/swaywm/wlroots/pull/2628 (could also be independently rebased onto master, but wouldn't be as useful on its own)

Relates to https://github.com/swaywm/wlroots/issues/2188

Virtualised outputs use the "suggested X" and "suggested Y" DRM props to indicate their relative position on the host WM.

This change adds members `suggested_x` and `suggested_y` to `struct wlr_output` which contain the value of these props. Also, a `suggested_position` signal is added so that compositors can be notified if there is a changed in the suggested position.