### PR TITLE
matrix: deprecate wlr_matrix_projection

### DIFF
--- a/include/wlr/types/wlr_matrix.h
+++ b/include/wlr/types/wlr_matrix.h
@@ -44,7 +44,10 @@ void wlr_matrix_transform(float mat[static 9],
 	enum wl_output_transform transform);
 
 /** Writes a 2D orthographic projection matrix to mat of (width, height) with a
- *  specified wl_output_transform*/
+ *  specified wl_output_transform.
+ *
+ *  Deprecated: this function is deprecated and will be removed in a future
+ *  version of wlroots. */
 void wlr_matrix_projection(float mat[static 9], int width, int height,
 	enum wl_output_transform transform);
 


### PR DESCRIPTION
This function has baked-in GL assumptions. Compositors shouldn't
need to use it.