### PR TITLE
backend/headless: add WLR_HEADLESS_DEVICE env variable

### DIFF
--- a/backend/headless/backend.c
+++ b/backend/headless/backend.c
@@ -153,6 +153,16 @@ static bool backend_init(struct wlr_headless_backend *backend,
 }
 
 static int open_drm_render_node(void) {
+	const char *name = getenv("WLR_HEADLESS_DEVICE");
+	if (name != NULL) {
+		wlr_log(WLR_DEBUG, "Opening '%s' due to WLR_HEADLESS_DEVICE", name);
+		int fd = open(name, O_RDWR | O_CLOEXEC);
+		if (fd < 0) {
+			wlr_log_errno(WLR_ERROR, "Failed to open '%s'", name);
+		}
+		return fd;
+	}
+
 	uint32_t flags = 0;
 	int devices_len = drmGetDevices2(flags, NULL, 0);
 	if (devices_len < 0) {

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -26,6 +26,8 @@ wlroots reads these environment variables
 
 * *WLR_HEADLESS_OUTPUTS*: when using the headless backend specifies the number
   of outputs
+* *WLR_HEADLESS_DEVICE*: specifies the DRM device instead of using the first
+  available one
 
 ## libinput backend
 


### PR DESCRIPTION
This lets users select the DRM node to use for rendering.

* * *

It would be nice to have a generalized env variable to select the rendering device regardless of the backend. However this would break the DRM backend, which expects buffers coming from the primary device.