### PR TITLE
xdg-output: destroy outputs before manager

### DIFF
--- a/types/wlr_xdg_output_v1.c
+++ b/types/wlr_xdg_output_v1.c
@@ -227,6 +227,10 @@ static void handle_layout_change(struct wl_listener *listener, void *data) {
 }
 
 static void manager_destroy(struct wlr_xdg_output_manager_v1 *manager) {
+	struct wlr_xdg_output_v1 *output, *tmp;
+	wl_list_for_each_safe(output, tmp, &manager->outputs, link) {
+		output_destroy(output);
+	}
 	wlr_signal_emit_safe(&manager->events.destroy, manager);
 	wl_list_remove(&manager->display_destroy.link);
 	wl_list_remove(&manager->layout_add.link);


### PR DESCRIPTION
Since output_destroy() calls wl_list_remove() on the output's link,
the manager must still be valid. This is the same bug fixed in bf926e3
but with a different interface.

valgrind log that led to discovery thanks to @Leon-Plickat
```
==12503== Invalid write of size 8
==12503==    at 0x4873F07: wl_list_remove (wayland-util.c:55)
==12503==    by 0x49F3D5A: output_destroy (wlr_xdg_output_v1.c:75)
==12503==    by 0x49F4077: handle_output_destroy (wlr_xdg_output_v1.c:168)
==12503==    by 0x49F6A25: wlr_signal_emit_safe (signal.c:29)
==12503==    by 0x49DE57B: output_layout_output_destroy (wlr_output_layout.c:50)
==12503==    by 0x49DE665: wlr_output_layout_destroy (wlr_output_layout.c:70)
==12503==    by 0x237A00: Root.deinit (Root.zig:121)
==12503==    by 0x220133: Server.deinit (Server.zig:140)
==12503==    by 0x21D91D: main.0 (main.zig:120)
==12503==    by 0x220771: std.start.callMain (start.zig:334)
==12503==    by 0x220771: std.start.initEventLoopAndCallMain (start.zig:276)
==12503==    by 0x220771: std.start.callMainWithArgs (start.zig:239)
==12503==    by 0x220771: main (start.zig:246)
==12503==  Address 0x118a7a68 is 24 bytes inside a block of size 144 free'd
==12503==    at 0x483B9AB: free (vg_replace_malloc.c:538)
==12503==    by 0x49F4333: manager_destroy (wlr_xdg_output_v1.c:235)
==12503==    by 0x49F435E: handle_layout_destroy (wlr_xdg_output_v1.c:241)
==12503==    by 0x49F6A25: wlr_signal_emit_safe (signal.c:29)
==12503==    by 0x49DE637: wlr_output_layout_destroy (wlr_output_layout.c:66)
==12503==    by 0x237A00: Root.deinit (Root.zig:121)
==12503==    by 0x220133: Server.deinit (Server.zig:140)
==12503==    by 0x21D91D: main.0 (main.zig:120)
==12503==    by 0x220771: std.start.callMain (start.zig:334)
==12503==    by 0x220771: std.start.initEventLoopAndCallMain (start.zig:276)
==12503==    by 0x220771: std.start.callMainWithArgs (start.zig:239)
==12503==    by 0x220771: main (start.zig:246)
==12503==  Block was alloc'd at
==12503==    at 0x483CB65: calloc (vg_replace_malloc.c:760)
==12503==    by 0x49F43CE: wlr_xdg_output_manager_v1_create (wlr_xdg_output_v1.c:259)
==12503==    by 0x22ACF1: .wlroots.types.xdg_output_v1.XdgOutputManagerV1.create (xdg_output_v1.zig:23)
==12503==    by 0x2253F6: Root.init (Root.zig:91)
==12503==    by 0x21F713: Server.init (Server.zig:115)
==12503==    by 0x21D5FB: main.0 (main.zig:119)
==12503==    by 0x220771: std.start.callMain (start.zig:334)
==12503==    by 0x220771: std.start.initEventLoopAndCallMain (start.zig:276)
==12503==    by 0x220771: std.start.callMainWithArgs (start.zig:239)
==12503==    by 0x220771: main (start.zig:246)
```