### PR TITLE
drm: check for PRIME support

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -30,14 +30,13 @@
 
 bool check_drm_features(struct wlr_drm_backend *drm) {
 	uint64_t cap;
-	if (drm->parent) {
-		if (drmGetCap(drm->fd, DRM_CAP_PRIME, &cap) ||
-				!(cap & DRM_PRIME_CAP_IMPORT)) {
-			wlr_log(WLR_ERROR,
-				"PRIME import not supported on secondary GPU");
-			return false;
-		}
+	if (drmGetCap(drm->fd, DRM_CAP_PRIME, &cap) ||
+			!(cap & DRM_PRIME_CAP_IMPORT)) {
+		wlr_log(WLR_ERROR, "PRIME import not supported");
+		return false;
+	}
 
+	if (drm->parent) {
 		if (drmGetCap(drm->parent->fd, DRM_CAP_PRIME, &cap) ||
 				!(cap & DRM_PRIME_CAP_EXPORT)) {
 			wlr_log(WLR_ERROR,

--- a/render/gbm_allocator.c
+++ b/render/gbm_allocator.c
@@ -160,6 +160,13 @@ static struct wlr_gbm_allocator *get_gbm_alloc_from_alloc(
 }
 
 struct wlr_gbm_allocator *wlr_gbm_allocator_create(int fd) {
+	uint64_t cap;
+	if (drmGetCap(fd, DRM_CAP_PRIME, &cap) ||
+			!(cap & DRM_PRIME_CAP_EXPORT)) {
+		wlr_log(WLR_ERROR, "PRIME export not supported");
+		return NULL;
+	}
+
 	struct wlr_gbm_allocator *alloc = calloc(1, sizeof(*alloc));
 	if (alloc == NULL) {
 		return NULL;

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -746,6 +746,11 @@ struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_egl *egl) {
 	wlr_log(WLR_INFO, "GL renderer: %s", glGetString(GL_RENDERER));
 	wlr_log(WLR_INFO, "Supported GLES2 extensions: %s", exts_str);
 
+	if (!renderer->egl->exts.image_dmabuf_import_ext) {
+		wlr_log(WLR_ERROR, "EGL_EXT_image_dma_buf_import not supported");
+		free(renderer);
+		return NULL;
+	}
 	if (!check_gl_ext(exts_str, "GL_EXT_texture_format_BGRA8888")) {
 		wlr_log(WLR_ERROR, "BGRA8888 format not supported by GLES2");
 		free(renderer);


### PR DESCRIPTION
PRIME support for buffer sharing has become mandatory since the renderer
rewrite. Make sure we check for the appropriate capabilities in backend,
allocator and renderer.

See also #2819.