### PR TITLE
backend/x11: Use native cursors

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -11,6 +11,7 @@ packages:
   - wayland-dev
   - wayland-protocols
   - xcb-util-image-dev
+  - xcb-util-renderutil-dev
   - xcb-util-wm-dev
 sources:
   - https://github.com/swaywm/wlroots

--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -11,6 +11,7 @@ packages:
   - wayland-protocols
   - xcb-util-errors
   - xcb-util-image
+  - xcb-util-renderutil
   - xcb-util-wm
   - seatd
 sources:

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -18,6 +18,7 @@ packages:
   - x11/libxkbcommon
   - x11/pixman
   - x11/xcb-util-errors
+  - x11/xcb-util-renderutil
   - x11/xcb-util-wm
   - sysutils/seatd
   - gmake

--- a/backend/x11/meson.build
+++ b/backend/x11/meson.build
@@ -4,6 +4,8 @@ x11_required = [
 	'xcb',
 	'xcb-dri3',
 	'xcb-present',
+	'xcb-render',
+	'xcb-renderutil',
 	'xcb-xfixes',
 	'xcb-xinput',
 ]

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -51,6 +51,11 @@ struct wlr_x11_output {
 	pixman_region32_t exposed;
 
 	uint64_t last_msc;
+
+	struct {
+		struct wlr_swapchain *swapchain;
+		xcb_render_picture_t pic;
+	} cursor;
 };
 
 struct wlr_x11_touchpoint {
@@ -70,7 +75,8 @@ struct wlr_x11_backend {
 	xcb_depth_t *depth;
 	xcb_visualid_t visualid;
 	xcb_colormap_t colormap;
-	xcb_cursor_t cursor;
+	xcb_cursor_t transparent_cursor;
+	xcb_render_pictformat_t argb32;
 	uint32_t dri3_major_version, dri3_minor_version;
 
 	size_t requested_outputs;

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -1808,6 +1808,7 @@ void xwm_set_cursor(struct wlr_xwm *xwm, const uint8_t *pixels, uint32_t stride,
 	xcb_render_create_cursor(xwm->xcb_conn, xwm->cursor, pic, hotspot_x,
 		hotspot_y);
 	xcb_free_pixmap(xwm->xcb_conn, pix);
+	xcb_render_free_picture(xwm->xcb_conn, pic);
 
 	uint32_t values[] = {xwm->cursor};
 	xcb_change_window_attributes(xwm->xcb_conn, xwm->screen->root,


### PR DESCRIPTION
Note that I played around with returning 'false' for non-NULL textures. However this did not have the desired effect. But I don't think it's a shortcoming of this change. The native cursor was correctly removed in that case though.