### PR TITLE
xdg-foreign: Make imported object inert when exported is destroyed

### DIFF
--- a/types/wlr_xdg_foreign_v1.c
+++ b/types/wlr_xdg_foreign_v1.c
@@ -159,6 +159,7 @@ static void finish_imported(struct wlr_xdg_imported_v1 *imported) {
 
 	wl_list_remove(&imported->link);
 	wl_list_init(&imported->link);
+	wl_resource_set_user_data(imported->resource, NULL);
 	free(imported);
 }
 
@@ -167,6 +168,7 @@ static void finish_exported(struct wlr_xdg_exported_v1 *exported) {
 
 	wl_list_remove(&exported->xdg_surface_destroy.link);
 	wl_list_remove(&exported->link);
+	wl_resource_set_user_data(exported->resource, NULL);
 	free(exported);
 }
 
@@ -185,7 +187,6 @@ static void handle_xdg_surface_destroy(
 	struct wlr_xdg_exported_v1 *exported =
 		wl_container_of(listener, exported, xdg_surface_destroy);
 
-	wl_resource_set_user_data(exported->resource, NULL);
 	finish_exported(exported);
 }
 

--- a/types/wlr_xdg_foreign_v1.c
+++ b/types/wlr_xdg_foreign_v1.c
@@ -145,7 +145,7 @@ static struct wlr_xdg_foreign_v1 *xdg_foreign_from_exporter_resource(
 	return wl_resource_get_user_data(resource);
 }
 
