### PR TITLE
xwayland/cursor: free cursor in wlr_xwayland_destroy

### DIFF
--- a/xwayland/xwayland.c
+++ b/xwayland/xwayland.c
@@ -64,6 +64,7 @@ void wlr_xwayland_destroy(struct wlr_xwayland *xwayland) {
 
 	wl_list_remove(&xwayland->server_destroy.link);
 	wl_list_remove(&xwayland->server_ready.link);
+	free(xwayland->cursor);
 
 	wlr_xwayland_set_seat(xwayland, NULL);
 	wlr_xwayland_server_destroy(xwayland->server);


### PR DESCRIPTION
Running the asan build has detected what seems like a large number of memory leaks on shutdown. This was the first one I saw and seems like a relatively simple fix (the old cursor memory is freed in [wlr_xwayland_set_cursor.c:119](https://github.com/neon64/wlroots/blob/28584167dd50b388e3e1755be2946e45d9d0c2bd/xwayland/xwayland.c#L119) but not on shutdown)