### PR TITLE
render/egl: check "EGL_KHR_platform_gbm" for EGL_PLATFORM_GBM_KHR platform

### DIFF
--- a/render/egl.c
+++ b/render/egl.c
@@ -172,6 +172,13 @@ struct wlr_egl *wlr_egl_create(EGLenum platform, void *remote_display) {
 		return NULL;
 	}
 
+	if (platform == EGL_PLATFORM_GBM_KHR) {
+		if (!check_egl_ext(client_exts_str, "EGL_KHR_platform_gbm")) {
+			wlr_log(WLR_ERROR, "EGL_KHR_platform_gbm not supported");
+			return NULL;
+		}
+	}
+
 	if (!check_egl_ext(client_exts_str, "EGL_EXT_platform_base")) {
 		wlr_log(WLR_ERROR, "EGL_EXT_platform_base not supported");
 		return NULL;


### PR DESCRIPTION
See the https://www.khronos.org/registry/EGL/extensions/KHR/EGL_KHR_platform_gbm.txt
example code. In use EGL_PLATFORM_GBM_KHR before, should be check the
"EGL_KHR_platform_gbm" extension.