### PR TITLE
Change the WLR_DRM_DEVICES separator to a comma

### DIFF
--- a/backend/session/session.c
+++ b/backend/session/session.c
@@ -288,7 +288,7 @@ static ssize_t explicit_find_gpus(struct wlr_session *session,
 
 	size_t i = 0;
 	char *save;
-	char *ptr = strtok_r(gpus, ":", &save);
+	char *ptr = strtok_r(gpus, ",", &save);
 	do {
 		if (i >= ret_len) {
 			break;
@@ -300,7 +300,7 @@ static ssize_t explicit_find_gpus(struct wlr_session *session,
 		} else {
 			++i;
 		}
-	} while ((ptr = strtok_r(NULL, ":", &save)));
+	} while ((ptr = strtok_r(NULL, ",", &save)));
 
 	free(gpus);
 	return i;

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -14,7 +14,7 @@ wlroots reads these environment variables
 
 ## DRM backend
 
-* *WLR_DRM_DEVICES*: specifies the DRM devices (as a colon separated list)
+* *WLR_DRM_DEVICES*: specifies the DRM devices (as a comma separated list)
   instead of auto probing them. The first existing device in this list is
   considered the primary DRM device.
 * *WLR_DRM_NO_ATOMIC*: set to 1 to use legacy DRM interface instead of atomic


### PR DESCRIPTION
Change the `WLR_DRM_DEVICES` device list separator to a comma.
This allows the use of stable `/dev/dri/by-path` symlinks, which contain colons in their paths.

Fixes #1386.