### PR TITLE
render: introduce shared memory allocator

### DIFF
--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -20,6 +20,7 @@
 #include "backend/wayland.h"
 #include "render/drm_format_set.h"
 #include "render/gbm_allocator.h"
+#include "render/pixel_format.h"
 #include "render/wlr_renderer.h"
 #include "util/signal.h"
 
@@ -190,6 +191,17 @@ static const struct wl_drm_listener legacy_drm_listener = {
 	.capabilities = legacy_drm_handle_capabilities,
 };
 
+static void shm_handle_format(void *data, struct wl_shm *shm,
+		uint32_t shm_format) {
+	struct wlr_wl_backend *wl = data;
+	uint32_t drm_format = convert_wl_shm_format_to_drm(shm_format);
+	wlr_drm_format_set_add(&wl->shm_formats, drm_format, DRM_FORMAT_MOD_INVALID);
+}
+
+static const struct wl_shm_listener shm_listener = {
+	.format = shm_handle_format,
+};
+
 static void registry_global(void *data, struct wl_registry *registry,
 		uint32_t name, const char *iface, uint32_t version) {
 	struct wlr_wl_backend *wl = data;
@@ -233,6 +245,9 @@ static void registry_global(void *data, struct wl_registry *registry,
 	} else if (strcmp(iface, wl_drm_interface.name) == 0) {
 		wl->legacy_drm = wl_registry_bind(registry, name, &wl_drm_interface, 1);
 		wl_drm_add_listener(wl->legacy_drm, &legacy_drm_listener, wl);
+	} else if (strcmp(iface, wl_shm_interface.name) == 0) {
+		wl->shm = wl_registry_bind(registry, name, &wl_shm_interface, 1);
+		wl_shm_add_listener(wl->shm, &shm_listener, wl);
 	}
 }
 
