### PR TITLE
Stop using wl_shm_format

### DIFF
--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -425,7 +425,7 @@ static bool output_cursor_to_picture(struct wlr_x11_output *output,
 	wlr_renderer_end(x11->renderer);
 
 	bool result = wlr_renderer_read_pixels(
-		x11->renderer, WL_SHM_FORMAT_ARGB8888, NULL,
+		x11->renderer, DRM_FORMAT_ARGB8888, NULL,
 		width * 4, width, height, 0, 0, 0, 0,
 		data);
 

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -107,11 +107,10 @@ struct wlr_gles2_texture {
 	bool has_alpha;
 
 	// Only affects target == GL_TEXTURE_2D
-	enum wl_shm_format wl_format; // used to interpret upload data
+	uint32_t drm_format; // used to interpret upload data
 };
 
-const struct wlr_gles2_pixel_format *get_gles2_format_from_wl(
-	enum wl_shm_format fmt);
+const struct wlr_gles2_pixel_format *get_gles2_format_from_drm(uint32_t fmt);
 const struct wlr_gles2_pixel_format *get_gles2_format_from_gl(
 	GLint gl_format, GLint gl_type, bool alpha);
 const enum wl_shm_format *get_gles2_wl_formats(size_t *len);

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -15,7 +15,7 @@
 #include <wlr/util/log.h>
 
 struct wlr_gles2_pixel_format {
-	enum wl_shm_format wl_format;
+	uint32_t drm_format;
 	GLint gl_format, gl_type;
 	int depth, bpp;
 	bool has_alpha;

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -121,7 +121,7 @@ struct wlr_gles2_texture *gles2_get_texture(
 	struct wlr_texture *wlr_texture);
 
 struct wlr_texture *gles2_texture_from_pixels(struct wlr_renderer *wlr_renderer,
-	enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width, uint32_t height,
+	uint32_t fmt, uint32_t stride, uint32_t width, uint32_t height,
 	const void *data);
 struct wlr_texture *gles2_texture_from_wl_drm(struct wlr_renderer *wlr_renderer,
 	struct wl_resource *data);

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -113,7 +113,7 @@ struct wlr_gles2_texture {
 const struct wlr_gles2_pixel_format *get_gles2_format_from_drm(uint32_t fmt);
 const struct wlr_gles2_pixel_format *get_gles2_format_from_gl(
 	GLint gl_format, GLint gl_type, bool alpha);
-const enum wl_shm_format *get_gles2_wl_formats(size_t *len);
+const uint32_t *get_gles2_shm_formats(size_t *len);
 
 struct wlr_gles2_renderer *gles2_get_renderer(
 	struct wlr_renderer *wlr_renderer);

--- a/include/render/shm_format.h
+++ b/include/render/shm_format.h
@@ -1,0 +1,9 @@
+#ifndef RENDER_SHM_FORMAT_H
+#define RENDER_SHM_FORMAT_H
+
+#include <wayland-server-protocol.h>
+
+uint32_t convert_wl_shm_format_to_drm(enum wl_shm_format fmt);
+enum wl_shm_format convert_drm_format_to_wl_shm(uint32_t fmt);
+
+#endif

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -32,8 +32,8 @@ struct wlr_renderer_impl {
 		const float color[static 4], const float matrix[static 9]);
 	void (*render_ellipse_with_matrix)(struct wlr_renderer *renderer,
 		const float color[static 4], const float matrix[static 9]);
-	const enum wl_shm_format *(*get_shm_texture_formats)(
-		struct wlr_renderer *renderer, size_t *len);
+	const uint32_t *(*get_shm_texture_formats)(struct wlr_renderer *renderer,
+		size_t *len);
 	bool (*resource_is_wl_drm_buffer)(struct wlr_renderer *renderer,
 		struct wl_resource *resource);
 	void (*wl_drm_buffer_get_size)(struct wlr_renderer *renderer,

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -43,7 +43,7 @@ struct wlr_renderer_impl {
 	const struct wlr_drm_format_set *(*get_dmabuf_render_formats)(
 		struct wlr_renderer *renderer);
 	uint32_t (*preferred_read_format)(struct wlr_renderer *renderer);
-	bool (*read_pixels)(struct wlr_renderer *renderer, enum wl_shm_format fmt,
+	bool (*read_pixels)(struct wlr_renderer *renderer, uint32_t fmt,
 		uint32_t *flags, uint32_t stride, uint32_t width, uint32_t height,
 		uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y,
 		void *data);

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -42,7 +42,7 @@ struct wlr_renderer_impl {
 		struct wlr_renderer *renderer);
 	const struct wlr_drm_format_set *(*get_dmabuf_render_formats)(
 		struct wlr_renderer *renderer);
-	enum wl_shm_format (*preferred_read_format)(struct wlr_renderer *renderer);
+	uint32_t (*preferred_read_format)(struct wlr_renderer *renderer);
 	bool (*read_pixels)(struct wlr_renderer *renderer, enum wl_shm_format fmt,
 		uint32_t *flags, uint32_t stride, uint32_t width, uint32_t height,
 		uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y,

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -48,8 +48,8 @@ struct wlr_renderer_impl {
 		uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y,
 		void *data);
 	struct wlr_texture *(*texture_from_pixels)(struct wlr_renderer *renderer,
-		enum wl_shm_format fmt, uint32_t stride, uint32_t width,
-		uint32_t height, const void *data);
+		uint32_t fmt, uint32_t stride, uint32_t width, uint32_t height,
+		const void *data);
 	struct wlr_texture *(*texture_from_wl_drm)(struct wlr_renderer *renderer,
 		struct wl_resource *data);
 	struct wlr_texture *(*texture_from_dmabuf)(struct wlr_renderer *renderer,

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -10,7 +10,7 @@
 #define WLR_RENDER_INTERFACE_H
 
 #include <stdbool.h>
-#include <wayland-server-protocol.h>
+#include <wayland-server-core.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/render/wlr_texture.h>
 #include <wlr/types/wlr_box.h>

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -110,7 +110,7 @@ const struct wlr_drm_format_set *wlr_renderer_get_dmabuf_texture_formats(
  * If `flags` is not NULl, the caller indicates that it accepts frame flags
  * defined in `enum wlr_renderer_read_pixels_flags`.
  */
-bool wlr_renderer_read_pixels(struct wlr_renderer *r, enum wl_shm_format fmt,
+bool wlr_renderer_read_pixels(struct wlr_renderer *r, uint32_t fmt,
 	uint32_t *flags, uint32_t stride, uint32_t width, uint32_t height,
 	uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y, void *data);
 

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -10,7 +10,7 @@
 #define WLR_RENDER_WLR_RENDERER_H
 
 #include <stdint.h>
-#include <wayland-server-protocol.h>
+#include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/render/wlr_texture.h>
 #include <wlr/types/wlr_box.h>

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -85,7 +85,7 @@ void wlr_render_ellipse_with_matrix(struct wlr_renderer *r,
  * Get the shared-memory formats supporting import usage. Buffers allocated
  * with a format from this list may be imported via wlr_texture_from_pixels.
  */
-const enum wl_shm_format *wlr_renderer_get_shm_texture_formats(
+const uint32_t *wlr_renderer_get_shm_texture_formats(
 	struct wlr_renderer *r, size_t *len);
 /**
  * Returns true if this wl_buffer is a wl_drm buffer.

--- a/include/wlr/render/wlr_texture.h
+++ b/include/wlr/render/wlr_texture.h
@@ -29,7 +29,7 @@ struct wlr_texture {
  * between attaching a renderer to an output and committing it.
  */
 struct wlr_texture *wlr_texture_from_pixels(struct wlr_renderer *renderer,
-	enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width, uint32_t height,
+	uint32_t fmt, uint32_t stride, uint32_t width, uint32_t height,
 	const void *data);
 
 /**

--- a/include/wlr/render/wlr_texture.h
+++ b/include/wlr/render/wlr_texture.h
@@ -10,7 +10,7 @@
 #define WLR_RENDER_WLR_TEXTURE_H
 
 #include <stdint.h>
-#include <wayland-server-protocol.h>
+#include <wayland-server-core.h>
 #include <wlr/render/dmabuf.h>
 
 struct wlr_renderer;

--- a/include/wlr/types/wlr_linux_dmabuf_v1.h
+++ b/include/wlr/types/wlr_linux_dmabuf_v1.h
@@ -10,7 +10,7 @@
 #define WLR_TYPES_WLR_LINUX_DMABUF_H
 
 #include <stdint.h>
-#include <wayland-server-protocol.h>
+#include <wayland-server-core.h>
 #include <wlr/render/dmabuf.h>
 
 struct wlr_dmabuf_v1_buffer {

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -340,8 +340,7 @@ void wlr_output_attach_buffer(struct wlr_output *output,
  * Get the preferred format for reading pixels.
  * This function might change the current rendering context.
  */
-bool wlr_output_preferred_read_format(struct wlr_output *output,
-	enum wl_shm_format *fmt);
+uint32_t wlr_output_preferred_read_format(struct wlr_output *output);
 /**
  * Set the damage region for the frame to be submitted. This is the region of
  * the screen that has changed since the last frame.

--- a/render/gles2/pixel_format.c
+++ b/render/gles2/pixel_format.c
@@ -2,7 +2,6 @@
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 #include "render/gles2.h"
-#include "render/shm_format.h"
 
 /*
  * The DRM formats are little endian while the GL formats are big endian,
@@ -66,11 +65,11 @@ const struct wlr_gles2_pixel_format *get_gles2_format_from_gl(
 	return NULL;
 }
 
-const enum wl_shm_format *get_gles2_wl_formats(size_t *len) {
-	static enum wl_shm_format wl_formats[sizeof(formats) / sizeof(formats[0])];
+const uint32_t *get_gles2_shm_formats(size_t *len) {
+	static uint32_t shm_formats[sizeof(formats) / sizeof(formats[0])];
 	*len = sizeof(formats) / sizeof(formats[0]);
 	for (size_t i = 0; i < sizeof(formats) / sizeof(formats[0]); i++) {
-		wl_formats[i] = convert_drm_format_to_wl_shm(formats[i].drm_format);
+		shm_formats[i] = formats[i].drm_format;
 	}
-	return wl_formats;
+	return shm_formats;
 }

--- a/render/gles2/pixel_format.c
+++ b/render/gles2/pixel_format.c
@@ -45,10 +45,9 @@ static const struct wlr_gles2_pixel_format formats[] = {
 
 // TODO: more pixel formats
 
-const struct wlr_gles2_pixel_format *get_gles2_format_from_wl(
-		enum wl_shm_format fmt) {
+const struct wlr_gles2_pixel_format *get_gles2_format_from_drm(uint32_t fmt) {
 	for (size_t i = 0; i < sizeof(formats) / sizeof(*formats); ++i) {
-		if (convert_drm_format_to_wl_shm(formats[i].drm_format) == fmt) {
+		if (formats[i].drm_format == fmt) {
 			return &formats[i];
 		}
 	}

--- a/render/gles2/pixel_format.c
+++ b/render/gles2/pixel_format.c
@@ -1,14 +1,16 @@
+#include <drm_fourcc.h>
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 #include "render/gles2.h"
+#include "render/shm_format.h"
 
 /*
- * The wayland formats are little endian while the GL formats are big endian,
- * so WL_SHM_FORMAT_ARGB8888 is actually compatible with GL_BGRA_EXT.
+ * The DRM formats are little endian while the GL formats are big endian,
+ * so DRM_FORMAT_ARGB8888 is actually compatible with GL_BGRA_EXT.
  */
 static const struct wlr_gles2_pixel_format formats[] = {
 	{
-		.wl_format = WL_SHM_FORMAT_ARGB8888,
+		.drm_format = DRM_FORMAT_ARGB8888,
 		.depth = 32,
 		.bpp = 32,
 		.gl_format = GL_BGRA_EXT,
@@ -16,7 +18,7 @@ static const struct wlr_gles2_pixel_format formats[] = {
 		.has_alpha = true,
 	},
 	{
-		.wl_format = WL_SHM_FORMAT_XRGB8888,
+		.drm_format = DRM_FORMAT_XRGB8888,
 		.depth = 24,
 		.bpp = 32,
 		.gl_format = GL_BGRA_EXT,
@@ -24,7 +26,7 @@ static const struct wlr_gles2_pixel_format formats[] = {
 		.has_alpha = false,
 	},
 	{
-		.wl_format = WL_SHM_FORMAT_XBGR8888,
+		.drm_format = DRM_FORMAT_XBGR8888,
 		.depth = 24,
 		.bpp = 32,
 		.gl_format = GL_RGBA,
@@ -32,7 +34,7 @@ static const struct wlr_gles2_pixel_format formats[] = {
 		.has_alpha = false,
 	},
 	{
-		.wl_format = WL_SHM_FORMAT_ABGR8888,
+		.drm_format = DRM_FORMAT_ABGR8888,
 		.depth = 32,
 		.bpp = 32,
 		.gl_format = GL_RGBA,
@@ -46,7 +48,7 @@ static const struct wlr_gles2_pixel_format formats[] = {
 const struct wlr_gles2_pixel_format *get_gles2_format_from_wl(
 		enum wl_shm_format fmt) {
 	for (size_t i = 0; i < sizeof(formats) / sizeof(*formats); ++i) {
-		if (formats[i].wl_format == fmt) {
+		if (convert_drm_format_to_wl_shm(formats[i].drm_format) == fmt) {
 			return &formats[i];
 		}
 	}
@@ -69,7 +71,7 @@ const enum wl_shm_format *get_gles2_wl_formats(size_t *len) {
 	static enum wl_shm_format wl_formats[sizeof(formats) / sizeof(formats[0])];
 	*len = sizeof(formats) / sizeof(formats[0]);
 	for (size_t i = 0; i < sizeof(formats) / sizeof(formats[0]); i++) {
-		wl_formats[i] = formats[i].wl_format;
+		wl_formats[i] = convert_drm_format_to_wl_shm(formats[i].drm_format);
 	}
 	return wl_formats;
 }

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -14,6 +14,7 @@
 #include <wlr/types/wlr_linux_dmabuf_v1.h>
 #include <wlr/util/log.h>
 #include "render/gles2.h"
+#include "render/shm_format.h"
 
 static const GLfloat verts[] = {
 	1, 0, // top right
@@ -471,7 +472,7 @@ static enum wl_shm_format gles2_preferred_read_format(
 	const struct wlr_gles2_pixel_format *fmt =
 		get_gles2_format_from_gl(gl_format, gl_type, alpha_size > 0);
 	if (fmt != NULL) {
-		return fmt->wl_format;
+		return convert_drm_format_to_wl_shm(fmt->drm_format);
 	}
 
 	if (renderer->exts.read_format_bgra_ext) {

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <drm_fourcc.h>
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 #include <stdint.h>
@@ -450,7 +451,7 @@ static const struct wlr_drm_format_set *gles2_get_dmabuf_render_formats(
 	return wlr_egl_get_dmabuf_render_formats(renderer->egl);
 }
 
-static enum wl_shm_format gles2_preferred_read_format(
+static uint32_t gles2_preferred_read_format(
 		struct wlr_renderer *wlr_renderer) {
 	struct wlr_gles2_renderer *renderer =
 		gles2_get_renderer_in_context(wlr_renderer);
@@ -472,13 +473,13 @@ static enum wl_shm_format gles2_preferred_read_format(
 	const struct wlr_gles2_pixel_format *fmt =
 		get_gles2_format_from_gl(gl_format, gl_type, alpha_size > 0);
 	if (fmt != NULL) {
-		return convert_drm_format_to_wl_shm(fmt->drm_format);
+		return fmt->drm_format;
 	}
 
 	if (renderer->exts.read_format_bgra_ext) {
-		return WL_SHM_FORMAT_XRGB8888;
+		return DRM_FORMAT_XRGB8888;
 	}
-	return WL_SHM_FORMAT_XBGR8888;
+	return DRM_FORMAT_XBGR8888;
 }
 
 static bool gles2_read_pixels(struct wlr_renderer *wlr_renderer,

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -483,14 +483,14 @@ static uint32_t gles2_preferred_read_format(
 }
 
 static bool gles2_read_pixels(struct wlr_renderer *wlr_renderer,
-		enum wl_shm_format wl_fmt, uint32_t *flags, uint32_t stride,
+		uint32_t drm_format, uint32_t *flags, uint32_t stride,
 		uint32_t width, uint32_t height, uint32_t src_x, uint32_t src_y,
 		uint32_t dst_x, uint32_t dst_y, void *data) {
 	struct wlr_gles2_renderer *renderer =
 		gles2_get_renderer_in_context(wlr_renderer);
 
 	const struct wlr_gles2_pixel_format *fmt =
-		get_gles2_format_from_drm(convert_wl_shm_format_to_drm(wl_fmt));
+		get_gles2_format_from_drm(drm_format);
 	if (fmt == NULL) {
 		wlr_log(WLR_ERROR, "Cannot read pixels: unsupported pixel format");
 		return false;

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -488,7 +488,8 @@ static bool gles2_read_pixels(struct wlr_renderer *wlr_renderer,
 	struct wlr_gles2_renderer *renderer =
 		gles2_get_renderer_in_context(wlr_renderer);
 
-	const struct wlr_gles2_pixel_format *fmt = get_gles2_format_from_wl(wl_fmt);
+	const struct wlr_gles2_pixel_format *fmt =
+		get_gles2_format_from_drm(convert_wl_shm_format_to_drm(wl_fmt));
 	if (fmt == NULL) {
 		wlr_log(WLR_ERROR, "Cannot read pixels: unsupported pixel format");
 		return false;

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -405,9 +405,9 @@ static void gles2_render_ellipse_with_matrix(struct wlr_renderer *wlr_renderer,
 	pop_gles2_debug(renderer);
 }
 
-static const enum wl_shm_format *gles2_get_shm_texture_formats(
+static const uint32_t *gles2_get_shm_texture_formats(
 		struct wlr_renderer *wlr_renderer, size_t *len) {
-	return get_gles2_wl_formats(len);
+	return get_gles2_shm_formats(len);
 }
 
 static bool gles2_resource_is_wl_drm_buffer(struct wlr_renderer *wlr_renderer,

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -15,7 +15,6 @@
 #include <wlr/types/wlr_linux_dmabuf_v1.h>
 #include <wlr/util/log.h>
 #include "render/gles2.h"
-#include "render/shm_format.h"
 
 static const GLfloat verts[] = {
 	1, 0, // top right

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -11,6 +11,7 @@
 #include <wlr/types/wlr_matrix.h>
 #include <wlr/util/log.h>
 #include "render/gles2.h"
+#include "render/shm_format.h"
 #include "util/signal.h"
 
 static const struct wlr_texture_impl texture_impl;
@@ -152,7 +153,7 @@ struct wlr_texture *gles2_texture_from_pixels(struct wlr_renderer *wlr_renderer,
 	texture->renderer = renderer;
 	texture->target = GL_TEXTURE_2D;
 	texture->has_alpha = fmt->has_alpha;
-	texture->wl_format = fmt->wl_format;
+	texture->wl_format = convert_drm_format_to_wl_shm(fmt->drm_format);
 
 	struct wlr_egl_context prev_ctx;
 	wlr_egl_save_context(&prev_ctx);

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -12,7 +12,6 @@
 #include <wlr/types/wlr_matrix.h>
 #include <wlr/util/log.h>
 #include "render/gles2.h"
-#include "render/shm_format.h"
 #include "util/signal.h"
 
 static const struct wlr_texture_impl texture_impl;
@@ -134,14 +133,14 @@ static const struct wlr_texture_impl texture_impl = {
 };
 
 struct wlr_texture *gles2_texture_from_pixels(struct wlr_renderer *wlr_renderer,
-		enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width,
+		uint32_t drm_format, uint32_t stride, uint32_t width,
 		uint32_t height, const void *data) {
 	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
 
 	const struct wlr_gles2_pixel_format *fmt =
-		get_gles2_format_from_drm(convert_wl_shm_format_to_drm(wl_fmt));
+		get_gles2_format_from_drm(drm_format);
 	if (fmt == NULL) {
-		wlr_log(WLR_ERROR, "Unsupported pixel format %"PRIu32, wl_fmt);
+		wlr_log(WLR_ERROR, "Unsupported pixel format 0x%"PRIX32, drm_format);
 		return NULL;
 	}
 

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <drm_fourcc.h>
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 #include <stdint.h>
@@ -43,7 +44,7 @@ static bool gles2_texture_write_pixels(struct wlr_texture *wlr_texture,
 	}
 
 	const struct wlr_gles2_pixel_format *fmt =
-		get_gles2_format_from_wl(texture->wl_format);
+		get_gles2_format_from_drm(texture->drm_format);
 	assert(fmt);
 
 	struct wlr_egl_context prev_ctx;
@@ -137,7 +138,8 @@ struct wlr_texture *gles2_texture_from_pixels(struct wlr_renderer *wlr_renderer,
 		uint32_t height, const void *data) {
 	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
 
-	const struct wlr_gles2_pixel_format *fmt = get_gles2_format_from_wl(wl_fmt);
+	const struct wlr_gles2_pixel_format *fmt =
+		get_gles2_format_from_drm(convert_wl_shm_format_to_drm(wl_fmt));
 	if (fmt == NULL) {
 		wlr_log(WLR_ERROR, "Unsupported pixel format %"PRIu32, wl_fmt);
 		return NULL;
@@ -153,7 +155,7 @@ struct wlr_texture *gles2_texture_from_pixels(struct wlr_renderer *wlr_renderer,
 	texture->renderer = renderer;
 	texture->target = GL_TEXTURE_2D;
 	texture->has_alpha = fmt->has_alpha;
-	texture->wl_format = convert_drm_format_to_wl_shm(fmt->drm_format);
+	texture->drm_format = fmt->drm_format;
 
 	struct wlr_egl_context prev_ctx;
 	wlr_egl_save_context(&prev_ctx);
@@ -211,7 +213,7 @@ struct wlr_texture *gles2_texture_from_wl_drm(struct wlr_renderer *wlr_renderer,
 	wlr_texture_init(&texture->wlr_texture, &texture_impl, width, height);
 	texture->renderer = renderer;
 
-	texture->wl_format = 0xFFFFFFFF; // texture can't be written anyways
+	texture->drm_format = DRM_FORMAT_INVALID; // texture can't be written anyways
 	texture->image = image;
 	texture->inverted_y = inverted_y;
 
@@ -279,7 +281,7 @@ struct wlr_texture *gles2_texture_from_dmabuf(struct wlr_renderer *wlr_renderer,
 		attribs->width, attribs->height);
 	texture->renderer = renderer;
 	texture->has_alpha = true;
-	texture->wl_format = 0xFFFFFFFF; // texture can't be written anyways
+	texture->drm_format = DRM_FORMAT_INVALID; // texture can't be written anyways
 	texture->inverted_y =
 		(attribs->flags & WLR_DMABUF_ATTRIBUTES_FLAGS_Y_INVERT) != 0;
 

--- a/render/meson.build
+++ b/render/meson.build
@@ -4,6 +4,7 @@ wlr_files += files(
 	'egl.c',
 	'drm_format_set.c',
 	'gbm_allocator.c',
+	'shm_format.c',
 	'swapchain.c',
 	'wlr_renderer.c',
 	'wlr_texture.c',

--- a/render/shm_format.c
+++ b/render/shm_format.c
@@ -1,0 +1,24 @@
+#include <drm_fourcc.h>
+#include "render/shm_format.h"
+
+uint32_t convert_wl_shm_format_to_drm(enum wl_shm_format fmt) {
+	switch (fmt) {
+	case WL_SHM_FORMAT_XRGB8888:
+		return DRM_FORMAT_XRGB8888;
+	case WL_SHM_FORMAT_ARGB8888:
+		return DRM_FORMAT_ARGB8888;
+	default:
+		return (uint32_t)fmt;
+	}
+}
+
+enum wl_shm_format convert_drm_format_to_wl_shm(uint32_t fmt) {
+	switch (fmt) {
+	case DRM_FORMAT_XRGB8888:
+		return WL_SHM_FORMAT_XRGB8888;
+	case DRM_FORMAT_ARGB8888:
+		return WL_SHM_FORMAT_ARGB8888;
+	default:
+		return (enum wl_shm_format)fmt;
+	}
+}

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -189,7 +189,7 @@ const struct wlr_drm_format_set *wlr_renderer_get_dmabuf_render_formats(
 	return r->impl->get_dmabuf_render_formats(r);
 }
 
-bool wlr_renderer_read_pixels(struct wlr_renderer *r, enum wl_shm_format fmt,
+bool wlr_renderer_read_pixels(struct wlr_renderer *r, uint32_t fmt,
 		uint32_t *flags, uint32_t stride, uint32_t width, uint32_t height,
 		uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y,
 		void *data) {

--- a/render/wlr_texture.c
+++ b/render/wlr_texture.c
@@ -20,9 +20,9 @@ void wlr_texture_destroy(struct wlr_texture *texture) {
 }
 
 struct wlr_texture *wlr_texture_from_pixels(struct wlr_renderer *renderer,
-		enum wl_shm_format wl_fmt, uint32_t stride, uint32_t width,
-		uint32_t height, const void *data) {
-	return renderer->impl->texture_from_pixels(renderer, wl_fmt, stride, width,
+		uint32_t fmt, uint32_t stride, uint32_t width, uint32_t height,
+		const void *data) {
+	return renderer->impl->texture_from_pixels(renderer, fmt, stride, width,
 		height, data);
 }
 

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -1,5 +1,6 @@
 #define _POSIX_C_SOURCE 200809L
 #include <assert.h>
+#include <drm_fourcc.h>
 #include <stdlib.h>
 #include <string.h>
 #include <tgmath.h>
@@ -450,19 +451,18 @@ bool wlr_output_attach_render(struct wlr_output *output, int *buffer_age) {
 	return true;
 }
 
-bool wlr_output_preferred_read_format(struct wlr_output *output,
-		enum wl_shm_format *fmt) {
+uint32_t wlr_output_preferred_read_format(struct wlr_output *output) {
 	struct wlr_renderer *renderer = wlr_backend_get_renderer(output->backend);
 	if (!renderer->impl->preferred_read_format || !renderer->impl->read_pixels) {
-		return false;
+		return DRM_FORMAT_INVALID;
 	}
 
 	if (!output->impl->attach_render(output, NULL)) {
-		return false;
+		return DRM_FORMAT_INVALID;
 	}
-	*fmt = renderer->impl->preferred_read_format(renderer);
+	uint32_t fmt = renderer->impl->preferred_read_format(renderer);
 	output->impl->rollback_render(output);
-	return true;
+	return fmt;
 }
 
 void wlr_output_set_damage(struct wlr_output *output,

--- a/types/wlr_screencopy_v1.c
+++ b/types/wlr_screencopy_v1.c
@@ -8,6 +8,7 @@
 #include <wlr/backend.h>
 #include <wlr/util/log.h>
 #include "wlr-screencopy-unstable-v1-protocol.h"
+#include "render/shm_format.h"
 #include "util/signal.h"
 
 #define SCREENCOPY_MANAGER_VERSION 3
@@ -551,12 +552,14 @@ static void capture_output(struct wl_client *wl_client,
 	struct wlr_renderer *renderer = wlr_backend_get_renderer(output->backend);
 	assert(renderer);
 
-	if (!wlr_output_preferred_read_format(frame->output, &frame->format)) {
+	uint32_t drm_format = wlr_output_preferred_read_format(frame->output);
+	if (drm_format == DRM_FORMAT_INVALID) {
 		wlr_log(WLR_ERROR,
 			"Failed to capture output: no read format supported by renderer");
 		goto error;
 	}
 
+	frame->format = convert_drm_format_to_wl_shm(drm_format);
 	frame->fourcc = get_output_fourcc(output);
 
 	struct wlr_box buffer_box = {0};

--- a/types/wlr_screencopy_v1.c
+++ b/types/wlr_screencopy_v1.c
@@ -233,7 +233,8 @@ static void frame_handle_output_precommit(struct wl_listener *listener,
 	int x = frame->box.x;
 	int y = frame->box.y;
 
-	enum wl_shm_format fmt = wl_shm_buffer_get_format(shm_buffer);
+	enum wl_shm_format wl_shm_format = wl_shm_buffer_get_format(shm_buffer);
+	uint32_t drm_format = convert_wl_shm_format_to_drm(wl_shm_format);
 	int32_t width = wl_shm_buffer_get_width(shm_buffer);
 	int32_t height = wl_shm_buffer_get_height(shm_buffer);
 	int32_t stride = wl_shm_buffer_get_stride(shm_buffer);
@@ -241,7 +242,7 @@ static void frame_handle_output_precommit(struct wl_listener *listener,
 	wl_shm_buffer_begin_access(shm_buffer);
 	void *data = wl_shm_buffer_get_data(shm_buffer);
 	uint32_t renderer_flags = 0;
-	bool ok = wlr_renderer_read_pixels(renderer, fmt, &renderer_flags,
+	bool ok = wlr_renderer_read_pixels(renderer, drm_format, &renderer_flags,
 		stride, width, height, x, y, 0, 0, data);
 	uint32_t flags = renderer_flags & WLR_RENDERER_READ_PIXELS_Y_INVERT ?
 		ZWLR_SCREENCOPY_FRAME_V1_FLAGS_Y_INVERT : 0;


### PR DESCRIPTION
Replace everything with DRM fourcc formats and use it as the only source of truth for format definitions.

Closes: https://github.com/swaywm/wlroots/issues/2738