### PR TITLE
Add kernel tracing instrumentation

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -26,6 +26,7 @@
 #include "backend/drm/util.h"
 #include "render/swapchain.h"
 #include "util/signal.h"
+#include "util/trace.h"
 
 bool check_drm_features(struct wlr_drm_backend *drm) {
 	uint64_t cap;
@@ -330,6 +331,9 @@ static void drm_plane_set_committed(struct wlr_drm_plane *plane) {
 static bool drm_crtc_commit(struct wlr_drm_connector *conn, uint32_t flags) {
 	struct wlr_drm_backend *drm = conn->backend;
 	struct wlr_drm_crtc *crtc = conn->crtc;
+
+	wlr_trace("drm_crtc_commit");
+
 	bool ok = drm->iface->crtc_commit(drm, conn, flags);
 	if (ok && !(flags & DRM_MODE_ATOMIC_TEST_ONLY)) {
 		memcpy(&crtc->current, &crtc->pending, sizeof(struct wlr_drm_crtc_state));
@@ -540,6 +544,8 @@ static bool drm_connector_commit(struct wlr_output *output) {
 	struct wlr_drm_connector *conn = get_drm_connector_from_output(output);
 	struct wlr_drm_backend *drm = conn->backend;
 
+	wlr_trace("drm_connector_commit (begin_ctx=%"PRIu32")", output->commit_seq);
+
 	if (!drm_connector_test(output)) {
 		return false;
 	}
@@ -583,6 +589,8 @@ static bool drm_connector_commit(struct wlr_output *output) {
 			return false;
 		}
 	}
+
+	wlr_trace("drm_connector_commit (end_ctx=%"PRIu32")", output->commit_seq);
 
 	return true;
 }

--- a/include/util/trace.h
+++ b/include/util/trace.h
@@ -1,0 +1,9 @@
+#ifndef UTIL_TRACE_H
+#define UTIL_TRACE_H
+
+#include <wlr/util/log.h>
+
+void wlr_trace(const char *format, ...) _WLR_ATTRIB_PRINTF(1, 2);
+void wlr_vtrace(const char *format, va_list args) _WLR_ATTRIB_PRINTF(1, 0);
+
+#endif

--- a/util/meson.build
+++ b/util/meson.build
@@ -6,8 +6,8 @@ wlr_files += files(
 	'shm.c',
 	'signal.c',
 	'time.c',
+	'trace.c',
 )
-
 
 if features.get('xdg-foreign')
 	if uuid.found()

--- a/util/trace.c
+++ b/util/trace.c
@@ -1,0 +1,30 @@
+#include <stdio.h>
+#include "util/trace.h"
+
+static bool trace_initialized = false;
+static FILE *trace_file = NULL;
+
+void wlr_vtrace(const char *fmt, va_list args) {
+	if (!trace_initialized) {
+		trace_initialized = true;
+		trace_file = fopen("/sys/kernel/tracing/trace_marker", "w");
+		if (trace_file != NULL) {
+			wlr_log(WLR_INFO, "Kernel tracing is enabled");
+		}
+	}
+
+	if (trace_file == NULL) {
+		return;
+	}
+
+	vfprintf(trace_file, fmt, args);
+	fprintf(trace_file, "\n");
+	fflush(trace_file);
+}
+
+void wlr_trace(const char *fmt, ...) {
+	va_list args;
+	va_start(args, fmt);
+	wlr_vtrace(fmt, args);
+	va_end(args);
+}


### PR DESCRIPTION
Useful to figure out what happens and when. The trace points can be visualized via gpuvis.

Not sure we want that upstream, I'm just submitting this as a draft so that one can easily add new tracepoints during an investigation.