### PR TITLE
render/egl: fail to create wlr_egl on software renderer

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -39,6 +39,11 @@ wlroots reads these environment variables
 
 * *WLR_X11_OUTPUTS*: when using the X11 backend specifies the number of outputs
 
+## gles2 renderer
+
+* *WLR_RENDERER_ALLOW_SOFTWARE*: allows the gles2 renderer to use software
+  rendering
+
 # Generic
 
 * *DISPLAY*: if set probe X11 backend in `wlr_backend_autocreate`

--- a/render/egl.c
+++ b/render/egl.c
@@ -272,6 +272,18 @@ struct wlr_egl *wlr_egl_create(EGLenum platform, void *remote_display,
 			goto error;
 		}
 
+		if (check_egl_ext(device_exts_str, "EGL_MESA_device_software")) {
+			const char *allow_software = getenv("WLR_RENDERER_ALLOW_SOFTWARE");
+			if (strcmp(allow_software, "1") == 0) {
+				wlr_log(WLR_INFO, "Using software rendering");
+			} else {
+				wlr_log(WLR_ERROR, "Software rendering detected, please use "
+						"the WLR_RENDERER_ALLOW_SOFTWARE environment variable "
+						"to proceed");
+				goto error;
+			}
+		}
+
 		egl->exts.device_drm_ext =
 			check_egl_ext(device_exts_str, "EGL_EXT_device_drm");
 	}


### PR DESCRIPTION
The creation of `wlr_egl` will fail is the device extension
EGL_MESA_device_software is defined. The creation process is allowed to
continue only if the environment variable `WLR_RENDERER_ALLOW_SOFTWARE`
is defiled.

