### PR TITLE
output: split wlr_output_update_enabled

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -785,7 +785,7 @@ bool drm_connector_set_mode(struct wlr_drm_connector *conn,
 			realloc_crtcs(drm);
 			attempt_enable_needs_modeset(drm);
 		}
-		wlr_output_update_enabled(&conn->output, false);
+		wlr_output_update_disabled(&conn->output);
 		return true;
 	}
 
@@ -820,7 +820,7 @@ bool drm_connector_set_mode(struct wlr_drm_connector *conn,
 	conn->state = WLR_DRM_CONN_CONNECTED;
 	conn->desired_mode = NULL;
 	wlr_output_update_mode(&conn->output, wlr_mode);
-	wlr_output_update_enabled(&conn->output, true);
+	wlr_output_update_enabled(&conn->output);
 	conn->desired_enabled = true;
 
 	// When switching VTs, the mode is not updated but the buffers become
@@ -1181,7 +1181,7 @@ static void realloc_crtcs(struct wlr_drm_backend *drm) {
 			if (prev_enabled) {
 				wlr_drm_conn_log(conn, WLR_DEBUG, "Output has lost its CRTC");
 				conn->state = WLR_DRM_CONN_NEEDS_MODESET;
-				wlr_output_update_enabled(&conn->output, false);
+				wlr_output_update_disabled(&conn->output);
 				conn->desired_mode = conn->output.current_mode;
 				wlr_output_update_mode(&conn->output, NULL);
 			}
@@ -1199,7 +1199,7 @@ static void realloc_crtcs(struct wlr_drm_backend *drm) {
 			(struct wlr_drm_mode *)conn->output.current_mode;
 		if (!drm_connector_init_renderer(conn, mode)) {
 			wlr_drm_conn_log(conn, WLR_ERROR, "Failed to initialize renderer");
-			wlr_output_update_enabled(&conn->output, false);
+			wlr_output_update_disabled(&conn->output);
 			continue;
 		}
 
@@ -1410,7 +1410,11 @@ void scan_drm_connectors(struct wlr_drm_backend *drm) {
 
 			// TODO: this results in connectors being enabled without a mode
 			// set
-			wlr_output_update_enabled(&wlr_conn->output, wlr_conn->crtc != NULL);
+			if (wlr_conn->crtc != NULL) {
+				wlr_output_update_enabled(&wlr_conn->output);
+			} else {
+				wlr_output_update_disabled(&wlr_conn->output);
+			}
 			wlr_conn->desired_enabled = true;
 
 			wlr_conn->state = WLR_DRM_CONN_NEEDS_MODESET;

--- a/backend/headless/backend.c
+++ b/backend/headless/backend.c
@@ -29,7 +29,7 @@ static bool backend_start(struct wlr_backend *wlr_backend) {
 	struct wlr_headless_output *output;
 	wl_list_for_each(output, &backend->outputs, link) {
 		wl_event_source_timer_update(output->frame_timer, output->frame_delay);
-		wlr_output_update_enabled(&output->wlr_output, true);
+		wlr_output_update_enabled(&output->wlr_output);
 		wlr_signal_emit_safe(&backend->backend.events.new_output,
 			&output->wlr_output);
 	}

--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -212,7 +212,7 @@ struct wlr_output *wlr_headless_add_output(struct wlr_backend *wlr_backend,
 
 	if (backend->started) {
 		wl_event_source_timer_update(output->frame_timer, output->frame_delay);
-		wlr_output_update_enabled(wlr_output, true);
+		wlr_output_update_enabled(wlr_output);
 		wlr_signal_emit_safe(&backend->backend.events.new_output, wlr_output);
 	}
 

--- a/backend/noop/backend.c
+++ b/backend/noop/backend.c
@@ -17,7 +17,7 @@ static bool backend_start(struct wlr_backend *wlr_backend) {
 
 	struct wlr_noop_output *output;
 	wl_list_for_each(output, &backend->outputs, link) {
-		wlr_output_update_enabled(&output->wlr_output, true);
+		wlr_output_update_enabled(&output->wlr_output);
 		wlr_signal_emit_safe(&backend->backend.events.new_output,
 			&output->wlr_output);
 	}

--- a/backend/noop/output.c
+++ b/backend/noop/output.c
@@ -83,7 +83,7 @@ struct wlr_output *wlr_noop_add_output(struct wlr_backend *wlr_backend) {
 	wl_list_insert(&backend->outputs, &output->link);
 
 	if (backend->started) {
-		wlr_output_update_enabled(wlr_output, true);
+		wlr_output_update_enabled(wlr_output);
 		wlr_signal_emit_safe(&backend->backend.events.new_output, wlr_output);
 	}
 

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -646,7 +646,7 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *wlr_backend) {
 	wl_display_roundtrip(output->backend->remote_display);
 
 	wl_list_insert(&backend->outputs, &output->link);
-	wlr_output_update_enabled(wlr_output, true);
+	wlr_output_update_enabled(wlr_output);
 
 	wlr_signal_emit_safe(&backend->backend.events.new_output, wlr_output);
 

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -441,7 +441,7 @@ struct wlr_output *wlr_x11_output_create(struct wlr_backend *backend) {
 
 	wl_list_insert(&x11->outputs, &output->link);
 
-	wlr_output_update_enabled(wlr_output, true);
+	wlr_output_update_enabled(wlr_output);
 
 	wlr_input_device_init(&output->pointer_dev, WLR_INPUT_DEVICE_POINTER,
 		&input_device_impl, "X11 pointer", 0, 0);

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -112,10 +112,11 @@ void wlr_output_update_custom_mode(struct wlr_output *output, int32_t width,
 /**
  * Update the current output status.
  *
- * The backend must call this function when the status is updated to notify
+ * The backend must call either of these functions when the status is updated to notify
  * compositors about the change.
  */
-void wlr_output_update_enabled(struct wlr_output *output, bool enabled);
+void wlr_output_update_enabled(struct wlr_output *output);
+void wlr_output_update_disabled(struct wlr_output *output);
 /**
  * Notify compositors that they need to submit a new frame in order to apply
  * output changes.

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -130,12 +130,21 @@ void wlr_output_destroy_global(struct wlr_output *output) {
 	output->global = NULL;
 }
 
-void wlr_output_update_enabled(struct wlr_output *output, bool enabled) {
-	if (output->enabled == enabled) {
+void wlr_output_update_enabled(struct wlr_output *output) {
+	if (output->enabled) {
 		return;
 	}
 
-	output->enabled = enabled;
+	output->enabled = true;
+	wlr_signal_emit_safe(&output->events.enable, output);
+}
+
+void wlr_output_update_disabled(struct wlr_output *output) {
+	if (!output->enabled) {
+		return;
+	}
+
+	output->enabled = false;
 	wlr_signal_emit_safe(&output->events.enable, output);
 }
 


### PR DESCRIPTION
This PR splits `wlr_output_update_enabled(output, enabled)` into `wlr_output_update_enabled(output)` and `wlr_output_update_disabled(output)`. 

I'm not going to repeat the reasons why I would like `wlr_output_update_enabled` to be split in this PR, so please see #2679 for the reasons why as the reasons stated there apply to this PR as well.

And please see this comment too, for clarification and more info:

https://github.com/swaywm/wlroots/pull/2679#issuecomment-765792893

(Although the above comment applies to a different function, `wlr_output_enable`, it also applies to why I'm doing it here with `wlr_output_update_enabled`, just FYI to clarify and not cause confusion, I hope.)

(And although I think because `wlr_output_update_enabled` seems to be a private function that also seems to only be used by the backends and not compositors that utilize wlroots (also), I think, it would seem that changing/refactoring it doesn't really matter as much and/or as such (and I don't really think so, in my opinion), unless I'm wrong and it *does* matter, that is.)