### PR TITLE
xwayland: use strerror(...) instead of %m

### DIFF
--- a/xwayland/selection/incoming.c
+++ b/xwayland/selection/incoming.c
@@ -24,10 +24,10 @@ static int xwm_data_source_write(int fd, uint32_t mask, void *data) {
 
 	ssize_t len = write(fd, property + transfer->property_start, remainder);
 	if (len == -1) {
+		wlr_log_errno(WLR_ERROR, "write error to target fd %d", fd);
 		xwm_selection_transfer_destroy_property_reply(transfer);
 		xwm_selection_transfer_remove_source(transfer);
 		xwm_selection_transfer_close_source_fd(transfer);
-		wlr_log(WLR_ERROR, "write error to target fd: %m");
 		return 1;
 	}
 


### PR DESCRIPTION
Previously, any error would be masked by an internal isatty call:

```
24:31:48.174 [DEBUG] [wlr] [xwayland/selection/incoming.c:386] XCB_SELECTION_NOTIFY (selection=277, property=278, target=256)
24:31:48.174 [ERROR] [wlr] [xwayland/selection/incoming.c:30] write error to target fd: Inappropriate ioctl for device
```