### PR TITLE
Remove gl matrix from public rendering interface part1

### DIFF
--- a/examples/fullscreen-shell.c
+++ b/examples/fullscreen-shell.c
@@ -16,6 +16,9 @@
 #include <wlr/types/wlr_surface.h>
 #include <wlr/util/log.h>
 
+/* Temp workaround */
+#include "render/gles2.h"
+
 /**
  * A minimal fullscreen-shell server. It only supports rendering.
  */
@@ -67,11 +70,15 @@ static void render_surface(struct wlr_surface *surface,
 		.height = surface->current.height * output->scale,
 	};
 
+	/* Temp workaround */
+	struct wlr_gles2_renderer *gles2_renderer =
+		(struct wlr_gles2_renderer *)rdata->renderer;
+
 	float matrix[9];
 	enum wl_output_transform transform =
 		wlr_output_transform_invert(surface->current.transform);
 	wlr_matrix_project_box(matrix, &box, transform, 0,
-		output->transform_matrix);
+		gles2_renderer->transform_matrix);
 
 	wlr_render_texture_with_matrix(rdata->renderer, texture, matrix, 1);
 
@@ -96,6 +103,8 @@ static void output_handle_frame(struct wl_listener *listener, void *data) {
 
 	float color[4] = {0.3, 0.3, 0.3, 1.0};
 	wlr_renderer_clear(renderer, color);
+
+	wlr_renderer_set_transform(renderer, output->wlr_output->transform);
 
 	if (output->surface != NULL) {
 		struct render_data rdata = {

--- a/examples/fullscreen-shell.c
+++ b/examples/fullscreen-shell.c
@@ -16,9 +16,6 @@
 #include <wlr/types/wlr_surface.h>
 #include <wlr/util/log.h>
 
-/* Temp workaround */
-#include "render/gles2.h"
-
 /**
  * A minimal fullscreen-shell server. It only supports rendering.
  */
@@ -70,17 +67,10 @@ static void render_surface(struct wlr_surface *surface,
 		.height = surface->current.height * output->scale,
 	};
 
-	/* Temp workaround */
-	struct wlr_gles2_renderer *gles2_renderer =
-		(struct wlr_gles2_renderer *)rdata->renderer;
-
-	float matrix[9];
 	enum wl_output_transform transform =
 		wlr_output_transform_invert(surface->current.transform);
-	wlr_matrix_project_box(matrix, &box, transform, 0,
-		gles2_renderer->transform_matrix);
 
-	wlr_render_texture_with_matrix(rdata->renderer, texture, matrix, 1);
+	wlr_render_texture(rdata->renderer, texture, transform, &box, 1.f);
 
 	wlr_surface_send_frame_done(surface, rdata->when);
 }

--- a/examples/fullscreen-shell.c
+++ b/examples/fullscreen-shell.c
@@ -70,7 +70,7 @@ static void render_surface(struct wlr_surface *surface,
 	enum wl_output_transform transform =
 		wlr_output_transform_invert(surface->current.transform);
 
-	wlr_render_texture(rdata->renderer, texture, transform, &box, 1.f);
+	wlr_render_texture(rdata->renderer, texture, transform, &box, 1.f, 0.f);
 
 	wlr_surface_send_frame_done(surface, rdata->when);
 }

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -22,6 +22,9 @@
 #include <xkbcommon/xkbcommon.h>
 #include "cat.h"
 
+/* Temp workaround */
+#include "render/gles2.h"
+
 struct sample_state {
 	struct wl_display *display;
 	struct wl_listener new_output;
@@ -119,6 +122,12 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	wlr_renderer_begin(sample->renderer, wlr_output->width, wlr_output->height);
 	wlr_renderer_clear(sample->renderer, (float[]){0.25f, 0.25f, 0.25f, 1});
 
+	wlr_renderer_set_transform(sample->renderer, wlr_output->transform);
+
+	/* Temp workaround */
+	struct wlr_gles2_renderer *gles2_renderer =
+		(struct wlr_gles2_renderer *)sample->renderer;
+
 	animate_cat(sample, output->output);
 
 	struct wlr_box box = {
@@ -133,7 +142,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 			&local_x, &local_y);
 
 		wlr_render_texture(sample->renderer, sample->cat_texture,
-			wlr_output->transform_matrix, local_x, local_y, 1.0f);
+			gles2_renderer->transform_matrix, local_x, local_y, 1.0f);
 	}
 
 	wlr_renderer_end(sample->renderer);

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -135,7 +135,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 			&local_x, &local_y);
 
 		wlr_render_texture(sample->renderer, sample->cat_texture,
-			WL_OUTPUT_TRANSFORM_NORMAL, &box, 1.f);
+			WL_OUTPUT_TRANSFORM_NORMAL, &box, 1.f, 0.f);
 	}
 
 	wlr_renderer_end(sample->renderer);

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -141,7 +141,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 		wlr_output_layout_output_coords(sample->layout, output->output,
 			&local_x, &local_y);
 
