### PR TITLE
xwayland/selection: prevent fd leak on unsupported MIME type

### DIFF
--- a/xwayland/selection/incoming.c
+++ b/xwayland/selection/incoming.c
@@ -158,6 +158,7 @@ static void source_send(struct wlr_xwm_selection *selection,
 	if (!found) {
 		wlr_log(WLR_DEBUG, "Cannot send X11 selection to Wayland: "
 			"unsupported MIME type");
+		close(fd);
 		return;
 	}
 


### PR DESCRIPTION
Since we never end up calling xcb_convert_selection, the file descriptor
ends up getting leaked (i.e., not cleaned up within
xwm_data_source_write).