### PR TITLE
render/egl: remove *config_attribs, wlr_egl->config and wlr_egl_(create, destroy)_surface

### DIFF
--- a/examples/egl_common.c
+++ b/examples/egl_common.c
@@ -1,0 +1,127 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <wayland-client.h>
+#include <wlr/util/log.h>
+
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+
+#include "egl_common.h"
+
+EGLDisplay egl_display;
+EGLConfig egl_config;
+EGLContext egl_context;
+
+PFNEGLGETPLATFORMDISPLAYEXTPROC eglGetPlatformDisplayEXT;
+PFNEGLCREATEPLATFORMWINDOWSURFACEEXTPROC eglCreatePlatformWindowSurfaceEXT;
+
+EGLint config_attribs[] = {
+	EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+	EGL_RED_SIZE, 1,
+	EGL_GREEN_SIZE, 1,
+	EGL_BLUE_SIZE, 1,
+	EGL_ALPHA_SIZE, 1,
+	EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+	EGL_NONE,
+};
+
+EGLint context_attribs[] = {
+	EGL_CONTEXT_CLIENT_VERSION, 2,
+	EGL_NONE,
+};
+
+bool egl_init(struct wl_display *display) {
+	const char *client_exts_str = 
+		eglQueryString(EGL_NO_DISPLAY, EGL_EXTENSIONS);
+	if (client_exts_str == NULL) {
+		if (eglGetError() == EGL_BAD_DISPLAY) {
+			wlr_log(WLR_ERROR, 
+				"EGL_EXT_client_extensions not supported");
+		} else {
+			wlr_log(WLR_ERROR, 
+				"Failed to query EGL client extensions");
+		}
+		return false;
+	}
+
+	if (!strstr(client_exts_str, "EGL_EXT_platform_base")) {
+		wlr_log(WLR_ERROR, "EGL_EXT_platform_base not supported");
+		return false;
+	}
+
+	if (!strstr(client_exts_str, "EGL_EXT_platform_wayland")) {
+		wlr_log(WLR_ERROR, "EGL_EXT_platform_wayland not supported");
+		return false;
+	}
+
+	eglGetPlatformDisplayEXT = 
+		(void *)eglGetProcAddress("eglGetPlatformDisplayEXT");
+	if (eglGetPlatformDisplayEXT == NULL) {
+		wlr_log(WLR_ERROR, "Failed to get eglGetPlatformDisplayEXT");
+		return false;
+	}
+
+	eglCreatePlatformWindowSurfaceEXT = 
+		(void *)eglGetProcAddress("eglCreatePlatformWindowSurfaceEXT");
+	if (eglCreatePlatformWindowSurfaceEXT == NULL) {
+		wlr_log(WLR_ERROR, 
+			"Failed to get eglCreatePlatformWindowSurfaceEXT");
+		return false;
+	}
+
+	egl_display = 
+		eglGetPlatformDisplayEXT(EGL_PLATFORM_WAYLAND_EXT, 
+			display, NULL);
+	if (egl_display == EGL_NO_DISPLAY) {
+		wlr_log(WLR_ERROR, "Failed to create EGL display");
+		goto error;
+	}
+
+	EGLint major, minor;
+	if (eglInitialize(egl_display, &major, &minor) == EGL_FALSE) {
+		wlr_log(WLR_ERROR, "Failed to initialize EGL");
+		goto error;
+	}
+
+	EGLint matched = 0;
+	if (!eglChooseConfig(egl_display, config_attribs, 
+			&egl_config, 1, &matched)) {
+		wlr_log(WLR_ERROR, "eglChooseConfig failed");
+		goto error;
+	}
+	if (matched == 0) {
+		wlr_log(WLR_ERROR, "Failed to match an EGL config");
+		goto error;
+	}
+
+	egl_context = 
+		eglCreateContext(egl_display, egl_config, 
+			EGL_NO_CONTEXT, context_attribs);
+	if (egl_context == EGL_NO_CONTEXT) {
+		wlr_log(WLR_ERROR, "Failed to create EGL context");
+		goto error;
+	}
+
+	return true;
+
+error:
+	eglMakeCurrent(EGL_NO_DISPLAY, EGL_NO_SURFACE, 
+		EGL_NO_SURFACE, EGL_NO_CONTEXT);
+	if (egl_display) {
+		eglTerminate(egl_display);
+	}
+	eglReleaseThread();
+	return false;
+}
+
+void egl_finish(void) {
+	eglMakeCurrent(egl_display, EGL_NO_SURFACE, 
+		EGL_NO_SURFACE, EGL_NO_CONTEXT);
+	eglDestroyContext(egl_display, egl_context);
+	eglTerminate(egl_display);
+	eglReleaseThread();
+}