-		wlr_render_texture(sample->renderer, sample->cat_texture,
+		wlr_render_texture_at(sample->renderer, sample->cat_texture,
 			gles2_renderer->transform_matrix, local_x, local_y, 1.0f);
 	}
 

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -22,9 +22,6 @@
 #include <xkbcommon/xkbcommon.h>
 #include "cat.h"
 
-/* Temp workaround */
-#include "render/gles2.h"
-
 struct sample_state {
 	struct wl_display *display;
 	struct wl_listener new_output;
@@ -124,10 +121,6 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 
 	wlr_renderer_set_transform(sample->renderer, wlr_output->transform);
 
-	/* Temp workaround */
-	struct wlr_gles2_renderer *gles2_renderer =
-		(struct wlr_gles2_renderer *)sample->renderer;
-
 	animate_cat(sample, output->output);
 
 	struct wlr_box box = {
@@ -141,8 +134,8 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 		wlr_output_layout_output_coords(sample->layout, output->output,
 			&local_x, &local_y);
 
-		wlr_render_texture_at(sample->renderer, sample->cat_texture,
-			gles2_renderer->transform_matrix, local_x, local_y, 1.0f);
+		wlr_render_texture(sample->renderer, sample->cat_texture,
+			WL_OUTPUT_TRANSFORM_NORMAL, &box, 1.f);
 	}
 
 	wlr_renderer_end(sample->renderer);

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -78,7 +78,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 
 			// TODO use wlr_render_texture_at once the api has changed
 			wlr_render_texture(sample->renderer, sample->cat_texture,
-				WL_OUTPUT_TRANSFORM_NORMAL, &box, 1.f);
+				WL_OUTPUT_TRANSFORM_NORMAL, &box, 1.f, 0.f);
 		}
 	}
 

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -75,7 +75,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 
 	for (int y = -128 + (int)sample_output->y_offs; y < height; y += 128) {
 		for (int x = -128 + (int)sample_output->x_offs; x < width; x += 128) {
-			wlr_render_texture(sample->renderer, sample->cat_texture,
+			wlr_render_texture_at(sample->renderer, sample->cat_texture,
 				gles2_renderer->transform_matrix, x, y, 1.0f);
 		}
 	}

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -22,9 +22,6 @@
 #include <xkbcommon/xkbcommon.h>
 #include "cat.h"
 
-/* Temp workaround */
-#include "render/gles2.h"
-
 struct sample_state {
 	struct wl_display *display;
 	struct wl_listener new_output;
@@ -69,14 +66,19 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 
 	wlr_renderer_set_transform(sample->renderer, wlr_output->transform);
 
-	/* Temp workaround */
-	struct wlr_gles2_renderer *gles2_renderer =
-		(struct wlr_gles2_renderer *)sample->renderer;
+	struct wlr_box box = {
+		.width = sample->cat_texture->width,
+		.height = sample->cat_texture->height,
+	};
 
 	for (int y = -128 + (int)sample_output->y_offs; y < height; y += 128) {
 		for (int x = -128 + (int)sample_output->x_offs; x < width; x += 128) {
-			wlr_render_texture_at(sample->renderer, sample->cat_texture,
-				gles2_renderer->transform_matrix, x, y, 1.0f);
+			box.x = x;
+			box.y = y;
+
+			// TODO use wlr_render_texture_at once the api has changed
+			wlr_render_texture(sample->renderer, sample->cat_texture,
+				WL_OUTPUT_TRANSFORM_NORMAL, &box, 1.f);
 		}
 	}
 

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -22,6 +22,9 @@
 #include <xkbcommon/xkbcommon.h>
 #include "cat.h"
 
+/* Temp workaround */
+#include "render/gles2.h"
+
 struct sample_state {
 	struct wl_display *display;
 	struct wl_listener new_output;
@@ -64,10 +67,16 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	wlr_renderer_begin(sample->renderer, wlr_output->width, wlr_output->height);
 	wlr_renderer_clear(sample->renderer, (float[]){0.25f, 0.25f, 0.25f, 1});
 
+	wlr_renderer_set_transform(sample->renderer, wlr_output->transform);
+
+	/* Temp workaround */
+	struct wlr_gles2_renderer *gles2_renderer =
+		(struct wlr_gles2_renderer *)sample->renderer;
+
 	for (int y = -128 + (int)sample_output->y_offs; y < height; y += 128) {
 		for (int x = -128 + (int)sample_output->x_offs; x < width; x += 128) {
 			wlr_render_texture(sample->renderer, sample->cat_texture,
-				wlr_output->transform_matrix, x, y, 1.0f);
+				gles2_renderer->transform_matrix, x, y, 1.0f);
 		}
 	}
 

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -20,6 +20,9 @@
 #include <wlr/util/log.h>
 #include <xkbcommon/xkbcommon.h>
 
+/* Temp workaround */
+#include "render/gles2.h"
+
 struct sample_state {
 	struct wl_display *display;
 	struct wlr_renderer *renderer;
@@ -90,6 +93,12 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	wlr_renderer_begin(sample->renderer, wlr_output->width, wlr_output->height);
 	wlr_renderer_clear(sample->renderer, (float[]){0.25f, 0.25f, 0.25f, 1});
 
+	wlr_renderer_set_transform(sample->renderer, wlr_output->transform);
+
+	/* Temp workaround */
+	struct wlr_gles2_renderer *gles2_renderer =
+		(struct wlr_gles2_renderer *)sample->renderer;
+
 	float distance = 0.8f * (1 - sample->distance);
 	float tool_color[4] = { distance, distance, distance, 1 };
 	for (size_t i = 0; sample->button && i < 4; ++i) {
@@ -106,7 +115,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 		.width = pad_width, .height = pad_height,
 	};
 	wlr_render_rect(sample->renderer, &box, sample->pad_color,
-		wlr_output->transform_matrix);
+		gles2_renderer->transform_matrix);
 
 	if (sample->proximity) {
 		struct wlr_box box = {
@@ -117,7 +126,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 		};
 		float matrix[9];
 		wlr_matrix_project_box(matrix, &box, WL_OUTPUT_TRANSFORM_NORMAL,
-			sample->ring, wlr_output->transform_matrix);
+			sample->ring, gles2_renderer->transform_matrix);
 		wlr_render_quad_with_matrix(sample->renderer, tool_color, matrix);
 
 		box.x += sample->x_tilt;
@@ -125,7 +134,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 		box.width /= 2;
 		box.height /= 2;
 		wlr_render_rect(sample->renderer, &box, tool_color,
-			wlr_output->transform_matrix);
+			gles2_renderer->transform_matrix);
 	}
 
 	wlr_renderer_end(sample->renderer);

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -22,6 +22,9 @@
 #include <xkbcommon/xkbcommon.h>
 #include "cat.h"
 
