### PR TITLE
[DON'T MERGE YET] subsurface: fix incorrect behaviour

### DIFF
--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -804,8 +804,10 @@ static void subsurface_handle_place_above(struct wl_client *client,
 		return;
 	}
 
+	assert(sibling->parent == subsurface->parent);
+
 	wl_list_remove(&subsurface->parent_pending_link);
-	wl_list_insert(&sibling->parent_pending_link,
+	wl_list_insert(sibling->parent_pending_link.prev,
 		&subsurface->parent_pending_link);
 
 	subsurface->reordered = true;
@@ -831,8 +833,10 @@ static void subsurface_handle_place_below(struct wl_client *client,
 		return;
 	}
 
+	assert(sibling->parent == subsurface->parent);
+
 	wl_list_remove(&subsurface->parent_pending_link);
-	wl_list_insert(sibling->parent_pending_link.prev,
+	wl_list_insert(&sibling->parent_pending_link,
 		&subsurface->parent_pending_link);
 
 	subsurface->reordered = true;

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -986,6 +986,9 @@ static void subsurface_handle_parent_destroy(struct wl_listener *listener,
 		void *data) {
 	struct wlr_subsurface *subsurface =
 		wl_container_of(listener, subsurface, parent_destroy);
+	assert(data == subsurface->parent);
+	assert(subsurface->surface != subsurface->parent);
+
 	subsurface_unmap(subsurface);
 	wl_list_remove(&subsurface->parent_link);
 	wl_list_remove(&subsurface->parent_pending_link);

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -1039,8 +1039,8 @@ struct wlr_subsurface *wlr_subsurface_create(struct wlr_surface *surface,
 	subsurface->parent = parent;
 	wl_signal_add(&parent->events.destroy, &subsurface->parent_destroy);
 	subsurface->parent_destroy.notify = subsurface_handle_parent_destroy;
-	wl_list_insert(parent->subsurfaces.prev, &subsurface->parent_link);
-	wl_list_insert(parent->subsurface_pending_list.prev,
+	wl_list_insert(&parent->subsurfaces, &subsurface->parent_link);
+	wl_list_insert(&parent->subsurface_pending_list,
 		&subsurface->parent_pending_link);
 
 	surface->role_data = subsurface;


### PR DESCRIPTION
Correct `subsurface_handle_place_above`, `subsurface_handle_place_below` and some other subsurface-related functions to have it match Weston's equivalent code for correctness, sanity and implementation parity.

See the commits for more info.

Code refs:

For `subsurface_handle_place_above`:

https://github.com/swaywm/wlroots/blob/master/types/wlr_surface.c#L787
https://github.com/wayland-project/weston/blob/master/libweston/compositor.c#L4423

For `subsurface_handle_place_below`:

https://github.com/swaywm/wlroots/blob/master/types/wlr_surface.c#L814
https://github.com/wayland-project/weston/blob/master/libweston/compositor.c#L4447

And for the missing `assert`:

https://github.com/wayland-project/weston/blob/master/libweston/compositor.c#L4417


Issue refs:

#1865, varmd/wine-wayland#23

@ascent12, @emersion:

Do the subsurface test clients work with this PR?

EDIT:

Just in case it wasn't clear, `subsurface_handle_place_above` is currently doing what `subsurface_handle_place_below` should be doing and `subsurface_handle_place_below` was doing vice versa and both of the handler functions lacked an `assert` for making sure that the parent of the subsurface matched the parent of the sibling that gets found, if I understood the code correctly. 