### PR TITLE
build: use get_variable instead of get_pkgconfig_variable

### DIFF
--- a/include/xwayland/meson.build
+++ b/include/xwayland/meson.build
@@ -1,7 +1,7 @@
 have_listenfd = false
 if xwayland.found()
-	xwayland_path = xwayland.get_pkgconfig_variable('xwayland')
-	have_listenfd = xwayland.get_pkgconfig_variable('have_listenfd') == 'true'
+	xwayland_path = xwayland.get_variable(pkgconfig: 'xwayland')
+	have_listenfd = xwayland.get_variable(pkgconfig: 'have_listenfd') == 'true'
 else
 	xwayland_path = xwayland_prog.full_path()
 endif


### PR DESCRIPTION
This fixes the following warning:

    WARNING: Project targeting '>=0.56.0' but tried to use feature deprecated since '0.56.0': Dependency.get_pkgconfig_variable. use Dependency.get_variable(pkgconfig : ...) instead