### PR TITLE
select built-in backend as you wish, can disable EGL, GLES, GBM or libinput

### DIFF
--- a/backend/drm/meson.build
+++ b/backend/drm/meson.build
@@ -1,3 +1,7 @@
+if not gbm.found()
+  subdir_done()
+endif
+
 wlr_files += files(
 	'atomic.c',
 	'backend.c',
@@ -8,3 +12,5 @@ wlr_files += files(
 	'renderer.c',
 	'util.c',
 )
+
+features += {'drm-backend': true}

--- a/backend/headless/backend.c
+++ b/backend/headless/backend.c
@@ -4,17 +4,17 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <xf86drm.h>
 #include <wlr/interfaces/wlr_input_device.h>
 #include <wlr/interfaces/wlr_output.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/util/log.h>
-#include <xf86drm.h>
-#include "backend/headless.h"
+#include "render/allocator.h"
 #include "render/drm_format_set.h"
-#include "render/gbm_allocator.h"
 #include "render/wlr_renderer.h"
 #include "types/wlr_buffer.h"
 #include "util/signal.h"
+#include "backend/headless.h"
 
 struct wlr_headless_backend *headless_backend_from_backend(
 		struct wlr_backend *wlr_backend) {

--- a/backend/libinput/meson.build
+++ b/backend/libinput/meson.build
@@ -1,3 +1,6 @@
+libinput = dependency('libinput', version: '>=1.14.0',
+                      required: meson.current_source_dir() in backends)
+
 wlr_files += files(
 	'backend.c',
 	'events.c',
@@ -8,3 +11,6 @@ wlr_files += files(
 	'tablet_tool.c',
 	'touch.c',
 )
+
+features += {'libinput-backend': true}
+wlr_deps += libinput

--- a/backend/meson.build
+++ b/backend/meson.build
@@ -1,11 +1,18 @@
 wlr_files += files('backend.c')
 
-subdir('drm')
-subdir('headless')
-subdir('libinput')
-subdir('multi')
-subdir('noop')
-subdir('wayland')
-subdir('x11')
+backends = get_option('backends')
 
+if 'auto' in backends and get_option('auto_features').disabled()
+  warning('The global auto features is set to disabled but we would still enable those backends if their dependencies are met')
+endif
+
+foreach backend : ['drm', 'noop', 'libinput', 'x11']
+  if backend in backends or 'auto' in backends
+    subdir(backend)
+  endif
+endforeach
+
+subdir('headless')
+subdir('multi')
 subdir('session')
+subdir('wayland')

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -6,12 +6,11 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#include <wlr/config.h>
-
 #include <drm_fourcc.h>
 #include <wayland-server-core.h>
 #include <xf86drm.h>
 
+#include <wlr/config.h>
 #include <wlr/backend/interface.h>
 #include <wlr/interfaces/wlr_input_device.h>
 #include <wlr/interfaces/wlr_output.h>
@@ -19,7 +18,6 @@
 
 #include "backend/wayland.h"
 #include "render/drm_format_set.h"
-#include "render/gbm_allocator.h"
 #include "render/pixel_format.h"
 #include "render/shm_allocator.h"
 #include "render/wlr_renderer.h"

--- a/backend/x11/meson.build
+++ b/backend/x11/meson.build
@@ -11,16 +11,16 @@ x11_required = [
 ]
 
 msg = []
-if get_option('x11-backend').enabled()
-	msg += 'Install "@0@" or pass "-Dx11-backend=disabled" to disable it.'
-endif
-if not get_option('x11-backend').disabled()
-	msg += 'Required for X11 backend support.'
+
+if 'x11' in backends
+	msg += 'Install "@0@" or don\'t enable X11 backend.'
+else
+	msg += 'Due to lack of "@0@", X11 backend support is disabled.'
 endif
 
 foreach lib : x11_required
 	dep = dependency(lib,
-		required: get_option('x11-backend'),
+                required: meson.current_source_dir() in backends,
 		not_found_message: '\n'.join(msg).format(lib),
 	)
 	if not dep.found()

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -2,14 +2,10 @@ threads = dependency('threads')
 wayland_egl = dependency('wayland-egl')
 wayland_cursor = dependency('wayland-cursor')
 libpng = dependency('libpng', required: false, disabler: true)
-egl = dependency('egl', required: false, disabler: true)
-glesv2 = dependency('glesv2', required: false, disabler: true)
 # These versions correspond to ffmpeg 4.0
 libavutil = dependency('libavutil', version: '>=56.14.100', required: false, disabler: true)
 libavcodec = dependency('libavcodec', version: '>=58.18.100', required: false, disabler: true)
 libavformat = dependency('libavformat', version: '>=58.12.100', required: false, disabler: true)
-# Only needed for drm_fourcc.h
-libdrm = dependency('libdrm').partial_dependency(compile_args: true, includes: true)
 
 # epoll is a separate library in FreeBSD
 if host_machine.system() == 'freebsd'
@@ -57,7 +53,7 @@ compositors = {
 clients = {
 	'idle': {
 		'src': 'idle.c',
-		'dep': threads,
+		'dep': [threads],
 		'proto': ['kde-idle'],
 	},
 	'idle-inhibit': {
@@ -125,7 +121,7 @@ clients = {
 			libavcodec,
 			libavformat,
 			libavutil,
-			drm.partial_dependency(compile_args: true), # <drm_fourcc.h>
+			drm_headers,
 			threads,
 		],
 		'proto': ['wlr-export-dmabuf-unstable-v1'],
@@ -175,12 +171,12 @@ clients = {
 	},
 	'virtual-pointer': {
 		'src': 'virtual-pointer.c',
-		'dep': wlroots,
+		'dep': [wlroots],
 		'proto': ['wlr-virtual-pointer-unstable-v1'],
 	},
 	'input-method-keyboard-grab': {
 		'src': 'input-method-keyboard-grab.c',
-		'dep': xkbcommon,
+		'dep': [xkbcommon],
 		'proto': [
 			'input-method-unstable-v2',
 		],
@@ -196,13 +192,24 @@ foreach name, info : compositors
 	executable(
 		name,
 		[info.get('src'), extra_src],
-		dependencies: [wlroots, libdrm],
+		dependencies: [wlroots, drm_headers, info.get('dep', [])],
 		include_directories: [wlr_inc, proto_inc],
 		build_by_default: get_option('examples'),
 	)
 endforeach
 
 foreach name, info : clients
+	broken = false
+	foreach dep : info.get('dep')
+	  if dep.found() == false
+	    broken = true
+	    break
+	  endif
+	endforeach
+	if broken
+	  continue
+	endif
+
 	extra_src = []
 	foreach p : info.get('proto')
 		extra_src += protocols_code[p]

--- a/include/wlr/config.h.in
+++ b/include/wlr/config.h.in
@@ -7,4 +7,8 @@
 
 #mesondefine WLR_HAS_XWAYLAND
 
+#mesondefine WLR_HAS_GLES2_RENDERER
+
+#mesondefine WLR_HAS_DRM_BACKEND
+#mesondefine WLR_HAS_LIBINPUT_BACKEND
 #endif

--- a/meson.build
+++ b/meson.build
@@ -86,7 +86,9 @@ else
 endif
 
 features = {
+	'drm-backend': false,
 	'x11-backend': false,
+	'libinput-backend': false,
 	'xwayland': false,
 	'gles2-renderer': false,
 }
@@ -97,8 +99,8 @@ internal_features = {
 wayland_server = dependency('wayland-server', version: '>=1.19')
 wayland_client = dependency('wayland-client')
 drm = dependency('libdrm', version: '>=2.4.95')
-gbm = dependency('gbm', version: '>=17.1.0')
-libinput = dependency('libinput', version: '>=1.14.0')
+# Only needed for drm_fourcc.h
+drm_headers = drm.partial_dependency(compile_args: true, includes: true)
 xkbcommon = dependency('xkbcommon')
 udev = dependency('libudev')
 pixman = dependency('pixman-1')
@@ -111,8 +113,6 @@ wlr_deps = [
 	wayland_server,
 	wayland_client,
 	drm,
-	gbm,
-	libinput,
 	xkbcommon,
 	udev,
 	pixman,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,7 @@
 option('xcb-errors', type: 'feature', value: 'auto', description: 'Use xcb-errors util library')
 option('xwayland', type: 'feature', value: 'auto', yield: true, description: 'Enable support for X11 applications')
-option('x11-backend', type: 'feature', value: 'auto', description: 'Enable X11 backend')
 option('examples', type: 'boolean', value: true, description: 'Build example applications')
 option('icon_directory', description: 'Location used to look for cursors (default: ${datadir}/icons)', type: 'string', value: '')
 option('renderers', type: 'array', choices: ['auto', 'gles2'], value: ['auto'], description: 'Select built-in renderers')
+option('backends', type: 'array', choices: ['auto', 'drm', 'noop', 'libinput', 'x11'],
+       value: ['auto'], description: 'Select the backend support')

--- a/render/meson.build
+++ b/render/meson.build
@@ -1,8 +1,11 @@
 renderers = get_option('renderers')
-if 'auto' in renderers and get_option('auto_features').enabled()
+
+if 'auto' in renderers and get_option('auto_features').disabled()
+  warning('The global auto features is set to disabled but we would still enable those renderers if their dependencies are met')
+endif
+
+if 'auto' in renderers
 	renderers = ['gles2']
-elif 'auto' in renderers and get_option('auto_features').disabled()
-	renderers = []
 endif
 
 wlr_files += files(


### PR DESCRIPTION
Some SoCs don't have a GPU
Nvidia doesn't support gbm
Some products don't need input device, it would only display something

More option and flexible can be achieve as long as the more allocators and software renderer are merged.
