### PR TITLE
backend/x11: add support for shm buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ If you choose to enable X11 support:
 * xcb-icccm
 * xcb-image
 * xcb-render
+* xcb-shm
 * xcb-errors (optional, for improved error reporting)
 
 Run these commands:

--- a/backend/x11/meson.build
+++ b/backend/x11/meson.build
@@ -5,6 +5,7 @@ x11_required = [
 	'xcb-present',
 	'xcb-render',
 	'xcb-renderutil',
+	'xcb-shm',
 	'xcb-xfixes',
 	'xcb-xinput',
 ]

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -75,6 +75,9 @@ struct wlr_x11_backend {
 	xcb_colormap_t colormap;
 	xcb_cursor_t transparent_cursor;
 	xcb_render_pictformat_t argb32;
+
+	bool have_shm;
+	bool have_dri3;
 	uint32_t dri3_major_version, dri3_minor_version;
 
 	size_t requested_outputs;
@@ -87,6 +90,7 @@ struct wlr_x11_backend {
 	int drm_fd;
 	struct wlr_renderer *renderer;
 	struct wlr_drm_format_set dri3_formats;
+	struct wlr_drm_format_set shm_formats;
 	const struct wlr_x11_format *x11_format;
 	struct wlr_drm_format *drm_format;
 	struct wlr_allocator *allocator;


### PR DESCRIPTION
Closes #2866.

This doesn't work in Xwayland for me, since `shared_pixmaps` is 0 when running there.
I'm not sure if that's the case for Xwayland in general.