### PR TITLE
render: make gles2 renderer optional

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -32,18 +32,23 @@ compositors = {
 	},
 	'touch': {
 		'src': ['touch.c', 'cat.c'],
+		'dep': [glesv2],
 	},
 	'tablet': {
 		'src': 'tablet.c',
+		'dep': [glesv2],
 	},
 	'rotation': {
 		'src': ['rotation.c', 'cat.c'],
+		'dep': [glesv2],
 	},
 	'multi-pointer': {
 		'src': 'multi-pointer.c',
+		'dep': [glesv2],
 	},
 	'output-layout': {
 		'src': ['output-layout.c', 'cat.c'],
+		'dep': [glesv2],
 	},
 	'fullscreen-shell': {
 		'src': 'fullscreen-shell.c',
@@ -193,7 +198,7 @@ foreach name, info : compositors
 	executable(
 		name,
 		[info.get('src'), extra_src],
-		dependencies: [wlroots, libdrm],
+		dependencies: [wlroots, libdrm, info.get('dep', [])],
 		include_directories: [wlr_inc, proto_inc],
 		build_by_default: get_option('examples'),
 	)

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,6 +1,9 @@
 subdir('wlr')
 
 exclude_files = ['meson.build', 'config.h.in', 'version.h.in']
+if not features.get('gles2-renderer')
+	exclude_files += 'render/gles2.h'
+endif
 if not features.get('x11-backend')
 	exclude_files += 'backend/x11.h'
 endif

--- a/include/wlr/config.h.in
+++ b/include/wlr/config.h.in
@@ -8,6 +8,8 @@
 
 #mesondefine WLR_HAS_X11_BACKEND
 
+#mesondefine WLR_HAS_GLES2_RENDERER
+
 #mesondefine WLR_HAS_XWAYLAND
 
 #mesondefine WLR_HAS_XCB_ERRORS

--- a/meson.build
+++ b/meson.build
@@ -83,6 +83,7 @@ endif
 features = {
 	'systemd': false,
 	'elogind': false,
+	'gles2-renderer': false,
 	'libseat': false,
 	'x11-backend': false,
 	'xwayland': false,
@@ -95,7 +96,6 @@ wayland_server = dependency('wayland-server', version: '>=1.19')
 wayland_client = dependency('wayland-client')
 wayland_protos = dependency('wayland-protocols', version: '>=1.17')
 egl = dependency('egl')
-glesv2 = dependency('glesv2')
 drm = dependency('libdrm', version: '>=2.4.95')
 gbm = dependency('gbm', version: '>=17.1.0')
 libinput = dependency('libinput', version: '>=1.14.0')
@@ -122,7 +122,6 @@ wlr_deps = [
 	wayland_client,
 	wayland_protos,
 	egl,
-	glesv2,
 	drm,
 	gbm,
 	libinput,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,3 +8,4 @@ option('x11-backend', type: 'feature', value: 'auto', description: 'Enable X11 b
 option('examples', type: 'boolean', value: true, description: 'Build example applications')
 option('icon_directory', description: 'Location used to look for cursors (default: ${datadir}/icons)', type: 'string', value: '')
 option('xdg-foreign', type: 'feature', value: 'auto', description: 'Enable xdg-foreign protocol')
+option('gles2-renderer', type: 'feature', value: 'enabled', description: 'Enable GLES2 renderer')

--- a/render/gles2/meson.build
+++ b/render/gles2/meson.build
@@ -1,3 +1,23 @@
+msg = []
+if get_option('gles2-renderer').enabled()
+	msg += 'Install "glesv2" or pass "-Dgles2-renderer=disabled".'
+endif
+if not get_option('gles2-renderer').disabled()
+	msg += 'Required for GLES2 support.'
+endif
+
+glesv2 = dependency('glesv2',
+	required: get_option('gles2-renderer'),
+	not_found_message: '\n'.join(msg),
+)
+if not glesv2.found()
+	subdir_done()
+endif
+
+features += { 'gles2-renderer': true }
+
+wlr_deps += glesv2
+
 wlr_files += files(
 	'pixel_format.c',
 	'renderer.c',

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -2,8 +2,8 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <gbm.h>
+#include <wlr/config.h>
 #include <wlr/render/egl.h>
-#include <wlr/render/gles2.h>
 #include <wlr/render/interface.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_matrix.h>
@@ -12,6 +12,10 @@
 #include "render/pixel_format.h"
 #include "render/wlr_renderer.h"
 #include "backend/backend.h"
+
+#if WLR_HAS_GLES2_RENDERER
+#include <wlr/render/gles2.h>
+#endif
 
 void wlr_renderer_init(struct wlr_renderer *renderer,
 		const struct wlr_renderer_impl *impl) {
@@ -252,6 +256,7 @@ bool wlr_renderer_init_wl_display(struct wlr_renderer *r,
 }
 
 struct wlr_renderer *wlr_renderer_autocreate_with_drm_fd(int drm_fd) {
+#if WLR_HAS_GLES2_RENDERER
 	struct gbm_device *gbm_device = gbm_create_device(drm_fd);
 	if (!gbm_device) {
 		wlr_log(WLR_ERROR, "Failed to create GBM device");
@@ -274,6 +279,10 @@ struct wlr_renderer *wlr_renderer_autocreate_with_drm_fd(int drm_fd) {
 	}
 
 	return renderer;
+#else
+	wlr_log(WLR_ERROR, "wlroots wasn't built with the GLES2 renderer");
+	return NULL;
+#endif
 }
 
 struct wlr_renderer *wlr_renderer_autocreate(struct wlr_backend *backend) {


### PR DESCRIPTION
Some compositors may not need the GLES2 renderer, because they provide
their own. Allow to build wlroots without it.

~~Depends on https://github.com/swaywm/wlroots/pull/2733~~