### PR TITLE
Add static+const qualifiers

### DIFF
--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -87,7 +87,7 @@ static int backend_get_drm_fd(struct wlr_backend *backend) {
 	}
 }
 
-static struct wlr_backend_impl backend_impl = {
+static const struct wlr_backend_impl backend_impl = {
 	.start = backend_start,
 	.destroy = backend_destroy,
 	.get_renderer = backend_get_renderer,

--- a/backend/libinput/tablet_tool.c
+++ b/backend/libinput/tablet_tool.c
@@ -13,7 +13,7 @@
 #include "backend/libinput.h"
 #include "util/signal.h"
 
-static struct wlr_tablet_impl tablet_impl;
+static const struct wlr_tablet_impl tablet_impl;
 
 static bool tablet_is_libinput(struct wlr_tablet *tablet) {
 	return tablet->impl == &tablet_impl;
@@ -71,7 +71,7 @@ static void destroy_tablet(struct wlr_tablet *wlr_tablet) {
 	free(tablet);
 }
 
-static struct wlr_tablet_impl tablet_impl = {
+static const struct wlr_tablet_impl tablet_impl = {
 	.destroy = destroy_tablet,
 };
 

--- a/backend/multi/backend.c
+++ b/backend/multi/backend.c
@@ -110,7 +110,7 @@ static int multi_backend_get_drm_fd(struct wlr_backend *backend) {
 	return -1;
 }
 
-struct wlr_backend_impl backend_impl = {
+static const struct wlr_backend_impl backend_impl = {
 	.start = multi_backend_start,
 	.destroy = multi_backend_destroy,
 	.get_renderer = multi_backend_get_renderer,

--- a/backend/session/session.c
+++ b/backend/session/session.c
@@ -25,7 +25,7 @@ extern const struct session_impl session_logind;
 extern const struct session_impl session_direct;
 extern const struct session_impl session_noop;
 
-static const struct session_impl *impls[] = {
+static const struct session_impl *const impls[] = {
 #if WLR_HAS_LIBSEAT
 	&session_libseat,
 #endif
@@ -137,7 +137,7 @@ struct wlr_session *wlr_session_create(struct wl_display *disp) {
 				env_wlr_session);
 		}
 	} else {
-		const struct session_impl **iter;
+		const struct session_impl *const *iter;
 		for (iter = impls; !session && *iter; ++iter) {
 			session = (*iter)->create(disp);
 		}

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -339,7 +339,7 @@ static int backend_get_drm_fd(struct wlr_backend *backend) {
 	return wl->drm_fd;
 }
 
-static struct wlr_backend_impl backend_impl = {
+static const struct wlr_backend_impl backend_impl = {
 	.start = backend_start,
 	.destroy = backend_destroy,
 	.get_renderer = backend_get_renderer,

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -541,7 +541,7 @@ static void xdg_surface_handle_configure(void *data,
 	// nothing else?
 }
 
-static struct xdg_surface_listener xdg_surface_listener = {
+static const struct xdg_surface_listener xdg_surface_listener = {
 	.configure = xdg_surface_handle_configure,
 };
 
@@ -566,7 +566,7 @@ static void xdg_toplevel_handle_close(void *data,
 	wlr_output_destroy(&output->wlr_output);
 }
 
-static struct xdg_toplevel_listener xdg_toplevel_listener = {
+static const struct xdg_toplevel_listener xdg_toplevel_listener = {
 	.configure = xdg_toplevel_handle_configure,
 	.close = xdg_toplevel_handle_close,
 };

--- a/backend/wayland/seat.c
+++ b/backend/wayland/seat.c
@@ -281,7 +281,7 @@ static void keyboard_handle_repeat_info(void *data,
 	// This space is intentionally left blank
 }
 
-static struct wl_keyboard_listener keyboard_listener = {
+static const struct wl_keyboard_listener keyboard_listener = {
 	.keymap = keyboard_handle_keymap,
 	.enter = keyboard_handle_enter,
 	.leave = keyboard_handle_leave,
@@ -369,7 +369,7 @@ static void touch_handle_orientation(void *data, struct wl_touch *wl_touch,
 	// no-op
 }
 
-static struct wl_touch_listener touch_listener = {
+static const struct wl_touch_listener touch_listener = {
 	.down = touch_handle_down,
 	.up = touch_handle_up,
 	.motion = touch_handle_motion,
@@ -441,7 +441,7 @@ static void input_device_destroy(struct wlr_input_device *wlr_dev) {
 	free(dev);
 }
 
-static struct wlr_input_device_impl input_device_impl = {
+static const struct wlr_input_device_impl input_device_impl = {
 	.destroy = input_device_destroy,
 };
 
@@ -474,7 +474,7 @@ struct wlr_wl_input_device *create_wl_input_device(
 	return dev;
 }
 
-static struct wlr_pointer_impl pointer_impl;
+static const struct wlr_pointer_impl pointer_impl;
 
 struct wlr_wl_pointer *pointer_get_wl(struct wlr_pointer *wlr_pointer) {
 	assert(wlr_pointer->impl == &pointer_impl);
@@ -497,7 +497,7 @@ static void pointer_destroy(struct wlr_pointer *wlr_pointer) {
 	free(pointer);
 }
 
-static struct wlr_pointer_impl pointer_impl = {
+static const struct wlr_pointer_impl pointer_impl = {
 	.destroy = pointer_destroy,
 };
 
@@ -544,7 +544,7 @@ static void gesture_swipe_end(void *data,
 	wlr_signal_emit_safe(&wlr_dev->pointer->events.swipe_end, &wlr_event);
 }
 
-static struct zwp_pointer_gesture_swipe_v1_listener gesture_swipe_impl = {
+static const struct zwp_pointer_gesture_swipe_v1_listener gesture_swipe_impl = {
 	.begin = gesture_swipe_begin,
 	.update = gesture_swipe_update,
 	.end = gesture_swipe_end,
@@ -595,7 +595,7 @@ static void gesture_pinch_end(void *data,
 	wlr_signal_emit_safe(&wlr_dev->pointer->events.pinch_end, &wlr_event);
 }
 
-static struct zwp_pointer_gesture_pinch_v1_listener gesture_pinch_impl = {
+static const struct zwp_pointer_gesture_pinch_v1_listener gesture_pinch_impl = {
 	.begin = gesture_pinch_begin,
 	.update = gesture_pinch_update,
 	.end = gesture_pinch_end,

--- a/include/wlr/interfaces/wlr_tablet_tool.h
+++ b/include/wlr/interfaces/wlr_tablet_tool.h
@@ -16,7 +16,7 @@ struct wlr_tablet_impl {
 };
 
 void wlr_tablet_init(struct wlr_tablet *tablet,
-		struct wlr_tablet_impl *impl);
+		const struct wlr_tablet_impl *impl);
 void wlr_tablet_destroy(struct wlr_tablet *tablet);
 
 #endif

--- a/include/wlr/types/wlr_tablet_tool.h
+++ b/include/wlr/types/wlr_tablet_tool.h
@@ -61,7 +61,7 @@ struct wlr_tablet_tool {
 struct wlr_tablet_impl;
 
 struct wlr_tablet {
-	struct wlr_tablet_impl *impl;
+	const struct wlr_tablet_impl *impl;
 
 	struct {
 		struct wl_signal axis;

--- a/include/xcursor/cursor_data.h
+++ b/include/xcursor/cursor_data.h
@@ -27,7 +27,7 @@
 
 #include <stdint.h>
 
-static uint32_t cursor_data[] = {
+static const uint32_t cursor_data[] = {
 	0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0x00000000, 0x00000000,
 	0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
 	0x00000000, 0x00000000, 0x00000000, 0x00000000, 0xffffffff, 0xff000000,
@@ -532,7 +532,7 @@ static uint32_t cursor_data[] = {
 	0x00000000, 0x00000000,
 };
 
-static struct cursor_metadata {
+static const struct cursor_metadata {
 	char *name;
 	int width, height;
 	int hotspot_x, hotspot_y;

--- a/include/xwayland/xwm.h
+++ b/include/xwayland/xwm.h
@@ -86,7 +86,7 @@ enum atom_name {
 	ATOM_LAST // keep last
 };
 
-extern const char *atom_map[ATOM_LAST];
+extern const char *const atom_map[ATOM_LAST];
 
 struct wlr_xwm {
 	struct wlr_xwayland *xwayland;

--- a/types/tablet_v2/wlr_tablet_v2.c
+++ b/types/tablet_v2/wlr_tablet_v2.c
@@ -86,7 +86,7 @@ static void tablet_seat_handle_destroy(struct wl_client *client,
 	wl_resource_destroy(resource);
 }
 
-static struct zwp_tablet_seat_v2_interface seat_impl = {
+static const struct zwp_tablet_seat_v2_interface seat_impl = {
 	.destroy = tablet_seat_handle_destroy,
 };
 
@@ -212,7 +212,7 @@ static void get_tablet_seat(struct wl_client *wl_client, struct wl_resource *res
 	}
 }
 
-static struct zwp_tablet_manager_v2_interface manager_impl = {
+static const struct zwp_tablet_manager_v2_interface manager_impl = {
 	.get_tablet_seat = get_tablet_seat,
 	.destroy = tablet_manager_destroy,
 };

--- a/types/tablet_v2/wlr_tablet_v2_pad.c
+++ b/types/tablet_v2/wlr_tablet_v2_pad.c
@@ -12,7 +12,7 @@
 #include <wlr/types/wlr_tablet_v2.h>
 #include <wlr/util/log.h>
 
-static struct wlr_tablet_pad_v2_grab_interface default_pad_grab_interface;
+static const struct wlr_tablet_pad_v2_grab_interface default_pad_grab_interface;
 
 struct tablet_pad_auxiliary_user_data {
 	struct wlr_tablet_pad_client_v2 *pad;
@@ -58,7 +58,7 @@ static void handle_tablet_pad_ring_v2_destroy(struct wl_client *client,
 	wl_resource_destroy(resource);
 }
 
-static struct zwp_tablet_pad_ring_v2_interface tablet_pad_ring_impl = {
+static const struct zwp_tablet_pad_ring_v2_interface tablet_pad_ring_impl = {
 	.set_feedback = handle_tablet_pad_ring_v2_set_feedback,
 	.destroy = handle_tablet_pad_ring_v2_destroy,
 };
@@ -96,7 +96,7 @@ static void handle_tablet_pad_strip_v2_destroy(struct wl_client *client,
 	wl_resource_destroy(resource);
 }
 
-static struct zwp_tablet_pad_strip_v2_interface tablet_pad_strip_impl = {
+static const struct zwp_tablet_pad_strip_v2_interface tablet_pad_strip_impl = {
 	.set_feedback = handle_tablet_pad_strip_v2_set_feedback,
 	.destroy = handle_tablet_pad_strip_v2_destroy,
 };
@@ -118,7 +118,7 @@ static void handle_tablet_pad_v2_set_feedback( struct wl_client *client,
 	wl_signal_emit(&pad->pad->events.button_feedback, &evt);
 }
 
-static struct zwp_tablet_pad_v2_interface tablet_pad_impl = {
+static const struct zwp_tablet_pad_v2_interface tablet_pad_impl = {
 	.set_feedback = handle_tablet_pad_v2_set_feedback,
 	.destroy = handle_tablet_pad_v2_destroy,
 };
@@ -184,7 +184,7 @@ static void handle_tablet_pad_group_v2_destroy(struct wl_client *client,
 	wl_resource_destroy(resource);
 }
 
-static struct zwp_tablet_pad_group_v2_interface tablet_pad_group_impl = {
+static const struct zwp_tablet_pad_group_v2_interface tablet_pad_group_impl = {
 	.destroy = handle_tablet_pad_group_v2_destroy,
 };
 
@@ -696,7 +696,7 @@ static void default_pad_cancel(struct wlr_tablet_pad_v2_grab *grab) {
 	// Do nothing, the default cancel can be ignored.
 }
 
-static struct wlr_tablet_pad_v2_grab_interface default_pad_grab_interface  = {
+static const struct wlr_tablet_pad_v2_grab_interface default_pad_grab_interface  = {
 	.enter = default_pad_enter,
 	.button = default_pad_button,
 	.strip = default_pad_strip,

--- a/types/tablet_v2/wlr_tablet_v2_tablet.c
+++ b/types/tablet_v2/wlr_tablet_v2_tablet.c
@@ -30,7 +30,7 @@ static void handle_tablet_v2_destroy(struct wl_client *client,
 	wl_resource_destroy(resource);
 }
 
-static struct zwp_tablet_v2_interface tablet_impl = {
+static const struct zwp_tablet_v2_interface tablet_impl = {
 	.destroy = handle_tablet_v2_destroy,
 };
 

--- a/types/tablet_v2/wlr_tablet_v2_tool.c
+++ b/types/tablet_v2/wlr_tablet_v2_tool.c
@@ -52,7 +52,7 @@ static void handle_tablet_tool_v2_destroy(struct wl_client *client,
 		struct wl_resource *resource) {
 	wl_resource_destroy(resource);
 }
-static struct zwp_tablet_tool_v2_interface tablet_tool_impl = {
+static const struct zwp_tablet_tool_v2_interface tablet_tool_impl = {
 	.set_cursor = handle_tablet_tool_v2_set_cursor,
 	.destroy = handle_tablet_tool_v2_destroy,
 };

--- a/types/wlr_input_inhibitor.c
+++ b/types/wlr_input_inhibitor.c
@@ -7,7 +7,7 @@
 #include "util/signal.h"
 
 static const struct zwlr_input_inhibit_manager_v1_interface inhibit_manager_implementation;
-static struct zwlr_input_inhibitor_v1_interface input_inhibitor_implementation;
+static const struct zwlr_input_inhibitor_v1_interface input_inhibitor_implementation;
 
 static struct wlr_input_inhibit_manager *input_inhibit_manager_from_resource(
 		struct wl_resource *resource) {
@@ -44,7 +44,7 @@ static void input_inhibitor_resource_destroy(struct wl_resource *resource) {
 	input_inhibit_manager_deactivate(manager);
 }
 
-static struct zwlr_input_inhibitor_v1_interface input_inhibitor_implementation = {
+static const struct zwlr_input_inhibitor_v1_interface input_inhibitor_implementation = {
 	.destroy = input_inhibitor_destroy,
 };
 

--- a/types/wlr_tablet_tool.c
+++ b/types/wlr_tablet_tool.c
@@ -5,7 +5,7 @@
 #include <wlr/types/wlr_tablet_tool.h>
 
 void wlr_tablet_init(struct wlr_tablet *tablet,
-		struct wlr_tablet_impl *impl) {
+		const struct wlr_tablet_impl *impl) {
 	tablet->impl = impl;
 	wl_signal_init(&tablet->events.axis);
 	wl_signal_init(&tablet->events.proximity);

--- a/xcursor/wlr_xcursor.c
+++ b/xcursor/wlr_xcursor.c
@@ -46,7 +46,7 @@ static void xcursor_destroy(struct wlr_xcursor *cursor) {
 #include "xcursor/cursor_data.h"
 
 static struct wlr_xcursor *xcursor_create_from_data(
-		struct cursor_metadata *metadata, struct wlr_xcursor_theme *theme) {
+		const struct cursor_metadata *metadata, struct wlr_xcursor_theme *theme) {
 	struct wlr_xcursor *cursor;
 	struct wlr_xcursor_image *image;
 	int size;

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -18,7 +18,7 @@
 #include "util/signal.h"
 #include "xwayland/xwm.h"
 
-const char *atom_map[ATOM_LAST] = {
+const char *const atom_map[ATOM_LAST] = {
 	[WL_SURFACE_ID] = "WL_SURFACE_ID",
 	[WM_DELETE_WINDOW] = "WM_DELETE_WINDOW",
 	[WM_PROTOCOLS] = "WM_PROTOCOLS",


### PR DESCRIPTION
The three commits in this PR add const (and in one case, file-static) qualifiers to global variables that were missing them.
* The list of atoms in xwayland/xwm.c
* The cursor data used by the default theme
* A number of "implementation function lists", which include structs of function pointers for wlroots backends, and for handling Wayland events and requests

Since `xwayland/xwm.h` is an internal header, and `wlr/interfaces/wlr_tablet_tool.h` and `wlr/types/wlr_tablet_tool.h`  are unstable API, I presume changing types slightly is fine.

I found these variables by checking ``objdump -t libwlroots.so.7 | grep "\.data" ``for initialized global variables not linked as read only. I did not look at tinywl or any of the examples.

* * *

Breaking change: `wlr_tablet.impl` is now `const`.