### PR TITLE
render/gbm_allocator: fix gbm_device use-after-free

### DIFF
--- a/include/render/gbm_allocator.h
+++ b/include/render/gbm_allocator.h
@@ -8,7 +8,9 @@
 struct wlr_gbm_buffer {
 	struct wlr_buffer base;
 
-	struct gbm_bo *gbm_bo;
+	struct wl_list link; // wlr_gbm_allocator.buffers
+
+	struct gbm_bo *gbm_bo; // NULL if the gbm_device has been destroyed
 	struct wlr_dmabuf_attributes dmabuf;
 };
 
@@ -17,6 +19,8 @@ struct wlr_gbm_allocator {
 
 	int fd;
 	struct gbm_device *gbm_device;
+
+	struct wl_list buffers; // wlr_gbm_buffer.link
 };
 
 /**


### PR DESCRIPTION
We need to destroy any gbm_bo we've created before gbm_device_destroy.

Closes: https://github.com/swaywm/wlroots/issues/2601