### PR TITLE
xcursor: quiet debug log

### DIFF
--- a/xcursor/wlr_xcursor.c
+++ b/xcursor/wlr_xcursor.c
@@ -240,15 +240,8 @@ struct wlr_xcursor_theme *wlr_xcursor_theme_load(const char *name, int size) {
 		load_default_theme(theme);
 	}
 
-	wlr_log(WLR_DEBUG, "Loaded cursor theme '%s', available cursors:",
-			theme->name);
-	for (size_t i = 0; i < theme->cursor_count; ++i) {
-		struct wlr_xcursor *c = theme->cursors[i];
-		struct wlr_xcursor_image *i = c->images[0];
-		wlr_log(WLR_DEBUG, "%s (%u images) %" PRIu32 "x%" PRIu32 "+%" PRIu32 ",%" PRIu32,
-				c->name, c->image_count,
-				i->width, i->height, i->hotspot_x, i->hotspot_y);
-	}
+	wlr_log(WLR_DEBUG, "Loaded cursor theme '%s' at size %d (%d available cursors)",
+			theme->name, size, theme->cursor_count);
 
 	return theme;
 


### PR DESCRIPTION
Stop listing all available cursors each time a cursor theme is
loaded. They can be obtained from the CLI instead, e.g.

    ls /usr/share/icons/Adwaita/cursors