### PR TITLE
Fix #2018, false positive -Wstringop-truncation warning

### DIFF
--- a/xcursor/xcursor.c
+++ b/xcursor/xcursor.c
@@ -655,8 +655,11 @@ _XcursorAddPathElt (char *path, const char *elt, int len)
 	elt++;
 	len--;
     }
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
     strncpy (path + pathlen, elt, len);
     path[pathlen + len] = '\0';
+#pragma GCC diagnostic pop
 }
 
 static char *

--- a/xcursor/xcursor.c
+++ b/xcursor/xcursor.c
@@ -655,11 +655,7 @@ _XcursorAddPathElt (char *path, const char *elt, int len)
 	elt++;
 	len--;
     }
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstringop-truncation"
-    strncpy (path + pathlen, elt, len);
-    path[pathlen + len] = '\0';
-#pragma GCC diagnostic pop
+    strncat (path + pathlen, elt, len);
 }
 
 static char *


### PR DESCRIPTION
Fix false positive stringop-truncation warning/error with GCC 10 on s390x by indicating GCC to explicitly ignore this case, as it is clearly a false positive (NUL is set in the following line).

This allow the compilation to succeed with -Werror on.

Fixes: https://github.com/swaywm/wlroots/issues/2018