### PR TITLE
render/egl: don't fail on EGL_MESA_device_software

### DIFF
--- a/render/egl.c
+++ b/render/egl.c
@@ -279,10 +279,13 @@ struct wlr_egl *wlr_egl_create(EGLenum platform, void *remote_display) {
 			if (allow_software != NULL && strcmp(allow_software, "1") == 0) {
 				wlr_log(WLR_INFO, "Using software rendering");
 			} else {
-				wlr_log(WLR_ERROR, "Software rendering detected, please use "
-						"the WLR_RENDERER_ALLOW_SOFTWARE environment variable "
-						"to proceed");
-				goto error;
+				// Because of a Mesa bug, sometimes EGL_MESA_device_software is
+				// advertised for hardware renderers. See:
+				// https://gitlab.freedesktop.org/mesa/mesa/-/issues/4178
+				// TODO: fail without WLR_RENDERER_ALLOW_SOFTWARE
+				wlr_log(WLR_INFO, "Warning: software rendering may be in use");
+				wlr_log(WLR_INFO, "If you experience slow rendering, "
+					"please check the OpenGL drivers are correctly installed");
 			}
 		}
 
@@ -298,7 +301,7 @@ struct wlr_egl *wlr_egl_create(EGLenum platform, void *remote_display) {
 	}
 
 	if (!check_egl_ext(display_exts_str, "EGL_KHR_surfaceless_context")) {
-		wlr_log(WLR_ERROR, 
+		wlr_log(WLR_ERROR,
 			"EGL_KHR_surfaceless_context not supported");
 		goto error;
 	}


### PR DESCRIPTION
Mesa may advertise EGL_MESA_device_software even when hardware
drivers are in use [1]. Demote the error to a warning until the Mesa
bug is fixed.

[1]: https://gitlab.freedesktop.org/mesa/mesa/-/issues/4178

References: https://github.com/swaywm/wlroots/pull/2689

cc @bl4ckb0ne