### PR TITLE
render/gbm_allocator: make wlr_gbm_allocator_create return a wlr_allocator

### DIFF
--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -62,7 +62,7 @@ void finish_drm_renderer(struct wlr_drm_renderer *renderer) {
 		return;
 	}
 
-	wlr_allocator_destroy(&renderer->allocator->base);
+	wlr_allocator_destroy(renderer->allocator);
 	wlr_renderer_destroy(renderer->wlr_rend);
 	gbm_device_destroy(renderer->gbm);
 }
@@ -83,8 +83,8 @@ static bool init_drm_surface(struct wlr_drm_surface *surf,
 	wlr_swapchain_destroy(surf->swapchain);
 	surf->swapchain = NULL;
 
-	surf->swapchain = wlr_swapchain_create(&renderer->allocator->base,
-		width, height, drm_format);
+	surf->swapchain = wlr_swapchain_create(renderer->allocator, width, height,
+			drm_format);
 	if (surf->swapchain == NULL) {
 		wlr_log(WLR_ERROR, "Failed to create swapchain");
 		memset(surf, 0, sizeof(*surf));

--- a/backend/headless/backend.c
+++ b/backend/headless/backend.c
@@ -220,21 +220,21 @@ struct wlr_backend *wlr_headless_backend_create(struct wl_display *display) {
 		goto error_dup;
 	}
 
-	struct wlr_gbm_allocator *gbm_alloc = wlr_gbm_allocator_create(drm_fd);
-	if (gbm_alloc == NULL) {
+	struct wlr_allocator *alloc = wlr_gbm_allocator_create(drm_fd);
+	if (alloc == NULL) {
 		wlr_log(WLR_ERROR, "Failed to create GBM allocator");
 		close(drm_fd);
 		goto error_dup;
 	}
 
-	if (!backend_init(backend, display, &gbm_alloc->base, NULL)) {
+	if (!backend_init(backend, display, alloc, NULL)) {
 		goto error_init;
 	}
 
 	return &backend->backend;
 
 error_init:
-	wlr_allocator_destroy(&gbm_alloc->base);
+	wlr_allocator_destroy(alloc);
 error_dup:
 	close(backend->drm_fd);
 error_drm_fd:
@@ -266,14 +266,14 @@ struct wlr_backend *wlr_headless_backend_create_with_renderer(
 		goto error_dup;
 	}
 
-	struct wlr_gbm_allocator *gbm_alloc = wlr_gbm_allocator_create(drm_fd);
-	if (gbm_alloc == NULL) {
+	struct wlr_allocator *alloc = wlr_gbm_allocator_create(drm_fd);
+	if (alloc == NULL) {
 		wlr_log(WLR_ERROR, "Failed to create GBM allocator");
 		close(drm_fd);
 		goto error_dup;
 	}
 
-	if (!backend_init(backend, display, &gbm_alloc->base, renderer)) {
+	if (!backend_init(backend, display, alloc, renderer)) {
 		goto error_init;
 	}
 
@@ -283,7 +283,7 @@ struct wlr_backend *wlr_headless_backend_create_with_renderer(
 	return &backend->backend;
 
 error_init:
-	wlr_allocator_destroy(&gbm_alloc->base);
+	wlr_allocator_destroy(alloc);
 error_dup:
 	close(backend->drm_fd);
 error_drm_fd:

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -435,13 +435,12 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display,
 		goto error_drm_fd;
 	}
 
-	struct wlr_gbm_allocator *gbm_alloc = wlr_gbm_allocator_create(drm_fd);
-	if (gbm_alloc == NULL) {
+	wl->allocator = wlr_gbm_allocator_create(drm_fd);
+	if (wl->allocator == NULL) {
 		wlr_log(WLR_ERROR, "Failed to create GBM allocator");
 		close(drm_fd);
 		goto error_drm_fd;
 	}
-	wl->allocator = &gbm_alloc->base;
 
 	wl->renderer = wlr_renderer_autocreate(&wl->backend);
 	if (wl->renderer == NULL) {

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -578,13 +578,12 @@ struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
 		goto error_event;
 	}
 
-	struct wlr_gbm_allocator *gbm_alloc = wlr_gbm_allocator_create(drm_fd);
-	if (gbm_alloc == NULL) {
+	x11->allocator = wlr_gbm_allocator_create(drm_fd);
+	if (x11->allocator == NULL) {
 		wlr_log(WLR_ERROR, "Failed to create GBM allocator");
 		close(drm_fd);
 		goto error_event;
 	}
-	x11->allocator = &gbm_alloc->base;
 
 	x11->renderer = wlr_renderer_autocreate(&x11->backend);
 	if (x11->renderer == NULL) {

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -16,7 +16,7 @@ struct wlr_drm_renderer {
 	struct gbm_device *gbm;
 
 	struct wlr_renderer *wlr_rend;
-	struct wlr_gbm_allocator *allocator;
+	struct wlr_allocator *allocator;
 };
 
 struct wlr_drm_surface {

--- a/include/render/gbm_allocator.h
+++ b/include/render/gbm_allocator.h
@@ -28,6 +28,6 @@ struct wlr_gbm_allocator {
  *
  * Takes ownership over the FD.
  */
-struct wlr_gbm_allocator *wlr_gbm_allocator_create(int drm_fd);
+struct wlr_allocator *wlr_gbm_allocator_create(int drm_fd);
 
 #endif

--- a/render/gbm_allocator.c
+++ b/render/gbm_allocator.c
@@ -159,7 +159,7 @@ static struct wlr_gbm_allocator *get_gbm_alloc_from_alloc(
 	return (struct wlr_gbm_allocator *)alloc;
 }
 
-struct wlr_gbm_allocator *wlr_gbm_allocator_create(int fd) {
+struct wlr_allocator *wlr_gbm_allocator_create(int fd) {
 	uint64_t cap;
 	if (drmGetCap(fd, DRM_CAP_PRIME, &cap) ||
 			!(cap & DRM_PRIME_CAP_EXPORT)) {
@@ -186,7 +186,7 @@ struct wlr_gbm_allocator *wlr_gbm_allocator_create(int fd) {
 	wlr_log(WLR_DEBUG, "Created GBM allocator with backend %s",
 		gbm_device_get_backend_name(alloc->gbm_device));
 
-	return alloc;
+	return &alloc->base;
 }
 
 static void allocator_destroy(struct wlr_allocator *wlr_alloc) {


### PR DESCRIPTION
This patch will prepare the field for dealing with multiple allocators (`drm_dumb` and `shm`) in the coming pixman renderer #2661 

/cc @emersion 