### PR TITLE
Add EGLStreams support for DRM backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ build/
 build-*/
 wayland-*-protocol.*
 wlr-example.ini
+.cache/
+.vscode/
+compile_commands.json
+

--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -139,8 +139,12 @@ static void set_plane_props(struct atomic *atom, struct wlr_drm_backend *drm,
 		goto error;
 	}
 
-	uint32_t width = gbm_bo_get_width(fb->bo);
-	uint32_t height = gbm_bo_get_height(fb->bo);
+	bool is_eglstreams = drm->is_eglstreams;
+
+	uint32_t width = is_eglstreams ?
+		(uint32_t)fb->wlr_buf->width : gbm_bo_get_width(fb->bo);
+	uint32_t height = is_eglstreams ?
+		(uint32_t)fb->wlr_buf->height : gbm_bo_get_height(fb->bo);
 
 	// The src_* properties are in 16.16 fixed point
 	atomic_add(atom, id, props->src_x, 0);

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -172,6 +172,7 @@ struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
 	if (parent != NULL) {
 		drm->parent = get_drm_backend_from_backend(parent);
 	}
+	drm->is_eglstreams = drm_is_eglstreams(dev->fd);
 
 	drm->dev_change.notify = handle_dev_change;
 	wl_signal_add(&dev->events.change, &drm->dev_change);

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -192,7 +192,9 @@ static bool init_planes(struct wlr_drm_backend *drm) {
 
 		// We don't really care about overlay planes, as we don't support them
 		// yet.
-		if (type == DRM_PLANE_TYPE_OVERLAY) {
+		if (type == DRM_PLANE_TYPE_OVERLAY ||
+			// HW cursors are not supported for EGLStreams
+			(drm->is_eglstreams && type == DRM_PLANE_TYPE_CURSOR)) {
 			drmModeFreePlane(plane);
 			continue;
 		}
@@ -330,7 +332,16 @@ static void drm_plane_set_committed(struct wlr_drm_plane *plane) {
 static bool drm_crtc_commit(struct wlr_drm_connector *conn, uint32_t flags) {
 	struct wlr_drm_backend *drm = conn->backend;
 	struct wlr_drm_crtc *crtc = conn->crtc;
-	bool ok = drm->iface->crtc_commit(drm, conn, flags);
+
+	// Here, for EGLStreams, only modesetting is handled.
+	// Commit&Flip is done with EGL.
+	if (drm->is_eglstreams && (flags & DRM_MODE_PAGE_FLIP_EVENT)) {
+		wlr_egl_flip_eglstreams_page(&conn->output);
+	}
+	bool ok = drm->is_eglstreams && !crtc->pending_modeset;
+	if (!ok) {
+		ok = drm->iface->crtc_commit(drm, conn, flags);
+	}
 	if (ok && !(flags & DRM_MODE_ATOMIC_TEST_ONLY)) {
 		memcpy(&crtc->current, &crtc->pending, sizeof(struct wlr_drm_crtc_state));
 		drm_plane_set_committed(crtc->primary);
@@ -405,6 +416,10 @@ static bool test_buffer(struct wlr_drm_connector *conn,
 	struct wlr_drm_crtc *crtc = conn->crtc;
 	if (!crtc) {
 		return false;
+	}
+
+	if (drm->is_eglstreams) {
+		return true;
 	}
 
 	struct wlr_dmabuf_attributes attribs;
@@ -484,6 +499,7 @@ static bool drm_connector_commit_buffer(struct wlr_output *output) {
 	struct wlr_drm_plane *plane = crtc->primary;
 
 	assert(output->pending.committed & WLR_OUTPUT_STATE_BUFFER);
+
 	switch (output->pending.buffer_type) {
 	case WLR_OUTPUT_STATE_BUFFER_RENDER:
 		if (!drm_plane_lock_surface(plane, drm)) {
@@ -1333,6 +1349,14 @@ void scan_drm_connectors(struct wlr_drm_backend *drm) {
 
 			wlr_output_init(&wlr_conn->output, &drm->backend, &output_impl,
 				drm->display);
+			if (drm->is_eglstreams) {
+				wlr_log(WLR_INFO, "Forcing software cursors for EGLStreams mode");
+				wlr_conn->output.software_cursor_locks = 1;
+				// EGL vs DRM is 180 flipped
+				// FIXME: Is there a better way to do this?
+				wlr_conn->output.transform =
+					wlr_egl_normalize_output_transform(wlr_conn->output.transform);
+			}
 
 			memcpy(wlr_conn->output.name, wlr_conn->name,
 				sizeof(wlr_conn->output.name));
@@ -1459,7 +1483,6 @@ static int mhz_to_nsec(int mhz) {
 static void page_flip_handler(int fd, unsigned seq,
 		unsigned tv_sec, unsigned tv_usec, unsigned crtc_id, void *data) {
 	struct wlr_drm_backend *drm = data;
-
 	bool found = false;
 	struct wlr_drm_connector *conn;
 	wl_list_for_each(conn, &drm->outputs, link) {
@@ -1509,7 +1532,7 @@ static void page_flip_handler(int fd, unsigned seq,
 		/* The DRM backend guarantees that the presentation event will be for
 		 * the last submitted frame. */
 		.commit_seq = conn->output.commit_seq,
-		.when = &present_time,
+		.when =  tv_sec == 0 && tv_usec == 0 ? NULL: &present_time,
 		.seq = seq,
 		.refresh = mhz_to_nsec(conn->output.refresh),
 		.flags = present_flags,
@@ -1589,4 +1612,11 @@ void destroy_drm_connector(struct wlr_drm_connector *conn) {
 	drmModeFreeCrtc(conn->old_crtc);
 	wl_list_remove(&conn->link);
 	free(conn);
+}
+
+bool drm_is_eglstreams(int drm_fd) {
+	drmVersion *version = drmGetVersion(drm_fd);
+	int is_eglstreams = strcmp(version->name, "nvidia-drm") == 0;
+	drmFreeVersion(version);
+	return is_eglstreams;
 }

--- a/backend/headless/output.c
+++ b/backend/headless/output.c
@@ -26,7 +26,7 @@ static bool output_set_custom_mode(struct wlr_output *wlr_output, int32_t width,
 
 	wlr_swapchain_destroy(output->swapchain);
 	output->swapchain = wlr_swapchain_create(output->backend->allocator,
-			width, height, output->backend->format);
+			width, height, output->backend->format, NULL);
 	if (!output->swapchain) {
 		wlr_output_destroy(wlr_output);
 		return false;
@@ -191,7 +191,7 @@ struct wlr_output *wlr_headless_add_output(struct wlr_backend *wlr_backend,
 	struct wlr_output *wlr_output = &output->wlr_output;
 
 	output->swapchain = wlr_swapchain_create(backend->allocator,
-		width, height, backend->format);
+		width, height, backend->format, NULL);
 	if (!output->swapchain) {
 		goto error;
 	}

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -100,7 +100,8 @@ static bool output_set_custom_mode(struct wlr_output *wlr_output,
 
 	if (wlr_output->width != width || wlr_output->height != height) {
 		struct wlr_swapchain *swapchain = wlr_swapchain_create(
-			output->backend->allocator, width, height, output->backend->format);
+			output->backend->allocator, width, height, output->backend->format,
+			NULL);
 		if (swapchain == NULL) {
 			return false;
 		}
@@ -306,7 +307,6 @@ static bool output_commit(struct wlr_output *wlr_output) {
 		case WLR_OUTPUT_STATE_BUFFER_RENDER:
 			assert(output->back_buffer != NULL);
 			wlr_buffer = output->back_buffer;
-
 			wlr_renderer_bind_buffer(output->backend->renderer, NULL);
 			break;
 		case WLR_OUTPUT_STATE_BUFFER_SCANOUT:;
@@ -410,7 +410,7 @@ static bool output_set_cursor(struct wlr_output *wlr_output,
 			wlr_swapchain_destroy(output->cursor.swapchain);
 			output->cursor.swapchain = wlr_swapchain_create(
 				output->backend->allocator, width, height,
-				output->backend->format);
+				output->backend->format, NULL);
 			if (output->cursor.swapchain == NULL) {
 				return false;
 			}
@@ -644,7 +644,8 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *wlr_backend) {
 	wl_surface_commit(output->surface);
 
 	output->swapchain = wlr_swapchain_create(output->backend->allocator,
-		wlr_output->width, wlr_output->height, output->backend->format);
+		wlr_output->width, wlr_output->height, output->backend->format,
+		NULL);
 	if (output->swapchain == NULL) {
 		goto error;
 	}

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -389,7 +389,7 @@ static bool output_cursor_to_picture(struct wlr_x11_output *output,
 		wlr_swapchain_destroy(output->cursor.swapchain);
 		output->cursor.swapchain = wlr_swapchain_create(
 			x11->allocator, width, height,
-			x11->drm_format);
+			x11->drm_format, NULL);
 		if (output->cursor.swapchain == NULL) {
 			return false;
 		}
@@ -540,7 +540,7 @@ struct wlr_output *wlr_x11_output_create(struct wlr_backend *backend) {
 	wlr_output_update_custom_mode(wlr_output, 1024, 768, 0);
 
 	output->swapchain = wlr_swapchain_create(x11->allocator,
-		wlr_output->width, wlr_output->height, x11->drm_format);
+		wlr_output->width, wlr_output->height, x11->drm_format, NULL);
 	if (!output->swapchain) {
 		wlr_log(WLR_ERROR, "Failed to create swapchain");
 		free(output);
@@ -643,7 +643,7 @@ void handle_x11_configure_notify(struct wlr_x11_output *output,
 			output->swapchain->height != ev->height) {
 		struct wlr_swapchain *swapchain = wlr_swapchain_create(
 			output->x11->allocator, ev->width, ev->height,
-			output->x11->drm_format);
+			output->x11->drm_format, NULL);
 		if (!swapchain) {
 			return;
 		}

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -93,6 +93,7 @@ struct wlr_drm_backend {
 
 	struct wlr_drm_renderer renderer;
 	struct wlr_session *session;
+	bool is_eglstreams;
 };
 
 enum wlr_drm_connector_state {
@@ -157,6 +158,8 @@ size_t drm_crtc_get_gamma_lut_size(struct wlr_drm_backend *drm,
 	struct wlr_drm_crtc *crtc);
 
 struct wlr_drm_fb *plane_get_next_fb(struct wlr_drm_plane *plane);
+
+bool drm_is_eglstreams(int drm_fd);
 
 #define wlr_drm_conn_log(conn, verb, fmt, ...) \
 	wlr_log(verb, "connector %s: " fmt, conn->name, ##__VA_ARGS__)

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -36,6 +36,9 @@ struct wlr_drm_fb {
 	struct gbm_bo *bo;
 	uint32_t id;
 
+	struct wlr_drm_backend *backend;
+	uint32_t handle;
+
 	struct wl_listener wlr_buf_destroy;
 };
 

--- a/include/render/allocator.h
+++ b/include/render/allocator.h
@@ -10,7 +10,8 @@ struct wlr_allocator;
 
 struct wlr_allocator_interface {
 	struct wlr_buffer *(*create_buffer)(struct wlr_allocator *alloc,
-		int width, int height, const struct wlr_drm_format *format);
+		int width, int height, const struct wlr_drm_format *format,
+		void *data);
 	void (*destroy)(struct wlr_allocator *alloc);
 };
 
@@ -33,7 +34,7 @@ void wlr_allocator_destroy(struct wlr_allocator *alloc);
  * wlr_buffer_drop.
  */
 struct wlr_buffer *wlr_allocator_create_buffer(struct wlr_allocator *alloc,
-	int width, int height, const struct wlr_drm_format *format);
+	int width, int height, const struct wlr_drm_format *format, void *data);
 
 // For wlr_allocator implementors
 void wlr_allocator_init(struct wlr_allocator *alloc,

--- a/include/render/eglstreams_allocator.h
+++ b/include/render/eglstreams_allocator.h
@@ -1,0 +1,50 @@
+
+#ifndef RENDER_EGLSTREAM_ALLOCATOR_H
+#define RENDER_EGLSTREAM_ALLOCATOR_H
+
+#include <wlr/types/wlr_buffer.h>
+#include "render/allocator.h"
+#include "wlr/render/egl.h"
+#include "render/gbm_allocator.h"
+
+
+struct wlr_eglstreams_allocator;
+
+struct wlr_eglstream_plane {
+	struct wlr_eglstream stream;
+	uint32_t id;
+	struct wl_list link; // wlr_eglstreams_allocator.planes
+	uint32_t locks;
+	struct wlr_eglstreams_allocator *alloc;
+	int width;
+	int height;
+};
+
+struct wlr_eglstream_buffer {
+	struct wlr_buffer base;
+	struct wlr_eglstream_plane *plane;
+};
+
+struct wlr_eglstreams_allocator {
+	// Dumb gdb allocator just not to change the rest of api
+	struct wlr_gbm_allocator base_gbm;
+
+	struct wlr_drm_backend *drm;
+	struct wl_list planes;
+};
+
+/**
+ * Creates a new EGLStreams allocator from a DRM Renderer.
+ * TODO: All creators should return generic wlr_allocator.
+ */
+struct wlr_gbm_allocator *
+	wlr_eglstreams_allocator_create(struct wlr_drm_backend *drm);
+
+/**
+ * Returns configured plane for given id if any.
+ */
+struct wlr_eglstream_plane *wlr_eglstream_plane_for_id(
+		struct wlr_allocator *wlr_alloc, uint32_t plane_id);
+
+#endif
+

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -77,6 +77,7 @@ struct wlr_gles2_renderer {
 
 	struct wlr_gles2_buffer *current_buffer;
 	uint32_t viewport_width, viewport_height;
+	struct wl_list client_streams; //wlr_egl_client_stream.link
 };
 
 struct wlr_gles2_buffer {
@@ -101,13 +102,24 @@ struct wlr_gles2_texture {
 	GLenum target;
 	GLuint tex;
 
+	// Either of two is non-null
 	EGLImageKHR image;
+	EGLStreamKHR stream;
 
 	bool inverted_y;
 	bool has_alpha;
 
 	// Only affects target == GL_TEXTURE_2D
 	uint32_t drm_format; // used to interpret upload data
+};
+
+struct  wlr_egl_client_stream {
+	struct wlr_gles2_renderer *renderer;
+	GLuint tex;
+	EGLStreamKHR stream;
+	struct wl_resource* resource;
+	struct wl_list link; // wlr_gles2_renderer client_streams
+	struct wl_listener destroy_listener;
 };
 
 const struct wlr_gles2_pixel_format *get_gles2_format_from_drm(uint32_t fmt);
@@ -127,6 +139,8 @@ struct wlr_texture *gles2_texture_from_wl_drm(struct wlr_renderer *wlr_renderer,
 	struct wl_resource *data);
 struct wlr_texture *gles2_texture_from_dmabuf(struct wlr_renderer *wlr_renderer,
 	struct wlr_dmabuf_attributes *attribs);
+struct wlr_texture *gles2_texture_from_wl_eglstream(struct wlr_renderer *wlr_renderer,
+	struct wl_resource *data);
 
 void push_gles2_debug_(struct wlr_gles2_renderer *renderer,
 	const char *file, const char *func);

--- a/include/render/swapchain.h
+++ b/include/render/swapchain.h
@@ -20,6 +20,7 @@ struct wlr_swapchain {
 
 	int width, height;
 	struct wlr_drm_format *format;
+	void *backend_data;
 
 	struct wlr_swapchain_slot slots[WLR_SWAPCHAIN_CAP];
 
@@ -28,7 +29,7 @@ struct wlr_swapchain {
 
 struct wlr_swapchain *wlr_swapchain_create(
 	struct wlr_allocator *alloc, int width, int height,
-	const struct wlr_drm_format *format);
+	const struct wlr_drm_format *format, void *backend_data);
 void wlr_swapchain_destroy(struct wlr_swapchain *swapchain);
 /**
  * Acquire a buffer from the swap chain.

--- a/include/wlr/render/gles2.h
+++ b/include/wlr/render/gles2.h
@@ -17,7 +17,6 @@ struct wlr_egl;
 
 struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_egl *egl);
 
-struct wlr_egl *wlr_gles2_renderer_get_egl(struct wlr_renderer *renderer);
 bool wlr_gles2_renderer_check_ext(struct wlr_renderer *renderer,
 	const char *ext);
 
@@ -32,5 +31,7 @@ struct wlr_gles2_texture_attribs {
 bool wlr_texture_is_gles2(struct wlr_texture *texture);
 void wlr_gles2_texture_get_attribs(struct wlr_texture *texture,
 	struct wlr_gles2_texture_attribs *attribs);
+
+struct wlr_egl *gles2_renderer_get_egl(struct wlr_renderer *renderer);
 
 #endif

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -61,6 +61,9 @@ struct wlr_renderer_impl {
 		struct wlr_dmabuf_attributes *dst,
 		struct wlr_dmabuf_attributes *src);
 	int (*get_drm_fd)(struct wlr_renderer *renderer);
+	struct wlr_texture *(*texture_from_wl_eglstream)(struct wlr_renderer *renderer,
+		struct wl_resource *data);
+	struct wlr_egl *(*get_egl)(struct wlr_renderer *renderer);
 };
 
 void wlr_renderer_init(struct wlr_renderer *renderer,

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -139,4 +139,14 @@ int wlr_renderer_get_drm_fd(struct wlr_renderer *r);
  */
 void wlr_renderer_destroy(struct wlr_renderer *renderer);
 
+/**
+ * Gets underlying wlr_elg if defined.
+ */
+struct wlr_egl *wlr_renderer_get_egl(struct wlr_renderer *renderer);
+
+/**
+ * Gets the parameters of wayland buffer.
+ */
+bool wlr_renderer_wl_buffer_get_params(struct wlr_renderer *renderer,
+	struct wl_resource *buffer, int *width, int *height, int *inverted_y);
 #endif

--- a/include/wlr/render/wlr_texture.h
+++ b/include/wlr/render/wlr_texture.h
@@ -52,6 +52,16 @@ struct wlr_texture *wlr_texture_from_dmabuf(struct wlr_renderer *renderer,
 	struct wlr_dmabuf_attributes *attribs);
 
 /**
+ * Create a new texture from a EGLSTREAM_WL resource. The returned texture is
+ * immutable.
+ *
+ * Should not be called in a rendering block like renderer_begin()/end() or
+ * between attaching a renderer to an output and committing it.
+ */
+struct wlr_texture *wlr_texture_from_wl_eglstream(struct wlr_renderer *renderer,
+	struct wl_resource *data);
+
+/**
  * Get the texture width and height.
  *
  * This function is deprecated. Access wlr_texture's width and height fields

--- a/include/wlr/types/wlr_buffer.h
+++ b/include/wlr/types/wlr_buffer.h
@@ -12,6 +12,7 @@
 #include <pixman.h>
 #include <wayland-server-core.h>
 #include <wlr/render/dmabuf.h>
+#include <wlr/render/egl.h>
 
 struct wlr_buffer;
 
@@ -41,6 +42,9 @@ struct wlr_buffer {
 		struct wl_signal destroy;
 		struct wl_signal release;
 	} events;
+
+	// Non-null for EGLStreams
+	struct wlr_eglstream *egl_stream;
 };
 
 /**

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -140,6 +140,9 @@ struct wlr_surface {
 	struct wl_listener renderer_destroy;
 
 	void *data;
+
+	// To handle transform y flipping
+	bool is_eglstream;
 };
 
 struct wlr_subsurface_state {

--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,8 @@ soversion = 7
 
 add_project_arguments([
 	'-DWLR_USE_UNSTABLE',
+	# Allow clients to die on their own, be not so strict
+	'-DWLR_RELAXED_CLIENT_HANDLING'
 ], language: 'c')
 
 cc = meson.get_compiler('c')
@@ -104,6 +106,7 @@ udev = dependency('libudev')
 pixman = dependency('pixman-1')
 math = cc.find_library('m')
 rt = cc.find_library('rt')
+dlfcn = cc.find_library('dl') # for libnvidia-egl-wayland.so.1 dynamic loading
 
 if not get_option('xdg-foreign').disabled()
 	uuid = dependency('uuid', required: false)
@@ -131,6 +134,7 @@ wlr_deps = [
 	pixman,
 	math,
 	rt,
+	dlfcn
 ]
 
 subdir('protocol')

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -47,6 +47,8 @@ protocols = {
 	'wlr-output-power-management-unstable-v1': 'wlr-output-power-management-unstable-v1.xml',
 	'wlr-screencopy-unstable-v1': 'wlr-screencopy-unstable-v1.xml',
 	'wlr-virtual-pointer-unstable-v1': 'wlr-virtual-pointer-unstable-v1.xml',
+	# Nvidia eglstrem controller (for client egl functionality)
+	'wl_eglstream_controller': 'wayland-eglstream-controller.xml',
 }
 
 protocols_code = {}

--- a/protocol/wayland-eglstream-controller.xml
+++ b/protocol/wayland-eglstream-controller.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wl_eglstream_controller">
+  <copyright>
+    SPDX-FileCopyrightText: 2017-2018, NVIDIA CORPORATION. All rights reserved.
+
+    SPDX-License-Identifier: MIT
+  </copyright>
+  <interface name="wl_eglstream_controller" version="2">
+    <!-- Present mode types. This enum defines what the present mode given
+         to a attach_eglstream_consumer_attribs request represents -->
+    <enum name="present_mode">
+      <description summary="Stream present mode">
+          - dont_care: Using this enum will tell the server to make its own
+                       decisions regarding present mode.
+
+          - fifo:      Tells the server to use a fifo present mode. The decision to
+                       use fifo synchronous is left up to the server.
+
+          - mailbox:   Tells the server to use a mailbox present mode.
+      </description>
+      <entry name="dont_care" value="0" summary="Let the Server decide present mode"/>
+      <entry name="fifo" value="1" summary="Use a fifo present mode"/>
+      <entry name="mailbox" value="2" summary="Use a mailbox mode"/>
+    </enum>
+
+    <enum name="attrib">
+      <description summary="Stream consumer attachment attributes">
+          - present_mode: Must be one of wl_eglstream_controller_present_mode. Tells the
+                          server the desired present mode that should be used.
+
+          - fifo_length:  Only valid when the present_mode attrib is provided and its
+                          value is specified as fifo. Tells the server the desired fifo
+                          length to be used when the desired present_mode is fifo.
+      </description>
+      <entry name="present_mode" value="0" summary="Tells the server the desired present mode"/>
+      <entry name="fifo_length" value="1" summary="Tells the server the desired fifo length when the desired presenation_mode is fifo."/>
+    </enum>
+
+    <request name="attach_eglstream_consumer" since="1">
+      <description summary="Create server stream and attach consumer">
+        Creates the corresponding server side EGLStream from the given wl_buffer
+        and attaches a consumer to it.
+      </description>
+      <arg name="wl_surface" type="object" interface="wl_surface"
+        summary="wl_surface corresponds to the client surface associated with
+        newly created eglstream"/>
+      <arg name="wl_resource" type="object" interface="wl_buffer"
+        summary="wl_resource corresponding to an EGLStream"/>
+    </request>
+
+    <request name="attach_eglstream_consumer_attribs" since="2">
+      <description summary="Create server stream and attach consumer using attributes">
+        Creates the corresponding server side EGLStream from the given wl_buffer
+        and attaches a consumer to it using the given attributes.
+      </description>
+      <arg name="wl_surface" type="object" interface="wl_surface"
+        summary="wl_surface corresponds to the client surface associated with
+        newly created eglstream"/>
+      <arg name="wl_resource" type="object" interface="wl_buffer"
+        summary="wl_resource corresponding to an EGLStream"/>
+      <arg name="attribs" type="array"
+        summary="Stream consumer attachment attribs">
+        <description summary="List of attributes with consumer attachment data">
+          It contains key-value pairs compatible with intptr_t type. A key must
+          be one of wl_eglstream_controller_attrib enumeration values. What a value
+          represents is attribute-specific.
+        </description>
+      </arg>
+    </request>
+  </interface>
+</protocol>

--- a/render/allocator.c
+++ b/render/allocator.c
@@ -18,6 +18,6 @@ void wlr_allocator_destroy(struct wlr_allocator *alloc) {
 }
 
 struct wlr_buffer *wlr_allocator_create_buffer(struct wlr_allocator *alloc,
-		int width, int height, const struct wlr_drm_format *format) {
-	return alloc->impl->create_buffer(alloc, width, height, format);
+		int width, int height, const struct wlr_drm_format *format, void *data) {
+	return alloc->impl->create_buffer(alloc, width, height, format, data);
 }

--- a/render/eglstreams_allocator.c
+++ b/render/eglstreams_allocator.c
@@ -1,0 +1,197 @@
+
+#define _POSIX_C_SOURCE 200809L
+#include <assert.h>
+#include <drm_fourcc.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <wlr/util/log.h>
+#include <xf86drm.h>
+#include <backend/drm/drm.h>
+#include "render/eglstreams_allocator.h"
+#include "render/wlr_renderer.h"
+
+static const struct wlr_buffer_impl buffer_impl;
+
+static struct wlr_eglstream_buffer *get_eglstresms_buffer_from_buffer(
+		struct wlr_buffer *buffer) {
+	assert(buffer->impl == &buffer_impl);
+	return (struct wlr_eglstream_buffer *)buffer;
+}
+
+static struct wlr_eglstream_buffer *create_buffer(struct wlr_eglstreams_allocator *alloc,
+		struct wlr_eglstream_plane *plane) {
+
+	struct wlr_eglstream_buffer *buffer = calloc(1, sizeof(*buffer));
+	if (buffer == NULL) {
+		return NULL;
+	}
+	wlr_buffer_init(&buffer->base, &buffer_impl, plane->width, plane->height);
+
+	buffer->base.egl_stream = &plane->stream;
+	buffer->plane = plane;
+	plane->locks++;
+
+	wlr_log(WLR_DEBUG, "Allocated %dx%d EGLStreams buffer",
+		buffer->base.width, buffer->base.height);
+
+	return buffer;
+}
+
+static void plane_unlock(struct wlr_eglstream_plane *plane) {
+	if (!plane) {
+		return;
+	}
+	if (plane->locks > 0 && --plane->locks > 0) {
+		return;
+	}	
+	wlr_log(WLR_INFO, "Destroying plane %u, %dx%d", plane->id,
+		plane->width, plane->height);
+	wlr_egl_destroy_eglstreams_surface(&plane->stream);
+	wl_list_remove(&plane->link);
+	free(plane);
+}
+
+static void buffer_destroy(struct wlr_buffer *wlr_buffer) {
+	struct wlr_eglstream_buffer *buffer =
+		get_eglstresms_buffer_from_buffer(wlr_buffer);
+	wlr_log(WLR_INFO, "Destroy buffer");
+	plane_unlock(buffer->plane);	
+	free(buffer);
+}
+
+static bool buffer_get_dmabuf(struct wlr_buffer *wlr_buffer,
+		struct wlr_dmabuf_attributes *attribs) {
+	// Disable dma-buf functiobality for EGLStreams.
+	// TODO: Enable when nvidia driver is ready.
+	wlr_log(WLR_ERROR, "Dma-Buf for EGLStreams is not supported");
+	return false;
+}
+
+static const struct wlr_buffer_impl buffer_impl = {
+	.destroy = buffer_destroy,
+	.get_dmabuf = buffer_get_dmabuf,
+};
+
+static const struct wlr_allocator_interface allocator_impl;
+
+static struct wlr_eglstreams_allocator *get_egstreams_alloc_from_alloc(
+		struct wlr_allocator *alloc) {
+	assert(alloc->impl == &allocator_impl);
+	return (struct wlr_eglstreams_allocator *)alloc;
+}
+
+struct wlr_gbm_allocator *
+	wlr_eglstreams_allocator_create(struct wlr_drm_backend *drm) {
+	struct wlr_eglstreams_allocator *alloc = calloc(1, sizeof(*alloc));
+	if (alloc == NULL) {
+		return NULL;
+	}
+	wlr_allocator_init(&alloc->base_gbm.base, &allocator_impl);
+
+	alloc->drm = drm;
+	wl_list_init(&alloc->planes);
+	wlr_log(WLR_DEBUG, "Created EGLStreams allocator"); 
+
+	return &alloc->base_gbm;
+}
+
+static void allocator_destroy(struct wlr_allocator *wlr_alloc) {
+	struct wlr_eglstreams_allocator *alloc =
+		get_egstreams_alloc_from_alloc(wlr_alloc);
+
+	free(alloc);
+}
+
+struct wlr_eglstream_plane *wlr_eglstream_plane_for_id(
+		struct wlr_allocator *wlr_alloc, uint32_t plane_id) {
+	struct wlr_eglstreams_allocator *alloc = get_egstreams_alloc_from_alloc(wlr_alloc);
+	struct wlr_eglstream_plane *plane;
+	bool found = false;
+	wl_list_for_each(plane, &alloc->planes, link) {
+		if (plane->id == plane_id) {
+			found = true;
+			break;
+		}
+	}
+	return found ? plane : NULL;
+}
+
+static struct wlr_eglstream_plane *find_or_create_plane(
+		struct wlr_eglstreams_allocator *alloc,
+		int width, int height, uint32_t plane_id) {
+
+	struct wlr_eglstream_plane *plane =
+		wlr_eglstream_plane_for_id(&alloc->base_gbm.base, plane_id);
+
+	struct wlr_renderer *renderer = alloc->drm->renderer.wlr_rend;
+
+	struct wlr_egl *egl = wlr_renderer_get_egl(renderer);
+	if (!egl) {
+		return NULL;
+	}
+
+	if (plane) {
+		if (width != plane->width || height != plane->height) {
+			wlr_log(WLR_ERROR, "Found EGLStream plane size differs. "
+				"%dx%d -> %dx%d (new)"
+				"New plane will be created",
+				plane->width, plane->height, width, height);
+			plane = NULL;
+		} else {
+			wlr_log(WLR_INFO, "Found allocated plane %u, %dx%d", plane_id,
+				plane->width, plane->height);
+		}
+	} else {
+		plane = NULL;
+	}
+
+	if (plane == NULL) {
+		plane = calloc(1, sizeof(*plane));
+		if (!plane) {
+			wlr_log(WLR_ERROR, "EGLStream plane allocation failed");
+			return NULL;
+		}
+		plane->id = plane_id;
+		plane->stream.drm = alloc->drm;
+		plane->stream.egl = egl;
+		plane->width = width;
+		plane->height = height;
+		if (!wlr_egl_create_eglstreams_surface(&plane->stream, 
+				plane_id, width, height)) {
+			wlr_log(WLR_ERROR, "EGLStream setup failed for plane %u", plane_id);
+			goto error;
+		}
+		wl_list_insert(&alloc->planes, &plane->link);
+	}
+
+	return plane;
+error:
+	free(plane);
+	return NULL;
+
+}
+
+static struct wlr_buffer *allocator_create_buffer(
+		struct wlr_allocator *wlr_alloc, int width, int height,
+		const struct wlr_drm_format *format, void *data) {
+	struct wlr_eglstreams_allocator *alloc =
+		get_egstreams_alloc_from_alloc(wlr_alloc);
+	// Note: every EGLStream buffer is just a pointer
+	// to the only one real EGLStream for drm plane.
+	struct wlr_eglstream_plane *plane =
+		find_or_create_plane(alloc, width, height, (uint32_t)(long)data);
+	if (!plane) {
+		return NULL;
+	}
+	struct wlr_eglstream_buffer *buffer = create_buffer(alloc, plane);
+	if (buffer == NULL) {
+		return NULL;
+	}
+	return &buffer->base;
+}
+
+static const struct wlr_allocator_interface allocator_impl = {
+	.destroy = allocator_destroy,
+	.create_buffer = allocator_create_buffer,
+};

--- a/render/gbm_allocator.c
+++ b/render/gbm_allocator.c
@@ -201,7 +201,8 @@ static void allocator_destroy(struct wlr_allocator *wlr_alloc) {
 
 static struct wlr_buffer *allocator_create_buffer(
 		struct wlr_allocator *wlr_alloc, int width, int height,
-		const struct wlr_drm_format *format) {
+		const struct wlr_drm_format *format, void *data) {
+	(void)data; // Unused here
 	struct wlr_gbm_allocator *alloc = get_gbm_alloc_from_alloc(wlr_alloc);
 	struct wlr_gbm_buffer *buffer = create_buffer(alloc, width, height, format);
 	if (buffer == NULL) {

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -133,9 +133,13 @@ static void gles2_texture_destroy(struct wlr_texture *wlr_texture) {
 	wlr_egl_make_current(texture->renderer->egl);
 
 	push_gles2_debug(texture->renderer);
+	if (!texture->stream) {
+		glDeleteTextures(1, &texture->tex);
+	}
 
-	glDeleteTextures(1, &texture->tex);
-	wlr_egl_destroy_image(texture->renderer->egl, texture->image);
+	if (texture->image) {
+		wlr_egl_destroy_image(texture->renderer->egl, texture->image);
+	}
 
 	pop_gles2_debug(texture->renderer);
 
@@ -238,6 +242,7 @@ struct wlr_texture *gles2_texture_from_wl_drm(struct wlr_renderer *wlr_renderer,
 	texture->drm_format = DRM_FORMAT_INVALID; // texture can't be written anyways
 	texture->image = image;
 	texture->inverted_y = inverted_y;
+	texture->stream = EGL_NO_STREAM_KHR;
 
 	switch (fmt) {
 	case EGL_TEXTURE_RGB:
@@ -323,6 +328,8 @@ struct wlr_texture *gles2_texture_from_dmabuf(struct wlr_renderer *wlr_renderer,
 
 	texture->target = external_only ? GL_TEXTURE_EXTERNAL_OES : GL_TEXTURE_2D;
 
+	texture->stream = EGL_NO_STREAM_KHR;
+
 	push_gles2_debug(renderer);
 
 	glGenTextures(1, &texture->tex);
@@ -337,6 +344,148 @@ struct wlr_texture *gles2_texture_from_dmabuf(struct wlr_renderer *wlr_renderer,
 	wlr_egl_restore_context(&prev_ctx);
 
 	return &texture->wlr_texture;
+}
+
+static void gles2_client_egl_stream_destroy(struct wl_listener *listener, void *data) {
+	struct wlr_egl_client_stream *client_stream =
+		wl_container_of(listener, client_stream, destroy_listener);
+	struct wlr_egl_context prev_ctx;
+	struct wlr_egl *egl = client_stream->renderer->egl;
+	wlr_egl_save_context(&prev_ctx);
+	wlr_egl_make_current(client_stream->renderer->egl);
+	egl->procs.eglDestroyStreamKHR(egl->display, client_stream->stream);
+	glDeleteTextures(1, &client_stream->tex);
+	wlr_egl_restore_context(&prev_ctx);
+	wl_list_remove(&client_stream->destroy_listener.link);
+	wl_list_remove(&client_stream->link);
+	free(client_stream);
+}
+
+struct wlr_texture *gles2_texture_from_wl_eglstream(struct wlr_renderer *wlr_renderer,
+		struct wl_resource *resource) {
+	struct wlr_egl_context prev_ctx;
+	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
+	struct wlr_egl *egl = renderer->egl;
+	wlr_egl_save_context(&prev_ctx);
+	wlr_egl_make_current(renderer->egl);
+	EGLAttrib stream_attribs[] = {
+		EGL_WAYLAND_EGLSTREAM_WL, (EGLAttrib)resource,
+		EGL_NONE
+	};
+
+	EGLStreamKHR stream = EGL_NO_STREAM_KHR;
+
+	struct wlr_egl_client_stream *attached_stream = NULL;
+	struct wlr_egl_client_stream *tmp;
+	wl_list_for_each(tmp, &renderer->client_streams, link) {
+		if (tmp->resource == resource) {
+			attached_stream = tmp;
+			break;
+		}
+	}
+
+	if (attached_stream) {
+		stream = attached_stream->stream;
+	} else {
+		stream = egl->procs.eglCreateStreamAttribNV(
+				egl->display, stream_attribs);
+	}
+
+	if (stream == EGL_NO_STREAM_KHR) {
+		goto error_ctx;
+	}
+
+	int width, height;
+	EGLint inverted_y;
+	if (!wlr_renderer_wl_buffer_get_params(wlr_renderer, resource, 
+				&width, &height, &inverted_y)) {
+		goto error_stream;
+	}
+
+	struct wlr_gles2_texture *texture =
+		calloc(1, sizeof(struct wlr_gles2_texture));
+	if (texture == NULL) {
+		wlr_log(WLR_ERROR, "Texture allocation failed");
+		goto error_stream;
+	}
+	wlr_texture_init(&texture->wlr_texture, &texture_impl, width, height);
+	texture->renderer = renderer;
+
+	texture->drm_format = DRM_FORMAT_INVALID;
+	texture->image = NULL;
+	texture->stream = stream;
+	texture->inverted_y = inverted_y;
+	texture->has_alpha = true;
+	texture->target = GL_TEXTURE_EXTERNAL_OES;
+
+	push_gles2_debug(renderer);
+
+	bool ok = false;
+	if (attached_stream) {
+		texture->tex = attached_stream->tex;
+		ok = true;
+	} else {
+		glGenTextures(1, &texture->tex);
+		glBindTexture(texture->target, texture->tex);
+		glTexParameteri(texture->target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTexParameteri(texture->target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	
+		if(egl->procs.eglStreamConsumerGLTextureExternalKHR(
+				egl->display, stream) == EGL_TRUE) {
+			attached_stream = calloc(1, sizeof(*attached_stream));
+			if (attached_stream) {
+				attached_stream->renderer = renderer;
+				attached_stream->stream = stream;
+				attached_stream->resource = resource;
+				attached_stream->tex = texture->tex;
+				attached_stream->destroy_listener.notify =
+					gles2_client_egl_stream_destroy;
+				wl_resource_add_destroy_listener(resource,
+						&attached_stream->destroy_listener);
+				wl_list_insert(&renderer->client_streams,
+						&attached_stream->link);
+				ok = true;
+			}
+		}
+		glBindTexture(texture->target, 0);
+
+		if (!ok) {
+			goto error_texture;
+		}
+	}
+
+	if (ok) {
+		EGLAttrib stream_state;
+		// Fetch new frame if available
+		if (egl->procs.eglQueryStreamAttribNV(egl->display,
+				stream, EGL_STREAM_STATE_KHR,
+				&stream_state) == EGL_TRUE &&
+			stream_state == EGL_STREAM_STATE_NEW_FRAME_AVAILABLE_KHR) {
+				egl->procs.eglStreamConsumerAcquireAttribNV(egl->display,
+					stream, NULL);
+		}
+	}
+
+
+	pop_gles2_debug(renderer);
+	wlr_egl_restore_context(&prev_ctx);
+
+	if (!ok) {
+		wlr_log(WLR_ERROR, "Could not bind EGLStream to GL texture");
+		goto error_texture;
+	}
+
+	return &texture->wlr_texture;
+
+error_texture:
+	glDeleteTextures(1, &texture->tex);
+	free(texture);
+error_stream:
+	egl->procs.eglDestroyStreamKHR(
+		egl->display, stream);
+error_ctx:
+	wlr_egl_restore_context(&prev_ctx);
+	return NULL;
 }
 
 void wlr_gles2_texture_get_attribs(struct wlr_texture *wlr_texture,

--- a/render/meson.build
+++ b/render/meson.build
@@ -8,6 +8,7 @@ wlr_files += files(
 	'swapchain.c',
 	'wlr_renderer.c',
 	'wlr_texture.c',
+	'eglstreams_allocator.c',
 )
 
 subdir('gles2')

--- a/render/swapchain.c
+++ b/render/swapchain.c
@@ -15,7 +15,7 @@ static void swapchain_handle_allocator_destroy(struct wl_listener *listener,
 
 struct wlr_swapchain *wlr_swapchain_create(
 		struct wlr_allocator *alloc, int width, int height,
-		const struct wlr_drm_format *format) {
+		const struct wlr_drm_format *format, void *backend_data) {
 	struct wlr_swapchain *swapchain = calloc(1, sizeof(*swapchain));
 	if (swapchain == NULL) {
 		return NULL;
@@ -23,6 +23,7 @@ struct wlr_swapchain *wlr_swapchain_create(
 	swapchain->allocator = alloc;
 	swapchain->width = width;
 	swapchain->height = height;
+	swapchain->backend_data = backend_data;
 
 	swapchain->format = wlr_drm_format_dup(format);
 	if (swapchain->format == NULL) {
@@ -104,7 +105,8 @@ struct wlr_buffer *wlr_swapchain_acquire(struct wlr_swapchain *swapchain,
 
 	wlr_log(WLR_DEBUG, "Allocating new swapchain buffer");
 	free_slot->buffer = wlr_allocator_create_buffer(swapchain->allocator,
-		swapchain->width, swapchain->height, swapchain->format);
+		swapchain->width, swapchain->height, swapchain->format,
+		swapchain->backend_data);
 	if (free_slot->buffer == NULL) {
 		wlr_log(WLR_ERROR, "Failed to allocate buffer");
 		return NULL;
@@ -126,6 +128,12 @@ static bool swapchain_has_buffer(struct wlr_swapchain *swapchain,
 void wlr_swapchain_set_buffer_submitted(struct wlr_swapchain *swapchain,
 		struct wlr_buffer *buffer) {
 	assert(buffer != NULL);
+
+	if (buffer->egl_stream) {
+		// Let EGL implementation manage buffer age.
+		// See wlr_egl_flip_eglstreams_page for details.
+		return;
+	}
 
 	if (!swapchain_has_buffer(swapchain, buffer)) {
 		return;

--- a/render/wlr_texture.c
+++ b/render/wlr_texture.c
@@ -42,6 +42,14 @@ struct wlr_texture *wlr_texture_from_dmabuf(struct wlr_renderer *renderer,
 	return renderer->impl->texture_from_dmabuf(renderer, attribs);
 }
 
+struct wlr_texture *wlr_texture_from_wl_eglstream(struct wlr_renderer *renderer,
+	struct wl_resource *data) {
+	if (!renderer->impl->texture_from_wl_eglstream) {
+		return NULL;
+	}
+	return renderer->impl->texture_from_wl_eglstream(renderer, data);
+}
+
 void wlr_texture_get_size(struct wlr_texture *texture, int *width,
 		int *height) {
 	*width = texture->width;

--- a/types/wlr_buffer.c
+++ b/types/wlr_buffer.c
@@ -13,6 +13,7 @@ void wlr_buffer_init(struct wlr_buffer *buffer,
 	buffer->impl = impl;
 	buffer->width = width;
 	buffer->height = height;
+	buffer->egl_stream = NULL;
 	wl_signal_init(&buffer->events.destroy);
 	wl_signal_init(&buffer->events.release);
 }
@@ -87,6 +88,9 @@ bool wlr_resource_get_buffer_size(struct wl_resource *resource,
 			wlr_dmabuf_v1_buffer_from_buffer_resource(resource);
 		*width = dmabuf->attributes.width;
 		*height = dmabuf->attributes.height;
+	} else if (wlr_renderer_wl_buffer_get_params(renderer,
+			resource, width, height, NULL)) {
+		(void)0;
 	} else {
 		*width = *height = 0;
 		return false;
@@ -209,6 +213,8 @@ struct wlr_client_buffer *wlr_client_buffer_import(
 		// We have imported the DMA-BUF, but we need to prevent the client from
 		// re-using the same DMA-BUF for the next frames, so we don't release
 		// the buffer yet.
+	} else if ((texture = wlr_texture_from_wl_eglstream(renderer, resource))) {
+		(void)0; // Nothing special is needed for EGLStream texture here
 	} else {
 		wlr_log(WLR_ERROR, "Cannot upload texture: unknown buffer type");
 

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -18,6 +18,7 @@
 #include <wlr/util/region.h>
 #include "util/global.h"
 #include "util/signal.h"
+#include "backend/drm/drm.h"
 
 #define OUTPUT_VERSION 3
 
@@ -229,6 +230,13 @@ void wlr_output_update_custom_mode(struct wlr_output *output, int32_t width,
 
 void wlr_output_set_transform(struct wlr_output *output,
 		enum wl_output_transform transform) {
+	if (wlr_output_is_drm(output)) {
+		struct wlr_drm_connector *conn = (struct wlr_drm_connector *)output;
+		if (conn->backend->is_eglstreams) {
+			// FIXME: There must be a better way to do this, I hope...
+			transform = wlr_egl_normalize_output_transform(transform);
+		}
+	}
 	if (output->transform == transform) {
 		output->pending.committed &= ~WLR_OUTPUT_STATE_TRANSFORM;
 		return;

--- a/types/wlr_xdg_decoration_v1.c
+++ b/types/wlr_xdg_decoration_v1.c
@@ -179,12 +179,14 @@ static void decoration_manager_handle_get_toplevel_decoration(
 		wlr_xdg_surface_from_toplevel_resource(toplevel_resource);
 	assert(surface->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL);
 
+#ifndef WLR_RELAXED_CLIENT_HANDLING
 	if (wlr_surface_has_buffer(surface->surface)) {
 		wl_resource_post_error(manager_resource,
 			ZXDG_TOPLEVEL_DECORATION_V1_ERROR_UNCONFIGURED_BUFFER,
 			"xdg_toplevel_decoration must not have a buffer at creation");
 		return;
 	}
+#endif
 
 	struct wlr_xdg_toplevel_decoration_v1 *decoration =
 		calloc(1, sizeof(struct wlr_xdg_toplevel_decoration_v1));

--- a/types/xdg_shell/wlr_xdg_surface.c
+++ b/types/xdg_shell/wlr_xdg_surface.c
@@ -329,12 +329,14 @@ static void xdg_surface_handle_surface_commit(struct wl_listener *listener,
 	struct wlr_xdg_surface *surface =
 		wl_container_of(listener, surface, surface_commit);
 
+#ifndef WLR_RELAXED_CLIENT_HANDLING
 	if (wlr_surface_has_buffer(surface->surface) && !surface->configured) {
 		wl_resource_post_error(surface->resource,
 			XDG_SURFACE_ERROR_UNCONFIGURED_BUFFER,
 			"xdg_surface has never been configured");
 		return;
 	}
+#endif
 
 	// surface->role might be NONE for inert popups
 	// So we check surface->surface->role


### PR DESCRIPTION
Supported:
1. Damage tracking
2. EGLStreams buffer allocator
3. VT switching, sleep/wakeup restoring
4. Client's wayland GL texture import
5. Multi-out

Known issues
1. Absence of Multi-GPU support. Due to lack of dma-buf (Nvidia's WIP)
2. Screenshots through dma-buf (the same reason). TODO with another
   approach if possible
3. XWayland acceleration support (Nvidia's WIP)
4. mpv with gpu -vo produces no output. Use wlshm

Note: All dma-buf extensions are disabled for EGLStreams mode.
Else chrome/chromium and other apps relying on them fail to start.

TIP: run mozilla with MOZ_ENABLE_WAYLAND=1, for chrome enable ozone with
wayland.

EGLStreams concepts are much like MacOS IOSurfaces.
The latter is proved to be reliable solution for frame buffer sharing/streaming.

**Last note:**
_I'm aware about linux graphics devs politics regarding EGLStreams and have no illusion about the fate of this PR._
_This is mainly for those who, like me, want to shake off dust from a stale nvidia GPUs._

P.S. I'm open to any issues and will try to add support for missing features if the proposed functionality will be merged.