### PR TITLE
backend/x11: drop x11-xcb dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ If you choose to enable X11 support:
 * xcb-xinput
 * xcb-image
 * xcb-render
-* x11-xcb
 * xcb-errors (optional, for improved error reporting)
 * x11-icccm (optional, for improved Xwayland introspection)
 

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -12,7 +12,6 @@
 #include <wlr/config.h>
 
 #include <drm_fourcc.h>
-#include <X11/Xlib-xcb.h>
 #include <wayland-server-core.h>
 #include <xcb/xcb.h>
 #include <xcb/dri3.h>
@@ -195,10 +194,7 @@ static void backend_destroy(struct wlr_backend *backend) {
 #endif
 
 	close(x11->drm_fd);
-
-	if (x11->xlib_conn) {
-		XCloseDisplay(x11->xlib_conn);
-	}
+	xcb_disconnect(x11->xcb);
 	free(x11);
 }
 
@@ -368,19 +364,11 @@ struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
 	x11->wl_display = display;
 	wl_list_init(&x11->outputs);
 
-	x11->xlib_conn = XOpenDisplay(x11_display);
-	if (!x11->xlib_conn) {
-		wlr_log(WLR_ERROR, "Failed to open X connection");
-		goto error_x11;
-	}
-
-	x11->xcb = XGetXCBConnection(x11->xlib_conn);
+	x11->xcb = xcb_connect(x11_display, NULL);
 	if (!x11->xcb || xcb_connection_has_error(x11->xcb)) {
 		wlr_log(WLR_ERROR, "Failed to open xcb connection");
-		goto error_display;
+		goto error_x11;
 	}
-
-	XSetEventQueueOwner(x11->xlib_conn, XCBOwnsEventQueue);
 
 	struct {
 		const char *name;
@@ -641,7 +629,7 @@ struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
 error_event:
 	wl_event_source_remove(x11->event_source);
 error_display:
-	XCloseDisplay(x11->xlib_conn);
+	xcb_disconnect(x11->xcb);
 error_x11:
 	free(x11);
 	return NULL;

--- a/backend/x11/meson.build
+++ b/backend/x11/meson.build
@@ -1,6 +1,5 @@
 x11_libs = []
 x11_required = [
-	'x11-xcb',
 	'xcb',
 	'xcb-dri3',
 	'xcb-present',

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -5,7 +5,6 @@
 
 #include <stdbool.h>
 
-#include <X11/Xlib-xcb.h>
 #include <wayland-server-core.h>
 #include <xcb/xcb.h>
 #include <xcb/present.h>
@@ -64,7 +63,6 @@ struct wlr_x11_backend {
 	struct wl_display *wl_display;
 	bool started;
 
-	Display *xlib_conn;
 	xcb_connection_t *xcb;
 	xcb_screen_t *screen;
 	xcb_depth_t *depth;


### PR DESCRIPTION
We don't need it anymore now that we've stopped using the EGL Xlib
platform.