### PR TITLE
render/gles2: make EGL context current in bind_buffer

### DIFF
--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -8,8 +8,6 @@
 #include <string.h>
 #include <unistd.h>
 #include <wayland-util.h>
-#include <wlr/render/egl.h>
-#include <wlr/render/gles2.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_matrix.h>
 #include <wlr/util/log.h>
@@ -115,10 +113,6 @@ bool drm_surface_make_current(struct wlr_drm_surface *surf,
 		return false;
 	}
 
-	struct wlr_egl *egl = wlr_gles2_renderer_get_egl(surf->renderer->wlr_rend);
-	if (!wlr_egl_make_current(egl)) {
-		return false;
-	}
 	if (!wlr_renderer_bind_buffer(surf->renderer->wlr_rend, surf->back_buffer)) {
 		wlr_log(WLR_ERROR, "Failed to attach buffer to renderer");
 		return false;
@@ -129,10 +123,8 @@ bool drm_surface_make_current(struct wlr_drm_surface *surf,
 
 void drm_surface_unset_current(struct wlr_drm_surface *surf) {
 	assert(surf->back_buffer != NULL);
-	struct wlr_egl *egl = wlr_gles2_renderer_get_egl(surf->renderer->wlr_rend);
 
 	wlr_renderer_bind_buffer(surf->renderer->wlr_rend, NULL);
-	wlr_egl_unset_current(egl);
 
 	wlr_buffer_unlock(surf->back_buffer);
 	surf->back_buffer = NULL;

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -10,8 +10,6 @@
 #include <wayland-client.h>
 
 #include <wlr/interfaces/wlr_output.h>
-#include <wlr/render/egl.h>
-#include <wlr/render/gles2.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_matrix.h>
 #include <wlr/util/log.h>
@@ -117,8 +115,6 @@ static bool output_set_custom_mode(struct wlr_output *wlr_output,
 static bool output_attach_render(struct wlr_output *wlr_output,
 		int *buffer_age) {
 	struct wlr_wl_output *output = get_wl_output_from_output(wlr_output);
-	struct wlr_egl *egl = wlr_gles2_renderer_get_egl(
-			output->backend->renderer);
 
 	wlr_buffer_unlock(output->back_buffer);
 	output->back_buffer = wlr_swapchain_acquire(output->swapchain, buffer_age);
@@ -126,9 +122,6 @@ static bool output_attach_render(struct wlr_output *wlr_output,
 		return false;
 	}
 
-	if (!wlr_egl_make_current(egl)) {
-		return false;
-	}
 	if (!wlr_renderer_bind_buffer(output->backend->renderer,
 			output->back_buffer)) {
 		return false;
@@ -313,10 +306,6 @@ static bool output_commit(struct wlr_output *wlr_output) {
 			wlr_buffer = output->back_buffer;
 
 			wlr_renderer_bind_buffer(output->backend->renderer, NULL);
-
-			struct wlr_egl *egl = wlr_gles2_renderer_get_egl(
-					output->backend->renderer);
-			wlr_egl_unset_current(egl);
 			break;
 		case WLR_OUTPUT_STATE_BUFFER_SCANOUT:;
 			wlr_buffer = wlr_output->pending.buffer;
@@ -376,10 +365,7 @@ static bool output_commit(struct wlr_output *wlr_output) {
 
 static void output_rollback_render(struct wlr_output *wlr_output) {
 	struct wlr_wl_output *output = get_wl_output_from_output(wlr_output);
-	struct wlr_egl *egl = wlr_gles2_renderer_get_egl(
-			output->backend->renderer);
 	wlr_renderer_bind_buffer(output->backend->renderer, NULL);
-	wlr_egl_unset_current(egl);
 }
 
 static bool output_set_cursor(struct wlr_output *wlr_output,
@@ -411,8 +397,6 @@ static bool output_set_cursor(struct wlr_output *wlr_output,
 	struct wl_surface *surface = output->cursor.surface;
 
 	if (texture != NULL) {
-		struct wlr_egl *egl = wlr_gles2_renderer_get_egl(
-				output->backend->renderer);
 		int width = texture->width * wlr_output->scale / scale;
 		int height = texture->height * wlr_output->scale / scale;
 
@@ -434,9 +418,6 @@ static bool output_set_cursor(struct wlr_output *wlr_output,
 			return false;
 		}
 
-		if (!wlr_egl_make_current(egl)) {
-			return false;
-		}
 		if (!wlr_renderer_bind_buffer(output->backend->renderer, wlr_buffer)) {
 			return false;
 		}
@@ -458,7 +439,6 @@ static bool output_set_cursor(struct wlr_output *wlr_output,
 		wlr_renderer_end(backend->renderer);
 
 		wlr_renderer_bind_buffer(output->backend->renderer, NULL);
-		wlr_egl_unset_current(egl);
 
 		struct wlr_wl_buffer *buffer =
 			get_or_create_wl_buffer(output->backend, wlr_buffer);

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -13,8 +13,6 @@
 #include <wlr/interfaces/wlr_output.h>
 #include <wlr/interfaces/wlr_pointer.h>
 #include <wlr/interfaces/wlr_touch.h>
-#include <wlr/render/egl.h>
-#include <wlr/render/gles2.h>
 #include <wlr/util/log.h>
 
 #include "backend/x11.h"
@@ -99,7 +97,6 @@ static bool output_attach_render(struct wlr_output *wlr_output,
 		int *buffer_age) {
 	struct wlr_x11_output *output = get_x11_output_from_output(wlr_output);
 	struct wlr_x11_backend *x11 = output->x11;
-	struct wlr_egl *egl = wlr_gles2_renderer_get_egl(x11->renderer);
 
 	wlr_buffer_unlock(output->back_buffer);
 	output->back_buffer = wlr_swapchain_acquire(output->swapchain, buffer_age);
@@ -107,9 +104,6 @@ static bool output_attach_render(struct wlr_output *wlr_output,
 		return false;
 	}
 
-	if (!wlr_egl_make_current(egl)) {
-		return false;
-	}
 	if (!wlr_renderer_bind_buffer(x11->renderer, output->back_buffer)) {
 		return false;
 	}
@@ -207,12 +201,10 @@ static struct wlr_x11_buffer *get_or_create_x11_buffer(
 
 static bool output_commit_buffer(struct wlr_x11_output *output) {
 	struct wlr_x11_backend *x11 = output->x11;
-	struct wlr_egl *egl = wlr_gles2_renderer_get_egl(x11->renderer);
 
 	assert(output->back_buffer != NULL);
 
 	wlr_renderer_bind_buffer(x11->renderer, NULL);
-	wlr_egl_unset_current(egl);
 
 	struct wlr_x11_buffer *x11_buffer =
 		get_or_create_x11_buffer(output, output->back_buffer);
@@ -319,10 +311,8 @@ static bool output_commit(struct wlr_output *wlr_output) {
 static void output_rollback_render(struct wlr_output *wlr_output) {
 	struct wlr_x11_output *output = get_x11_output_from_output(wlr_output);
 	struct wlr_x11_backend *x11 = output->x11;
-	struct wlr_egl *egl = wlr_gles2_renderer_get_egl(x11->renderer);
 
 	wlr_renderer_bind_buffer(x11->renderer, NULL);
-	wlr_egl_unset_current(egl);
 }
 
 static const struct wlr_output_impl output_impl = {

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -139,10 +139,11 @@ error_buffer:
 
 static bool gles2_bind_buffer(struct wlr_renderer *wlr_renderer,
 		struct wlr_buffer *wlr_buffer) {
-	struct wlr_gles2_renderer *renderer =
-		gles2_get_renderer_in_context(wlr_renderer);
+	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
 
 	if (renderer->current_buffer != NULL) {
+		assert(wlr_egl_is_current(renderer->egl));
+
 		push_gles2_debug(renderer);
 		glFlush();
 		glBindFramebuffer(GL_FRAMEBUFFER, 0);
@@ -153,8 +154,11 @@ static bool gles2_bind_buffer(struct wlr_renderer *wlr_renderer,
 	}
 
 	if (wlr_buffer == NULL) {
+		wlr_egl_unset_current(renderer->egl);
 		return true;
 	}
+
+	wlr_egl_make_current(renderer->egl);
 
 	struct wlr_gles2_buffer *buffer = get_buffer(renderer, wlr_buffer);
 	if (buffer == NULL) {


### PR DESCRIPTION
Instead of requiring callers to manually make the EGL context current
before binding a buffer and unsetting it after unbinding a buffer, do
it inside wlr_renderer_bind_buffer.

This hides renderer-specific implementation details inside the
wlr_renderer interface. Non-GLES2 renderers may not use EGL.
This removes almost all EGL dependencies from the backends, the only
remaining one is wlr_renderer_autocreate args.

References: https://github.com/swaywm/wlroots/issues/2618
References: https://github.com/swaywm/wlroots/pull/2615#issuecomment-756687006

cc @bl4ckb0ne @any1

* * *

This is _not_ a breaking change because `wlr_renderer_bind_buffer` is a private wlroots API.