### PR TITLE
render/egl: remove wlr_egl_context->(draw, read)_surface

### DIFF
--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -32,8 +32,6 @@
 struct wlr_egl_context {
 	EGLDisplay display;
 	EGLContext context;
-	EGLSurface draw_surface;
-	EGLSurface read_surface;
 };
 
 struct wlr_egl {

--- a/render/egl.c
+++ b/render/egl.c
@@ -426,8 +426,6 @@ bool wlr_egl_is_current(struct wlr_egl *egl) {
 void wlr_egl_save_context(struct wlr_egl_context *context) {
 	context->display = eglGetCurrentDisplay();
 	context->context = eglGetCurrentContext();
-	context->draw_surface = eglGetCurrentSurface(EGL_DRAW);
-	context->read_surface = eglGetCurrentSurface(EGL_READ);
 }
 
 bool wlr_egl_restore_context(struct wlr_egl_context *context) {
@@ -444,8 +442,8 @@ bool wlr_egl_restore_context(struct wlr_egl_context *context) {
 		return true;
 	}
 
-	return eglMakeCurrent(display, context->draw_surface,
-			context->read_surface, context->context);
+	return eglMakeCurrent(display, EGL_NO_SURFACE,
+			EGL_NO_SURFACE, context->context);
 }
 
 EGLImageKHR wlr_egl_create_image_from_wl_drm(struct wlr_egl *egl,

--- a/render/egl.c
+++ b/render/egl.c
@@ -292,6 +292,12 @@ struct wlr_egl *wlr_egl_create(EGLenum platform, void *remote_display) {
 		goto error;
 	}
 
+	if (!check_egl_ext(display_exts_str, "EGL_KHR_surfaceless_context")) {
+		wlr_log(WLR_ERROR, 
+			"EGL_KHR_surfaceless_context not supported");
+		goto error;
+	}
+
 	wlr_log(WLR_INFO, "Using EGL %d.%d", (int)major, (int)minor);
 	wlr_log(WLR_INFO, "Supported EGL client extensions: %s", client_exts_str);
 	wlr_log(WLR_INFO, "Supported EGL display extensions: %s", display_exts_str);


### PR DESCRIPTION
Just another bit of EGL housekeeping done for #1352 and #2624.

Breaking changes:

`wlr_egl_context->draw_surface` and `wlr_egl_context->read_surface` have been deleted and no longer exist.

Cc:

@emersion, @ascent12, @ammen99

EDIT: Just to clarify and to clear up confusion, this PR is intended to accompany #2666(which got merged not too long ago).