-static void finish_imported(struct wlr_xdg_imported_v1 *imported) {
+static void destroy_imported(struct wlr_xdg_imported_v1 *imported) {
 	imported->exported = NULL;
 	struct wlr_xdg_imported_child_v1 *child, *child_tmp;
 	wl_list_for_each_safe(child, child_tmp, &imported->children, link) {
@@ -163,7 +163,7 @@ static void finish_imported(struct wlr_xdg_imported_v1 *imported) {
 	free(imported);
 }
 
-static void finish_exported(struct wlr_xdg_exported_v1 *exported) {
+static void destroy_exported(struct wlr_xdg_exported_v1 *exported) {
 	wlr_xdg_foreign_exported_finish(&exported->base);
 
 	wl_list_remove(&exported->xdg_surface_destroy.link);
@@ -178,7 +178,7 @@ static void xdg_exported_handle_resource_destroy(
 		xdg_exported_from_resource(resource);
 
 	if (exported) {
-		finish_exported(exported);
+		destroy_exported(exported);
 	}
 }
 
@@ -187,7 +187,7 @@ static void handle_xdg_surface_destroy(
 	struct wlr_xdg_exported_v1 *exported =
 		wl_container_of(listener, exported, xdg_surface_destroy);
 
-	finish_exported(exported);
+	destroy_exported(exported);
 }
 
 static void xdg_exporter_handle_export(struct wl_client *wl_client,
@@ -277,7 +277,7 @@ static void xdg_imported_handle_resource_destroy(
 		return;
 	}
 
-	finish_imported(imported);
+	destroy_imported(imported);
 }
 
 static void xdg_imported_handle_exported_destroy(struct wl_listener *listener,
@@ -285,7 +285,7 @@ static void xdg_imported_handle_exported_destroy(struct wl_listener *listener,
 	struct wlr_xdg_imported_v1 *imported =
 		wl_container_of(listener, imported, exported_destroyed);
 	zxdg_imported_v1_send_destroyed(imported->resource);
-	finish_imported(imported);
+	destroy_imported(imported);
 }
 
 static void xdg_importer_handle_import(struct wl_client *wl_client,

--- a/types/wlr_xdg_foreign_v2.c
+++ b/types/wlr_xdg_foreign_v2.c
@@ -145,7 +145,7 @@ static struct wlr_xdg_foreign_v2 *xdg_foreign_from_exporter_resource(
 	return wl_resource_get_user_data(resource);
 }
 
-static void finish_imported(struct wlr_xdg_imported_v2 *imported) {
+static void destroy_imported(struct wlr_xdg_imported_v2 *imported) {
 	imported->exported = NULL;
 	struct wlr_xdg_imported_child_v2 *child, *child_tmp;
 	wl_list_for_each_safe(child, child_tmp, &imported->children, link) {
@@ -163,7 +163,7 @@ static void finish_imported(struct wlr_xdg_imported_v2 *imported) {
 	free(imported);
 }
 
-static void finish_exported(struct wlr_xdg_exported_v2 *exported) {
+static void destroy_exported(struct wlr_xdg_exported_v2 *exported) {
 	wlr_xdg_foreign_exported_finish(&exported->base);
 
 	wl_list_remove(&exported->xdg_surface_destroy.link);
@@ -178,7 +178,7 @@ static void xdg_exported_handle_resource_destroy(
 		xdg_exported_from_resource(resource);
 
 	if (exported) {
-		finish_exported(exported);
+		destroy_exported(exported);
 	}
 }
 
@@ -187,7 +187,7 @@ static void handle_xdg_surface_destroy(
 	struct wlr_xdg_exported_v2 *exported =
 		wl_container_of(listener, exported, xdg_surface_destroy);
 
-	finish_exported(exported);
+	destroy_exported(exported);
 }
 
 static void xdg_exporter_handle_export(struct wl_client *wl_client,
@@ -277,7 +277,7 @@ static void xdg_imported_handle_resource_destroy(
 		return;
 	}
 
-	finish_imported(imported);
+	destroy_imported(imported);
 }
 
 static void xdg_imported_handle_exported_destroy(struct wl_listener *listener,
@@ -285,7 +285,7 @@ static void xdg_imported_handle_exported_destroy(struct wl_listener *listener,
 	struct wlr_xdg_imported_v2 *imported =
 		wl_container_of(listener, imported, exported_destroyed);
 	zxdg_imported_v2_send_destroyed(imported->resource);
-	finish_imported(imported);
+	destroy_imported(imported);
 }
 
 static void xdg_importer_handle_import(struct wl_client *wl_client,

--- a/types/wlr_xdg_foreign_v2.c
+++ b/types/wlr_xdg_foreign_v2.c
@@ -159,6 +159,7 @@ static void finish_imported(struct wlr_xdg_imported_v2 *imported) {
 
 	wl_list_remove(&imported->link);
 	wl_list_init(&imported->link);
+	wl_resource_set_user_data(imported->resource, NULL);
 	free(imported);
 }
 
@@ -167,6 +168,7 @@ static void finish_exported(struct wlr_xdg_exported_v2 *exported) {
 
 	wl_list_remove(&exported->xdg_surface_destroy.link);
 	wl_list_remove(&exported->link);
+	wl_resource_set_user_data(exported->resource, NULL);
 	free(exported);
 }
 
@@ -185,7 +187,6 @@ static void handle_xdg_surface_destroy(
 	struct wlr_xdg_exported_v2 *exported =
 		wl_container_of(listener, exported, xdg_surface_destroy);
 
-	wl_resource_set_user_data(exported->resource, NULL);
 	finish_exported(exported);
 }
 


### PR DESCRIPTION
Fixes a double-free experienced with Firefox and xdg-desktop-portal-gtk (when closing a file dialog window):
```
==13501==ERROR: AddressSanitizer: attempting double-free on 0x60700019b7a0 in thread T0:
    #0 0x7f6d0acc5b6f in __interceptor_free (/nix/store/sipmc4wnbcws4vahqlf5i06zz7xgnp23-gcc-10.2.0-lib/lib/libasan.so.6+0xacb6f)
    #1 0x7f6d0a59e882 in finish_imported ../types/wlr_xdg_foreign_v1.c:162
    #2 0x7f6d0a59e8e3 in xdg_imported_handle_resource_destroy ../types/wlr_xdg_foreign_v1.c:279
    #3 0x7f6d0a5efdbe in destroy_resource (/nix/store/w6rq0kfag1yqb3pj0bi9g84nrv9nbckf-wayland-1.18.0/lib/libwayland-server.so.0+0x7dbe)
    #4 0x7f6d0a5f04ff in wl_resource_destroy (/nix/store/w6rq0kfag1yqb3pj0bi9g84nrv9nbckf-wayland-1.18.0/lib/libwayland-server.so.0+0x84ff)
    #5 0x7f6d0a59eb30 in xdg_imported_handle_destroy ../types/wlr_xdg_foreign_v1.c:28
    #6 0x7f6d09a08b2c in ffi_call_unix64 (/nix/store/z1kwafc0yf8jzhmm8f0j72nc196jl1sq-libffi-3.3/lib/libffi.so.7+0x7b2c)
    #7 0x7f6d09a0783b in ffi_call_int (/nix/store/z1kwafc0yf8jzhmm8f0j72nc196jl1sq-libffi-3.3/lib/libffi.so.7+0x683b)
    #8 0x7f6d0a5f54d1 in wl_closure_invoke (/nix/store/w6rq0kfag1yqb3pj0bi9g84nrv9nbckf-wayland-1.18.0/lib/libwayland-server.so.0+0xd4d1)
    #9 0x7f6d0a5f0ae1 in wl_client_connection_data (/nix/store/w6rq0kfag1yqb3pj0bi9g84nrv9nbckf-wayland-1.18.0/lib/libwayland-server.so.0+0x8ae1)
    #10 0x7f6d0a5f3491 in wl_event_loop_dispatch (/nix/store/w6rq0kfag1yqb3pj0bi9g84nrv9nbckf-wayland-1.18.0/lib/libwayland-server.so.0+0xb491)
    #11 0x7f6d0a5f1104 in wl_display_run (/nix/store/w6rq0kfag1yqb3pj0bi9g84nrv9nbckf-wayland-1.18.0/lib/libwayland-server.so.0+0x9104)
    #12 0x429ec6 in server_run ../sway/server.c:260
    #13 0x428702 in main ../sway/main.c:431
    #14 0x7f6d0a315dec in __libc_start_main (/nix/store/gafigwfaimlziam6qhw1m8dz4h952g1n-glibc-2.32-35/lib/libc.so.6+0x27dec)
    #15 0x4106a9 in _start (/nix/store/ismwrznvf7hyh4yrw5513gqayz83zxyn-sway-unwrapped-1.5.1/bin/sway+0x4106a9)

0x60700019b7a0 is located 0 bytes inside of 72-byte region [0x60700019b7a0,0x60700019b7e8)
freed by thread T0 here:
==13501==AddressSanitizer CHECK failed: ../../../../gcc-10.2.0/libsanitizer/asan/asan_descriptions.cpp:175 "((id)) != (0)" (0x0, 0x0)
    #0 0x7f6d0acce657  (/nix/store/sipmc4wnbcws4vahqlf5i06zz7xgnp23-gcc-10.2.0-lib/lib/libasan.so.6+0xb5657)
    #1 0x7f6d0acebd5a  (/nix/store/sipmc4wnbcws4vahqlf5i06zz7xgnp23-gcc-10.2.0-lib/lib/libasan.so.6+0xd2d5a)
    #2 0x7f6d0ac4901c  (/nix/store/sipmc4wnbcws4vahqlf5i06zz7xgnp23-gcc-10.2.0-lib/lib/libasan.so.6+0x3001c)
    #3 0x7f6d0ac4ac3b  (/nix/store/sipmc4wnbcws4vahqlf5i06zz7xgnp23-gcc-10.2.0-lib/lib/libasan.so.6+0x31c3b)
    #4 0x7f6d0ac4b2f5  (/nix/store/sipmc4wnbcws4vahqlf5i06zz7xgnp23-gcc-10.2.0-lib/lib/libasan.so.6+0x322f5)
    #5 0x7f6d0acce45b  (/nix/store/sipmc4wnbcws4vahqlf5i06zz7xgnp23-gcc-10.2.0-lib/lib/libasan.so.6+0xb545b)
    #6 0x7f6d0accc5a6  (/nix/store/sipmc4wnbcws4vahqlf5i06zz7xgnp23-gcc-10.2.0-lib/lib/libasan.so.6+0xb35a6)
    #7 0x7f6d0acc5b43 in __interceptor_free (/nix/store/sipmc4wnbcws4vahqlf5i06zz7xgnp23-gcc-10.2.0-lib/lib/libasan.so.6+0xacb43)
    #8 0x7f6d0a59e882 in finish_imported ../types/wlr_xdg_foreign_v1.c:162
    #9 0x7f6d0a59e8e3 in xdg_imported_handle_resource_destroy ../types/wlr_xdg_foreign_v1.c:279
    #10 0x7f6d0a5efdbe in destroy_resource (/nix/store/w6rq0kfag1yqb3pj0bi9g84nrv9nbckf-wayland-1.18.0/lib/libwayland-server.so.0+0x7dbe)
    #11 0x7f6d0a5f04ff in wl_resource_destroy (/nix/store/w6rq0kfag1yqb3pj0bi9g84nrv9nbckf-wayland-1.18.0/lib/libwayland-server.so.0+0x84ff)
    #12 0x7f6d0a59eb30 in xdg_imported_handle_destroy ../types/wlr_xdg_foreign_v1.c:28
    #13 0x7f6d09a08b2c in ffi_call_unix64 (/nix/store/z1kwafc0yf8jzhmm8f0j72nc196jl1sq-libffi-3.3/lib/libffi.so.7+0x7b2c)
    #14 0x7f6d09a0783b in ffi_call_int (/nix/store/z1kwafc0yf8jzhmm8f0j72nc196jl1sq-libffi-3.3/lib/libffi.so.7+0x683b)
    #15 0x7f6d0a5f54d1 in wl_closure_invoke (/nix/store/w6rq0kfag1yqb3pj0bi9g84nrv9nbckf-wayland-1.18.0/lib/libwayland-server.so.0+0xd4d1)
    #16 0x7f6d0a5f0ae1 in wl_client_connection_data (/nix/store/w6rq0kfag1yqb3pj0bi9g84nrv9nbckf-wayland-1.18.0/lib/libwayland-server.so.0+0x8ae1)
    #17 0x7f6d0a5f3491 in wl_event_loop_dispatch (/nix/store/w6rq0kfag1yqb3pj0bi9g84nrv9nbckf-wayland-1.18.0/lib/libwayland-server.so.0+0xb491)
    #18 0x7f6d0a5f1104 in wl_display_run (/nix/store/w6rq0kfag1yqb3pj0bi9g84nrv9nbckf-wayland-1.18.0/lib/libwayland-server.so.0+0x9104)
    #19 0x429ec6 in server_run ../sway/server.c:260
    #20 0x428702 in main ../sway/main.c:431
    #21 0x7f6d0a315dec in __libc_start_main (/nix/store/gafigwfaimlziam6qhw1m8dz4h952g1n-glibc-2.32-35/lib/libc.so.6+0x27dec)
    #22 0x4106a9 in _start (/nix/store/ismwrznvf7hyh4yrw5513gqayz83zxyn-sway-unwrapped-1.5.1/bin/sway+0x4106a9)
```