### PR TITLE
Fix #2777, compiler false positive in xcursor.c

### DIFF
--- a/xcursor/xcursor.c
+++ b/xcursor/xcursor.c
@@ -655,11 +655,8 @@ _XcursorAddPathElt (char *path, const char *elt, int len)
 	elt++;
 	len--;
     }
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstringop-truncation"
-    strncpy (path + pathlen, elt, len);
+    memcpy (path + pathlen, elt, len);
     path[pathlen + len] = '\0';
-#pragma GCC diagnostic pop
 }
 
 static char *

--- a/xcursor/xcursor.c
+++ b/xcursor/xcursor.c
@@ -655,7 +655,11 @@ _XcursorAddPathElt (char *path, const char *elt, int len)
 	elt++;
 	len--;
     }
-    strncat (path + pathlen, elt, len);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+    strncpy (path + pathlen, elt, len);
+    path[pathlen + len] = '\0';
+#pragma GCC diagnostic pop
 }
 
 static char *


### PR DESCRIPTION
This reverts commit 7dffe9339bf8a92a556098d86712c4c38ac95226, which introduced
another linter error with -O3:
    
      error: ‘strncat’ specified bound 7 equals source length [-Werror=stringop-overflow=]

and replace strncpy() with memcpy() to suppress the original warning.