--- a/examples/egl_common.h
+++ b/examples/egl_common.h
@@ -1,0 +1,19 @@
+#ifndef _EGL_COMMON_H
+#define _EGL_COMMON_H
+#endif
+
+#include <stdbool.h>
+#include <wayland-client.h>
+
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+
+extern EGLDisplay egl_display;
+extern EGLConfig egl_config;
+extern EGLContext egl_context;
+
+extern PFNEGLCREATEPLATFORMWINDOWSURFACEEXTPROC eglCreatePlatformWindowSurfaceEXT;
+
+bool egl_init(struct wl_display *display);
+
+void egl_finish(void);

--- a/examples/idle-inhibit.c
+++ b/examples/idle-inhibit.c
@@ -5,6 +5,7 @@
 #include <wayland-client.h>
 #include <wayland-egl.h>
 #include <wlr/render/egl.h>
+#include "egl_common.h"
 #include "idle-inhibit-unstable-v1-client-protocol.h"
 #include "xdg-shell-client-protocol.h"
 
@@ -27,12 +28,11 @@ static struct xdg_wm_base *wm_base = NULL;
 static struct zwp_idle_inhibit_manager_v1 *idle_inhibit_manager = NULL;
 static struct zwp_idle_inhibitor_v1 *idle_inhibitor = NULL;
 
