### PR TITLE
render/egl: add check for EGL_KHR_surfaceless_context

### DIFF
--- a/render/egl.c
+++ b/render/egl.c
@@ -292,6 +292,12 @@ struct wlr_egl *wlr_egl_create(EGLenum platform, void *remote_display) {
 		goto error;
 	}
 
+	if (!check_egl_ext(display_exts_str, "EGL_KHR_surfaceless_context")) {
+		wlr_log(WLR_ERROR, 
+			"EGL_KHR_surfaceless_context not supported");
+		goto error;
+	}
+
 	wlr_log(WLR_INFO, "Using EGL %d.%d", (int)major, (int)minor);
 	wlr_log(WLR_INFO, "Supported EGL client extensions: %s", client_exts_str);
 	wlr_log(WLR_INFO, "Supported EGL display extensions: %s", display_exts_str);


### PR DESCRIPTION
As surfaces are no longer going to be used for `wlr_egl`, I may as well just go and add this check as it is needed for safety whenever surface-less rendering is being used.

EDIT: I think this is also relevant: #1352