### PR TITLE
output: send commit event after pending state is cleared

### DIFF
--- a/include/wlr/types/wlr_output_damage.h
+++ b/include/wlr/types/wlr_output_damage.h
@@ -42,6 +42,8 @@ struct wlr_output_damage {
 	pixman_region32_t previous[WLR_OUTPUT_DAMAGE_PREVIOUS_LEN];
 	size_t previous_idx;
 
+	enum wlr_output_state_buffer_type pending_buffer_type;
+
 	struct {
 		struct wl_signal frame;
 		struct wl_signal destroy;
@@ -54,6 +56,7 @@ struct wlr_output_damage {
 	struct wl_listener output_needs_frame;
 	struct wl_listener output_damage;
 	struct wl_listener output_frame;
+	struct wl_listener output_precommit;
 	struct wl_listener output_commit;
 };
 

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -614,13 +614,6 @@ bool wlr_output_commit(struct wlr_output *output) {
 
 	output->commit_seq++;
 
-	struct wlr_output_event_commit event = {
-		.output = output,
-		.committed = output->pending.committed,
-		.when = &now,
-	};
-	wlr_signal_emit_safe(&output->events.commit, &event);
-
 	bool scale_updated = output->pending.committed & WLR_OUTPUT_STATE_SCALE;
 	if (scale_updated) {
 		output->scale = output->pending.scale;
@@ -653,7 +646,16 @@ bool wlr_output_commit(struct wlr_output *output) {
 		output->needs_frame = false;
 	}
 
+	uint32_t committed = output->pending.committed;
 	output_state_clear(&output->pending);
+
+	struct wlr_output_event_commit event = {
+		.output = output,
+		.committed = committed,
+		.when = &now,
+	};
+	wlr_signal_emit_safe(&output->events.commit, &event);
+
 	return true;
 }
 


### PR DESCRIPTION
References: https://github.com/swaywm/wlroots/issues/2098

* * *

Breaking change: Compositors can no longer read the to-be-committed state from`wlr_output.pending` in an output `commit` event handler. Instead, use the current state and `wlr_output_event_commit`.