### PR TITLE
render: remove wlr_texture_to_dmabuf

### DIFF
--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -46,7 +46,6 @@ struct wlr_egl {
 		// Display extensions
 		bool bind_wayland_display_wl;
 		bool image_base_khr;
-		bool image_dma_buf_export_mesa;
 		bool image_dmabuf_import_ext;
 		bool image_dmabuf_import_modifiers_ext;
 
@@ -63,8 +62,6 @@ struct wlr_egl {
 		PFNEGLUNBINDWAYLANDDISPLAYWL eglUnbindWaylandDisplayWL;
 		PFNEGLQUERYDMABUFFORMATSEXTPROC eglQueryDmaBufFormatsEXT;
 		PFNEGLQUERYDMABUFMODIFIERSEXTPROC eglQueryDmaBufModifiersEXT;
-		PFNEGLEXPORTDMABUFIMAGEQUERYMESAPROC eglExportDMABUFImageQueryMESA;
-		PFNEGLEXPORTDMABUFIMAGEMESAPROC eglExportDMABUFImageMESA;
 		PFNEGLDEBUGMESSAGECONTROLKHRPROC eglDebugMessageControlKHR;
 		PFNEGLQUERYDISPLAYATTRIBEXTPROC eglQueryDisplayAttribEXT;
 		PFNEGLQUERYDEVICESTRINGEXTPROC eglQueryDeviceStringEXT;

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -72,8 +72,6 @@ struct wlr_texture_impl {
 		uint32_t stride, uint32_t width, uint32_t height,
 		uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y,
 		const void *data);
-	bool (*to_dmabuf)(struct wlr_texture *texture,
-		struct wlr_dmabuf_attributes *attribs);
 	void (*destroy)(struct wlr_texture *texture);
 };
 

--- a/include/wlr/render/wlr_texture.h
+++ b/include/wlr/render/wlr_texture.h
@@ -76,9 +76,6 @@ bool wlr_texture_write_pixels(struct wlr_texture *texture,
 	uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y,
 	const void *data);
 
-bool wlr_texture_to_dmabuf(struct wlr_texture *texture,
-	struct wlr_dmabuf_attributes *attribs);
-
 /**
  * Destroys this wlr_texture.
  */

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -98,34 +98,6 @@ static bool gles2_texture_write_pixels(struct wlr_texture *wlr_texture,
 	return true;
 }
 
-static bool gles2_texture_to_dmabuf(struct wlr_texture *wlr_texture,
-		struct wlr_dmabuf_attributes *attribs) {
-	struct wlr_gles2_texture *texture = gles2_get_texture(wlr_texture);
-
-	if (!texture->image) {
-		assert(texture->target == GL_TEXTURE_2D);
-
-		if (!texture->renderer->egl->exts.image_base_khr) {
-			return false;
-		}
-
-		texture->image = texture->renderer->egl->procs.eglCreateImageKHR(
-			texture->renderer->egl->display, texture->renderer->egl->context, EGL_GL_TEXTURE_2D_KHR,
-			(EGLClientBuffer)(uintptr_t)texture->tex, NULL);
-		if (texture->image == EGL_NO_IMAGE_KHR) {
-			return false;
-		}
-	}
-
-	uint32_t flags = 0;
-	if (texture->inverted_y) {
-		flags |= WLR_DMABUF_ATTRIBUTES_FLAGS_Y_INVERT;
-	}
-
-	return wlr_egl_export_image_to_dmabuf(texture->renderer->egl, texture->image,
-		wlr_texture->width, wlr_texture->height, flags, attribs);
-}
-
 static void gles2_texture_destroy(struct wlr_texture *wlr_texture) {
 	if (wlr_texture == NULL) {
 		return;
@@ -152,7 +124,6 @@ static void gles2_texture_destroy(struct wlr_texture *wlr_texture) {
 static const struct wlr_texture_impl texture_impl = {
 	.is_opaque = gles2_texture_is_opaque,
 	.write_pixels = gles2_texture_write_pixels,
-	.to_dmabuf = gles2_texture_to_dmabuf,
 	.destroy = gles2_texture_destroy,
 };
 

--- a/render/wlr_texture.c
+++ b/render/wlr_texture.c
@@ -65,11 +65,3 @@ bool wlr_texture_write_pixels(struct wlr_texture *texture,
 	return texture->impl->write_pixels(texture, stride, width, height,
 		src_x, src_y, dst_x, dst_y, data);
 }
-
-bool wlr_texture_to_dmabuf(struct wlr_texture *texture,
-		struct wlr_dmabuf_attributes *attribs) {
-	if (!texture->impl->to_dmabuf) {
-		return false;
-	}
-	return texture->impl->to_dmabuf(texture, attribs);
-}


### PR DESCRIPTION
This is unused in wlroots, and the use-cases for compositors are
pretty niche since they can access the original DMA-BUF via the
wlr_buffer.