### PR TITLE
Drop EGL from wlr_renderer_autocreate

### DIFF
--- a/backend/backend.c
+++ b/backend/backend.c
@@ -16,6 +16,7 @@
 #include <wlr/backend/wayland.h>
 #include <wlr/config.h>
 #include <wlr/util/log.h>
+#include "backend/backend.h"
 #include "backend/multi.h"
 
 #if WLR_HAS_X11_BACKEND
@@ -69,6 +70,13 @@ clockid_t wlr_backend_get_presentation_clock(struct wlr_backend *backend) {
 		return backend->impl->get_presentation_clock(backend);
 	}
 	return CLOCK_MONOTONIC;
+}
+
+int backend_get_drm_fd(struct wlr_backend *backend) {
+	if (!backend->impl->get_drm_fd) {
+		return -1;
+	}
+	return backend->impl->get_drm_fd(backend);
 }
 
 static size_t parse_outputs_env(const char *name) {

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -77,11 +77,22 @@ static clockid_t backend_get_presentation_clock(struct wlr_backend *backend) {
 	return drm->clock;
 }
 
+static int backend_get_drm_fd(struct wlr_backend *backend) {
+	struct wlr_drm_backend *drm = get_drm_backend_from_backend(backend);
+
+	if (drm->parent) {
+		return drm->parent->fd;
+	} else {
+		return drm->fd;
+	}
+}
+
 static struct wlr_backend_impl backend_impl = {
 	.start = backend_start,
 	.destroy = backend_destroy,
 	.get_renderer = backend_get_renderer,
 	.get_presentation_clock = backend_get_presentation_clock,
+	.get_drm_fd = backend_get_drm_fd,
 };
 
 bool wlr_backend_is_drm(struct wlr_backend *b) {

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -29,8 +29,7 @@ bool init_drm_renderer(struct wlr_drm_backend *drm,
 		return false;
 	}
 
-	renderer->wlr_rend = wlr_renderer_autocreate(EGL_PLATFORM_GBM_KHR,
-			renderer->gbm);
+	renderer->wlr_rend = wlr_renderer_autocreate(&drm->backend);
 	if (!renderer->wlr_rend) {
 		wlr_log(WLR_ERROR, "Failed to create EGL/WLR renderer");
 		goto error_gbm;

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <wayland-util.h>
+#include <wlr/render/egl.h>
 #include <wlr/render/gles2.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_matrix.h>

--- a/backend/headless/backend.c
+++ b/backend/headless/backend.c
@@ -219,8 +219,7 @@ struct wlr_backend *wlr_headless_backend_create(struct wl_display *display) {
 		goto error_dup;
 	}
 
-	struct wlr_renderer *renderer = wlr_renderer_autocreate(
-		EGL_PLATFORM_GBM_KHR, gbm_alloc->gbm_device);
+	struct wlr_renderer *renderer = wlr_renderer_autocreate(&backend->backend);
 	if (!renderer) {
 		wlr_log(WLR_ERROR, "Failed to create renderer");
 		goto error_renderer;

--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <wlr/interfaces/wlr_output.h>
+#include <wlr/render/egl.h>
 #include <wlr/render/gles2.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/util/log.h>

--- a/backend/multi/backend.c
+++ b/backend/multi/backend.c
@@ -6,6 +6,7 @@
 #include <wlr/backend/interface.h>
 #include <wlr/backend/session.h>
 #include <wlr/util/log.h>
+#include "backend/backend.h"
 #include "backend/multi.h"
 #include "util/signal.h"
 
@@ -96,12 +97,26 @@ static clockid_t multi_backend_get_presentation_clock(
 	return CLOCK_MONOTONIC;
 }
 
+static int multi_backend_get_drm_fd(struct wlr_backend *backend) {
+	struct wlr_multi_backend *multi = multi_backend_from_backend(backend);
+
+	struct subbackend_state *sub;
+	wl_list_for_each(sub, &multi->backends, link) {
+		if (sub->backend->impl->get_drm_fd) {
+			return backend_get_drm_fd(sub->backend);
+		}
+	}
+
+	return -1;
+}
+
 struct wlr_backend_impl backend_impl = {
 	.start = multi_backend_start,
 	.destroy = multi_backend_destroy,
 	.get_renderer = multi_backend_get_renderer,
 	.get_session = multi_backend_get_session,
 	.get_presentation_clock = multi_backend_get_presentation_clock,
+	.get_drm_fd = multi_backend_get_drm_fd,
 };
 
 static void handle_display_destroy(struct wl_listener *listener, void *data) {

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -437,8 +437,7 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display,
 	}
 	wl->allocator = &gbm_alloc->base;
 
-	wl->renderer = wlr_renderer_autocreate(EGL_PLATFORM_GBM_KHR,
-		gbm_alloc->gbm_device);
+	wl->renderer = wlr_renderer_autocreate(&wl->backend);
 	if (wl->renderer == NULL) {
 		wlr_log(WLR_ERROR, "Failed to create renderer");
 		goto error_allocator;

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -295,6 +295,7 @@ static void backend_destroy(struct wlr_backend *backend) {
 
 	wlr_renderer_destroy(wl->renderer);
 	wlr_allocator_destroy(wl->allocator);
+	close(wl->drm_fd);
 
 	wlr_drm_format_set_finish(&wl->linux_dmabuf_v1_formats);
 
@@ -332,10 +333,16 @@ static struct wlr_renderer *backend_get_renderer(struct wlr_backend *backend) {
 	return wl->renderer;
 }
 
+static int backend_get_drm_fd(struct wlr_backend *backend) {
+	struct wlr_wl_backend *wl = get_wl_backend_from_backend(backend);
+	return wl->drm_fd;
+}
+
 static struct wlr_backend_impl backend_impl = {
 	.start = backend_start,
 	.destroy = backend_destroy,
 	.get_renderer = backend_get_renderer,
+	.get_drm_fd = backend_get_drm_fd,
 };
 
 bool wlr_backend_is_wl(struct wlr_backend *b) {
@@ -409,18 +416,24 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display,
 	wl_event_source_check(wl->remote_display_src);
 
 	wlr_log(WLR_DEBUG, "Opening DRM render node %s", wl->drm_render_name);
-	int drm_fd = open(wl->drm_render_name, O_RDWR | O_NONBLOCK | O_CLOEXEC);
-	if (drm_fd < 0) {
+	wl->drm_fd = open(wl->drm_render_name, O_RDWR | O_NONBLOCK | O_CLOEXEC);
+	if (wl->drm_fd < 0) {
 		wlr_log_errno(WLR_ERROR, "Failed to open DRM render node %s",
 			wl->drm_render_name);
-		goto error_registry;
+		goto error_remote_display_src;
+	}
+
+	int drm_fd = fcntl(wl->drm_fd, F_DUPFD_CLOEXEC, 0);
+	if (drm_fd < 0) {
+		wlr_log(WLR_ERROR, "fcntl(F_DUPFD_CLOEXEC) failed");
+		goto error_drm_fd;
 	}
 
 	struct wlr_gbm_allocator *gbm_alloc = wlr_gbm_allocator_create(drm_fd);
 	if (gbm_alloc == NULL) {
 		wlr_log(WLR_ERROR, "Failed to create GBM allocator");
 		close(drm_fd);
-		goto error_registry;
+		goto error_drm_fd;
 	}
 	wl->allocator = &gbm_alloc->base;
 
@@ -428,7 +441,7 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display,
 		gbm_alloc->gbm_device);
 	if (wl->renderer == NULL) {
 		wlr_log(WLR_ERROR, "Failed to create renderer");
-		goto error_registry;
+		goto error_allocator;
 	}
 
 	uint32_t fmt = DRM_FORMAT_ARGB8888;
@@ -437,27 +450,27 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display,
 	if (remote_format == NULL) {
 		wlr_log(WLR_ERROR, "Remote compositor doesn't support format "
 			"0x%"PRIX32" via linux-dmabuf-unstable-v1", fmt);
-		goto error_event;
+		goto error_renderer;
 	}
 
 	const struct wlr_drm_format_set *render_formats =
 		wlr_renderer_get_dmabuf_render_formats(wl->renderer);
 	if (render_formats == NULL) {
 		wlr_log(WLR_ERROR, "Failed to get available DMA-BUF formats from renderer");
-		return false;
+		goto error_renderer;
 	}
 	const struct wlr_drm_format *render_format =
 		wlr_drm_format_set_get(render_formats, fmt);
 	if (render_format == NULL) {
 		wlr_log(WLR_ERROR, "Renderer doesn't support DRM format 0x%"PRIX32, fmt);
-		return false;
+		goto error_renderer;
 	}
 
 	wl->format = wlr_drm_format_intersect(remote_format, render_format);
 	if (wl->format == NULL) {
 		wlr_log(WLR_ERROR, "Failed to intersect remote and render modifiers "
 			"for format 0x%"PRIX32, fmt);
-		return false;
+		goto error_renderer;
 	}
 
 	wl->local_display_destroy.notify = handle_display_destroy;
@@ -465,7 +478,13 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display,
 
 	return &wl->backend;
 
-error_event:
+error_renderer:
+	wlr_renderer_destroy(wl->renderer);
+error_allocator:
+	wlr_allocator_destroy(wl->allocator);
+error_drm_fd:
+	close(wl->drm_fd);
+error_remote_display_src:
 	wl_event_source_remove(wl->remote_display_src);
 error_registry:
 	free(wl->drm_render_name);

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -10,6 +10,7 @@
 #include <wayland-client.h>
 
 #include <wlr/interfaces/wlr_output.h>
+#include <wlr/render/egl.h>
 #include <wlr/render/gles2.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_matrix.h>

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -547,8 +547,7 @@ struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
 	}
 	x11->allocator = &gbm_alloc->base;
 
-	x11->renderer = wlr_renderer_autocreate(EGL_PLATFORM_GBM_KHR,
-		gbm_alloc->gbm_device);
+	x11->renderer = wlr_renderer_autocreate(&x11->backend);
 	if (x11->renderer == NULL) {
 		wlr_log(WLR_ERROR, "Failed to create renderer");
 		goto error_event;

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -13,6 +13,7 @@
 #include <wlr/interfaces/wlr_output.h>
 #include <wlr/interfaces/wlr_pointer.h>
 #include <wlr/interfaces/wlr_touch.h>
+#include <wlr/render/egl.h>
 #include <wlr/render/gles2.h>
 #include <wlr/util/log.h>
 

--- a/include/backend/backend.h
+++ b/include/backend/backend.h
@@ -1,0 +1,8 @@
+#ifndef BACKEND_H
+#define BACKEND_H
+
+#include <wlr/backend.h>
+
+int backend_get_drm_fd(struct wlr_backend *backend);
+
+#endif

--- a/include/backend/headless.h
+++ b/include/backend/headless.h
@@ -8,6 +8,7 @@
 
 struct wlr_headless_backend {
 	struct wlr_backend backend;
+	int drm_fd;
 	struct wlr_renderer *renderer;
 	struct wlr_allocator *allocator;
 	struct wlr_drm_format *format;

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -20,6 +20,7 @@ struct wlr_wl_backend {
 	struct wl_display *local_display;
 	struct wl_list devices;
 	struct wl_list outputs;
+	int drm_fd;
 	struct wlr_renderer *renderer;
 	struct wlr_drm_format *format;
 	struct wlr_allocator *allocator;

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -76,6 +76,7 @@ struct wlr_x11_backend {
 	struct wlr_keyboard keyboard;
 	struct wlr_input_device keyboard_dev;
 
+	int drm_fd;
 	struct wlr_renderer *renderer;
 	struct wlr_drm_format_set dri3_formats;
 	const struct wlr_x11_format *x11_format;

--- a/include/wlr/backend/interface.h
+++ b/include/wlr/backend/interface.h
@@ -19,6 +19,7 @@ struct wlr_backend_impl {
 	struct wlr_renderer *(*get_renderer)(struct wlr_backend *backend);
 	struct wlr_session *(*get_session)(struct wlr_backend *backend);
 	clockid_t (*get_presentation_clock)(struct wlr_backend *backend);
+	int (*get_drm_fd)(struct wlr_backend *backend);
 };
 
 /**

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -41,6 +41,7 @@ struct wlr_egl {
 	EGLConfig config; // may be EGL_NO_CONFIG
 	EGLContext context;
 	EGLDeviceEXT device; // may be EGL_NO_DEVICE_EXT
+	struct gbm_device *gbm_device;
 
 	struct {
 		// Display extensions

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -12,7 +12,6 @@
 #include <stdint.h>
 #include <wayland-server-protocol.h>
 #include <wlr/backend.h>
-#include <wlr/render/egl.h>
 #include <wlr/render/wlr_texture.h>
 #include <wlr/types/wlr_box.h>
 

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -11,6 +11,7 @@
 
 #include <stdint.h>
 #include <wayland-server-protocol.h>
+#include <wlr/backend.h>
 #include <wlr/render/egl.h>
 #include <wlr/render/wlr_texture.h>
 #include <wlr/types/wlr_box.h>
@@ -33,8 +34,7 @@ struct wlr_renderer {
 	} events;
 };
 
-struct wlr_renderer *wlr_renderer_autocreate(EGLenum platform,
-	void *remote_display);
+struct wlr_renderer *wlr_renderer_autocreate(struct wlr_backend *backend);
 
 void wlr_renderer_begin(struct wlr_renderer *r, uint32_t width, uint32_t height);
 void wlr_renderer_end(struct wlr_renderer *r);

--- a/render/egl.c
+++ b/render/egl.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <gbm.h>
 #include <wlr/render/egl.h>
 #include <wlr/util/log.h>
 #include <wlr/util/region.h>
@@ -360,6 +361,10 @@ error:
 void wlr_egl_destroy(struct wlr_egl *egl) {
 	if (egl == NULL) {
 		return;
+	}
+
+	if (egl->gbm_device) {
+		gbm_device_destroy(egl->gbm_device);
 	}
 
 	wlr_drm_format_set_finish(&egl->dmabuf_render_formats);


### PR DESCRIPTION
Fixes #2563, requires https://github.com/swaywm/wlroots/pull/2613

* * *
Breaking change: `wlr_renderer_autocreate` no longer takes the arguments `EGLenum platform, void *remote_display`. Instead it takes a `struct wlr_backend *`.