### PR TITLE
examples: remove "major" and "minor" from egl_common.c

### DIFF
--- a/examples/egl_common.c
+++ b/examples/egl_common.c
@@ -81,8 +81,7 @@ bool egl_init(struct wl_display *display) {
 		goto error;
 	}
 
-	EGLint major, minor;
-	if (eglInitialize(egl_display, &major, &minor) == EGL_FALSE) {
+	if (eglInitialize(egl_display, NULL, NULL) == EGL_FALSE) {
 		wlr_log(WLR_ERROR, "Failed to initialize EGL");
 		goto error;
 	}


### PR DESCRIPTION
Remove "major" and "minor" from egl_common.c as they are not used by the examples that use `egl_common.c`.

In other words, just polishing `egl_common.c`

Also, whoops! Sorry about that. I should've removed those two variables as those were leftovers when I was copying from `render/egl.c` before #2666 got merged. :grimacing: 