### PR TITLE
xwayland: check executable exists on init, take 2

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -13,6 +13,7 @@ packages:
   - xcb-util-image-dev
   - xcb-util-renderutil-dev
   - xcb-util-wm-dev
+  - xorg-server-xwayland
 sources:
   - https://github.com/swaywm/wlroots
 tasks:

--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -13,6 +13,7 @@ packages:
   - xcb-util-image
   - xcb-util-renderutil
   - xcb-util-wm
+  - xorg-xwayland
   - seatd
 sources:
   - https://github.com/swaywm/wlroots

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -20,6 +20,7 @@ packages:
   - x11/xcb-util-errors
   - x11/xcb-util-renderutil
   - x11/xcb-util-wm
+  - x11-servers/xwayland
   - sysutils/seatd
   - gmake
 sources:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Install dependencies:
 
 If you choose to enable X11 support:
 
+* xwayland (build-time only, optional at runtime)
 * xcb
 * xcb-composite
 * xcb-xfixes

--- a/include/meson.build
+++ b/include/meson.build
@@ -6,6 +6,8 @@ if not features.get('x11-backend')
 endif
 if not features.get('xwayland')
 	exclude_files += 'xwayland.h'
+else
+	subdir('xwayland')
 endif
 if not features.get('xdg-foreign')
 	exclude_files += [

--- a/include/xwayland/meson.build
+++ b/include/xwayland/meson.build
@@ -1,0 +1,12 @@
+if xwayland.found()
+	xwayland_path = xwayland.get_pkgconfig_variable('xwayland')
+else
+	xwayland_path = xwayland_prog.full_path()
+endif
+
+xwayland_config_data = configuration_data()
+xwayland_config_data.set_quoted('XWAYLAND_PATH', xwayland_path)
+configure_file(
+	output: 'config.h',
+	configuration: xwayland_config_data,
+)

--- a/xwayland/meson.build
+++ b/xwayland/meson.build
@@ -18,6 +18,19 @@ if not get_option('xwayland').disabled()
 	msg += 'Required for Xwayland support.'
 endif
 
+xwayland = dependency('xwayland', required: false)
+if not xwayland.found()
+	# There's no Xwayland release with the pkg-config file shipped yet.
+	xwayland_prog = find_program('Xwayland', required: false)
+	if not xwayland_prog.found()
+		if get_option('xwayland').enabled()
+			error('\n'.join(msg).format('xwayland'))
+		else
+			subdir_done()
+		endif
+	endif
+endif
+
 foreach lib : xwayland_required
 	dep = dependency(lib,
 		required: get_option('xwayland'),

--- a/xwayland/server.c
+++ b/xwayland/server.c
@@ -16,6 +16,7 @@
 #include <wlr/xwayland.h>
 #include "sockets.h"
 #include "util/signal.h"
+#include "xwayland/config.h"
 
 static void safe_close(int fd) {
 	if (fd >= 0) {
@@ -442,6 +443,11 @@ void wlr_xwayland_server_destroy(struct wlr_xwayland_server *server) {
 struct wlr_xwayland_server *wlr_xwayland_server_create(
 		struct wl_display *wl_display,
 		struct wlr_xwayland_server_options *options) {
+	if (!getenv("WLR_XWAYLAND") && access(XWAYLAND_PATH, X_OK) != 0) {
+		wlr_log(WLR_ERROR, "Cannot find Xwayland binary \"%s\"", XWAYLAND_PATH);
+		return NULL;
+	}
+
 	struct wlr_xwayland_server *server =
 		calloc(1, sizeof(struct wlr_xwayland_server));
 	if (!server) {


### PR DESCRIPTION
### xwayland: add dependency on xwayland

Check that the pkg-config file is available. This will be required
in the future to check whether xwayland supports features such as
-listenfd, -initfd or -verbose.

This effectively makes our relationship with xwayland closer to what
a dynamic library is: checked at build-time, but can be overridden
at run-time.

### xwayland: check executable exists on init

Instead of walking PATH like a previous proposal (#2314), this one
checks that the Xwayland path specified in the pkg-config file
exists.

I think this is a reasonable compromise:

- Users that don't have Xwayland installed system-wide won't get
  a bogus DISPLAY env variable set up.
- Users that have WLR_XWAYLAND set won't be affected by this check.
- Users that have Xwayland installed system-wide and a different
  Xwayland in their PATH still get their custom Xwayland.
- Users that don't have Xwayland installed system-wide but have it
  somewhere else in PATH are left out. But this is pretty niche,
  and they can just set WLR_XWAYLAND.