### PR TITLE
region: make wlr_region_create private

### DIFF
--- a/include/types/wlr_region.h
+++ b/include/types/wlr_region.h
@@ -1,0 +1,13 @@
+#ifndef TYPES_WLR_REGION_H
+#define TYPES_WLR_REGION_H
+
+#include <wlr/types/wlr_region.h>
+
+/*
+ * Creates a new region resource with the provided new ID. If `resource_list` is
+ * non-NULL, adds the region's resource to the list.
+ */
+struct wl_resource *region_create(struct wl_client *client,
+	uint32_t version, uint32_t id);
+
+#endif

--- a/include/wlr/types/wlr_region.h
+++ b/include/wlr/types/wlr_region.h
@@ -12,13 +12,6 @@
 #include <pixman.h>
 #include <wayland-server-protocol.h>
 
-/*
- * Creates a new region resource with the provided new ID. If `resource_list` is
- * non-NULL, adds the region's resource to the list.
- */
-struct wl_resource *wlr_region_create(struct wl_client *client,
-	uint32_t version, uint32_t id, struct wl_list *resource_list);
-
 pixman_region32_t *wlr_region_from_resource(struct wl_resource *resource);
 
 #endif

--- a/types/wlr_compositor.c
+++ b/types/wlr_compositor.c
@@ -131,7 +131,7 @@ static void compositor_create_surface(struct wl_client *client,
 
 static void compositor_create_region(struct wl_client *client,
 		struct wl_resource *resource, uint32_t id) {
-	region_create(client, wl_resource_get_version(resource), id, NULL);
+	region_create(client, wl_resource_get_version(resource), id);
 }
 
 static const struct wl_compositor_interface compositor_impl = {

--- a/types/wlr_compositor.c
+++ b/types/wlr_compositor.c
@@ -2,9 +2,9 @@
 #include <stdlib.h>
 #include <wayland-server-core.h>
 #include <wlr/types/wlr_compositor.h>
-#include <wlr/types/wlr_region.h>
 #include <wlr/types/wlr_surface.h>
 #include <wlr/util/log.h>
+#include "types/wlr_region.h"
 #include "util/signal.h"
 
 #define COMPOSITOR_VERSION 4
@@ -131,7 +131,7 @@ static void compositor_create_surface(struct wl_client *client,
 
 static void compositor_create_region(struct wl_client *client,
 		struct wl_resource *resource, uint32_t id) {
-	wlr_region_create(client, wl_resource_get_version(resource), id, NULL);
+	region_create(client, wl_resource_get_version(resource), id, NULL);
 }
 
 static const struct wl_compositor_interface compositor_impl = {

--- a/types/wlr_region.c
+++ b/types/wlr_region.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <wayland-server-core.h>
 #include <wlr/types/wlr_region.h>
+#include "types/wlr_region.h"
 
 static void region_add(struct wl_client *client, struct wl_resource *resource,
 		int32_t x, int32_t y, int32_t width, int32_t height) {
@@ -41,7 +42,7 @@ static void region_handle_resource_destroy(struct wl_resource *resource) {
 	free(reg);
 }
 
-struct wl_resource *wlr_region_create(struct wl_client *client,
+struct wl_resource *region_create(struct wl_client *client,
 		uint32_t version, uint32_t id, struct wl_list *resource_list) {
 	pixman_region32_t *region = calloc(1, sizeof(pixman_region32_t));
 	if (region == NULL) {

--- a/types/wlr_region.c
+++ b/types/wlr_region.c
@@ -35,15 +35,12 @@ static const struct wl_region_interface region_impl = {
 
 static void region_handle_resource_destroy(struct wl_resource *resource) {
 	pixman_region32_t *reg = wlr_region_from_resource(resource);
-
-	wl_list_remove(wl_resource_get_link(resource));
-
 	pixman_region32_fini(reg);
 	free(reg);
 }
 
 struct wl_resource *region_create(struct wl_client *client,
-		uint32_t version, uint32_t id, struct wl_list *resource_list) {
+		uint32_t version, uint32_t id) {
 	pixman_region32_t *region = calloc(1, sizeof(pixman_region32_t));
 	if (region == NULL) {
 		wl_client_post_no_memory(client);
@@ -61,13 +58,6 @@ struct wl_resource *region_create(struct wl_client *client,
 	}
 	wl_resource_set_implementation(region_resource, &region_impl, region,
 		region_handle_resource_destroy);
-
-	struct wl_list *resource_link = wl_resource_get_link(region_resource);
-	if (resource_list != NULL) {
-		wl_list_insert(resource_list, resource_link);
-	} else {
-		wl_list_init(resource_link);
-	}
 
 	return region_resource;
 }


### PR DESCRIPTION
This function should only be called from the handler for
wl_compositor.create_region requests.

* * *

Breaking change: `wlr_region_create` has been removed.