### PR TITLE
output: remove scale/transform events

### DIFF
--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -170,8 +170,6 @@ struct wlr_output {
 		struct wl_signal bind; // wlr_output_event_bind
 		struct wl_signal enable;
 		struct wl_signal mode;
-		struct wl_signal scale;
-		struct wl_signal transform;
 		struct wl_signal description;
 		struct wl_signal destroy;
 	} events;

--- a/include/wlr/types/wlr_output_damage.h
+++ b/include/wlr/types/wlr_output_damage.h
@@ -49,8 +49,6 @@ struct wlr_output_damage {
 
 	struct wl_listener output_destroy;
 	struct wl_listener output_mode;
-	struct wl_listener output_transform;
-	struct wl_listener output_scale;
 	struct wl_listener output_needs_frame;
 	struct wl_listener output_damage;
 	struct wl_listener output_frame;

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -343,8 +343,6 @@ void wlr_output_init(struct wlr_output *output, struct wlr_backend *backend,
 	wl_signal_init(&output->events.bind);
 	wl_signal_init(&output->events.enable);
 	wl_signal_init(&output->events.mode);
-	wl_signal_init(&output->events.scale);
-	wl_signal_init(&output->events.transform);
 	wl_signal_init(&output->events.description);
 	wl_signal_init(&output->events.destroy);
 	pixman_region32_init(&output->pending.damage);
@@ -624,13 +622,11 @@ bool wlr_output_commit(struct wlr_output *output) {
 	bool scale_updated = output->pending.committed & WLR_OUTPUT_STATE_SCALE;
 	if (scale_updated) {
 		output->scale = output->pending.scale;
-		wlr_signal_emit_safe(&output->events.scale, output);
 	}
 
 	if (output->pending.committed & WLR_OUTPUT_STATE_TRANSFORM) {
 		output->transform = output->pending.transform;
 		output_update_matrix(output);
-		wlr_signal_emit_safe(&output->events.transform, output);
 	}
 
 	bool geometry_updated = output->pending.committed &


### PR DESCRIPTION
Per https://github.com/swaywm/wlroots/issues/2098, compositors should use the commit event instead.

Unfortunately we can't do the same for the `mode` and `enabled` events, because the backend can update those behind the compositor's back (without an output commit).

* * *

Breaking change: the `scale` and `transform` output events have been removed, compositors should use the `commit` event instead.