### PR TITLE
backend/drm: use atomic test-only commits for direct scan-out

### DIFF
--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -202,7 +202,7 @@ static bool atomic_crtc_commit(struct wlr_drm_backend *drm,
 
 	if (crtc->pending_modeset) {
 		flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
-	} else {
+	} else if (!(flags & DRM_MODE_ATOMIC_TEST_ONLY)) {
 		flags |= DRM_MODE_ATOMIC_NONBLOCK;
 	}
 

--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -31,8 +31,10 @@ static bool atomic_commit(struct atomic *atom,
 	}
 
 	int ret = drmModeAtomicCommit(drm->fd, atom->req, flags, drm);
-	if (ret) {
-		wlr_drm_conn_log_errno(conn, WLR_ERROR, "Atomic %s failed (%s)",
+	if (ret != 0) {
+		wlr_drm_conn_log_errno(conn,
+			(flags & DRM_MODE_ATOMIC_TEST_ONLY) ? WLR_DEBUG : WLR_ERROR,
+			"Atomic %s failed (%s)",
 			(flags & DRM_MODE_ATOMIC_TEST_ONLY) ? "test" : "commit",
 			(flags & DRM_MODE_ATOMIC_ALLOW_MODESET) ? "modeset" : "pageflip");
 		return false;

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -467,9 +467,6 @@ static bool drm_connector_commit_buffer(struct wlr_output *output) {
 		break;
 	case WLR_OUTPUT_STATE_BUFFER_SCANOUT:;
 		struct wlr_buffer *buffer = output->pending.buffer;
-		if (!test_buffer(conn, output->pending.buffer)) {
-			return false;
-		}
 		if (!drm_fb_import(&plane->pending_fb, drm, buffer,
 				&crtc->primary->formats)) {
 			wlr_log(WLR_ERROR, "Failed to import buffer");

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -399,13 +399,11 @@ static bool test_buffer(struct wlr_drm_connector *conn,
 		return false;
 	}
 
-	struct wlr_drm_fb *fb = NULL;
-	if (!drm_fb_import(&fb, drm, wlr_buffer, &crtc->primary->formats)) {
+	if (!drm_fb_import(&crtc->primary->pending_fb, drm, wlr_buffer,
+			&crtc->primary->formats)) {
 		return false;
 	}
-	drm_fb_clear(&fb);
-
-	return true;
+	return drm_crtc_commit(conn, DRM_MODE_ATOMIC_TEST_ONLY);
 }
 
 static bool drm_connector_test(struct wlr_output *output) {


### PR DESCRIPTION
This allows callers to use wlr_output_test to figure out whether a
buffer can be scanned out prior to committing the output.

References: https://github.com/swaywm/wlroots/issues/2250