### PR TITLE
output: split wlr_output_enable and wlr_output_enable_adaptive_sync

### DIFF
--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -286,7 +286,7 @@ void wlr_output_set_custom_mode(struct wlr_output *output, int32_t width,
 void wlr_output_set_transform(struct wlr_output *output,
 	enum wl_output_transform transform);
 /**
- * Enables or disables adaptive sync (ie. variable refresh rate) on this
+ * Enables adaptive sync (ie. variable refresh rate) on this
  * output. This is just a hint, the backend is free to ignore this setting.
  *
  * When enabled, compositors can submit frames a little bit later than the
@@ -294,7 +294,14 @@ void wlr_output_set_transform(struct wlr_output *output,
  *
  * Adaptive sync is double-buffered state, see `wlr_output_commit`.
  */
-void wlr_output_enable_adaptive_sync(struct wlr_output *output, bool enabled);
+void wlr_output_enable_adaptive_sync(struct wlr_output *output);
+/**
+ * Disables adaptive sync (ie. variable refresh rate) on this
+ * output. This is just a hint, the backend is free to ignore this setting.
+ *
+ * Adaptive sync is double-buffered state, see `wlr_output_commit`.
+ */
+void wlr_output_disable_adaptive_sync(struct wlr_output *output);
 /**
  * Sets a scale for the output.
  *

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -241,13 +241,20 @@ struct wlr_output_event_bind {
 struct wlr_surface;
 
 /**
- * Enables or disables the output. A disabled output is turned off and doesn't
- * emit `frame` events.
+ * Enables the output.
  *
- * Whether an output is enabled is double-buffered state, see
+ * Whether an output is enabled or disabled is double-buffered state, see
  * `wlr_output_commit`.
  */
-void wlr_output_enable(struct wlr_output *output, bool enable);
+void wlr_output_enable(struct wlr_output *output);
+/**
+ * Disables the output. A disabled output is turned off and doesn't
+ * emit `frame` events.
+ *
+ * Whether an output is enabled or disabled is double-buffered state, see
+ * `wlr_output_commit`.
+ */
+void wlr_output_disable(struct wlr_output *output);
 void wlr_output_create_global(struct wlr_output *output);
 void wlr_output_destroy_global(struct wlr_output *output);
 /**

--- a/tinywl/tinywl.c
+++ b/tinywl/tinywl.c
@@ -673,7 +673,7 @@ static void server_new_output(struct wl_listener *listener, void *data) {
 	if (!wl_list_empty(&wlr_output->modes)) {
 		struct wlr_output_mode *mode = wlr_output_preferred_mode(wlr_output);
 		wlr_output_set_mode(wlr_output, mode);
-		wlr_output_enable(wlr_output, true);
+		wlr_output_enable(wlr_output);
 		if (!wlr_output_commit(wlr_output)) {
 			return;
 		}

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -257,16 +257,28 @@ void wlr_output_set_scale(struct wlr_output *output, float scale) {
 	output->pending.scale = scale;
 }
 
-void wlr_output_enable_adaptive_sync(struct wlr_output *output, bool enabled) {
+void wlr_output_enable_adaptive_sync(struct wlr_output *output) {
 	bool currently_enabled =
 		output->adaptive_sync_status != WLR_OUTPUT_ADAPTIVE_SYNC_DISABLED;
-	if (currently_enabled == enabled) {
+	if (currently_enabled) {
 		output->pending.committed &= ~WLR_OUTPUT_STATE_ADAPTIVE_SYNC_ENABLED;
 		return;
 	}
 
 	output->pending.committed |= WLR_OUTPUT_STATE_ADAPTIVE_SYNC_ENABLED;
-	output->pending.adaptive_sync_enabled = enabled;
+	output->pending.adaptive_sync_enabled = true;
+}
+
+void wlr_output_disable_adaptive_sync(struct wlr_output *output) {
+	bool currently_enabled =
+		output->adaptive_sync_status != WLR_OUTPUT_ADAPTIVE_SYNC_DISABLED;
+	if (!currently_enabled) {
+		output->pending.committed &= ~WLR_OUTPUT_STATE_ADAPTIVE_SYNC_ENABLED;
+		return;
+	}
+
+	output->pending.committed |= WLR_OUTPUT_STATE_ADAPTIVE_SYNC_ENABLED;
+	output->pending.adaptive_sync_enabled = false;
 }
 
 void wlr_output_set_subpixel(struct wlr_output *output,

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -144,14 +144,24 @@ static void output_update_matrix(struct wlr_output *output) {
 		output->height, output->transform);
 }
 
-void wlr_output_enable(struct wlr_output *output, bool enable) {
-	if (output->enabled == enable) {
+void wlr_output_enable(struct wlr_output *output) {
+	if (output->enabled) {
 		output->pending.committed &= ~WLR_OUTPUT_STATE_ENABLED;
 		return;
 	}
 
 	output->pending.committed |= WLR_OUTPUT_STATE_ENABLED;
-	output->pending.enabled = enable;
+	output->pending.enabled = true;
+}
+
+void wlr_output_disable(struct wlr_output *output) {
+	if (!output->enabled) {
+		output->pending.committed &= ~WLR_OUTPUT_STATE_ENABLED;
+		return;
+	}
+
+	output->pending.committed |= WLR_OUTPUT_STATE_ENABLED;
+	output->pending.enabled = false;
 }
 
 static void output_state_clear_mode(struct wlr_output_state *state) {


### PR DESCRIPTION
Split `wlr_output_enable(output, enable)` into `wlr_output_enable(output)` and `wlr_output_disable(output)` and split `wlr_output_enable_adaptive_sync(output, enabled)` into `wlr_output_enable_adaptive_sync(output)` and `wlr_output_disable_adaptive_sync(output)`.

Breaking changes:

`wlr_output_enable` no longer takes a `bool enable` parameter and `wlr_output_enable_adaptive_sync` no longer takes a `bool enabled` parameter.

Solution:

Replace `wlr_output_enable(output, true)` with `wlr_output_enable(output)` and replace `wlr_output_enable(output, false)` with `wlr_output_disable(output)`.

Matching Sway PR: swaywm/sway#5965

Mentions:

@emersion 