+/* Temp workaround */
+#include "render/gles2.h"
+
 struct sample_state {
 	struct wl_display *display;
 	struct wlr_renderer *renderer;
@@ -79,12 +82,18 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	wlr_renderer_begin(sample->renderer, wlr_output->width, wlr_output->height);
 	wlr_renderer_clear(sample->renderer, (float[]){0.25f, 0.25f, 0.25f, 1});
 
+	wlr_renderer_set_transform(sample->renderer, wlr_output->transform);
+
+	/* Temp workaround */
+	struct wlr_gles2_renderer *gles2_renderer =
+		(struct wlr_gles2_renderer *)sample->renderer;
+
 	struct touch_point *p;
 	wl_list_for_each(p, &sample->touch_points, link) {
 		int x = (int)(p->x * width) - sample->cat_texture->width / 2;
 		int y = (int)(p->y * height) - sample->cat_texture->height / 2;
 		wlr_render_texture(sample->renderer, sample->cat_texture,
-			wlr_output->transform_matrix, x, y, 1.0f);
+			gles2_renderer->transform_matrix, x, y, 1.0f);
 	}
 
 	wlr_renderer_end(sample->renderer);

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -92,7 +92,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	wl_list_for_each(p, &sample->touch_points, link) {
 		int x = (int)(p->x * width) - sample->cat_texture->width / 2;
 		int y = (int)(p->y * height) - sample->cat_texture->height / 2;
-		wlr_render_texture(sample->renderer, sample->cat_texture,
+		wlr_render_texture_at(sample->renderer, sample->cat_texture,
 			gles2_renderer->transform_matrix, x, y, 1.0f);
 	}
 

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -22,9 +22,6 @@
 #include <xkbcommon/xkbcommon.h>
 #include "cat.h"
 
-/* Temp workaround */
-#include "render/gles2.h"
-
 struct sample_state {
 	struct wl_display *display;
 	struct wlr_renderer *renderer;
@@ -84,16 +81,19 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 
 	wlr_renderer_set_transform(sample->renderer, wlr_output->transform);
 
-	/* Temp workaround */
-	struct wlr_gles2_renderer *gles2_renderer =
-		(struct wlr_gles2_renderer *)sample->renderer;
+	struct wlr_box box = {
+		.width = sample->cat_texture->width,
+		.height = sample->cat_texture->height,
+	};
 
 	struct touch_point *p;
 	wl_list_for_each(p, &sample->touch_points, link) {
-		int x = (int)(p->x * width) - sample->cat_texture->width / 2;
-		int y = (int)(p->y * height) - sample->cat_texture->height / 2;
-		wlr_render_texture_at(sample->renderer, sample->cat_texture,
-			gles2_renderer->transform_matrix, x, y, 1.0f);
+		box.x = (int)(p->x * width) - sample->cat_texture->width / 2;
+		box.y = (int)(p->y * height) - sample->cat_texture->height / 2;
+
+		// TODO use wlr_render_texture_at once the api has changed
+		wlr_render_texture(sample->renderer, sample->cat_texture,
+			WL_OUTPUT_TRANSFORM_NORMAL, &box, 1.f);
 	}
 
 	wlr_renderer_end(sample->renderer);

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -93,7 +93,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 
 		// TODO use wlr_render_texture_at once the api has changed
 		wlr_render_texture(sample->renderer, sample->cat_texture,
-			WL_OUTPUT_TRANSFORM_NORMAL, &box, 1.f);
+			WL_OUTPUT_TRANSFORM_NORMAL, &box, 1.f, 0.f);
 	}
 
 	wlr_renderer_end(sample->renderer);

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -37,6 +37,9 @@ struct wlr_gles2_renderer {
 	struct wlr_egl *egl;
 	int drm_fd;
 
+	bool has_transform;
+	float transform_matrix[9];
+
 	const char *exts_str;
 	struct {
 		bool read_format_bgra_ext;

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -26,6 +26,8 @@ struct wlr_renderer_impl {
 	void (*set_transform)(struct wlr_renderer *r,
 		enum wl_output_transform transform);
 	void (*scissor)(struct wlr_renderer *renderer, struct wlr_box *box);
+	bool (*render_texture)(struct wlr_renderer *r, struct wlr_texture *texture,
+		enum wl_output_transform transform, struct wlr_box *box, float alpha);
 	bool (*render_subtexture_with_matrix)(struct wlr_renderer *renderer,
 		struct wlr_texture *texture, const struct wlr_fbox *box,
 		const float matrix[static 9], float alpha);

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -14,7 +14,6 @@
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/render/wlr_texture.h>
 #include <wlr/types/wlr_box.h>
-#include <wlr/types/wlr_output.h>
 #include <wlr/render/dmabuf.h>
 
 struct wlr_renderer_impl {
@@ -24,7 +23,7 @@ struct wlr_renderer_impl {
 		uint32_t height);
 	void (*end)(struct wlr_renderer *renderer);
 	void (*clear)(struct wlr_renderer *renderer, const float color[static 4]);
-	void (*set_transform)(struct wlr_renderer *r, int width, int height,
+	void (*set_transform)(struct wlr_renderer *r,
 		enum wl_output_transform transform);
 	void (*scissor)(struct wlr_renderer *renderer, struct wlr_box *box);
 	bool (*render_subtexture_with_matrix)(struct wlr_renderer *renderer,

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -27,7 +27,8 @@ struct wlr_renderer_impl {
 		enum wl_output_transform transform);
 	void (*scissor)(struct wlr_renderer *renderer, struct wlr_box *box);
 	bool (*render_texture)(struct wlr_renderer *r, struct wlr_texture *texture,
-		enum wl_output_transform transform, struct wlr_box *box, float alpha);
+		enum wl_output_transform transform, struct wlr_box *box, float alpha,
+		float rotation);
 	bool (*render_subtexture_with_matrix)(struct wlr_renderer *renderer,
 		struct wlr_texture *texture, const struct wlr_fbox *box,
 		const float matrix[static 9], float alpha);

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -24,6 +24,8 @@ struct wlr_renderer_impl {
 		uint32_t height);
 	void (*end)(struct wlr_renderer *renderer);
 	void (*clear)(struct wlr_renderer *renderer, const float color[static 4]);
+	void (*set_transform)(struct wlr_renderer *r, int width, int height,
+		enum wl_output_transform transform);
 	void (*scissor)(struct wlr_renderer *renderer, struct wlr_box *box);
 	bool (*render_subtexture_with_matrix)(struct wlr_renderer *renderer,
 		struct wlr_texture *texture, const struct wlr_fbox *box,

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -39,9 +39,10 @@ void wlr_renderer_begin(struct wlr_renderer *r, uint32_t width, uint32_t height)
 void wlr_renderer_end(struct wlr_renderer *r);
 void wlr_renderer_clear(struct wlr_renderer *r, const float color[static 4]);
 /**
- * TODO
+ * Gives the output transform to the renderer.
+ * If the rendering is done in software, this call should be ignored
  */
-void wlr_renderer_set_transform(struct wlr_renderer *r, int width, int height,
+void wlr_renderer_set_transform(struct wlr_renderer *r,
 	enum wl_output_transform transform);
 /**
  * Defines a scissor box. Only pixels that lie within the scissor box can be

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -56,6 +56,11 @@ void wlr_renderer_scissor(struct wlr_renderer *r, struct wlr_box *box);
 bool wlr_render_texture_at(struct wlr_renderer *r, struct wlr_texture *texture,
 	const float projection[static 9], int x, int y, float alpha);
 /**
+ * Renders the requested texture with the provided box.
+ */
+bool wlr_render_texture(struct wlr_renderer *r, struct wlr_texture *texture,
+	enum wl_output_transform transform, struct wlr_box *box, float alpha);
+/**
  * Renders the requested texture using the provided matrix.
  */
 bool wlr_render_texture_with_matrix(struct wlr_renderer *r,

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -39,6 +39,11 @@ void wlr_renderer_begin(struct wlr_renderer *r, uint32_t width, uint32_t height)
 void wlr_renderer_end(struct wlr_renderer *r);
 void wlr_renderer_clear(struct wlr_renderer *r, const float color[static 4]);
 /**
+ * TODO
+ */
+void wlr_renderer_set_transform(struct wlr_renderer *r, int width, int height,
+	enum wl_output_transform transform);
+/**
  * Defines a scissor box. Only pixels that lie within the scissor box can be
  * modified by drawing functions. Providing a NULL `box` disables the scissor
  * box.

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -59,7 +59,8 @@ bool wlr_render_texture_at(struct wlr_renderer *r, struct wlr_texture *texture,
  * Renders the requested texture with the provided box.
  */
 bool wlr_render_texture(struct wlr_renderer *r, struct wlr_texture *texture,
-	enum wl_output_transform transform, struct wlr_box *box, float alpha);
+	enum wl_output_transform transform, struct wlr_box *box, float alpha,
+	float rotation);
 /**
  * Renders the requested texture using the provided matrix.
  */

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -53,7 +53,7 @@ void wlr_renderer_scissor(struct wlr_renderer *r, struct wlr_box *box);
 /**
  * Renders the requested texture.
  */
-bool wlr_render_texture(struct wlr_renderer *r, struct wlr_texture *texture,
+bool wlr_render_texture_at(struct wlr_renderer *r, struct wlr_texture *texture,
 	const float projection[static 9], int x, int y, float alpha);
 /**
  * Renders the requested texture using the provided matrix.

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -144,7 +144,6 @@ struct wlr_output {
 	bool needs_frame;
 	// damage for cursors and fullscreen surface, in output-local coordinates
 	bool frame_pending;
-	float transform_matrix[9];
 
 	struct wlr_output_state pending;
 

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -12,6 +12,7 @@
 #include <wlr/render/interface.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_matrix.h>
+#include <wlr/types/wlr_buffer.h>
 #include <wlr/types/wlr_linux_dmabuf_v1.h>
 #include <wlr/util/log.h>
 #include "render/gles2.h"

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -331,6 +331,31 @@ static bool gles2_render_subtexture_with_matrix(
 	return true;
 }
 
+static bool gles2_render_texture(struct wlr_renderer *wlr_renderer,
+		struct wlr_texture *wlr_texture, enum wl_output_transform transform,
+		struct wlr_box *box, float alpha) {
+	struct wlr_gles2_renderer *renderer =
+		gles2_get_renderer_in_context(wlr_renderer);
+
+	float matrix[9];
+	if (renderer->has_transform) {
+		wlr_matrix_project_box(matrix, box, transform, 0,
+			renderer->transform_matrix);
+	} else {
+		wlr_matrix_projection(matrix, box->width, box->height, transform);
+	}
+
+	struct wlr_fbox fbox = {
+		.x = 0,
+		.y = 0,
+		.width = box->width,
+		.height = box->height,
+	};
+
+	return gles2_render_subtexture_with_matrix(wlr_renderer, wlr_texture,
+			&fbox, matrix, alpha);
+}
+
 static void gles2_render_quad_with_matrix(struct wlr_renderer *wlr_renderer,
 		const float color[static 4], const float matrix[static 9]) {
 	struct wlr_gles2_renderer *renderer =
@@ -694,6 +719,7 @@ static const struct wlr_renderer_impl renderer_impl = {
 	.clear = gles2_clear,
 	.set_transform = gles2_set_transform,
 	.scissor = gles2_scissor,
+	.render_texture = gles2_render_texture,
 	.render_subtexture_with_matrix = gles2_render_subtexture_with_matrix,
 	.render_quad_with_matrix = gles2_render_quad_with_matrix,
 	.render_ellipse_with_matrix = gles2_render_ellipse_with_matrix,

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -333,13 +333,13 @@ static bool gles2_render_subtexture_with_matrix(
 
 static bool gles2_render_texture(struct wlr_renderer *wlr_renderer,
 		struct wlr_texture *wlr_texture, enum wl_output_transform transform,
-		struct wlr_box *box, float alpha) {
+		struct wlr_box *box, float alpha, float rotation) {
 	struct wlr_gles2_renderer *renderer =
 		gles2_get_renderer_in_context(wlr_renderer);
 
 	float matrix[9];
 	if (renderer->has_transform) {
-		wlr_matrix_project_box(matrix, box, transform, 0,
+		wlr_matrix_project_box(matrix, box, transform, rotation,
 			renderer->transform_matrix);
 	} else {
 		wlr_matrix_projection(matrix, box->width, box->height, transform);

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -86,7 +86,7 @@ void wlr_renderer_scissor(struct wlr_renderer *r, struct wlr_box *box) {
 	r->impl->scissor(r, box);
 }
 
-bool wlr_render_texture(struct wlr_renderer *r, struct wlr_texture *texture,
+bool wlr_render_texture_at(struct wlr_renderer *r, struct wlr_texture *texture,
 		const float projection[static 9], int x, int y, float alpha) {
 	struct wlr_box box = {
 		.x = x,

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -73,6 +73,14 @@ void wlr_renderer_clear(struct wlr_renderer *r, const float color[static 4]) {
 	r->impl->clear(r, color);
 }
 
+void wlr_renderer_set_transform(struct wlr_renderer *r, int width, int height,
+		enum wl_output_transform transform) {
+	assert(r->rendering);
+	if (r->impl->set_transform) {
+		r->impl->set_transform(r, width, height, transform);
+	}
+}
+
 void wlr_renderer_scissor(struct wlr_renderer *r, struct wlr_box *box) {
 	assert(r->rendering);
 	r->impl->scissor(r, box);

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -104,9 +104,10 @@ bool wlr_render_texture_at(struct wlr_renderer *r, struct wlr_texture *texture,
 }
 
 bool wlr_render_texture(struct wlr_renderer *r, struct wlr_texture *texture,
-		enum wl_output_transform transform, struct wlr_box *box, float alpha) {
+		enum wl_output_transform transform, struct wlr_box *box, float alpha,
+		float rotation) {
 	assert(r->rendering);
-	return r->impl->render_texture(r, texture, transform, box, alpha);
+	return r->impl->render_texture(r, texture, transform, box, alpha, rotation);
 }
 
 bool wlr_render_texture_with_matrix(struct wlr_renderer *r,

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -73,11 +73,11 @@ void wlr_renderer_clear(struct wlr_renderer *r, const float color[static 4]) {
 	r->impl->clear(r, color);
 }
 
-void wlr_renderer_set_transform(struct wlr_renderer *r, int width, int height,
+void wlr_renderer_set_transform(struct wlr_renderer *r,
 		enum wl_output_transform transform) {
 	assert(r->rendering);
 	if (r->impl->set_transform) {
-		r->impl->set_transform(r, width, height, transform);
+		r->impl->set_transform(r, transform);
 	}
 }
 

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -18,6 +18,7 @@ void wlr_renderer_init(struct wlr_renderer *renderer,
 	assert(impl->begin);
 	assert(impl->clear);
 	assert(impl->scissor);
+	assert(impl->render_texture);
 	assert(impl->render_subtexture_with_matrix);
 	assert(impl->render_quad_with_matrix);
 	assert(impl->render_ellipse_with_matrix);
@@ -100,6 +101,12 @@ bool wlr_render_texture_at(struct wlr_renderer *r, struct wlr_texture *texture,
 		projection);
 
 	return wlr_render_texture_with_matrix(r, texture, matrix, alpha);
+}
+
+bool wlr_render_texture(struct wlr_renderer *r, struct wlr_texture *texture,
+		enum wl_output_transform transform, struct wlr_box *box, float alpha) {
+	assert(r->rendering);
+	return r->impl->render_texture(r, texture, transform, box, alpha);
 }
 
 bool wlr_render_texture_with_matrix(struct wlr_renderer *r,


### PR DESCRIPTION
This patch is the first part of an ongoing progress to remove the GL-assumptions from the public interface of `wlr_renderer`. 

Here any mention of "transform matrix" is removed from the public API, and all of the matrix calculations for rendering a texture is done inside the gles2 renderer. This is done because the future pixman renderer can't use matrices to calculate position and requires an explicit x/y position. 

@emersion I was thinking about leaving the `wlr_render_*_with_matrix` functions for the next release to ease the transition and label them with a deprecation warning, and then remove them later on.