### PR TITLE
docs: Minor libseat corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Install dependencies:
 * xkbcommon
 * udev
 * pixman
+* libseat (optional, for seatd support)
 * systemd (optional, for logind support)
 * elogind (optional, for logind support on systems without systemd)
 * libuuid (optional, for xdg-foreign support)

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -7,7 +7,7 @@ wlroots reads these environment variables
 * *WLR_NO_HARDWARE_CURSORS*: set to 1 to use software cursors instead of
   hardware cursors
 * *WLR_SESSION*: specifies the `wlr_session` to be used (available sessions:
-  logind/systemd, seatd, direct)
+  logind/systemd, libseat, direct)
 * *WLR_DIRECT_TTY*: specifies the tty to be used (instead of using /dev/tty)
 * *WLR_XWAYLAND*: specifies the path to an Xwayland binary to be used (instead
   of following shell search semantics for "Xwayland")


### PR DESCRIPTION
The optional dependency wasn't mentioned in the readme, and the env docs incorrectly listed "seatd" as being the WLR_SESSION selector for it.