### PR TITLE
region: remove leftover description of resource_list

### DIFF
--- a/include/types/wlr_region.h
+++ b/include/types/wlr_region.h
@@ -4,8 +4,7 @@
 #include <wlr/types/wlr_region.h>
 
 /*
- * Creates a new region resource with the provided new ID. If `resource_list` is
- * non-NULL, adds the region's resource to the list.
+ * Creates a new region resource with the provided new ID.
  */
 struct wl_resource *region_create(struct wl_client *client,
 	uint32_t version, uint32_t id);


### PR DESCRIPTION
`resource_list` no longer exists for regions. Remove the last remaining description of what it was responsible for.