### PR TITLE
Build tinywl from meson

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -17,15 +17,11 @@ sources:
 tasks:
   - setup: |
       cd wlroots
-      meson build -Dauto_features=enabled -Dlogind=disabled -Dlibseat=disabled -Dxcb-errors=disabled
+      meson build -Dauto_features=enabled -Dlogind=disabled -Dlibseat=disabled -Dxcb-errors=disabled -Dtinywl=true
   - build: |
       cd wlroots
       ninja -C build
-      sudo ninja -C build install
   - build-features-disabled: |
       cd wlroots
       meson build --reconfigure -Dauto_features=disabled
       ninja -C build
-  - tinywl: |
-      cd wlroots/tinywl
-      make

--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -18,14 +18,11 @@ sources:
 tasks:
   - setup: |
       cd wlroots
-      CC=gcc meson build-gcc -Dauto_features=enabled -Dlogind-provider=systemd --prefix /usr
-      CC=clang meson build-clang -Dauto_features=enabled -Dlogind-provider=systemd
+      CC=gcc meson build-gcc -Dauto_features=enabled -Dlogind-provider=systemd -Dtinywl=true
+      CC=clang meson build-clang -Dauto_features=enabled -Dlogind-provider=systemd -Dtinywl=true
   - gcc: |
       cd wlroots/build-gcc
       ninja
-      sudo ninja install
-      cd ../tinywl
-      make
   - clang: |
       cd wlroots/build-clang
       ninja

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -26,9 +26,5 @@ sources:
 tasks:
   - wlroots: |
       cd wlroots
-      meson build -Dauto_features=enabled -Dlogind=disabled
+      meson build -Dauto_features=enabled -Dlogind=disabled -Dtinywl=true
       ninja -C build
-      sudo ninja -C build install
-  - tinywl: |
-      cd wlroots/tinywl
-      gmake

--- a/meson.build
+++ b/meson.build
@@ -180,6 +180,10 @@ if get_option('examples')
 	subdir('examples')
 endif
 
+if get_option('tinywl')
+	subdir('tinywl')
+endif
+
 pkgconfig = import('pkgconfig')
 pkgconfig.generate(lib_wlr,
 	version: meson.project_version(),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,3 +8,4 @@ option('x11-backend', type: 'feature', value: 'auto', description: 'Enable X11 b
 option('examples', type: 'boolean', value: true, description: 'Build example applications')
 option('icon_directory', description: 'Location used to look for cursors (default: ${datadir}/icons)', type: 'string', value: '')
 option('xdg-foreign', type: 'feature', value: 'auto', description: 'Enable xdg-foreign protocol')
+option('tinywl', type: 'boolean', value: false, description: 'Build the tinywl compositor')

--- a/tinywl/meson.build
+++ b/tinywl/meson.build
@@ -1,0 +1,6 @@
+executable(
+	'tinywl',
+	['tinywl.c', protocols_server_header['xdg-shell'], protocols_code['xdg-shell']],
+	dependencies: wlroots,
+	include_directories: [wlr_inc, proto_inc],
+)


### PR DESCRIPTION
I am using this in my dev branches, so I figured it would benefit the community. Option is off by default.