-struct wlr_egl *egl;
 struct wl_egl_window *egl_window;
 struct wlr_egl_surface *egl_surface;
 
 static void draw(void) {
-	eglMakeCurrent(egl->display, egl_surface, egl_surface, egl->context);
+	eglMakeCurrent(egl_display, egl_surface, egl_surface, egl_context);
 
 	float color[] = {1.0, 1.0, 0.0, 1.0};
 	if (idle_inhibitor) {
@@ -43,7 +43,7 @@ static void draw(void) {
 	glClearColor(color[0], color[1], color[2], 1.0);
 	glClear(GL_COLOR_BUFFER_BIT);
 
-	eglSwapBuffers(egl->display, egl_surface);
+	eglSwapBuffers(egl_display, egl_surface);
 }
 
 static void pointer_handle_button(void *data, struct wl_pointer *pointer, uint32_t serial,
@@ -192,8 +192,7 @@ int main(int argc, char **argv) {
 		return EXIT_FAILURE;
 	}
 
-	EGLint attribs[] = { EGL_NONE };
-	egl = wlr_egl_create(EGL_PLATFORM_WAYLAND_EXT, display, attribs);
+	egl_init(display);
 
 	struct wl_surface *surface = wl_compositor_create_surface(compositor);
 	struct xdg_surface *xdg_surface =
@@ -214,7 +213,8 @@ int main(int argc, char **argv) {
 	wl_surface_commit(surface);
 
 	egl_window = wl_egl_window_create(surface, width, height);
-	egl_surface = wlr_egl_create_surface(egl, egl_window);
+	egl_surface = eglCreatePlatformWindowSurfaceEXT(
+		egl_display, egl_config, egl_window, NULL);
 
 	wl_display_roundtrip(display);
 

--- a/examples/layer-shell.c
+++ b/examples/layer-shell.c
@@ -13,6 +13,7 @@
 #include <wayland-egl.h>
 #include <wlr/render/egl.h>
 #include <wlr/util/log.h>
+#include "egl_common.h"
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
 #include "xdg-shell-client-protocol.h"
 
@@ -29,7 +30,6 @@ struct zwlr_layer_surface_v1 *layer_surface;
 static struct wl_output *wl_output;
 
 struct wl_surface *wl_surface;
-struct wlr_egl *egl;
 struct wl_egl_window *egl_window;
 struct wlr_egl_surface *egl_surface;
 struct wl_callback *frame_callback;
@@ -94,7 +94,7 @@ static struct wl_callback_listener popup_frame_listener = {
 };
 
 static void draw(void) {
-	eglMakeCurrent(egl->display, egl_surface, egl_surface, egl->context);
+	eglMakeCurrent(egl_display, egl_surface, egl_surface, egl_context);
 	struct timespec ts;
 	clock_gettime(CLOCK_MONOTONIC, &ts);
 
@@ -143,7 +143,7 @@ static void draw(void) {
 	frame_callback = wl_surface_frame(wl_surface);
 	wl_callback_add_listener(frame_callback, &frame_listener, NULL);
 
-	eglSwapBuffers(egl->display, egl_surface);
+	eglSwapBuffers(egl_display, egl_surface);
 
 	demo.last_frame = ts;
 }
@@ -151,7 +151,7 @@ static void draw(void) {
 static void draw_popup(void) {
 	static float alpha_mod = -0.01;
 
-	eglMakeCurrent(egl->display, popup_egl_surface, popup_egl_surface, egl->context);
+	eglMakeCurrent(egl_display, popup_egl_surface, popup_egl_surface, egl_context);
 	glViewport(0, 0, popup_width, popup_height);
 	glClearColor(popup_red, 0.5f, 0.5f, popup_alpha);
 	popup_alpha += alpha_mod;
@@ -163,7 +163,7 @@ static void draw_popup(void) {
 	popup_frame_callback = wl_surface_frame(popup_wl_surface);
 	assert(popup_frame_callback);
 	wl_callback_add_listener(popup_frame_callback, &popup_frame_listener, NULL);
-	eglSwapBuffers(egl->display, popup_egl_surface);
+	eglSwapBuffers(egl_display, popup_egl_surface);
 	wl_surface_commit(popup_wl_surface);
 }
 
@@ -188,7 +188,7 @@ static void xdg_popup_configure(void *data, struct xdg_popup *xdg_popup,
 }
 
 static void popup_destroy(void) {
-	wlr_egl_destroy_surface(egl, popup_egl_surface);
+	eglDestroySurface(egl_display, popup_egl_surface);
 	wl_egl_window_destroy(popup_egl_window);
 	xdg_popup_destroy(popup);
 	wl_surface_destroy(popup_wl_surface);
@@ -242,8 +242,9 @@ static void create_popup(uint32_t serial) {
 	popup_wl_surface = surface;
 	popup_egl_window = wl_egl_window_create(surface, popup_width, popup_height);
 	assert(popup_egl_window);
-	popup_egl_surface = wlr_egl_create_surface(egl, popup_egl_window);
-	assert(popup_egl_surface);
+	popup_egl_surface = eglCreatePlatformWindowSurfaceEXT(
+			egl_display, egl_config, popup_egl_window, NULL);
+	assert(popup_egl_surface != EGL_NO_SURFACE);
 	draw_popup();
 }
 
@@ -260,7 +261,7 @@ static void layer_surface_configure(void *data,
 
 static void layer_surface_closed(void *data,
 		struct zwlr_layer_surface_v1 *surface) {
-	wlr_egl_destroy_surface(egl, egl_surface);
+	eglDestroySurface(egl_display, egl_surface);
 	wl_egl_window_destroy(egl_window);
 	zwlr_layer_surface_v1_destroy(surface);
 	wl_surface_destroy(wl_surface);
@@ -631,8 +632,7 @@ int main(int argc, char **argv) {
 	cursor_surface = wl_compositor_create_surface(compositor);
 	assert(cursor_surface);
 
-	EGLint attribs[] = { EGL_ALPHA_SIZE, 8, EGL_NONE };
-	egl = wlr_egl_create(EGL_PLATFORM_WAYLAND_EXT, display, attribs);
+	egl_init(display);
 
 	wl_surface = wl_compositor_create_surface(compositor);
 	assert(wl_surface);
@@ -654,8 +654,9 @@ int main(int argc, char **argv) {
 
 	egl_window = wl_egl_window_create(wl_surface, width, height);
 	assert(egl_window);
-	egl_surface = wlr_egl_create_surface(egl, egl_window);
-	assert(egl_surface);
+	egl_surface = eglCreatePlatformWindowSurfaceEXT(
+		egl_display, egl_config, egl_window, NULL);
+	assert(egl_surface != EGL_NO_SURFACE);
 
 	wl_display_roundtrip(display);
 	draw();

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -54,7 +54,7 @@ clients = {
 		'proto': ['kde-idle'],
 	},
 	'idle-inhibit': {
-		'src': 'idle-inhibit.c',
+		'src': ['idle-inhibit.c', 'egl_common.c'],
 		'dep': [wayland_egl, wlroots],
 		'proto': [
 			'idle-inhibit-unstable-v1',
@@ -62,7 +62,7 @@ clients = {
 		],
 	},
 	'keyboard-shortcuts-inhibit': {
-		'src': 'keyboard-shortcuts-inhibit.c',
+		'src': ['keyboard-shortcuts-inhibit.c', 'egl_common.c'],
 		'dep': [wayland_egl, wayland_cursor, wlroots],
 		'proto': [
 			'keyboard-shortcuts-inhibit-unstable-v1',
@@ -70,7 +70,7 @@ clients = {
 		],
 	},
 	'layer-shell': {
-		'src': 'layer-shell.c',
+		'src': ['layer-shell.c', 'egl_common.c'],
 		'dep': [wayland_egl, wayland_cursor, wlroots],
 		'proto': [
 			'wlr-layer-shell-unstable-v1',
@@ -78,7 +78,7 @@ clients = {
 		],
 	},
 	'input-inhibitor': {
-		'src': 'input-inhibitor.c',
+		'src': ['input-inhibitor.c', 'egl_common.c'],
 		'dep': [wayland_egl, wayland_cursor, wlroots],
 		'proto': [
 			'wlr-input-inhibitor-unstable-v1',
@@ -96,7 +96,7 @@ clients = {
 		'proto': ['wlr-output-power-management-unstable-v1'],
 	},
 	'pointer-constraints': {
-		'src': 'pointer-constraints.c',
+		'src': ['pointer-constraints.c', 'egl_common.c'],
 		'dep': [wayland_egl, wlroots],
 		'proto': [
 			'pointer-constraints-unstable-v1',
@@ -104,7 +104,7 @@ clients = {
 		],
 	},
 	'relative-pointer': {
-		'src': 'relative-pointer-unstable-v1.c',
+		'src': ['relative-pointer-unstable-v1.c', 'egl_common.c'],
 		'dep': [wayland_egl, wlroots],
 		'proto': [
 			'pointer-constraints-unstable-v1',
@@ -137,7 +137,7 @@ clients = {
 		],
 	},
 	'toplevel-decoration': {
-		'src': 'toplevel-decoration.c',
+		'src': ['toplevel-decoration.c', 'egl_common.c'],
 		'dep': [wayland_egl, wlroots],
 		'proto': [
 			'xdg-decoration-unstable-v1',
@@ -154,7 +154,7 @@ clients = {
 		],
 	},
 	'text-input': {
-		'src': 'text-input.c',
+		'src': ['text-input.c', 'egl_common.c'],
 		'dep': [wayland_egl, wayland_cursor, wlroots],
 		'proto': [
 			'text-input-unstable-v3',

--- a/examples/pointer-constraints.c
+++ b/examples/pointer-constraints.c
@@ -6,6 +6,7 @@
 #include <wayland-client.h>
 #include <wayland-egl.h>
 #include <wlr/render/egl.h>
+#include "egl_common.h"
 #include "xdg-shell-client-protocol.h"
 #include "pointer-constraints-unstable-v1-client-protocol.h"
 
@@ -16,7 +17,6 @@ static struct wl_seat *seat = NULL;
 static struct xdg_wm_base *wm_base = NULL;
 static struct zwp_pointer_constraints_v1 *pointer_constraints = NULL;
 
-struct wlr_egl *egl;
 struct wl_egl_window *egl_window;
 struct wlr_egl_surface *egl_surface;
 struct zwp_locked_pointer_v1* locked_pointer;
@@ -32,7 +32,7 @@ enum {
 struct wl_region *regions[3];
 
 static void draw(void) {
-	eglMakeCurrent(egl->display, egl_surface, egl_surface, egl->context);
+	eglMakeCurrent(egl_display, egl_surface, egl_surface, egl_context);
 
 	float color[] = {1.0, 1.0, 0.0, 1.0};
 
@@ -40,7 +40,7 @@ static void draw(void) {
 	glClearColor(color[0], color[1], color[2], 1.0);
 	glClear(GL_COLOR_BUFFER_BIT);
 
-	eglSwapBuffers(egl->display, egl_surface);
+	eglSwapBuffers(egl_display, egl_surface);
 }
 
 static void pointer_handle_button(void *data, struct wl_pointer *pointer,
@@ -211,8 +211,7 @@ int main(int argc, char **argv) {
 	wl_region_add(joint_region, 256, 256, 256, 256);
 	regions[REGION_TYPE_JOINT] = joint_region;
 
-	EGLint attribs[] = { EGL_NONE };
-	egl = wlr_egl_create(EGL_PLATFORM_WAYLAND_EXT, display, attribs);
+	egl_init(display);
 
 	struct wl_surface *surface = wl_compositor_create_surface(compositor);
 	struct xdg_surface *xdg_surface =
@@ -241,7 +240,8 @@ int main(int argc, char **argv) {
 	wl_surface_commit(surface);
 
 	egl_window = wl_egl_window_create(surface, width, height);
-	egl_surface = wlr_egl_create_surface(egl, egl_window);
+	egl_surface = eglCreatePlatformWindowSurfaceEXT(
+		egl_display, egl_config, egl_window, NULL);
 
 	wl_display_roundtrip(display);
 

--- a/examples/text-input.c
+++ b/examples/text-input.c
@@ -7,6 +7,7 @@
 #include <wayland-client.h>
 #include <wayland-egl.h>
 #include <wlr/render/egl.h>
+#include "egl_common.h"
 #include "text-input-unstable-v3-client-protocol.h"
 #include "xdg-shell-client-protocol.h"
 
@@ -63,12 +64,11 @@ static struct xdg_wm_base *wm_base = NULL;
 static struct zwp_text_input_manager_v3 *text_input_manager = NULL;
 static struct zwp_text_input_v3 *text_input	= NULL;
 
-struct wlr_egl *egl;
 struct wl_egl_window *egl_window;
 struct wlr_egl_surface *egl_surface;
 
 static void draw(void) {
-	eglMakeCurrent(egl->display, egl_surface, egl_surface, egl->context);
+	eglMakeCurrent(egl_display, egl_surface, egl_surface, egl_context);
 
 	float color[] = {1.0, 1.0, 0.0, 1.0};
 	color[0] = enabled * 1.0;
@@ -78,7 +78,7 @@ static void draw(void) {
 	glClearColor(color[0], color[1], color[2], 1.0);
 	glClear(GL_COLOR_BUFFER_BIT);
 
-	eglSwapBuffers(egl->display, egl_surface);
+	eglSwapBuffers(egl_display, egl_surface);
 }
 
 static size_t utf8_strlen(char *str) {
@@ -363,8 +363,7 @@ int main(int argc, char **argv) {
 
 	zwp_text_input_v3_add_listener(text_input, &text_input_listener, NULL);
 
-	EGLint attribs[] = { EGL_NONE };
-	egl = wlr_egl_create(EGL_PLATFORM_WAYLAND_EXT, display, attribs);
+	egl_init(display);
 
 	struct wl_surface *surface = wl_compositor_create_surface(compositor);
 	struct xdg_surface *xdg_surface =
@@ -377,7 +376,8 @@ int main(int argc, char **argv) {
 	wl_surface_commit(surface);
 
 	egl_window = wl_egl_window_create(surface, width, height);
-	egl_surface = wlr_egl_create_surface(egl, egl_window);
+	egl_surface = eglCreatePlatformWindowSurfaceEXT(
+		egl_display, egl_config, egl_window, NULL);
 
 	wl_display_roundtrip(display);
 

--- a/examples/toplevel-decoration.c
+++ b/examples/toplevel-decoration.c
@@ -5,6 +5,7 @@
 #include <wayland-client.h>
 #include <wayland-egl.h>
 #include <wlr/render/egl.h>
+#include "egl_common.h"
 #include "xdg-shell-client-protocol.h"
 #include "xdg-decoration-unstable-v1-client-protocol.h"
 
@@ -20,7 +21,6 @@ static struct wl_compositor *compositor = NULL;
 static struct xdg_wm_base *wm_base = NULL;
 static struct zxdg_decoration_manager_v1 *decoration_manager = NULL;
 
-struct wlr_egl *egl;
 struct wl_egl_window *egl_window;
 struct wlr_egl_surface *egl_surface;
 
@@ -53,7 +53,7 @@ static void request_preferred_mode(void) {
 }
 
 static void draw(void) {
-	eglMakeCurrent(egl->display, egl_surface, egl_surface, egl->context);
+	eglMakeCurrent(egl_display, egl_surface, egl_surface, egl_context);
 
 	float color[] = {1.0, 1.0, 0.0, 1.0};
 	if (current_mode == ZXDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE) {
@@ -64,7 +64,7 @@ static void draw(void) {
 	glClearColor(color[0], color[1], color[2], 1.0);
 	glClear(GL_COLOR_BUFFER_BIT);
 
-	eglSwapBuffers(egl->display, egl_surface);
+	eglSwapBuffers(egl_display, egl_surface);
 }
 
 static void xdg_surface_handle_configure(void *data,
@@ -218,8 +218,7 @@ int main(int argc, char **argv) {
 		return EXIT_FAILURE;
 	}
 
-	EGLint attribs[] = { EGL_NONE };
-	egl = wlr_egl_create(EGL_PLATFORM_WAYLAND_EXT, display, attribs);
+	egl_init(display);
 
 	struct wl_surface *surface = wl_compositor_create_surface(compositor);
 	struct xdg_surface *xdg_surface =
@@ -238,7 +237,8 @@ int main(int argc, char **argv) {
 	wl_surface_commit(surface);
 
 	egl_window = wl_egl_window_create(surface, width, height);
-	egl_surface = wlr_egl_create_surface(egl, egl_window);
+	egl_surface = eglCreatePlatformWindowSurfaceEXT(
+		egl_display, egl_config, egl_window, NULL);
 
 	wl_display_roundtrip(display);
 

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -38,7 +38,6 @@ struct wlr_egl_context {
 
 struct wlr_egl {
 	EGLDisplay display;
-	EGLConfig config; // may be EGL_NO_CONFIG
 	EGLContext context;
 	EGLDeviceEXT device; // may be EGL_NO_DEVICE_EXT
 	struct gbm_device *gbm_device;
@@ -80,11 +79,8 @@ struct wlr_egl {
 /**
  * Initializes an EGL context for the given platform and remote display.
  * Will attempt to load all possibly required api functions.
- *
- * If config_attribs is NULL, the EGL config is not created.
  */
-struct wlr_egl *wlr_egl_create(EGLenum platform, void *remote_display,
-	const EGLint *config_attribs);
+struct wlr_egl *wlr_egl_create(EGLenum platform, void *remote_display);
 
 /**
  * Frees all related EGL resources, makes the context not-current and

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -57,7 +57,6 @@ struct wlr_egl {
 
 	struct {
 		PFNEGLGETPLATFORMDISPLAYEXTPROC eglGetPlatformDisplayEXT;
-		PFNEGLCREATEPLATFORMWINDOWSURFACEEXTPROC eglCreatePlatformWindowSurfaceEXT;
 		PFNEGLCREATEIMAGEKHRPROC eglCreateImageKHR;
 		PFNEGLDESTROYIMAGEKHRPROC eglDestroyImageKHR;
 		PFNEGLQUERYWAYLANDBUFFERWL eglQueryWaylandBufferWL;
@@ -99,12 +98,6 @@ void wlr_egl_destroy(struct wlr_egl *egl);
  * to it.
  */
 bool wlr_egl_bind_display(struct wlr_egl *egl, struct wl_display *local_display);
-
-/**
- * Returns a surface for the given native window
- * The window must match the remote display the wlr_egl was created with.
- */
-EGLSurface wlr_egl_create_surface(struct wlr_egl *egl, void *window);
 
 /**
  * Creates an EGL image from the given wl_drm buffer resource.
@@ -163,8 +156,6 @@ void wlr_egl_save_context(struct wlr_egl_context *context);
  * Restore EGL context that was previously saved using wlr_egl_save_current().
  */
 bool wlr_egl_restore_context(struct wlr_egl_context *context);
-
-bool wlr_egl_destroy_surface(struct wlr_egl *egl, EGLSurface surface);
 
 int wlr_egl_dup_drm_fd(struct wlr_egl *egl);
 

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -466,9 +466,6 @@ static enum wl_shm_format gles2_preferred_read_format(
 		glGetRenderbufferParameteriv(GL_RENDERBUFFER,
 			GL_RENDERBUFFER_ALPHA_SIZE, &alpha_size);
 		glBindRenderbuffer(GL_RENDERBUFFER, 0);
-	} else if (renderer->egl->config != EGL_NO_CONFIG_KHR) {
-		eglGetConfigAttrib(renderer->egl->display, renderer->egl->config,
-			EGL_ALPHA_SIZE, &alpha_size);
 	}
 
 	const struct wlr_gles2_pixel_format *fmt =

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -257,8 +257,7 @@ struct wlr_renderer *wlr_renderer_autocreate_with_drm_fd(int drm_fd) {
 		return NULL;
 	}
 
-	struct wlr_egl *egl = wlr_egl_create(EGL_PLATFORM_GBM_KHR, gbm_device,
-			NULL);
+	struct wlr_egl *egl = wlr_egl_create(EGL_PLATFORM_GBM_KHR, gbm_device);
 	if (egl == NULL) {
 		wlr_log(WLR_ERROR, "Could not initialize EGL");
 		gbm_device_destroy(gbm_device);


### PR DESCRIPTION
Just another part of #2624 and #1352 that I felt needed to be done.

Breaking changes:

`EGLint *config_attribs`, `wlr_egl->config`, `wlr_egl_create_surface` and `wlr_egl_destroy_surface` have been removed and no longer exist.

CC(if needed):

@emersion @bl4ckb0ne @ascent12 

EDIT: Fixed a typo.

EDIT 2: Removed `wlr_egl_create_surface` and `wlr_egl_destroy_surface` and removed a dependency on `wlr_egl` from some example clients. 