### PR TITLE
render: destroy textures with renderer

### DIFF
--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -67,6 +67,7 @@ struct wlr_gles2_renderer {
 	} shaders;
 
 	struct wl_list buffers; // wlr_gles2_buffer.link
+	struct wl_list textures; // wlr_gles2_texture.link
 
 	struct wlr_gles2_buffer *current_buffer;
 	uint32_t viewport_width, viewport_height;
@@ -87,6 +88,7 @@ struct wlr_gles2_buffer {
 struct wlr_gles2_texture {
 	struct wlr_texture wlr_texture;
 	struct wlr_gles2_renderer *renderer;
+	struct wl_list link; // wlr_gles2_renderer.textures
 
 	// Basically:
 	//   GL_TEXTURE_2D == mutable

--- a/include/render/pixman.h
+++ b/include/render/pixman.h
@@ -17,6 +17,7 @@ struct wlr_pixman_renderer {
 	struct wlr_renderer wlr_renderer;
 
 	struct wl_list buffers; // wlr_pixman_buffer.link
+	struct wl_list textures; // wlr_pixman_texture.link
 
 	struct wlr_pixman_buffer *current_buffer;
 	int32_t width, height;
@@ -37,6 +38,7 @@ struct wlr_pixman_buffer {
 struct wlr_pixman_texture {
 	struct wlr_texture wlr_texture;
 	struct wlr_pixman_renderer *renderer;
+	struct wl_list link; // wlr_pixman_renderer.textures
 
 	void *data;
 	pixman_image_t *image;

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -542,6 +542,11 @@ static void gles2_destroy(struct wlr_renderer *wlr_renderer) {
 		destroy_buffer(buffer);
 	}
 
+	struct wlr_gles2_texture *tex, *tex_tmp;
+	wl_list_for_each_safe(tex, tex_tmp, &renderer->textures, link) {
+		wlr_texture_destroy(&tex->wlr_texture);
+	}
+
 	push_gles2_debug(renderer);
 	glDeleteProgram(renderer->shaders.quad.program);
 	glDeleteProgram(renderer->shaders.tex_rgba.program);
@@ -763,6 +768,7 @@ struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_egl *egl) {
 	wlr_renderer_init(&renderer->wlr_renderer, &renderer_impl);
 
 	wl_list_init(&renderer->buffers);
+	wl_list_init(&renderer->textures);
 
 	renderer->egl = egl;
 	renderer->exts_str = exts_str;

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -105,6 +105,8 @@ static void gles2_texture_destroy(struct wlr_texture *wlr_texture) {
 
 	struct wlr_gles2_texture *texture = gles2_get_texture(wlr_texture);
 
+	wl_list_remove(&texture->link);
+
 	struct wlr_egl_context prev_ctx;
 	wlr_egl_save_context(&prev_ctx);
 	wlr_egl_make_current(texture->renderer->egl);
@@ -181,6 +183,8 @@ struct wlr_texture *gles2_texture_from_pixels(struct wlr_renderer *wlr_renderer,
 
 	wlr_egl_restore_context(&prev_ctx);
 
+	wl_list_insert(&renderer->textures, &texture->link);
+
 	return &texture->wlr_texture;
 }
 
@@ -247,6 +251,8 @@ struct wlr_texture *gles2_texture_from_wl_drm(struct wlr_renderer *wlr_renderer,
 	pop_gles2_debug(renderer);
 
 	wlr_egl_restore_context(&prev_ctx);
+
+	wl_list_insert(&renderer->textures, &texture->link);
 
 	return &texture->wlr_texture;
 
@@ -315,6 +321,8 @@ struct wlr_texture *gles2_texture_from_dmabuf(struct wlr_renderer *wlr_renderer,
 	pop_gles2_debug(renderer);
 
 	wlr_egl_restore_context(&prev_ctx);
+
+	wl_list_insert(&renderer->textures, &texture->link);
 
 	return &texture->wlr_texture;
 }

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -99,10 +99,6 @@ static bool gles2_texture_write_pixels(struct wlr_texture *wlr_texture,
 }
 
 static void gles2_texture_destroy(struct wlr_texture *wlr_texture) {
-	if (wlr_texture == NULL) {
-		return;
-	}
-
 	struct wlr_gles2_texture *texture = gles2_get_texture(wlr_texture);
 
 	wl_list_remove(&texture->link);

--- a/render/pixman/renderer.c
+++ b/render/pixman/renderer.c
@@ -43,11 +43,7 @@ static bool texture_is_opaque(struct wlr_texture *wlr_texture) {
 }
 
 static void texture_destroy(struct wlr_texture *wlr_texture) {
-	if (wlr_texture == NULL) {
-		return;
-	}
 	struct wlr_pixman_texture *texture = get_texture(wlr_texture);
-
 	wl_list_remove(&texture->link);
 	pixman_image_unref(texture->image);
 	free(texture->data);


### PR DESCRIPTION
This prevents some leaks and stray `wlr_texture`s that don't have a renderer anymore.

cc @bl4ckb0ne for the pixman bits