### PR TITLE
backend/drm: use local DRM FD for wlr_rend

### DIFF
--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -28,7 +28,7 @@ bool init_drm_renderer(struct wlr_drm_backend *drm,
 		return false;
 	}
 
-	renderer->wlr_rend = wlr_renderer_autocreate(&drm->backend);
+	renderer->wlr_rend = wlr_renderer_autocreate_with_drm_fd(drm->fd);
 	if (!renderer->wlr_rend) {
 		wlr_log(WLR_ERROR, "Failed to create EGL/WLR renderer");
 		goto error_gbm;

--- a/include/render/wlr_renderer.h
+++ b/include/render/wlr_renderer.h
@@ -4,6 +4,10 @@
 #include <wlr/render/wlr_renderer.h>
 
 /**
+ * Automatically select and create a renderer suitable for the DRM FD.
+ */
+struct wlr_renderer *wlr_renderer_autocreate_with_drm_fd(int drm_fd);
+/**
  * Bind a buffer to the renderer.
  *
  * All subsequent rendering operations will operate on the supplied buffer.

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -250,14 +250,8 @@ bool wlr_renderer_init_wl_display(struct wlr_renderer *r,
 	return true;
 }
 
-struct wlr_renderer *wlr_renderer_autocreate(struct wlr_backend *backend) {
-	int fd = backend_get_drm_fd(backend);
-	if (fd < 0) {
-		wlr_log(WLR_ERROR, "Failed to get DRM FD from backend");
-		return NULL;
-	}
-
-	struct gbm_device *gbm_device = gbm_create_device(fd);
+struct wlr_renderer *wlr_renderer_autocreate_with_drm_fd(int drm_fd) {
+	struct gbm_device *gbm_device = gbm_create_device(drm_fd);
 	if (!gbm_device) {
 		wlr_log(WLR_ERROR, "Failed to create GBM device");
 		return NULL;
@@ -280,6 +274,16 @@ struct wlr_renderer *wlr_renderer_autocreate(struct wlr_backend *backend) {
 	}
 
 	return renderer;
+}
+
+struct wlr_renderer *wlr_renderer_autocreate(struct wlr_backend *backend) {
+	int drm_fd = backend_get_drm_fd(backend);
+	if (drm_fd < 0) {
+		wlr_log(WLR_ERROR, "Failed to get DRM FD from backend");
+		return NULL;
+	}
+
+	return wlr_renderer_autocreate_with_drm_fd(drm_fd);
 }
 
 int wlr_renderer_get_drm_fd(struct wlr_renderer *r) {


### PR DESCRIPTION
The new wlr_renderer_autocreate API is great for compositors, however
it causes some issues with DRM multi-GPU support.
    
A DRM child backend wants the compositor to use the parent GPU, so it
exposes the parent's DRM FD in get_drm_fd. However, in order to be able
to perform multi-GPU buffer copies, the child DRM backend still needs to
create a local renderer.
    
Use the new private wlr_renderer_autocreate_with_drm_fd function to
avoid creating a renderer for the parent GPU.
    
Fixes: e128e6c08dc0 ("render: drop egl parameters from wlr_renderer_autocreate")