### PR TITLE
build: disable libseat subproject server and man pages

### DIFF
--- a/backend/session/meson.build
+++ b/backend/session/meson.build
@@ -69,6 +69,7 @@ libseat = dependency('libseat',
 	required: get_option('libseat'),
 	version: '>=0.2.0',
 	fallback: ['seatd', 'libseat'],
+	default_options: ['server=disabled', 'man-pages=disabled'],
 )
 if libseat.found()
 	wlr_files += files('libseat.c')


### PR DESCRIPTION
When libseat is built as a subproject, we're not interested in
building the server or the man pages.