### PR TITLE
Remove WLR_HAS_XCB_ERRORS

### DIFF
--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -191,7 +191,7 @@ static void backend_destroy(struct wlr_backend *backend) {
 	wlr_drm_format_set_finish(&x11->dri3_formats);
 	free(x11->drm_format);
 
-#if WLR_HAS_XCB_ERRORS
+#if HAS_XCB_ERRORS
 	xcb_errors_context_free(x11->errors_context);
 #endif
 
@@ -617,7 +617,7 @@ struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
 		return false;
 	}
 
-#if WLR_HAS_XCB_ERRORS
+#if HAS_XCB_ERRORS
 	if (xcb_errors_context_new(x11->xcb, &x11->errors_context) != 0) {
 		wlr_log(WLR_ERROR, "Failed to create error context");
 		return false;
@@ -663,7 +663,7 @@ error_x11:
 }
 
 static void handle_x11_error(struct wlr_x11_backend *x11, xcb_value_error_t *ev) {
-#if WLR_HAS_XCB_ERRORS
+#if HAS_XCB_ERRORS
 	const char *major_name = xcb_errors_get_name_for_major_code(
 		x11->errors_context, ev->major_opcode);
 	if (!major_name) {
@@ -701,7 +701,7 @@ log_raw:
 
 static void handle_x11_unknown_event(struct wlr_x11_backend *x11,
 		xcb_generic_event_t *ev) {
-#if WLR_HAS_XCB_ERRORS
+#if HAS_XCB_ERRORS
 	const char *extension;
 	const char *event_name = xcb_errors_get_name_for_xcb_event(
 		x11->errors_context, ev, &extension);

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -9,7 +9,7 @@
 #include <xcb/xcb.h>
 #include <xcb/present.h>
 
-#if WLR_HAS_XCB_ERRORS
+#if HAS_XCB_ERRORS
 #include <xcb/xcb_errors.h>
 #endif
 
@@ -103,7 +103,7 @@ struct wlr_x11_backend {
 	// The time we last received an event
 	xcb_timestamp_t time;
 
-#if WLR_HAS_XCB_ERRORS
+#if HAS_XCB_ERRORS
 	xcb_errors_context_t *errors_context;
 #endif
 

--- a/include/wlr/config.h.in
+++ b/include/wlr/config.h.in
@@ -10,8 +10,6 @@
 
 #mesondefine WLR_HAS_XWAYLAND
 
-#mesondefine WLR_HAS_XCB_ERRORS
-
 #mesondefine WLR_HAS_XDG_FOREIGN
 
 #endif

--- a/include/xwayland/xwm.h
+++ b/include/xwayland/xwm.h
@@ -5,7 +5,7 @@
 #include <wlr/config.h>
 #include <wlr/xwayland.h>
 #include <xcb/render.h>
-#if WLR_HAS_XCB_ERRORS
+#if HAS_XCB_ERRORS
 #include <xcb/xcb_errors.h>
 #endif
 #include "xwayland/selection.h"
@@ -113,7 +113,7 @@ struct wlr_xwm {
 	struct wlr_xwayland_surface *drag_focus;
 
 	const xcb_query_extension_reply_t *xfixes;
-#if WLR_HAS_XCB_ERRORS
+#if HAS_XCB_ERRORS
 	xcb_errors_context_t *errors_context;
 #endif
 	unsigned int last_focus_seq;

--- a/meson.build
+++ b/meson.build
@@ -86,8 +86,10 @@ features = {
 	'libseat': false,
 	'x11-backend': false,
 	'xwayland': false,
-	'xcb-errors': false,
 	'xdg-foreign': false,
+}
+internal_features = {
+	'xcb-errors': false,
 }
 
 wayland_server = dependency('wayland-server', version: '>=1.19')
@@ -143,6 +145,13 @@ subdir('xwayland')
 
 subdir('include')
 
+foreach name, have : internal_features
+	add_project_arguments(
+		'-DHAS_@0@=@1@'.format(name.underscorify().to_upper(), have.to_int()),
+		language: 'c',
+	)
+endforeach
+
 wlr_inc = include_directories('.', 'include')
 proto_inc = include_directories('protocol')
 
@@ -172,7 +181,7 @@ wlroots = declare_dependency(
 
 meson.override_dependency('wlroots', wlroots)
 
-summary(features, bool_yn: true)
+summary(features + internal_features, bool_yn: true)
 
 if get_option('examples')
 	subdir('examples')

--- a/xwayland/meson.build
+++ b/xwayland/meson.build
@@ -56,10 +56,9 @@ foreach lib, desc : xwayland_optional
 		required: get_option(lib),
 		not_found_message: '\n'.join(msg).format(lib),
 	)
-	if dep.found()
-		xwayland_libs += dep
-		features += { lib: true }
-	endif
+
+	internal_features += { lib: dep.found() }
+	xwayland_libs += dep
 endforeach
 
 wlr_files += files(

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -1330,7 +1330,7 @@ static void xwm_handle_focus_in(struct wlr_xwm *xwm,
 }
 
 static void xwm_handle_xcb_error(struct wlr_xwm *xwm, xcb_value_error_t *ev) {
-#if WLR_HAS_XCB_ERRORS
+#if HAS_XCB_ERRORS
 	const char *major_name =
 		xcb_errors_get_name_for_major_code(xwm->errors_context,
 			ev->major_opcode);
@@ -1368,7 +1368,7 @@ log_raw:
 }
 
 static void xwm_handle_unhandled_event(struct wlr_xwm *xwm, xcb_generic_event_t *ev) {
-#if WLR_HAS_XCB_ERRORS
+#if HAS_XCB_ERRORS
 	const char *extension;
 	const char *event_name =
 		xcb_errors_get_name_for_xcb_event(xwm->errors_context,
@@ -1598,7 +1598,7 @@ void xwm_destroy(struct wlr_xwm *xwm) {
 	if (xwm->event_source) {
 		wl_event_source_remove(xwm->event_source);
 	}
-#if WLR_HAS_XCB_ERRORS
+#if HAS_XCB_ERRORS
 	if (xwm->errors_context) {
 		xcb_errors_context_free(xwm->errors_context);
 	}
@@ -1840,7 +1840,7 @@ struct wlr_xwm *xwm_create(struct wlr_xwayland *xwayland, int wm_fd) {
 		return NULL;
 	}
 
-#if WLR_HAS_XCB_ERRORS
+#if HAS_XCB_ERRORS
 	if (xcb_errors_context_new(xwm->xcb_conn, &xwm->errors_context)) {
 		wlr_log(WLR_ERROR, "Could not allocate error context");
 		xwm_destroy(xwm);


### PR DESCRIPTION
wlroots' dependency on this library doesn't change the features
exposed to compositors. It's purely a wlroots implementation detail.
Thus downstream compositors shouldn't really care about it.