### PR TITLE
backend/wayland/output: silence warning in NDEBUG build.

### DIFF
--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -535,6 +535,7 @@ static void xdg_surface_handle_configure(void *data,
 	xdg_surface_ack_configure(xdg_surface, serial);
 
 	// nothing else?
+	(void)output;
 }
 
 static struct xdg_surface_listener xdg_surface_listener = {


### PR DESCRIPTION
output isn't used anywhere but the assert. Leave below "// nothing else?"
comment, to remind anyone who eventually adds more stuff to remove the
line, if it becomes no longer necessary.