### PR TITLE
build: add subproject fallback for libseat

### DIFF
--- a/backend/session/meson.build
+++ b/backend/session/meson.build
@@ -65,7 +65,11 @@ endif
 
 # libseat
 
-libseat = dependency('libseat', required: get_option('libseat'), version: '>=0.2.0')
+libseat = dependency('libseat',
+	required: get_option('libseat'),
+	version: '>=0.2.0',
+	fallback: ['seatd', 'libseat'],
+)
 if libseat.found()
 	wlr_files += files('libseat.c')
 	wlr_deps += libseat


### PR DESCRIPTION
This allows libseat to be compiled as a Meson subproject when it's
not installed system-wide. This can ease development and compilation
on distributions where libseat isn't packaged.

cc @kennylevinsen 