### PR TITLE
backend/drm: add wlr_drm_connector_get_id

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1046,6 +1046,11 @@ bool wlr_output_is_drm(struct wlr_output *output) {
 	return output->impl == &output_impl;
 }
 
+uint32_t wlr_drm_connector_get_id(struct wlr_output *output) {
+	struct wlr_drm_connector *conn = get_drm_connector_from_output(output);
+	return conn->id;
+}
+
 static const int32_t subpixel_map[] = {
 	[DRM_MODE_SUBPIXEL_UNKNOWN] = WL_OUTPUT_SUBPIXEL_UNKNOWN,
 	[DRM_MODE_SUBPIXEL_HORIZONTAL_RGB] = WL_OUTPUT_SUBPIXEL_HORIZONTAL_RGB,

--- a/include/wlr/backend/drm.h
+++ b/include/wlr/backend/drm.h
@@ -29,6 +29,11 @@ bool wlr_backend_is_drm(struct wlr_backend *backend);
 bool wlr_output_is_drm(struct wlr_output *output);
 
 /**
+ * Get the KMS connector object ID.
+ */
+uint32_t wlr_drm_connector_get_id(struct wlr_output *output);
+
+/**
  * Add mode to the list of available modes
  */
 typedef struct _drmModeModeInfo drmModeModeInfo;


### PR DESCRIPTION
This allows a compositor to get a KMS connector object ID from a
wlr_output. The compositor can then query more information about
the connector via libdrm.

This gives more freedom to compositors and allows them to read
KMS properties that wlroots doesn't know about. For instance,
they could read the EDID or the suggested_{X,Y} properties and
change their output configuration based on that.