### PR TITLE
xwayland/selection: rename Wayland-facing data and helpers

### DIFF
--- a/include/xwayland/selection.h
+++ b/include/xwayland/selection.h
@@ -18,8 +18,8 @@ struct wlr_xwm_selection_transfer {
 	bool flush_property_on_delete;
 	bool property_set;
 	struct wl_array source_data;
-	int source_fd;
-	struct wl_event_source *source;
+	int wl_client_fd;
+	struct wl_event_source *event_source;
 
 	// when sending to x11
 	xcb_selection_request_event_t request;
@@ -41,9 +41,9 @@ struct wlr_xwm_selection {
 	struct wl_list outgoing;
 };
 
-void xwm_selection_transfer_remove_source(
+void xwm_selection_transfer_remove_event_source(
 	struct wlr_xwm_selection_transfer *transfer);
-void xwm_selection_transfer_close_source_fd(
+void xwm_selection_transfer_close_wl_client_fd(
 	struct wlr_xwm_selection_transfer *transfer);
 void xwm_selection_transfer_destroy_property_reply(
 	struct wlr_xwm_selection_transfer *transfer);

--- a/xwayland/selection/selection.c
+++ b/xwayland/selection/selection.c
@@ -11,19 +11,19 @@
 #include "xwayland/selection.h"
 #include "xwayland/xwm.h"
 
-void xwm_selection_transfer_remove_source(
+void xwm_selection_transfer_remove_event_source(
 		struct wlr_xwm_selection_transfer *transfer) {
-	if (transfer->source != NULL) {
-		wl_event_source_remove(transfer->source);
-		transfer->source = NULL;
+	if (transfer->event_source != NULL) {
+		wl_event_source_remove(transfer->event_source);
+		transfer->event_source = NULL;
 	}
 }
 
-void xwm_selection_transfer_close_source_fd(
+void xwm_selection_transfer_close_wl_client_fd(
 		struct wlr_xwm_selection_transfer *transfer) {
-	if (transfer->source_fd >= 0) {
-		close(transfer->source_fd);
-		transfer->source_fd = -1;
+	if (transfer->wl_client_fd >= 0) {
+		close(transfer->wl_client_fd);
+		transfer->wl_client_fd = -1;
 	}
 }
 


### PR DESCRIPTION
Previously, wlr_xwm_selection_transfer.source_fd meant:

- the source of data in a Wayland -> X11 copy (good)
- the destination of data in a X11 -> Wayland copy (confusing)

This made reading through xwayland/selection/incoming.c difficult: in
many places, "source" actually means "destination".