### PR TITLE
xwayland/selection: use one target window per selection

### DIFF
--- a/include/xwayland/xwm.h
+++ b/include/xwayland/xwm.h
@@ -103,13 +103,8 @@ struct wlr_xwm {
 	xcb_render_pictformat_t render_format_id;
 	xcb_cursor_t cursor;
 
-	// FIXME: need one per selection to simultaneously request both mimetypes,
-	// I think.
-	xcb_window_t selection_window;
 	struct wlr_xwm_selection clipboard_selection;
 	struct wlr_xwm_selection primary_selection;
-
-	xcb_window_t dnd_window;
 	struct wlr_xwm_selection dnd_selection;
 
 	struct wlr_xwayland_surface *focus_surface;

--- a/xwayland/selection/dnd.c
+++ b/xwayland/selection/dnd.c
@@ -64,7 +64,7 @@ static void xwm_dnd_send_enter(struct wlr_xwm *xwm) {
 	struct wl_array *mime_types = &drag->source->mime_types;
 
 	xcb_client_message_data_t data = { 0 };
-	data.data32[0] = xwm->dnd_window;
+	data.data32[0] = xwm->dnd_selection.window;
 	data.data32[1] = XDND_VERSION << 24;
 
 	// If we have 3 MIME types or less, we can send them directly in the
@@ -94,7 +94,7 @@ static void xwm_dnd_send_enter(struct wlr_xwm *xwm) {
 
 		xcb_change_property(xwm->xcb_conn,
 			XCB_PROP_MODE_REPLACE,
-			xwm->dnd_window,
+			xwm->dnd_selection.window,
 			xwm->atoms[DND_TYPE_LIST],
 			XCB_ATOM_ATOM,
 			32, // format
@@ -110,7 +110,7 @@ static void xwm_dnd_send_position(struct wlr_xwm *xwm, uint32_t time, int16_t x,
 	assert(drag != NULL);
 
 	xcb_client_message_data_t data = { 0 };
-	data.data32[0] = xwm->dnd_window;
+	data.data32[0] = xwm->dnd_selection.window;
 	data.data32[2] = (x << 16) | y;
 	data.data32[3] = time;
 	data.data32[4] =
@@ -126,7 +126,7 @@ static void xwm_dnd_send_drop(struct wlr_xwm *xwm, uint32_t time) {
 	assert(dest != NULL);
 
 	xcb_client_message_data_t data = { 0 };
-	data.data32[0] = xwm->dnd_window;
+	data.data32[0] = xwm->dnd_selection.window;
 	data.data32[2] = time;
 
 	xwm_dnd_send_event(xwm, xwm->atoms[DND_DROP], &data);
@@ -139,7 +139,7 @@ static void xwm_dnd_send_leave(struct wlr_xwm *xwm) {
 	assert(dest != NULL);
 
 	xcb_client_message_data_t data = { 0 };
-	data.data32[0] = xwm->dnd_window;
+	data.data32[0] = xwm->dnd_selection.window;
 
 	xwm_dnd_send_event(xwm, xwm->atoms[DND_LEAVE], &data);
 }
@@ -151,7 +151,7 @@ static void xwm_dnd_send_leave(struct wlr_xwm *xwm) {
 	assert(dest != NULL);
 
 	xcb_client_message_data_t data = { 0 };
-	data.data32[0] = xwm->dnd_window;
+	data.data32[0] = xwm->dnd_selection.window;
 	data.data32[1] = drag->source->accepted;
 
 	if (drag->source->accepted) {


### PR DESCRIPTION
As before, this PR is based on https://github.com/swaywm/wlroots/pull/2701 and only the last commit contains changes.

---

Previously, the clipboard and primary selections shared the same window.
This was racey, and could have led to pasting failures.

On xfixes selection owner change notification, the logic for requesting
the supported mimetypes of the new owner's selection looks like:

```c
xcb_convert_selection(
  xwm->xcb_conn,
  selection->window,
  selection->atom,
  xwm->atoms[TARGETS],
  xwm->atoms[WL_SELECTION],
  selection->timestamp
);
```

This means: ask the selection owner to write its TARGETS for the
`selection->atom` selection (one of PRIMARY, CLIPBOARD, DND_SELECTION)
to `selection->window`'s WL_SELECTION atom.

However, `selection->window` is shared for both PRIMARY and CLIPBOARD
selections, and WL_SELECTION is used as the target atom in both cases.
So, there's a race when both selections change at the same time.

The CLIPBOARD selection might support mimetypes {A, B, C}, and the
PRIMARY only {A, B}. If the ConvertSelection requests/responses "cross
on the wire", so to speak, wlroots can end up believing that the PRIMARY
selection also supports C.

A Wayland client may then ask for the PRIMARY selection in C format,
which will fail with "convert selection failed". The Wayland client would
end up with a failed paste operation.

This commit fixes this by using a separate window for PRIMARY and
CLIPBOARD target requests, so that WL_SELECTION can be used as the
target atom in both cases.