@@ -302,6 +317,7 @@ static void backend_destroy(struct wlr_backend *backend) {
 	wlr_allocator_destroy(wl->allocator);
 	close(wl->drm_fd);
 
+	wlr_drm_format_set_finish(&wl->shm_formats);
 	wlr_drm_format_set_finish(&wl->linux_dmabuf_v1_formats);
 
 	struct wlr_wl_buffer *buffer, *tmp_buffer;
@@ -321,6 +337,9 @@ static void backend_destroy(struct wlr_backend *backend) {
 	}
 	if (wl->zwp_linux_dmabuf_v1) {
 		zwp_linux_dmabuf_v1_destroy(wl->zwp_linux_dmabuf_v1);
+	}
+	if (wl->shm) {
+		wl_shm_destroy(wl->shm);
 	}
 	if (wl->zwp_relative_pointer_manager_v1) {
 		zwp_relative_pointer_manager_v1_destroy(wl->zwp_relative_pointer_manager_v1);

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -38,10 +38,12 @@ struct wlr_wl_backend {
 	struct zxdg_decoration_manager_v1 *zxdg_decoration_manager_v1;
 	struct zwp_pointer_gestures_v1 *zwp_pointer_gestures_v1;
 	struct wp_presentation *presentation;
+	struct wl_shm *shm;
 	struct zwp_linux_dmabuf_v1 *zwp_linux_dmabuf_v1;
 	struct zwp_relative_pointer_manager_v1 *zwp_relative_pointer_manager_v1;
 	struct wl_list seats; // wlr_wl_seat.link
 	struct zwp_tablet_manager_v2 *tablet_manager;
+	struct wlr_drm_format_set shm_formats;
 	struct wlr_drm_format_set linux_dmabuf_v1_formats;
 	struct wl_drm *legacy_drm;
 	char *drm_render_name;

--- a/include/render/shm_allocator.h
+++ b/include/render/shm_allocator.h
@@ -1,0 +1,23 @@
+#ifndef RENDER_SHM_ALLOCATOR_H
+#define RENDER_SHM_ALLOCATOR_H
+
+#include <wlr/types/wlr_buffer.h>
+#include "render/allocator.h"
+
+struct wlr_shm_buffer {
+	struct wlr_buffer base;
+	struct wlr_shm_attributes shm;
+	void *data;
+	size_t size;
+};
+
+struct wlr_shm_allocator {
+	struct wlr_allocator base;
+};
+
+/**
+ * Creates a new shared memory allocator.
+ */
+struct wlr_shm_allocator *wlr_shm_allocator_create(void);
+
+#endif

--- a/include/types/wlr_buffer.h
+++ b/include/types/wlr_buffer.h
@@ -1,0 +1,15 @@
+#ifndef TYPES_WLR_BUFFER
+#define TYPES_WLR_BUFFER
+
+#include <wlr/types/wlr_buffer.h>
+/**
+ * Access a pointer to the allocated data from the underlying implementation,
+ * and its stride.
+ *
+ * The returned pointer should be pointing to a valid memory location for read
+ * and write operations.
+ */
+bool buffer_get_data_ptr(struct wlr_buffer *buffer, void **data,
+	size_t *stride);
+
+#endif

--- a/include/wlr/types/wlr_buffer.h
+++ b/include/wlr/types/wlr_buffer.h
@@ -19,6 +19,8 @@ struct wlr_buffer_impl {
 	void (*destroy)(struct wlr_buffer *buffer);
 	bool (*get_dmabuf)(struct wlr_buffer *buffer,
 		struct wlr_dmabuf_attributes *attribs);
+	bool (*get_data_ptr)(struct wlr_buffer *buffer, void **data,
+		size_t *stride);
 };
 
 /**

--- a/include/wlr/types/wlr_buffer.h
+++ b/include/wlr/types/wlr_buffer.h
@@ -15,12 +15,21 @@
 
 struct wlr_buffer;
 
+struct wlr_shm_attributes {
+	int fd;
+	uint32_t format;
+	int width, height, stride;
+	off_t offset;
+};
+
 struct wlr_buffer_impl {
 	void (*destroy)(struct wlr_buffer *buffer);
 	bool (*get_dmabuf)(struct wlr_buffer *buffer,
 		struct wlr_dmabuf_attributes *attribs);
 	bool (*get_data_ptr)(struct wlr_buffer *buffer, void **data,
 		size_t *stride);
+	bool (*get_shm)(struct wlr_buffer *buffer,
+		struct wlr_shm_attributes *attribs);
 };
 
 /**
@@ -78,6 +87,16 @@ void wlr_buffer_unlock(struct wlr_buffer *buffer);
  */
 bool wlr_buffer_get_dmabuf(struct wlr_buffer *buffer,
 	struct wlr_dmabuf_attributes *attribs);
+/**
+ * Read shared memory attributes of the buffer. If this buffer isn't shared
+ * memory, returns false.
+ *
+ * The returned shared memory attributes are valid for the lifetime of the
+ * wlr_buffer. The caller isn't responsible for cleaning up the shared memory
+ * attributes.
+ */
+bool wlr_buffer_get_shm(struct wlr_buffer *buffer,
+	struct wlr_shm_attributes *attribs);
 
 /**
  * A client buffer.

--- a/render/meson.build
+++ b/render/meson.build
@@ -5,6 +5,7 @@ wlr_files += files(
 	'drm_format_set.c',
 	'gbm_allocator.c',
 	'pixel_format.c',
+	'shm_allocator.c',
 	'swapchain.c',
 	'wlr_renderer.c',
 	'wlr_texture.c',

--- a/render/shm_allocator.c
+++ b/render/shm_allocator.c
@@ -1,0 +1,108 @@
+#include <assert.h>
+#include <drm_fourcc.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <wlr/util/log.h>
+#include "render/pixel_format.h"
+#include "render/shm_allocator.h"
+#include "util/shm.h"
+
+static const struct wlr_buffer_impl buffer_impl;
+
+static struct wlr_shm_buffer *shm_buffer_from_buffer(
+		struct wlr_buffer *wlr_buffer) {
+	assert(wlr_buffer->impl == &buffer_impl);
+	return (struct wlr_shm_buffer *)wlr_buffer;
+}
+
+static void buffer_destroy(struct wlr_buffer *wlr_buffer) {
+	struct wlr_shm_buffer *buffer = shm_buffer_from_buffer(wlr_buffer);
+	munmap(buffer->data, buffer->size);
+	close(buffer->shm.fd);
+	free(buffer);
+}
+
+static bool buffer_get_shm(struct wlr_buffer *wlr_buffer,
+		struct wlr_shm_attributes *shm) {
+	struct wlr_shm_buffer *buffer = shm_buffer_from_buffer(wlr_buffer);
+	memcpy(shm, &buffer->shm, sizeof(*shm));
+	return true;
+}
+
+static bool buffer_get_data_ptr(struct wlr_buffer *wlr_buffer, void **data,
+		size_t *stride) {
+	struct wlr_shm_buffer *buffer = shm_buffer_from_buffer(wlr_buffer);
+	*data = buffer->data;
+	*stride = buffer->shm.stride;
+	return true;
+}
+
+static const struct wlr_buffer_impl buffer_impl = {
+	.destroy = buffer_destroy,
+	.get_shm = buffer_get_shm,
+	.get_data_ptr = buffer_get_data_ptr,
+};
+
+static struct wlr_buffer *allocator_create_buffer(
+		struct wlr_allocator *wlr_allocator, int width, int height,
+		const struct wlr_drm_format *format) {
+	const struct wlr_pixel_format_info *info =
+		drm_get_pixel_format_info(format->format);
+	if (info == NULL) {
+		wlr_log(WLR_ERROR, "Unsupported pixel format 0x%"PRIX32, format->format);
+		return NULL;
+	}
+
+	struct wlr_shm_buffer *buffer = calloc(1, sizeof(*buffer));
+	if (buffer == NULL) {
+		return NULL;
+	}
+	wlr_buffer_init(&buffer->base, &buffer_impl, width, height);
+
+	// TODO: consider using a single file for multiple buffers
+	int bytes_per_pixel = info->bpp / 8;
+	int stride = width * bytes_per_pixel; // TODO: align?
+	buffer->size = stride * height;
+	buffer->shm.fd = allocate_shm_file(buffer->size);
+	if (buffer->shm.fd < 0) {
+		free(buffer);
+		return NULL;
+	}
+
+	buffer->shm.format = format->format;
+	buffer->shm.width = width;
+	buffer->shm.height = height;
+	buffer->shm.stride = stride;
+	buffer->shm.offset = 0;
+
+	buffer->data = mmap(NULL, buffer->size, PROT_READ | PROT_WRITE, MAP_SHARED,
+		buffer->shm.fd, 0);
+	if (buffer->data == MAP_FAILED) {
+		wlr_log_errno(WLR_ERROR, "mmap failed");
+		close(buffer->shm.fd);
+		free(buffer);
+		return NULL;
+	}
+
+	return &buffer->base;
+}
+
+static void allocator_destroy(struct wlr_allocator *wlr_allocator) {
+	free(wlr_allocator);
+}
+
+static const struct wlr_allocator_interface allocator_impl = {
+	.destroy = allocator_destroy,
+	.create_buffer = allocator_create_buffer,
+};
+
+struct wlr_shm_allocator *wlr_shm_allocator_create(void) {
+	struct wlr_shm_allocator *allocator = calloc(1, sizeof(*allocator));
+	if (allocator == NULL) {
+		return NULL;
+	}
+	wlr_allocator_init(&allocator->base, &allocator_impl);
+
+	return allocator;
+}

--- a/types/wlr_buffer.c
+++ b/types/wlr_buffer.c
@@ -74,6 +74,14 @@ bool buffer_get_data_ptr(struct wlr_buffer *buffer, void **data,
 	return buffer->impl->get_data_ptr(buffer, data, size);
 }
 
+bool wlr_buffer_get_shm(struct wlr_buffer *buffer,
+		struct wlr_shm_attributes *attribs) {
+	if (!buffer->impl->get_shm) {
+		return false;
+	}
+	return buffer->impl->get_shm(buffer, attribs);
+}
+
 bool wlr_resource_is_buffer(struct wl_resource *resource) {
 	return strcmp(wl_resource_get_class(resource), wl_buffer_interface.name) == 0;
 }

--- a/types/wlr_buffer.c
+++ b/types/wlr_buffer.c
@@ -5,6 +5,7 @@
 #include <wlr/types/wlr_linux_dmabuf_v1.h>
 #include <wlr/util/log.h>
 #include "render/pixel_format.h"
+#include "types/wlr_buffer.h"
 #include "util/signal.h"
 
 void wlr_buffer_init(struct wlr_buffer *buffer,
@@ -65,6 +66,13 @@ bool wlr_buffer_get_dmabuf(struct wlr_buffer *buffer,
 	return buffer->impl->get_dmabuf(buffer, attribs);
 }
 
+bool buffer_get_data_ptr(struct wlr_buffer *buffer, void **data,
+		size_t *size) {
+	if (!buffer->impl->get_data_ptr) {
+		return false;
+	}
+	return buffer->impl->get_data_ptr(buffer, data, size);
+}
 
 bool wlr_resource_is_buffer(struct wl_resource *resource) {
 	return strcmp(wl_resource_get_class(resource), wl_buffer_interface.name) == 0;


### PR DESCRIPTION
It allocates in local main memory via shm_open, and provides a FD
to allow sharing with other processes.

This is suitable for software rendering under the Wayland and X11
backends.

cc @bl4ckb0ne 