### PR TITLE
backend/drm: take detached output state in commit functions

### DIFF
--- a/backend/drm/legacy.c
+++ b/backend/drm/legacy.c
@@ -9,13 +9,15 @@
 #include "backend/drm/util.h"
 
 static bool legacy_crtc_commit(struct wlr_drm_backend *drm,
-		struct wlr_drm_connector *conn, uint32_t flags) {
+		struct wlr_drm_connector *conn, const struct wlr_output_state *state) {
 	struct wlr_output *output = &conn->output;
 	struct wlr_drm_crtc *crtc = conn->crtc;
 	struct wlr_drm_plane *cursor = crtc->cursor;
 
+	bool active = drm_connector_state_active(conn, state);
+
 	uint32_t fb_id = 0;
-	if (crtc->pending.active) {
+	if (active) {
 		struct wlr_drm_fb *fb = plane_get_next_fb(crtc->primary);
 		if (fb == NULL) {
 			wlr_log(WLR_ERROR, "%s: failed to acquire primary FB",
@@ -25,18 +27,17 @@ static bool legacy_crtc_commit(struct wlr_drm_backend *drm,
 		fb_id = fb->id;
 	}
 
-	if (crtc->pending_modeset) {
+	if (drm_connector_state_allow_modeset(state)) {
 		uint32_t *conns = NULL;
 		size_t conns_len = 0;
 		drmModeModeInfo *mode = NULL;
-		if (crtc->pending.active) {
+		if (active) {
 			conns = &conn->id;
 			conns_len = 1;
-			mode = &crtc->pending.mode->drm_mode;
+			mode = drm_connector_state_mode(conn, state);
 		}
 
-		uint32_t dpms = crtc->pending.active ?
-			DRM_MODE_DPMS_ON : DRM_MODE_DPMS_OFF;
+		uint32_t dpms = active ? DRM_MODE_DPMS_ON : DRM_MODE_DPMS_OFF;
 		if (drmModeConnectorSetProperty(drm->fd, conn->id, conn->props.dpms,
 				dpms) != 0) {
 			wlr_drm_conn_log_errno(conn, WLR_ERROR,
@@ -51,27 +52,27 @@ static bool legacy_crtc_commit(struct wlr_drm_backend *drm,
 		}
 	}
 
-	if (output->pending.committed & WLR_OUTPUT_STATE_GAMMA_LUT) {
+	if (state->committed & WLR_OUTPUT_STATE_GAMMA_LUT) {
 		if (!drm_legacy_crtc_set_gamma(drm, crtc,
-				output->pending.gamma_lut_size, output->pending.gamma_lut)) {
+				state->gamma_lut_size, state->gamma_lut)) {
 			return false;
 		}
 	}
 
-	if ((output->pending.committed & WLR_OUTPUT_STATE_ADAPTIVE_SYNC_ENABLED) &&
+	if ((state->committed & WLR_OUTPUT_STATE_ADAPTIVE_SYNC_ENABLED) &&
 			drm_connector_supports_vrr(conn)) {
 		if (drmModeObjectSetProperty(drm->fd, crtc->id, DRM_MODE_OBJECT_CRTC,
 				crtc->props.vrr_enabled,
-				output->pending.adaptive_sync_enabled) != 0) {
+				state->adaptive_sync_enabled) != 0) {
 			wlr_drm_conn_log_errno(conn, WLR_ERROR,
 				"drmModeObjectSetProperty(VRR_ENABLED) failed");
 			return false;
 		}
-		output->adaptive_sync_status = output->pending.adaptive_sync_enabled ?
+		output->adaptive_sync_status = state->adaptive_sync_enabled ?
 			WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED :
 			WLR_OUTPUT_ADAPTIVE_SYNC_DISABLED;
 		wlr_drm_conn_log(conn, WLR_DEBUG, "VRR %s",
-			output->pending.adaptive_sync_enabled ? "enabled" : "disabled");
+			state->adaptive_sync_enabled ? "enabled" : "disabled");
 	}
 
 	if (cursor != NULL && drm_connector_is_cursor_visible(conn)) {
@@ -102,7 +103,7 @@ static bool legacy_crtc_commit(struct wlr_drm_backend *drm,
 		}
 	}
 
-	if (flags & DRM_MODE_PAGE_FLIP_EVENT) {
+	if (active) {
 		if (drmModePageFlip(drm->fd, crtc->id, fb_id,
 				DRM_MODE_PAGE_FLIP_EVENT, drm)) {
 			wlr_drm_conn_log_errno(conn, WLR_ERROR, "drmModePageFlip failed");

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -49,9 +49,6 @@ struct wlr_drm_crtc_state {
 struct wlr_drm_crtc {
 	uint32_t id;
 
-	bool pending_modeset;
-	struct wlr_drm_crtc_state pending, current;
-
 	// Atomic modesetting only
 	uint32_t mode_id;
 	uint32_t gamma_lut;
@@ -157,6 +154,12 @@ size_t drm_crtc_get_gamma_lut_size(struct wlr_drm_backend *drm,
 	struct wlr_drm_crtc *crtc);
 
 struct wlr_drm_fb *plane_get_next_fb(struct wlr_drm_plane *plane);
+
+bool drm_connector_state_allow_modeset(const struct wlr_output_state *state);
+bool drm_connector_state_active(struct wlr_drm_connector *conn,
+	const struct wlr_output_state *state);
+drmModeModeInfo *drm_connector_state_mode(struct wlr_drm_connector *conn,
+	const struct wlr_output_state *state);
 
 #define wlr_drm_conn_log(conn, verb, fmt, ...) \
 	wlr_log(verb, "connector %s: " fmt, conn->name, ##__VA_ARGS__)

--- a/include/backend/drm/iface.h
+++ b/include/backend/drm/iface.h
@@ -15,7 +15,7 @@ struct wlr_drm_crtc;
 struct wlr_drm_interface {
 	// Commit al pending changes on a CRTC.
 	bool (*crtc_commit)(struct wlr_drm_backend *drm,
-		struct wlr_drm_connector *conn, uint32_t flags);
+		struct wlr_drm_connector *conn, const struct wlr_output_state *state);
 };
 
 extern const struct wlr_drm_interface atomic_iface;


### PR DESCRIPTION
Don't rely on wlr_output.pending, instead take a separate
wlr_output_state argument. This is desirable because the
DRM backend sometimes needs to perform commits under-the-hood,
for instance after switching VTs. We'd like to unify and
re-use our wlr_output_commit logic.