### PR TITLE
backend/drm: take output state as arg in commit functions, take 2

### DIFF
--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -169,8 +169,10 @@ static bool atomic_crtc_commit(struct wlr_drm_backend *drm,
 	struct wlr_output *output = &conn->output;
 	struct wlr_drm_crtc *crtc = conn->crtc;
 
+	bool modeset = drm_connector_state_is_modeset(state);
+
 	uint32_t mode_id = crtc->mode_id;
-	if (crtc->pending_modeset) {
+	if (modeset) {
 		if (!create_mode_blob(drm, crtc, &mode_id)) {
 			return false;
 		}
@@ -203,7 +205,7 @@ static bool atomic_crtc_commit(struct wlr_drm_backend *drm,
 		vrr_enabled = state->adaptive_sync_enabled;
 	}
 
-	if (crtc->pending_modeset) {
+	if (modeset) {
 		flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
 	} else if (!(flags & DRM_MODE_ATOMIC_TEST_ONLY)) {
 		flags |= DRM_MODE_ATOMIC_NONBLOCK;
@@ -213,7 +215,7 @@ static bool atomic_crtc_commit(struct wlr_drm_backend *drm,
 	atomic_begin(&atom);
 	atomic_add(&atom, conn->id, conn->props.crtc_id,
 		crtc->pending.active ? crtc->id : 0);
-	if (crtc->pending_modeset && crtc->pending.active &&
+	if (modeset && crtc->pending.active &&
 			conn->props.link_status != 0) {
 		atomic_add(&atom, conn->id, conn->props.link_status,
 			DRM_MODE_LINK_STATUS_GOOD);

--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -62,7 +62,9 @@ static bool create_mode_blob(struct wlr_drm_backend *drm,
 		return true;
 	}
 
-	if (drmModeCreatePropertyBlob(drm->fd, &conn->crtc->pending.mode->drm_mode,
+	drmModeModeInfo mode = {0};
+	drm_connector_state_mode(conn, state, &mode);
+	if (drmModeCreatePropertyBlob(drm->fd, &mode,
 			sizeof(drmModeModeInfo), blob_id)) {
 		wlr_log_errno(WLR_ERROR, "Unable to create mode property blob");
 		return false;

--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -55,13 +55,14 @@ static void atomic_add(struct atomic *atom, uint32_t id, uint32_t prop, uint64_t
 }
 
 static bool create_mode_blob(struct wlr_drm_backend *drm,
-		struct wlr_drm_crtc *crtc, uint32_t *blob_id) {
-	if (!crtc->pending.active) {
+		struct wlr_drm_connector *conn, const struct wlr_output_state *state,
+		uint32_t *blob_id) {
+	if (!drm_connector_state_active(conn, state)) {
 		*blob_id = 0;
 		return true;
 	}
 
-	if (drmModeCreatePropertyBlob(drm->fd, &crtc->pending.mode->drm_mode,
+	if (drmModeCreatePropertyBlob(drm->fd, &conn->crtc->pending.mode->drm_mode,
 			sizeof(drmModeModeInfo), blob_id)) {
 		wlr_log_errno(WLR_ERROR, "Unable to create mode property blob");
 		return false;
@@ -170,10 +171,11 @@ static bool atomic_crtc_commit(struct wlr_drm_backend *drm,
 	struct wlr_drm_crtc *crtc = conn->crtc;
 
 	bool modeset = drm_connector_state_is_modeset(state);
+	bool active = drm_connector_state_active(conn, state);
 
 	uint32_t mode_id = crtc->mode_id;
 	if (modeset) {
-		if (!create_mode_blob(drm, crtc, &mode_id)) {
+		if (!create_mode_blob(drm, conn, state, &mode_id)) {
 			return false;
 		}
 	}
@@ -213,16 +215,14 @@ static bool atomic_crtc_commit(struct wlr_drm_backend *drm,
 
 	struct atomic atom;
 	atomic_begin(&atom);
-	atomic_add(&atom, conn->id, conn->props.crtc_id,
-		crtc->pending.active ? crtc->id : 0);
-	if (modeset && crtc->pending.active &&
-			conn->props.link_status != 0) {
+	atomic_add(&atom, conn->id, conn->props.crtc_id, active ? crtc->id : 0);
+	if (modeset && active && conn->props.link_status != 0) {
 		atomic_add(&atom, conn->id, conn->props.link_status,
 			DRM_MODE_LINK_STATUS_GOOD);
 	}
 	atomic_add(&atom, crtc->id, crtc->props.mode_id, mode_id);
-	atomic_add(&atom, crtc->id, crtc->props.active, crtc->pending.active);
-	if (crtc->pending.active) {
+	atomic_add(&atom, crtc->id, crtc->props.active, active);
+	if (active) {
 		if (crtc->props.gamma_lut != 0) {
 			atomic_add(&atom, crtc->id, crtc->props.gamma_lut, gamma_lut);
 		}

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -111,11 +111,12 @@ static void handle_session_active(struct wl_listener *listener, void *data) {
 		scan_drm_connectors(drm);
 
 		struct wlr_drm_connector *conn;
-		wl_list_for_each(conn, &drm->outputs, link){
+		wl_list_for_each(conn, &drm->outputs, link) {
+			struct wlr_output_state state = {0};
 			if (conn->output.enabled && conn->output.current_mode != NULL) {
-				drm_connector_set_mode(conn, conn->output.current_mode);
+				drm_connector_set_mode(conn, &state, conn->output.current_mode);
 			} else {
-				drm_connector_set_mode(conn, NULL);
+				drm_connector_set_mode(conn, &state, NULL);
 			}
 		}
 	} else {

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -122,7 +122,7 @@ static void handle_session_active(struct wl_listener *listener, void *data) {
 				.mode_type = WLR_OUTPUT_STATE_MODE_FIXED,
 				.mode = mode,
 			};
-			drm_connector_set_mode(conn, &state);
+			drm_connector_commit_state(conn, &state);
 		}
 	} else {
 		wlr_log(WLR_INFO, "DRM fd paused");

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -122,7 +122,7 @@ static void handle_session_active(struct wl_listener *listener, void *data) {
 				.mode_type = WLR_OUTPUT_STATE_MODE_FIXED,
 				.mode = mode,
 			};
-			drm_connector_set_mode(conn, &state, mode);
+			drm_connector_set_mode(conn, &state);
 		}
 	} else {
 		wlr_log(WLR_INFO, "DRM fd paused");

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -112,12 +112,17 @@ static void handle_session_active(struct wl_listener *listener, void *data) {
 
 		struct wlr_drm_connector *conn;
 		wl_list_for_each(conn, &drm->outputs, link) {
-			struct wlr_output_state state = {0};
+			struct wlr_output_mode *mode = NULL;
 			if (conn->output.enabled && conn->output.current_mode != NULL) {
-				drm_connector_set_mode(conn, &state, conn->output.current_mode);
-			} else {
-				drm_connector_set_mode(conn, &state, NULL);
+				mode = conn->output.current_mode;
 			}
+			struct wlr_output_state state = {
+				.committed = WLR_OUTPUT_STATE_MODE | WLR_OUTPUT_STATE_ENABLED,
+				.enabled = mode != NULL,
+				.mode_type = WLR_OUTPUT_STATE_MODE_FIXED,
+				.mode = mode,
+			};
+			drm_connector_set_mode(conn, &state, mode);
 		}
 	} else {
 		wlr_log(WLR_INFO, "DRM fd paused");

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -330,7 +330,7 @@ static void drm_plane_set_committed(struct wlr_drm_plane *plane) {
 static bool drm_crtc_commit(struct wlr_drm_connector *conn, uint32_t flags) {
 	struct wlr_drm_backend *drm = conn->backend;
 	struct wlr_drm_crtc *crtc = conn->crtc;
-	bool ok = drm->iface->crtc_commit(drm, conn, flags);
+	bool ok = drm->iface->crtc_commit(drm, conn, &conn->output.pending, flags);
 	if (ok && !(flags & DRM_MODE_ATOMIC_TEST_ONLY)) {
 		memcpy(&crtc->current, &crtc->pending, sizeof(struct wlr_drm_crtc_state));
 		drm_plane_set_committed(crtc->primary);

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -735,7 +735,12 @@ static void attempt_enable_needs_modeset(struct wlr_drm_backend *drm) {
 				conn->desired_enabled) {
 			wlr_drm_conn_log(conn, WLR_DEBUG,
 				"Output has a desired mode and a CRTC, attempting a modeset");
-			struct wlr_output_state state = {0};
+			struct wlr_output_state state = {
+				.committed = WLR_OUTPUT_STATE_MODE | WLR_OUTPUT_STATE_ENABLED,
+				.enabled = true,
+				.mode_type = WLR_OUTPUT_STATE_MODE_FIXED,
+				.mode = conn->desired_mode,
+			};
 			drm_connector_set_mode(conn, &state, conn->desired_mode);
 		}
 	}
@@ -1056,7 +1061,10 @@ static void dealloc_crtc(struct wlr_drm_connector *conn) {
 
 	conn->crtc->pending_modeset = true;
 	conn->crtc->pending.active = false;
-	struct wlr_output_state state = {0};
+	struct wlr_output_state state = {
+		.committed = WLR_OUTPUT_STATE_ENABLED,
+		.enabled = false,
+	};
 	if (!drm_crtc_commit(conn, &state, 0)) {
 		// On GPU unplug, disabling the CRTC can fail with EPERM
 		wlr_drm_conn_log(conn, WLR_ERROR, "Failed to disable CRTC %"PRIu32,
@@ -1185,7 +1193,10 @@ static void realloc_crtcs(struct wlr_drm_backend *drm) {
 
 		struct wlr_drm_mode *mode =
 			(struct wlr_drm_mode *)conn->output.current_mode;
-		struct wlr_output_state state = {0};
+		struct wlr_output_state state = {
+			.committed = WLR_OUTPUT_STATE_ENABLED,
+			.enabled = true,
+		};
 		if (!drm_connector_init_renderer(conn, &state, mode)) {
 			wlr_drm_conn_log(conn, WLR_ERROR, "Failed to initialize renderer");
 			wlr_output_update_enabled(&conn->output, false);

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -427,9 +427,8 @@ static bool drm_connector_test(struct wlr_output *output) {
 	return true;
 }
 
-static bool drm_connector_commit_buffer(struct wlr_output *output,
+static bool drm_connector_commit_buffer(struct wlr_drm_connector *conn,
 		const struct wlr_output_state *state) {
-	struct wlr_drm_connector *conn = get_drm_connector_from_output(output);
 	struct wlr_drm_backend *drm = conn->backend;
 
 	struct wlr_drm_crtc *crtc = conn->crtc;
@@ -521,7 +520,7 @@ static bool drm_connector_commit(struct wlr_output *output) {
 		}
 	} else if (output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
 		// TODO: support modesetting with a buffer
-		if (!drm_connector_commit_buffer(output, &output->pending)) {
+		if (!drm_connector_commit_buffer(conn, &output->pending)) {
 			return false;
 		}
 	} else if (output->pending.committed &

--- a/backend/drm/legacy.c
+++ b/backend/drm/legacy.c
@@ -26,7 +26,7 @@ static bool legacy_crtc_commit(struct wlr_drm_backend *drm,
 		fb_id = fb->id;
 	}
 
-	if (crtc->pending_modeset) {
+	if (drm_connector_state_is_modeset(state)) {
 		uint32_t *conns = NULL;
 		size_t conns_len = 0;
 		drmModeModeInfo *mode = NULL;

--- a/backend/drm/legacy.c
+++ b/backend/drm/legacy.c
@@ -15,8 +15,10 @@ static bool legacy_crtc_commit(struct wlr_drm_backend *drm,
 	struct wlr_drm_crtc *crtc = conn->crtc;
 	struct wlr_drm_plane *cursor = crtc->cursor;
 
+	bool active = drm_connector_state_active(conn, state);
+
 	uint32_t fb_id = 0;
-	if (crtc->pending.active) {
+	if (active) {
 		struct wlr_drm_fb *fb = plane_get_next_fb(crtc->primary);
 		if (fb == NULL) {
 			wlr_log(WLR_ERROR, "%s: failed to acquire primary FB",
@@ -30,14 +32,13 @@ static bool legacy_crtc_commit(struct wlr_drm_backend *drm,
 		uint32_t *conns = NULL;
 		size_t conns_len = 0;
 		drmModeModeInfo *mode = NULL;
-		if (crtc->pending.active) {
+		if (active) {
 			conns = &conn->id;
 			conns_len = 1;
 			mode = &crtc->pending.mode->drm_mode;
 		}
 
-		uint32_t dpms = crtc->pending.active ?
-			DRM_MODE_DPMS_ON : DRM_MODE_DPMS_OFF;
+		uint32_t dpms = active ? DRM_MODE_DPMS_ON : DRM_MODE_DPMS_OFF;
 		if (drmModeConnectorSetProperty(drm->fd, conn->id, conn->props.dpms,
 				dpms) != 0) {
 			wlr_drm_conn_log_errno(conn, WLR_ERROR,

--- a/backend/drm/legacy.c
+++ b/backend/drm/legacy.c
@@ -32,10 +32,12 @@ static bool legacy_crtc_commit(struct wlr_drm_backend *drm,
 		uint32_t *conns = NULL;
 		size_t conns_len = 0;
 		drmModeModeInfo *mode = NULL;
+		drmModeModeInfo mode_info = {0};
 		if (active) {
 			conns = &conn->id;
 			conns_len = 1;
-			mode = &crtc->pending.mode->drm_mode;
+			drm_connector_state_mode(conn, state, &mode_info);
+			mode = &mode_info;
 		}
 
 		uint32_t dpms = active ? DRM_MODE_DPMS_ON : DRM_MODE_DPMS_OFF;

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -49,7 +49,6 @@ struct wlr_drm_crtc_state {
 struct wlr_drm_crtc {
 	uint32_t id;
 
-	bool pending_modeset;
 	struct wlr_drm_crtc_state pending, current;
 
 	// Atomic modesetting only
@@ -159,6 +158,8 @@ size_t drm_crtc_get_gamma_lut_size(struct wlr_drm_backend *drm,
 	struct wlr_drm_crtc *crtc);
 
 struct wlr_drm_fb *plane_get_next_fb(struct wlr_drm_plane *plane);
+
+bool drm_connector_state_is_modeset(const struct wlr_output_state *state);
 
 #define wlr_drm_conn_log(conn, verb, fmt, ...) \
 	wlr_log(verb, "connector %s: " fmt, conn->name, ##__VA_ARGS__)

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -143,7 +143,7 @@ void restore_drm_outputs(struct wlr_drm_backend *drm);
 void scan_drm_connectors(struct wlr_drm_backend *state);
 int handle_drm_event(int fd, uint32_t mask, void *data);
 void destroy_drm_connector(struct wlr_drm_connector *conn);
-bool drm_connector_set_mode(struct wlr_drm_connector *conn,
+bool drm_connector_commit_state(struct wlr_drm_connector *conn,
 	const struct wlr_output_state *state);
 bool drm_connector_is_cursor_visible(struct wlr_drm_connector *conn);
 bool drm_connector_supports_vrr(struct wlr_drm_connector *conn);

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -41,14 +41,8 @@ struct wlr_drm_plane {
 	union wlr_drm_plane_props props;
 };
 
-struct wlr_drm_crtc_state {
-	struct wlr_drm_mode *mode;
-};
-
 struct wlr_drm_crtc {
 	uint32_t id;
-
-	struct wlr_drm_crtc_state pending, current;
 
 	// Atomic modesetting only
 	uint32_t mode_id;
@@ -161,6 +155,8 @@ struct wlr_drm_fb *plane_get_next_fb(struct wlr_drm_plane *plane);
 bool drm_connector_state_is_modeset(const struct wlr_output_state *state);
 bool drm_connector_state_active(struct wlr_drm_connector *conn,
 	const struct wlr_output_state *state);
+void drm_connector_state_mode(struct wlr_drm_connector *conn,
+	const struct wlr_output_state *state, drmModeModeInfo *mode);
 
 #define wlr_drm_conn_log(conn, verb, fmt, ...) \
 	wlr_log(verb, "connector %s: " fmt, conn->name, ##__VA_ARGS__)

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -152,7 +152,7 @@ void scan_drm_connectors(struct wlr_drm_backend *state);
 int handle_drm_event(int fd, uint32_t mask, void *data);
 void destroy_drm_connector(struct wlr_drm_connector *conn);
 bool drm_connector_set_mode(struct wlr_drm_connector *conn,
-	struct wlr_output_mode *mode);
+	const struct wlr_output_state *state, struct wlr_output_mode *mode);
 bool drm_connector_is_cursor_visible(struct wlr_drm_connector *conn);
 bool drm_connector_supports_vrr(struct wlr_drm_connector *conn);
 size_t drm_crtc_get_gamma_lut_size(struct wlr_drm_backend *drm,

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -42,7 +42,6 @@ struct wlr_drm_plane {
 };
 
 struct wlr_drm_crtc_state {
-	bool active;
 	struct wlr_drm_mode *mode;
 };
 
@@ -160,6 +159,8 @@ size_t drm_crtc_get_gamma_lut_size(struct wlr_drm_backend *drm,
 struct wlr_drm_fb *plane_get_next_fb(struct wlr_drm_plane *plane);
 
 bool drm_connector_state_is_modeset(const struct wlr_output_state *state);
+bool drm_connector_state_active(struct wlr_drm_connector *conn,
+	const struct wlr_output_state *state);
 
 #define wlr_drm_conn_log(conn, verb, fmt, ...) \
 	wlr_log(verb, "connector %s: " fmt, conn->name, ##__VA_ARGS__)

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -144,7 +144,7 @@ void scan_drm_connectors(struct wlr_drm_backend *state);
 int handle_drm_event(int fd, uint32_t mask, void *data);
 void destroy_drm_connector(struct wlr_drm_connector *conn);
 bool drm_connector_set_mode(struct wlr_drm_connector *conn,
-	const struct wlr_output_state *state, struct wlr_output_mode *mode);
+	const struct wlr_output_state *state);
 bool drm_connector_is_cursor_visible(struct wlr_drm_connector *conn);
 bool drm_connector_supports_vrr(struct wlr_drm_connector *conn);
 size_t drm_crtc_get_gamma_lut_size(struct wlr_drm_backend *drm,

--- a/include/backend/drm/iface.h
+++ b/include/backend/drm/iface.h
@@ -15,7 +15,8 @@ struct wlr_drm_crtc;
 struct wlr_drm_interface {
 	// Commit al pending changes on a CRTC.
 	bool (*crtc_commit)(struct wlr_drm_backend *drm,
-		struct wlr_drm_connector *conn, uint32_t flags);
+		struct wlr_drm_connector *conn, const struct wlr_output_state *state,
+		uint32_t flags);
 };
 
 extern const struct wlr_drm_interface atomic_iface;


### PR DESCRIPTION
This is a re-do of #2704, but with the changes better split up and a few enhancements.