### PR TITLE
backend/x11: set a blank cursor rather than hiding globally

### DIFF
--- a/backend/x11/input_device.c
+++ b/backend/x11/input_device.c
@@ -212,36 +212,6 @@ void handle_x11_xinput_event(struct wlr_x11_backend *x11,
 		x11->time = ev->time;
 		break;
 	}
-	case XCB_INPUT_ENTER: {
-		xcb_input_enter_event_t *ev = (xcb_input_enter_event_t *)event;
-
-		output = get_x11_output_from_window_id(x11, ev->event);
-		if (!output) {
-			return;
-		}
-
-		if (!output->cursor_hidden) {
-			xcb_xfixes_hide_cursor(x11->xcb, output->win);
-			xcb_flush(x11->xcb);
-			output->cursor_hidden = true;
-		}
-		break;
-	}
-	case XCB_INPUT_LEAVE: {
-		xcb_input_leave_event_t *ev = (xcb_input_leave_event_t *)event;
-
-		output = get_x11_output_from_window_id(x11, ev->event);
-		if (!output) {
-			return;
-		}
-
-		if (output->cursor_hidden) {
-			xcb_xfixes_show_cursor(x11->xcb, output->win);
-			xcb_flush(x11->xcb);
-			output->cursor_hidden = false;
-		}
-		break;
-	}
 	case XCB_INPUT_TOUCH_BEGIN: {
 		xcb_input_touch_begin_event_t *ev = (xcb_input_touch_begin_event_t *)event;
 

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -381,11 +381,13 @@ struct wlr_output *wlr_x11_output_create(struct wlr_backend *backend) {
 
 	// The X11 protocol requires us to set a colormap and border pixel if the
 	// depth doesn't match the root window's
-	uint32_t mask = XCB_CW_BORDER_PIXEL | XCB_CW_EVENT_MASK | XCB_CW_COLORMAP;
+	uint32_t mask = XCB_CW_BORDER_PIXEL | XCB_CW_EVENT_MASK |
+		XCB_CW_COLORMAP | XCB_CW_CURSOR;
 	uint32_t values[] = {
 		0,
 		XCB_EVENT_MASK_EXPOSURE | XCB_EVENT_MASK_STRUCTURE_NOTIFY,
 		x11->colormap,
+		x11->cursor,
 	};
 	output->win = xcb_generate_id(x11->xcb);
 	xcb_create_window(x11->xcb, x11->depth->depth, output->win,
@@ -402,8 +404,6 @@ struct wlr_output *wlr_x11_output_create(struct wlr_backend *backend) {
 			XCB_INPUT_XI_EVENT_MASK_BUTTON_PRESS |
 			XCB_INPUT_XI_EVENT_MASK_BUTTON_RELEASE |
 			XCB_INPUT_XI_EVENT_MASK_MOTION |
-			XCB_INPUT_XI_EVENT_MASK_ENTER |
-			XCB_INPUT_XI_EVENT_MASK_LEAVE |
 			XCB_INPUT_XI_EVENT_MASK_TOUCH_BEGIN |
 			XCB_INPUT_XI_EVENT_MASK_TOUCH_END |
 			XCB_INPUT_XI_EVENT_MASK_TOUCH_UPDATE,

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -47,7 +47,6 @@ struct wlr_x11_output {
 
 	struct wl_list buffers; // wlr_x11_buffer::link
 
-	bool cursor_hidden;
 	uint64_t last_msc;
 };
 
@@ -68,6 +67,7 @@ struct wlr_x11_backend {
 	xcb_depth_t *depth;
 	xcb_visualid_t visualid;
 	xcb_colormap_t colormap;
+	xcb_cursor_t cursor;
 	uint32_t dri3_major_version, dri3_minor_version;
 
 	size_t requested_outputs;


### PR DESCRIPTION
This actually simplifies the logic since we no longer have to wait for
enter/leave events, and also improves the UX when e.g. handling a crash
with gdb attached.

See #2659