### PR TITLE
surface: introduce cached states

### DIFF
--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -162,7 +162,7 @@ struct wlr_subsurface {
 
 	struct wlr_subsurface_state current, pending;
 
-	struct wlr_surface_state cached;
+	uint32_t cached_seq;
 	bool has_cache;
 
 	bool synchronized;

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -31,6 +31,9 @@ enum wlr_surface_state_field {
 
 struct wlr_surface_state {
 	uint32_t committed; // enum wlr_surface_state_field
+	// Sequence number of the surface state. Incremented on each commit, may
+	// overflow.
+	uint32_t seq;
 
 	struct wl_resource *buffer_resource;
 	int32_t dx, dy; // relative to previous position

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -525,10 +525,6 @@ static void subsurface_commit(struct wlr_subsurface *subsurface) {
 		}
 		subsurface->has_cache = true;
 		subsurface->cached_seq = wlr_surface_lock_pending(surface);
-	} else if (subsurface->has_cache) {
-		wlr_surface_unlock_cached(surface, subsurface->cached_seq);
-		subsurface->has_cache = false;
-		subsurface->cached_seq = 0;
 	}
 }
 
@@ -964,7 +960,13 @@ static void subsurface_handle_set_desync(struct wl_client *client,
 		subsurface->synchronized = false;
 
 		if (!subsurface_is_synchronized(subsurface)) {
-			// TODO: do a synchronized commit to flush the cache
+			if (subsurface->has_cache) {
+				wlr_surface_unlock_cached(subsurface->surface,
+					subsurface->cached_seq);
+				subsurface->has_cache = false;
+				subsurface->cached_seq = 0;
+			}
+
 			subsurface_parent_commit(subsurface, true);
 		}
 	}

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -295,6 +295,7 @@ static void surface_state_copy(struct wlr_surface_state *state,
 	}
 
 	state->committed |= next->committed;
+	state->seq = next->seq;
 }
 
 /**
@@ -418,6 +419,7 @@ static void surface_commit_pending(struct wlr_surface *surface) {
 
 	surface_state_copy(&surface->previous, &surface->current);
 	surface_state_move(&surface->current, &surface->pending);
+	surface->pending.seq = surface->current.seq + 1;
 
 	if (invalid_buffer) {
 		surface_apply_damage(surface);
@@ -491,6 +493,7 @@ static void subsurface_commit(struct wlr_subsurface *subsurface) {
 	if (subsurface_is_synchronized(subsurface)) {
 		surface_state_move(&subsurface->cached, &surface->pending);
 		subsurface->has_cache = true;
+		surface->pending.seq = subsurface->cached.seq + 1;
 	} else {
 		if (subsurface->has_cache) {
 			surface_state_move(&surface->pending, &subsurface->cached);
@@ -692,6 +695,7 @@ struct wlr_surface *wlr_surface_create(struct wl_client *client,
 	surface_state_init(&surface->current);
 	surface_state_init(&surface->pending);
 	surface_state_init(&surface->previous);
+	surface->pending.seq = 1;
 
 	wl_signal_init(&surface->events.commit);
 	wl_signal_init(&surface->events.destroy);


### PR DESCRIPTION
Cached states allow a surface commit to be delayed. They are useful for:

- Subsurfaces
- The upcoming transactions protocol [1]
- Explicit synchronization

[1]: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/26

Prior art: https://github.com/swaywm/wlroots/pull/1685