### PR TITLE
backend/x11: clamp hotspot to texture bounds

### DIFF
--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -475,6 +475,19 @@ static bool output_set_cursor(struct wlr_output *wlr_output,
 	if (texture != NULL) {
 		width = texture->width * wlr_output->scale / scale;
 		height = texture->height * wlr_output->scale / scale;
+
+		if (hotspot_x < 0) {
+			hotspot_x = 0;
+		}
+		if ((uint32_t)hotspot_x > texture->width) {
+			hotspot_x = texture->width;
+		}
+		if (hotspot_y < 0) {
+			hotspot_y = 0;
+		}
+		if ((uint32_t)hotspot_y > texture->height) {
+			hotspot_y = texture->height;
+		}
 	}
 
 	struct wlr_box hotspot = { .x = hotspot_x, .y = hotspot_y };


### PR DESCRIPTION
When a new texture is set, the hotspot may actually belong to the
previous texture and be out of bounds. Rather than incur X errors for
these, clamp the hotspot to be inside of the texture.

This fixes weston examples updating their cursors (e.g.
weston-eventdemo).