### PR TITLE
tablet_v2: Fix implicit grab end detection

### DIFF
--- a/types/tablet_v2/wlr_tablet_v2_tool.c
+++ b/types/tablet_v2/wlr_tablet_v2_tool.c
@@ -848,6 +848,7 @@ void wlr_tablet_tool_v2_start_implicit_grab(
 	}
 
 	state->original = tool->focused_surface;
+	state->focused = tool->focused_surface;
 	grab->data = state;
 
 	wlr_tablet_tool_v2_start_grab(tool, grab);


### PR DESCRIPTION
Store the previously focused surface in `state->focused` as well as in
`state->original` when starting an implicit grab. That way at the end
of an implicit grab, the detection whether the grab started and ended
on the same surface works as intended, even if the original surface was
never left at all.

Some notes on how I found this bug:
I use Xournal++ to write down handwritten notes on my tablet. Xournal++ changes the cursor to a small unobtrusive dot when writing with a stylus. However, under sway, I always got short blinks of the original cursor when ending a stroke. Some investigation shows lots of the following errors:
`[sway/input/tablet.c:117] denying request to set cursor from unfocused client`
This is due to the focused surface temporarily being `null` after the stylus tip goes up because a tablet_out event is sent, where it shouldn't. I traced this wrongfully sent event down to the implicit grab code.