### PR TITLE
Cache and re-use DMA-BUF textures

### DIFF
--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -18,6 +18,7 @@
 #include "render/pixel_format.h"
 #include "render/swapchain.h"
 #include "render/wlr_renderer.h"
+#include "render/wlr_texture.h"
 
 bool init_drm_renderer(struct wlr_drm_backend *drm,
 		struct wlr_drm_renderer *renderer) {
@@ -135,12 +136,7 @@ static struct wlr_buffer *drm_surface_blit(struct wlr_drm_surface *surf,
 		return NULL;
 	}
 
-	struct wlr_dmabuf_attributes attribs = {0};
-	if (!wlr_buffer_get_dmabuf(buffer, &attribs)) {
-		return NULL;
-	}
-
-	struct wlr_texture *tex = wlr_texture_from_dmabuf(renderer, &attribs);
+	struct wlr_texture *tex = wlr_texture_from_buffer(renderer, buffer);
 	if (tex == NULL) {
 		return NULL;
 	}

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -103,6 +103,10 @@ struct wlr_gles2_texture {
 
 	// Only affects target == GL_TEXTURE_2D
 	uint32_t drm_format; // used to interpret upload data
+	// If imported from a wlr_buffer
+	struct wlr_buffer *buffer;
+
+	struct wl_listener buffer_destroy;
 };
 
 const struct wlr_gles2_pixel_format *get_gles2_format_from_drm(uint32_t fmt);
@@ -122,6 +126,8 @@ struct wlr_texture *gles2_texture_from_wl_drm(struct wlr_renderer *wlr_renderer,
 	struct wl_resource *data);
 struct wlr_texture *gles2_texture_from_dmabuf(struct wlr_renderer *wlr_renderer,
 	struct wlr_dmabuf_attributes *attribs);
+struct wlr_texture *gles2_texture_from_buffer(struct wlr_renderer *wlr_renderer,
+	struct wlr_buffer *buffer);
 
 void push_gles2_debug_(struct wlr_gles2_renderer *renderer,
 	const char *file, const char *func);

--- a/include/render/wlr_texture.h
+++ b/include/render/wlr_texture.h
@@ -1,0 +1,15 @@
+#ifndef RENDER_WLR_TEXTURE_H
+#define RENDER_WLR_TEXTURE_H
+
+#include <wlr/render/wlr_texture.h>
+
+/**
+ * Create a new texture from a buffer.
+ *
+ * Should not be called in a rendering block like renderer_begin()/end() or
+ * between attaching a renderer to an output and committing it.
+ */
+struct wlr_texture *wlr_texture_from_buffer(struct wlr_renderer *renderer,
+	struct wlr_buffer *buffer);
+
+#endif

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -57,6 +57,8 @@ struct wlr_renderer_impl {
 		struct wl_display *wl_display);
 	int (*get_drm_fd)(struct wlr_renderer *renderer);
 	uint32_t (*get_render_buffer_caps)(void);
+	struct wlr_texture *(*texture_from_buffer)(struct wlr_renderer *renderer,
+		struct wlr_buffer *buffer);
 };
 
 void wlr_renderer_init(struct wlr_renderer *renderer,

--- a/include/wlr/types/wlr_linux_dmabuf_v1.h
+++ b/include/wlr/types/wlr_linux_dmabuf_v1.h
@@ -11,11 +11,16 @@
 
 #include <stdint.h>
 #include <wayland-server-core.h>
+#include <wlr/types/wlr_buffer.h>
 #include <wlr/render/dmabuf.h>
 
 struct wlr_dmabuf_v1_buffer {
-	struct wl_resource *resource;
+	struct wlr_buffer base;
+
+	struct wl_resource *resource; // can be NULL if the client destroyed it
 	struct wlr_dmabuf_attributes attributes;
+
+	struct wl_listener release;
 };
 
 /**

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -597,6 +597,7 @@ static const struct wlr_renderer_impl renderer_impl = {
 	.init_wl_display = gles2_init_wl_display,
 	.get_drm_fd = gles2_get_drm_fd,
 	.get_render_buffer_caps = gles2_get_render_buffer_caps,
+	.texture_from_buffer = gles2_texture_from_buffer,
 };
 
 void push_gles2_debug_(struct wlr_gles2_renderer *renderer,

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -125,6 +125,20 @@ static const struct wlr_texture_impl texture_impl = {
 	.destroy = gles2_texture_destroy,
 };
 
+static struct wlr_gles2_texture *gles2_texture_create(
+		struct wlr_gles2_renderer *renderer, uint32_t width, uint32_t height) {
+	struct wlr_gles2_texture *texture =
+		calloc(1, sizeof(struct wlr_gles2_texture));
+	if (texture == NULL) {
+		wlr_log_errno(WLR_ERROR, "Allocation failed");
+		return NULL;
+	}
+	wlr_texture_init(&texture->wlr_texture, &texture_impl, width, height);
+	texture->renderer = renderer;
+	wl_list_insert(&renderer->textures, &texture->link);
+	return texture;
+}
+
 struct wlr_texture *gles2_texture_from_pixels(struct wlr_renderer *wlr_renderer,
 		uint32_t drm_format, uint32_t stride, uint32_t width,
 		uint32_t height, const void *data) {
@@ -146,13 +160,10 @@ struct wlr_texture *gles2_texture_from_pixels(struct wlr_renderer *wlr_renderer,
 	}
 
 	struct wlr_gles2_texture *texture =
-		calloc(1, sizeof(struct wlr_gles2_texture));
+		gles2_texture_create(renderer, width, height);
 	if (texture == NULL) {
-		wlr_log(WLR_ERROR, "Allocation failed");
 		return NULL;
 	}
-	wlr_texture_init(&texture->wlr_texture, &texture_impl, width, height);
-	texture->renderer = renderer;
 	texture->target = GL_TEXTURE_2D;
 	texture->has_alpha = fmt->has_alpha;
 	texture->drm_format = fmt->drm_format;
@@ -178,8 +189,6 @@ struct wlr_texture *gles2_texture_from_pixels(struct wlr_renderer *wlr_renderer,
 	pop_gles2_debug(renderer);
 
 	wlr_egl_restore_context(&prev_ctx);
-
-	wl_list_insert(&renderer->textures, &texture->link);
 
 	return &texture->wlr_texture;
 }
@@ -207,9 +216,8 @@ struct wlr_texture *gles2_texture_from_wl_drm(struct wlr_renderer *wlr_renderer,
 	}
 
 	struct wlr_gles2_texture *texture =
-		calloc(1, sizeof(struct wlr_gles2_texture));
+		gles2_texture_create(renderer, width, height);
 	if (texture == NULL) {
-		wlr_log(WLR_ERROR, "Allocation failed");
 		goto error_image;
 	}
 	wlr_texture_init(&texture->wlr_texture, &texture_impl, width, height);
@@ -248,11 +256,10 @@ struct wlr_texture *gles2_texture_from_wl_drm(struct wlr_renderer *wlr_renderer,
 
 	wlr_egl_restore_context(&prev_ctx);
 
-	wl_list_insert(&renderer->textures, &texture->link);
-
 	return &texture->wlr_texture;
 
 error_texture:
+	wl_list_remove(&texture->link);
 	free(texture);
 error_image:
 	wlr_egl_destroy_image(renderer->egl, image);
@@ -276,14 +283,10 @@ struct wlr_texture *gles2_texture_from_dmabuf(struct wlr_renderer *wlr_renderer,
 	}
 
 	struct wlr_gles2_texture *texture =
-		calloc(1, sizeof(struct wlr_gles2_texture));
+		gles2_texture_create(renderer, attribs->width, attribs->height);
 	if (texture == NULL) {
-		wlr_log(WLR_ERROR, "Allocation failed");
 		return NULL;
 	}
-	wlr_texture_init(&texture->wlr_texture, &texture_impl,
-		attribs->width, attribs->height);
-	texture->renderer = renderer;
 	texture->has_alpha = true;
 	texture->drm_format = DRM_FORMAT_INVALID; // texture can't be written anyways
 	texture->inverted_y =
@@ -299,6 +302,7 @@ struct wlr_texture *gles2_texture_from_dmabuf(struct wlr_renderer *wlr_renderer,
 	if (texture->image == EGL_NO_IMAGE_KHR) {
 		wlr_log(WLR_ERROR, "Failed to create EGL image from DMA-BUF");
 		wlr_egl_restore_context(&prev_ctx);
+		wl_list_remove(&texture->link);
 		free(texture);
 		return NULL;
 	}
@@ -317,8 +321,6 @@ struct wlr_texture *gles2_texture_from_dmabuf(struct wlr_renderer *wlr_renderer,
 	pop_gles2_debug(renderer);
 
 	wlr_egl_restore_context(&prev_ctx);
-
-	wl_list_insert(&renderer->textures, &texture->link);
 
 	return &texture->wlr_texture;
 }

--- a/render/wlr_texture.c
+++ b/render/wlr_texture.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <wlr/render/interface.h>
 #include <wlr/render/wlr_texture.h>
+#include "render/wlr_texture.h"
 
 void wlr_texture_init(struct wlr_texture *texture,
 		const struct wlr_texture_impl *impl, uint32_t width, uint32_t height) {
@@ -44,6 +45,15 @@ struct wlr_texture *wlr_texture_from_dmabuf(struct wlr_renderer *renderer,
 		return NULL;
 	}
 	return renderer->impl->texture_from_dmabuf(renderer, attribs);
+}
+
+struct wlr_texture *wlr_texture_from_buffer(struct wlr_renderer *renderer,
+		struct wlr_buffer *buffer) {
+	assert(!renderer->rendering);
+	if (!renderer->impl->texture_from_buffer) {
+		return NULL;
+	}
+	return renderer->impl->texture_from_buffer(renderer, buffer);
 }
 
 bool wlr_texture_is_opaque(struct wlr_texture *texture) {

--- a/types/wlr_buffer.c
+++ b/types/wlr_buffer.c
@@ -5,6 +5,7 @@
 #include <wlr/types/wlr_linux_dmabuf_v1.h>
 #include <wlr/util/log.h>
 #include "render/pixel_format.h"
+#include "render/wlr_texture.h"
 #include "types/wlr_buffer.h"
 #include "util/signal.h"
 
@@ -220,11 +221,11 @@ struct wlr_client_buffer *wlr_client_buffer_import(
 	} else if (wlr_dmabuf_v1_resource_is_buffer(resource)) {
 		struct wlr_dmabuf_v1_buffer *dmabuf =
 			wlr_dmabuf_v1_buffer_from_buffer_resource(resource);
-		texture = wlr_texture_from_dmabuf(renderer, &dmabuf->attributes);
+		texture = wlr_texture_from_buffer(renderer, &dmabuf->base);
 
-		// We have imported the DMA-BUF, but we need to prevent the client from
-		// re-using the same DMA-BUF for the next frames, so we don't release
-		// the buffer yet.
+		// The renderer is responsible for releasing the buffer when
+		// appropriate
+		resource_released = true;
 	} else {
 		wlr_log(WLR_ERROR, "Cannot upload texture: unknown buffer type");
 

--- a/types/wlr_screencopy_v1.c
+++ b/types/wlr_screencopy_v1.c
@@ -266,12 +266,7 @@ static void frame_handle_output_precommit(struct wl_listener *listener,
 static bool blit_dmabuf(struct wlr_renderer *renderer,
 		struct wlr_dmabuf_v1_buffer *dst_dmabuf,
 		struct wlr_dmabuf_attributes *src_attrs) {
-	struct wlr_client_buffer *dst_client_buffer =
-		wlr_client_buffer_import(renderer, dst_dmabuf->resource);
-	if (dst_client_buffer == NULL) {
-		return false;
-	}
-	struct wlr_buffer *dst_buffer = &dst_client_buffer->base;
+	struct wlr_buffer *dst_buffer = wlr_buffer_lock(&dst_dmabuf->base);
 
 	struct wlr_texture *src_tex = wlr_texture_from_dmabuf(renderer, src_attrs);
 	if (src_tex == NULL) {


### PR DESCRIPTION
If a client creates a `wl_buffer` and attaches it to a `wl_surface`, there's a good chance they're going to re-use it.

References: https://github.com/swaywm/wlroots/issues/2664