### PR TITLE
Make libinput and DRM backends optional

### DIFF
--- a/backend/drm/meson.build
+++ b/backend/drm/meson.build
@@ -1,3 +1,9 @@
+if get_option('drm-backend').disabled()
+	subdir_done()
+endif
+
+conf_data.set10('WLR_HAS_DRM_BACKEND', true)
+
 wlr_files += files(
 	'atomic.c',
 	'backend.c',

--- a/backend/libinput/meson.build
+++ b/backend/libinput/meson.build
@@ -1,3 +1,12 @@
+libinput = dependency('libinput', version: '>=1.14.0', required: get_option('libinput-backend'))
+if not libinput.found()
+	subdir_done()
+endif
+
+conf_data.set10('WLR_HAS_LIBINPUT_BACKEND', true)
+
+wlr_deps += libinput
+
 wlr_files += files(
 	'backend.c',
 	'events.c',

--- a/include/meson.build
+++ b/include/meson.build
@@ -7,6 +7,9 @@ endif
 if conf_data.get('WLR_HAS_LIBINPUT_BACKEND', 0) != 1
 	exclude_files += 'backend/libinput.h'
 endif
+if conf_data.get('WLR_HAS_DRM_BACKEND', 0) != 1
+	exclude_files += 'backend/drm.h'
+endif
 if conf_data.get('WLR_HAS_XWAYLAND', 0) != 1
 	exclude_files += 'xwayland.h'
 endif

--- a/include/meson.build
+++ b/include/meson.build
@@ -4,6 +4,9 @@ exclude_files = ['meson.build', 'config.h.in', 'version.h.in']
 if conf_data.get('WLR_HAS_X11_BACKEND', 0) != 1
 	exclude_files += 'backend/x11.h'
 endif
+if conf_data.get('WLR_HAS_LIBINPUT_BACKEND', 0) != 1
+	exclude_files += 'backend/libinput.h'
+endif
 if conf_data.get('WLR_HAS_XWAYLAND', 0) != 1
 	exclude_files += 'xwayland.h'
 endif

--- a/include/wlr/config.h.in
+++ b/include/wlr/config.h.in
@@ -7,6 +7,7 @@
 #mesondefine WLR_HAS_LIBSEAT
 
 #mesondefine WLR_HAS_X11_BACKEND
+#mesondefine WLR_HAS_LIBINPUT_BACKEND
 
 #mesondefine WLR_HAS_XWAYLAND
 

--- a/include/wlr/config.h.in
+++ b/include/wlr/config.h.in
@@ -8,6 +8,7 @@
 
 #mesondefine WLR_HAS_X11_BACKEND
 #mesondefine WLR_HAS_LIBINPUT_BACKEND
+#mesondefine WLR_HAS_DRM_BACKEND
 
 #mesondefine WLR_HAS_XWAYLAND
 

--- a/meson.build
+++ b/meson.build
@@ -84,6 +84,7 @@ conf_data.set10('WLR_HAS_SYSTEMD', false)
 conf_data.set10('WLR_HAS_ELOGIND', false)
 conf_data.set10('WLR_HAS_LIBSEAT', false)
 conf_data.set10('WLR_HAS_X11_BACKEND', false)
+conf_data.set10('WLR_HAS_LIBINPUT_BACKEND', false)
 conf_data.set10('WLR_HAS_XWAYLAND', false)
 conf_data.set10('WLR_HAS_XCB_ERRORS', false)
 conf_data.set10('WLR_HAS_XCB_ICCCM', false)
@@ -96,7 +97,6 @@ egl = dependency('egl')
 glesv2 = dependency('glesv2')
 drm = dependency('libdrm', version: '>=2.4.95')
 gbm = dependency('gbm', version: '>=17.1.0')
-libinput = dependency('libinput', version: '>=1.14.0')
 xkbcommon = dependency('xkbcommon')
 udev = dependency('libudev')
 pixman = dependency('pixman-1')
@@ -123,7 +123,6 @@ wlr_deps = [
 	glesv2,
 	drm,
 	gbm,
-	libinput,
 	xkbcommon,
 	udev,
 	pixman,
@@ -171,6 +170,7 @@ summary({
 	'libseat': conf_data.get('WLR_HAS_LIBSEAT', 0) == 1,
 	'xwayland': conf_data.get('WLR_HAS_XWAYLAND', 0) == 1,
 	'x11-backend': conf_data.get('WLR_HAS_X11_BACKEND', 0) == 1,
+	'libinput-backend': conf_data.get('WLR_HAS_LIBINPUT_BACKEND', 0) == 1,
 	'xcb-icccm': conf_data.get('WLR_HAS_XCB_ICCCM', 0) == 1,
 	'xcb-errors': conf_data.get('WLR_HAS_XCB_ERRORS', 0) == 1,
 	'xdg-foreign': conf_data.get('WLR_HAS_XDG_FOREIGN', 0) == 1,

--- a/meson.build
+++ b/meson.build
@@ -85,6 +85,7 @@ conf_data.set10('WLR_HAS_ELOGIND', false)
 conf_data.set10('WLR_HAS_LIBSEAT', false)
 conf_data.set10('WLR_HAS_X11_BACKEND', false)
 conf_data.set10('WLR_HAS_LIBINPUT_BACKEND', false)
+conf_data.set10('WLR_HAS_DRM_BACKEND', false)
 conf_data.set10('WLR_HAS_XWAYLAND', false)
 conf_data.set10('WLR_HAS_XCB_ERRORS', false)
 conf_data.set10('WLR_HAS_XCB_ICCCM', false)
@@ -171,6 +172,7 @@ summary({
 	'xwayland': conf_data.get('WLR_HAS_XWAYLAND', 0) == 1,
 	'x11-backend': conf_data.get('WLR_HAS_X11_BACKEND', 0) == 1,
 	'libinput-backend': conf_data.get('WLR_HAS_LIBINPUT_BACKEND', 0) == 1,
+	'drm-backend': conf_data.get('WLR_HAS_DRM_BACKEND', 0) == 1,
 	'xcb-icccm': conf_data.get('WLR_HAS_XCB_ICCCM', 0) == 1,
 	'xcb-errors': conf_data.get('WLR_HAS_XCB_ERRORS', 0) == 1,
 	'xdg-foreign': conf_data.get('WLR_HAS_XDG_FOREIGN', 0) == 1,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,6 +5,7 @@ option('xcb-errors', type: 'feature', value: 'auto', description: 'Use xcb-error
 option('xcb-icccm', type: 'feature', value: 'auto', description: 'Use xcb-icccm util library')
 option('xwayland', type: 'feature', value: 'auto', yield: true, description: 'Enable support for X11 applications')
 option('x11-backend', type: 'feature', value: 'auto', description: 'Enable X11 backend')
+option('libinput-backend', type: 'feature', value: 'auto', description: 'Enable libinput backend')
 option('examples', type: 'boolean', value: true, description: 'Build example applications')
 option('icon_directory', description: 'Location used to look for cursors (default: ${datadir}/icons)', type: 'string', value: '')
 option('xdg-foreign', type: 'feature', value: 'auto', description: 'Enable xdg-foreign protocol')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,6 +6,7 @@ option('xcb-icccm', type: 'feature', value: 'auto', description: 'Use xcb-icccm 
 option('xwayland', type: 'feature', value: 'auto', yield: true, description: 'Enable support for X11 applications')
 option('x11-backend', type: 'feature', value: 'auto', description: 'Enable X11 backend')
 option('libinput-backend', type: 'feature', value: 'auto', description: 'Enable libinput backend')
+option('drm-backend', type: 'feature', value: 'auto', description: 'Enable DRM backend')
 option('examples', type: 'boolean', value: true, description: 'Build example applications')
 option('icon_directory', description: 'Location used to look for cursors (default: ${datadir}/icons)', type: 'string', value: '')
 option('xdg-foreign', type: 'feature', value: 'auto', description: 'Enable xdg-foreign protocol')


### PR DESCRIPTION
Some compositors may not need the libinput or DRM backend, because they provide
their own backends. Allow to build wlroots without these.