### PR TITLE
output: correctly handle outputs without a test() impl

### DIFF
--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -580,6 +580,9 @@ bool wlr_output_test(struct wlr_output *output) {
 	if (!output_basic_test(output)) {
 		return false;
 	}
+	if (!output->impl->test) {
+		return true;
+	}
 	return output->impl->test(output);
 }
 


### PR DESCRIPTION
This fixes a crash when calling wlr_output_test() on a headless
output.

Closes: https://github.com/swaywm/sway/issues/6213