### PR TITLE
linux-dmabuf-v1: split params and buffer

### DIFF
--- a/include/wlr/types/wlr_linux_dmabuf_v1.h
+++ b/include/wlr/types/wlr_linux_dmabuf_v1.h
@@ -34,13 +34,6 @@ bool wlr_dmabuf_v1_resource_is_buffer(struct wl_resource *buffer_resource);
 struct wlr_dmabuf_v1_buffer *wlr_dmabuf_v1_buffer_from_buffer_resource(
 	struct wl_resource *buffer_resource);
 
-/**
- * Returns the wlr_dmabuf_buffer if the given resource was created
- * via the linux-dmabuf params protocol
- */
-struct wlr_dmabuf_v1_buffer *wlr_dmabuf_v1_buffer_from_params_resource(
-	struct wl_resource *params_resource);
-
 /* the protocol interface */
 struct wlr_linux_dmabuf_v1 {
 	struct wl_global *global;
@@ -59,12 +52,5 @@ struct wlr_linux_dmabuf_v1 {
  */
 struct wlr_linux_dmabuf_v1 *wlr_linux_dmabuf_v1_create(struct wl_display *display,
 	struct wlr_renderer *renderer);
-
-/**
- * Returns the wlr_linux_dmabuf if the given resource was created
- * via the linux_dmabuf protocol
- */
-struct wlr_linux_dmabuf_v1 *wlr_linux_dmabuf_v1_from_resource(
-	struct wl_resource *resource);
 
 #endif

--- a/include/wlr/types/wlr_linux_dmabuf_v1.h
+++ b/include/wlr/types/wlr_linux_dmabuf_v1.h
@@ -14,11 +14,8 @@
 #include <wlr/render/dmabuf.h>
 
 struct wlr_dmabuf_v1_buffer {
-	struct wlr_renderer *renderer;
-	struct wl_resource *buffer_resource;
-	struct wl_resource *params_resource;
+	struct wl_resource *resource;
 	struct wlr_dmabuf_attributes attributes;
-	bool has_modifier;
 };
 
 /**
@@ -33,6 +30,13 @@ bool wlr_dmabuf_v1_resource_is_buffer(struct wl_resource *buffer_resource);
  */
 struct wlr_dmabuf_v1_buffer *wlr_dmabuf_v1_buffer_from_buffer_resource(
 	struct wl_resource *buffer_resource);
+
+struct wlr_linux_buffer_params_v1 {
+	struct wl_resource *resource;
+	struct wlr_linux_dmabuf_v1 *linux_dmabuf;
+	struct wlr_dmabuf_attributes attributes;
+	bool has_modifier;
+};
 
 /* the protocol interface */
 struct wlr_linux_dmabuf_v1 {

--- a/types/wlr_screencopy_v1.c
+++ b/types/wlr_screencopy_v1.c
@@ -265,12 +265,8 @@ static void frame_handle_output_precommit(struct wl_listener *listener,
 static bool blit_dmabuf(struct wlr_renderer *renderer,
 		struct wlr_dmabuf_v1_buffer *dst_dmabuf,
 		struct wlr_dmabuf_attributes *src_attrs) {
-	if (dst_dmabuf->buffer_resource == NULL) {
-		return false;
-	}
-
 	struct wlr_client_buffer *dst_client_buffer =
-		wlr_client_buffer_import(renderer, dst_dmabuf->buffer_resource);
+		wlr_client_buffer_import(renderer, dst_dmabuf->resource);
 	if (dst_client_buffer == NULL) {
 		return false;
 	}


### PR DESCRIPTION
Previously, the same struct was used for linux-dmabuf-v1 params
and buffer. This made the whole logic a little bit awkward, because
a wlr_dmabuf_v1_buffer could either be still being constructed, or
be a complete buffer.

Introduce a separate wlr_linux_buffer_params_v1 struct for buffer
params still being constructed. Once the params are complete (ie.
once the create request is sent), the params struct is destroyed
and the buffer struct is created.

This will help with #2664 as well.