### PR TITLE
render/egl: fail on EGL_MESA_device_software

### DIFF
--- a/render/egl.c
+++ b/render/egl.c
@@ -279,13 +279,10 @@ struct wlr_egl *wlr_egl_create(EGLenum platform, void *remote_display) {
 			if (allow_software != NULL && strcmp(allow_software, "1") == 0) {
 				wlr_log(WLR_INFO, "Using software rendering");
 			} else {
-				// Because of a Mesa bug, sometimes EGL_MESA_device_software is
-				// advertised for hardware renderers. See:
-				// https://gitlab.freedesktop.org/mesa/mesa/-/issues/4178
-				// TODO: fail without WLR_RENDERER_ALLOW_SOFTWARE
-				wlr_log(WLR_INFO, "Warning: software rendering may be in use");
-				wlr_log(WLR_INFO, "If you experience slow rendering, "
-					"please check the OpenGL drivers are correctly installed");
+				wlr_log(WLR_ERROR, "Software rendering detected, please use "
+					"the WLR_RENDERER_ALLOW_SOFTWARE environment variable "
+					"to proceed");
+				goto error;
 			}
 		}
 


### PR DESCRIPTION
Partial revert of https://github.com/swaywm/wlroots/pull/2783/commits/60d2e44485db3e73c3863e2ea2def074f4b29825 since [mesa #4178][1] has been fixed.

We must wait the next mesa bugfix release before merging this.

[1]: https://gitlab.freedesktop.org/mesa/mesa/-/issues/4178