### PR TITLE
backend: move get_drm_fd to public interface

### DIFF
--- a/backend/backend.c
+++ b/backend/backend.c
@@ -16,7 +16,6 @@
 #include <wlr/backend/wayland.h>
 #include <wlr/config.h>
 #include <wlr/util/log.h>
-#include "backend/backend.h"
 #include "backend/multi.h"
 
 #if WLR_HAS_X11_BACKEND
@@ -72,7 +71,7 @@ clockid_t wlr_backend_get_presentation_clock(struct wlr_backend *backend) {
 	return CLOCK_MONOTONIC;
 }
 
-int backend_get_drm_fd(struct wlr_backend *backend) {
+int wlr_backend_get_drm_fd(struct wlr_backend *backend) {
 	if (!backend->impl->get_drm_fd) {
 		return -1;
 	}

--- a/backend/multi/backend.c
+++ b/backend/multi/backend.c
@@ -6,7 +6,6 @@
 #include <wlr/backend/interface.h>
 #include <wlr/backend/session.h>
 #include <wlr/util/log.h>
-#include "backend/backend.h"
 #include "backend/multi.h"
 #include "util/signal.h"
 
@@ -103,7 +102,7 @@ static int multi_backend_get_drm_fd(struct wlr_backend *backend) {
 	struct subbackend_state *sub;
 	wl_list_for_each(sub, &multi->backends, link) {
 		if (sub->backend->impl->get_drm_fd) {
-			return backend_get_drm_fd(sub->backend);
+			return wlr_backend_get_drm_fd(sub->backend);
 		}
 	}
 

--- a/include/backend/backend.h
+++ b/include/backend/backend.h
@@ -1,8 +1,0 @@
-#ifndef BACKEND_H
-#define BACKEND_H
-
-#include <wlr/backend.h>
-
-int backend_get_drm_fd(struct wlr_backend *backend);
-
-#endif

--- a/include/wlr/backend.h
+++ b/include/wlr/backend.h
@@ -57,5 +57,12 @@ struct wlr_session *wlr_backend_get_session(struct wlr_backend *backend);
  * Returns the clock used by the backend for presentation feedback.
  */
 clockid_t wlr_backend_get_presentation_clock(struct wlr_backend *backend);
+/**
+ * Returns the DRM node file descriptor used by the backend's underlying
+ * platform. Can be used by consumers for additional rendering operations.
+ * The consumer must not close the file descriptor since the backend continues
+ * to have ownership of it.
+ */
+int wlr_backend_get_drm_fd(struct wlr_backend *backend);
 
 #endif

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -11,7 +11,6 @@
 #include "util/signal.h"
 #include "render/pixel_format.h"
 #include "render/wlr_renderer.h"
-#include "backend/backend.h"
 
 void wlr_renderer_init(struct wlr_renderer *renderer,
 		const struct wlr_renderer_impl *impl) {
@@ -247,7 +246,7 @@ struct wlr_renderer *wlr_renderer_autocreate_with_drm_fd(int drm_fd) {
 }
 
 struct wlr_renderer *wlr_renderer_autocreate(struct wlr_backend *backend) {
-	int drm_fd = backend_get_drm_fd(backend);
+	int drm_fd = wlr_backend_get_drm_fd(backend);
 	if (drm_fd < 0) {
 		wlr_log(WLR_ERROR, "Failed to get DRM FD from backend");
 		return NULL;


### PR DESCRIPTION
As discussed on IRC: The get_drm_fd was made available in an internal header with a53ab146f. Move it now to the public header so consumers opting in to the unstable interfaces can make use of it.