### PR TITLE
Remove unnecessary directories in the include path

### DIFF
--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -12,9 +12,9 @@
 #include <wlr/backend/session.h>
 #include <wlr/render/drm_format_set.h>
 #include <xf86drmMode.h>
-#include "iface.h"
-#include "properties.h"
-#include "renderer.h"
+#include "backend/drm/iface.h"
+#include "backend/drm/properties.h"
+#include "backend/drm/renderer.h"
 
 struct wlr_drm_plane {
 	uint32_t type;

--- a/include/types/wlr_keyboard.h
+++ b/include/types/wlr_keyboard.h
@@ -1,4 +1,4 @@
-#include "wlr/types/wlr_keyboard.h"
+#include <wlr/types/wlr_keyboard.h>
 
 void keyboard_key_update(struct wlr_keyboard *keyboard,
 		struct wlr_event_keyboard_key *event);

--- a/include/wlr/types/wlr_keyboard_group.h
+++ b/include/wlr/types/wlr_keyboard_group.h
@@ -10,8 +10,8 @@
 #define WLR_TYPES_WLR_KEYBOARD_GROUP_H
 
 #include <wayland-server-core.h>
-#include "wlr/types/wlr_keyboard.h"
-#include "wlr/types/wlr_input_device.h"
+#include <wlr/types/wlr_keyboard.h>
+#include <wlr/types/wlr_input_device.h>
 
 struct wlr_keyboard_group {
 	struct wlr_keyboard keyboard;


### PR DESCRIPTION
Because the included file here is in the same directory as itself, it is
more appropriate to write only the file name, and doing so can help
unify the code style of the entire project.