### PR TITLE
render: drop wlr_renderer_blit_dmabuf

### DIFF
--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -57,9 +57,6 @@ struct wlr_renderer_impl {
 	void (*destroy)(struct wlr_renderer *renderer);
 	bool (*init_wl_display)(struct wlr_renderer *renderer,
 		struct wl_display *wl_display);
-	bool (*blit_dmabuf)(struct wlr_renderer *renderer,
-		struct wlr_dmabuf_attributes *dst,
-		struct wlr_dmabuf_attributes *src);
 	int (*get_drm_fd)(struct wlr_renderer *renderer);
 };
 

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -115,11 +115,6 @@ bool wlr_renderer_read_pixels(struct wlr_renderer *r, uint32_t fmt,
 	uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y, void *data);
 
 /**
- * Blits the dmabuf in src onto the one in dst.
- */
-bool wlr_renderer_blit_dmabuf(struct wlr_renderer *r,
-	struct wlr_dmabuf_attributes *dst, struct wlr_dmabuf_attributes *src);
-/**
  * Creates necessary shm and invokes the initialization of the implementation.
  *
  * Returns false on failure.

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -200,16 +200,6 @@ bool wlr_renderer_read_pixels(struct wlr_renderer *r, uint32_t fmt,
 		src_x, src_y, dst_x, dst_y, data);
 }
 
-bool wlr_renderer_blit_dmabuf(struct wlr_renderer *r,
-		struct wlr_dmabuf_attributes *dst,
-		struct wlr_dmabuf_attributes *src) {
-	assert(!r->rendering);
-	if (!r->impl->blit_dmabuf) {
-		return false;
-	}
-	return r->impl->blit_dmabuf(r, dst, src);
-}
-
 bool wlr_renderer_init_wl_display(struct wlr_renderer *r,
 		struct wl_display *wl_display) {
 	if (wl_display_init_shm(wl_display)) {


### PR DESCRIPTION
It can be replaced with wlr_renderer_bind_buffer. blit_dmabuf is
broken as-is (dies on an assertion).

If we want to optimize blits with e.g. `glBlitFramebuffer`, a function that deals with `wlr_buffer`s would be better (as it would better integrate with the Pixman renderer for instance).

~~Depends on https://github.com/swaywm/wlroots/pull/2788~~