### PR TITLE
surface: make wlr_surface_create private

### DIFF
--- a/include/types/wlr_surface.h
+++ b/include/types/wlr_surface.h
@@ -1,0 +1,15 @@
+#ifndef TYPES_WLR_SURFACE_H
+#define TYPES_WLR_SURFACE_H
+
+#include <wlr/types/wlr_surface.h>
+
+struct wlr_renderer;
+
+/**
+ * Create a new surface resource with the provided new ID. If `resource_list`
+ * is non-NULL, adds the surface's resource to the list.
+ */
+struct wlr_surface *surface_create(struct wl_client *client,
+	uint32_t version, uint32_t id, struct wlr_renderer *renderer);
+
+#endif

--- a/include/types/wlr_surface.h
+++ b/include/types/wlr_surface.h
@@ -6,8 +6,7 @@
 struct wlr_renderer;
 
 /**
- * Create a new surface resource with the provided new ID. If `resource_list`
- * is non-NULL, adds the surface's resource to the list.
+ * Create a new surface resource with the provided new ID.
  */
 struct wlr_surface *surface_create(struct wl_client *client,
 	uint32_t version, uint32_t id, struct wlr_renderer *renderer);

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -187,16 +187,6 @@ struct wlr_subsurface {
 typedef void (*wlr_surface_iterator_func_t)(struct wlr_surface *surface,
 	int sx, int sy, void *data);
 
-struct wlr_renderer;
-
-/**
- * Create a new surface resource with the provided new ID. If `resource_list`
- * is non-NULL, adds the surface's resource to the list.
- */
-struct wlr_surface *wlr_surface_create(struct wl_client *client,
-		uint32_t version, uint32_t id, struct wlr_renderer *renderer,
-		struct wl_list *resource_list);
-
 /**
  * Set the lifetime role for this surface. Returns 0 on success or -1 if the
  * role cannot be set.

--- a/types/wlr_compositor.c
+++ b/types/wlr_compositor.c
@@ -121,7 +121,7 @@ static void compositor_create_surface(struct wl_client *client,
 	struct wlr_compositor *compositor = compositor_from_resource(resource);
 
 	struct wlr_surface *surface = surface_create(client,
-		wl_resource_get_version(resource), id, compositor->renderer, NULL);
+		wl_resource_get_version(resource), id, compositor->renderer);
 	if (surface == NULL) {
 		wl_client_post_no_memory(client);
 		return;

--- a/types/wlr_compositor.c
+++ b/types/wlr_compositor.c
@@ -5,6 +5,7 @@
 #include <wlr/types/wlr_surface.h>
 #include <wlr/util/log.h>
 #include "types/wlr_region.h"
+#include "types/wlr_surface.h"
 #include "util/signal.h"
 
 #define COMPOSITOR_VERSION 4
@@ -119,7 +120,7 @@ static void compositor_create_surface(struct wl_client *client,
 		struct wl_resource *resource, uint32_t id) {
 	struct wlr_compositor *compositor = compositor_from_resource(resource);
 
-	struct wlr_surface *surface = wlr_surface_create(client,
+	struct wlr_surface *surface = surface_create(client,
 		wl_resource_get_version(resource), id, compositor->renderer, NULL);
 	if (surface == NULL) {
 		wl_client_post_no_memory(client);

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -676,8 +676,6 @@ static void surface_handle_resource_destroy(struct wl_resource *resource) {
 
 	wlr_signal_emit_safe(&surface->events.destroy, surface);
 
-	wl_list_remove(wl_resource_get_link(surface->resource));
-
 	struct wlr_surface_state *cached, *cached_tmp;
 	wl_list_for_each_safe(cached, cached_tmp, &surface->cached, cached_state_link) {
 		surface_state_destroy_cached(cached);
@@ -704,8 +702,7 @@ static void surface_handle_renderer_destroy(struct wl_listener *listener,
 }
 
 struct wlr_surface *surface_create(struct wl_client *client,
-		uint32_t version, uint32_t id, struct wlr_renderer *renderer,
-		struct wl_list *resource_list) {
+		uint32_t version, uint32_t id, struct wlr_renderer *renderer) {
 	assert(version <= SURFACE_VERSION);
 
 	struct wlr_surface *surface = calloc(1, sizeof(struct wlr_surface));
@@ -745,13 +742,6 @@ struct wlr_surface *surface_create(struct wl_client *client,
 
 	wl_signal_add(&renderer->events.destroy, &surface->renderer_destroy);
 	surface->renderer_destroy.notify = surface_handle_renderer_destroy;
-
-	struct wl_list *resource_link = wl_resource_get_link(surface->resource);
-	if (resource_list != NULL) {
-		wl_list_insert(resource_list, resource_link);
-	} else {
-		wl_list_init(resource_link);
-	}
 
 	return surface;
 }

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -10,6 +10,7 @@
 #include <wlr/types/wlr_output.h>
 #include <wlr/util/log.h>
 #include <wlr/util/region.h>
+#include "types/wlr_surface.h"
 #include "util/signal.h"
 #include "util/time.h"
 
@@ -702,7 +703,7 @@ static void surface_handle_renderer_destroy(struct wl_listener *listener,
 	wl_resource_destroy(surface->resource);
 }
 
-struct wlr_surface *wlr_surface_create(struct wl_client *client,
+struct wlr_surface *surface_create(struct wl_client *client,
 		uint32_t version, uint32_t id, struct wlr_renderer *renderer,
 		struct wl_list *resource_list) {
 	assert(version <= SURFACE_VERSION);


### PR DESCRIPTION
Same as https://github.com/swaywm/wlroots/pull/2662.

* * *

Breaking change: `wlr_surface_create` has been removed.