### PR TITLE
render: drop support for ellipses

### DIFF
--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -61,13 +61,6 @@ struct wlr_gles2_renderer {
 			GLint color;
 			GLint pos_attrib;
 		} quad;
-		struct {
-			GLuint program;
-			GLint proj;
-			GLint color;
-			GLint pos_attrib;
-			GLint tex_attrib;
-		} ellipse;
 		struct wlr_gles2_tex_shader tex_rgba;
 		struct wlr_gles2_tex_shader tex_rgbx;
 		struct wlr_gles2_tex_shader tex_ext;

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -30,8 +30,6 @@ struct wlr_renderer_impl {
 		const float matrix[static 9], float alpha);
 	void (*render_quad_with_matrix)(struct wlr_renderer *renderer,
 		const float color[static 4], const float matrix[static 9]);
-	void (*render_ellipse_with_matrix)(struct wlr_renderer *renderer,
-		const float color[static 4], const float matrix[static 9]);
 	const uint32_t *(*get_shm_texture_formats)(struct wlr_renderer *renderer,
 		size_t *len);
 	bool (*resource_is_wl_drm_buffer)(struct wlr_renderer *renderer,

--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -72,16 +72,6 @@ void wlr_render_rect(struct wlr_renderer *r, const struct wlr_box *box,
 void wlr_render_quad_with_matrix(struct wlr_renderer *r,
 	const float color[static 4], const float matrix[static 9]);
 /**
- * Renders a solid ellipse in the specified color.
- */
-void wlr_render_ellipse(struct wlr_renderer *r, const struct wlr_box *box,
-	const float color[static 4], const float projection[static 9]);
-/**
- * Renders a solid ellipse in the specified color with the specified matrix.
- */
-void wlr_render_ellipse_with_matrix(struct wlr_renderer *r,
-	const float color[static 4], const float matrix[static 9]);
-/**
  * Get the shared-memory formats supporting import usage. Buffers allocated
  * with a format from this list may be imported via wlr_texture_from_pixels.
  */

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -356,47 +356,6 @@ static void gles2_render_quad_with_matrix(struct wlr_renderer *wlr_renderer,
 	pop_gles2_debug(renderer);
 }
 
-static void gles2_render_ellipse_with_matrix(struct wlr_renderer *wlr_renderer,
-		const float color[static 4], const float matrix[static 9]) {
-	struct wlr_gles2_renderer *renderer =
-		gles2_get_renderer_in_context(wlr_renderer);
-
-	float gl_matrix[9];
-	wlr_matrix_multiply(gl_matrix, renderer->projection, matrix);
-	wlr_matrix_multiply(gl_matrix, flip_180, gl_matrix);
-
-	// OpenGL ES 2 requires the glUniformMatrix3fv transpose parameter to be set
-	// to GL_FALSE
-	wlr_matrix_transpose(gl_matrix, gl_matrix);
-
-	static const GLfloat texcoord[] = {
-		1, 0, // top right
-		0, 0, // top left
-		1, 1, // bottom right
-		0, 1, // bottom left
-	};
-
-	push_gles2_debug(renderer);
-	glUseProgram(renderer->shaders.ellipse.program);
-
-	glUniformMatrix3fv(renderer->shaders.ellipse.proj, 1, GL_FALSE, gl_matrix);
-	glUniform4f(renderer->shaders.ellipse.color, color[0], color[1], color[2], color[3]);
-
-	glVertexAttribPointer(renderer->shaders.ellipse.pos_attrib, 2, GL_FLOAT,
-			GL_FALSE, 0, verts);
-	glVertexAttribPointer(renderer->shaders.ellipse.tex_attrib, 2, GL_FLOAT,
-			GL_FALSE, 0, texcoord);
-
-	glEnableVertexAttribArray(renderer->shaders.ellipse.pos_attrib);
-	glEnableVertexAttribArray(renderer->shaders.ellipse.tex_attrib);
-
-	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-
-	glDisableVertexAttribArray(renderer->shaders.ellipse.pos_attrib);
-	glDisableVertexAttribArray(renderer->shaders.ellipse.tex_attrib);
-	pop_gles2_debug(renderer);
-}
-
 static const uint32_t *gles2_get_shm_texture_formats(
 		struct wlr_renderer *wlr_renderer, size_t *len) {
 	return get_gles2_shm_formats(len);
@@ -665,7 +624,6 @@ static void gles2_destroy(struct wlr_renderer *wlr_renderer) {
 
 	push_gles2_debug(renderer);
 	glDeleteProgram(renderer->shaders.quad.program);
-	glDeleteProgram(renderer->shaders.ellipse.program);
 	glDeleteProgram(renderer->shaders.tex_rgba.program);
 	glDeleteProgram(renderer->shaders.tex_rgbx.program);
 	glDeleteProgram(renderer->shaders.tex_ext.program);
@@ -695,7 +653,6 @@ static const struct wlr_renderer_impl renderer_impl = {
 	.scissor = gles2_scissor,
 	.render_subtexture_with_matrix = gles2_render_subtexture_with_matrix,
 	.render_quad_with_matrix = gles2_render_quad_with_matrix,
-	.render_ellipse_with_matrix = gles2_render_ellipse_with_matrix,
 	.get_shm_texture_formats = gles2_get_shm_texture_formats,
 	.resource_is_wl_drm_buffer = gles2_resource_is_wl_drm_buffer,
 	.wl_drm_buffer_get_size = gles2_wl_drm_buffer_get_size,
@@ -837,7 +794,6 @@ static void load_gl_proc(void *proc_ptr, const char *name) {
 
 extern const GLchar quad_vertex_src[];
 extern const GLchar quad_fragment_src[];
-extern const GLchar ellipse_fragment_src[];
 extern const GLchar tex_vertex_src[];
 extern const GLchar tex_fragment_src_rgba[];
 extern const GLchar tex_fragment_src_rgbx[];
@@ -930,16 +886,6 @@ struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_egl *egl) {
 	renderer->shaders.quad.color = glGetUniformLocation(prog, "color");
 	renderer->shaders.quad.pos_attrib = glGetAttribLocation(prog, "pos");
 
-	renderer->shaders.ellipse.program = prog =
-		link_program(renderer, quad_vertex_src, ellipse_fragment_src);
-	if (!renderer->shaders.ellipse.program) {
-		goto error;
-	}
-	renderer->shaders.ellipse.proj = glGetUniformLocation(prog, "proj");
-	renderer->shaders.ellipse.color = glGetUniformLocation(prog, "color");
-	renderer->shaders.ellipse.pos_attrib = glGetAttribLocation(prog, "pos");
-	renderer->shaders.ellipse.tex_attrib = glGetAttribLocation(prog, "texcoord");
-
 	renderer->shaders.tex_rgba.program = prog =
 		link_program(renderer, tex_vertex_src, tex_fragment_src_rgba);
 	if (!renderer->shaders.tex_rgba.program) {
@@ -986,7 +932,6 @@ struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_egl *egl) {
 
 error:
 	glDeleteProgram(renderer->shaders.quad.program);
-	glDeleteProgram(renderer->shaders.ellipse.program);
 	glDeleteProgram(renderer->shaders.tex_rgba.program);
 	glDeleteProgram(renderer->shaders.tex_rgbx.program);
 	glDeleteProgram(renderer->shaders.tex_ext.program);

--- a/render/gles2/shaders.c
+++ b/render/gles2/shaders.c
@@ -25,20 +25,6 @@ const GLchar quad_fragment_src[] =
 "	gl_FragColor = v_color;\n"
 "}\n";
 
-// Colored ellipses
-const GLchar ellipse_fragment_src[] =
-"precision mediump float;\n"
-"varying vec4 v_color;\n"
-"varying vec2 v_texcoord;\n"
-"\n"
-"void main() {\n"
-"	float l = length(v_texcoord - vec2(0.5, 0.5));\n"
-"	if (l > 0.5) {\n"
-"		discard;\n"
-"	}\n"
-"	gl_FragColor = v_color;\n"
-"}\n";
-
 // Textured quads
 const GLchar tex_vertex_src[] =
 "uniform mat3 proj;\n"

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -20,7 +20,6 @@ void wlr_renderer_init(struct wlr_renderer *renderer,
 	assert(impl->scissor);
 	assert(impl->render_subtexture_with_matrix);
 	assert(impl->render_quad_with_matrix);
-	assert(impl->render_ellipse_with_matrix);
 	assert(impl->get_shm_texture_formats);
 	assert(impl->texture_from_pixels);
 	renderer->impl = impl;
@@ -131,25 +130,6 @@ void wlr_render_quad_with_matrix(struct wlr_renderer *r,
 		const float color[static 4], const float matrix[static 9]) {
 	assert(r->rendering);
 	r->impl->render_quad_with_matrix(r, color, matrix);
-}
-
-void wlr_render_ellipse(struct wlr_renderer *r, const struct wlr_box *box,
-		const float color[static 4], const float projection[static 9]) {
-	if (box->width == 0 || box->height == 0) {
-		return;
-	}
-	assert(box->width > 0 && box->height > 0);
-	float matrix[9];
-	wlr_matrix_project_box(matrix, box, WL_OUTPUT_TRANSFORM_NORMAL, 0,
-		projection);
-
-	wlr_render_ellipse_with_matrix(r, color, matrix);
-}
-
-void wlr_render_ellipse_with_matrix(struct wlr_renderer *r,
-		const float color[static 4], const float matrix[static 9]) {
-	assert(r->rendering);
-	r->impl->render_ellipse_with_matrix(r, color, matrix);
 }
 
 const uint32_t *wlr_renderer_get_shm_texture_formats(struct wlr_renderer *r,


### PR DESCRIPTION
For anything more complicated than quads, compositors can easily
ship their own shaders.

Closes: https://github.com/swaywm/wlroots/issues/2759