### PR TITLE
Allow unfocused xwayland clients to access clipboard

### DIFF
--- a/xwayland/selection/incoming.c
+++ b/xwayland/selection/incoming.c
@@ -467,13 +467,6 @@ void xwm_handle_selection_notify(struct wlr_xwm *xwm,
 			xwm_selection_transfer_destroy(transfer);
 		}
 	} else if (event->target == xwm->atoms[TARGETS]) {
-		// No xwayland surface focused, deny access to clipboard
-		if (xwm->focus_surface == NULL) {
-			wlr_log(WLR_DEBUG, "denying write access to clipboard: "
-				"no xwayland surface focused");
-			return;
-		}
-
 		// This sets the Wayland clipboard (by calling wlr_seat_set_selection)
 		xwm_selection_get_targets(selection);
 	} else if (transfer) {

--- a/xwayland/selection/outgoing.c
+++ b/xwayland/selection/outgoing.c
@@ -410,15 +410,6 @@ void xwm_handle_selection_request(struct wlr_xwm *xwm,
 		return;
 	}
 
-	// No xwayland surface focused, deny access to clipboard
-	if (xwm->focus_surface == NULL && xwm->drag_focus == NULL) {
-		char *selection_name = xwm_get_atom_name(xwm, selection->atom);
-		wlr_log(WLR_DEBUG, "denying read access to selection %u (%s): "
-			"no xwayland surface focused", selection->atom, selection_name);
-		free(selection_name);
-		goto fail_notify_requestor;
-	}
-
 	if (req->target == xwm->atoms[TARGETS]) {
 		xwm_selection_send_targets(selection, req);
 	} else if (req->target == xwm->atoms[TIMESTAMP]) {


### PR DESCRIPTION
Fixes [1].  These checks were added in [2] in Dec 2017 to prevent
unfocused xwayland clients from accessing the clipboard.  But the
wlr-data-control-unstable-v1 protocol added in Dec 2018 [3] allows
unfocused clients to access the clipboard anyway
(eg. wl-copy/wl-paste), so the original checks seem obsolete.  Since
the checks are causing issues (eg. for open-vm-tools), this change
removes them.

[1] https://github.com/swaywm/wlroots/issues/2886
[2] https://github.com/swaywm/wlroots/commit/b884025558e750268a06818dc63bc46716c75843
[3] https://github.com/swaywm/wlr-protocols/commit/cdd0eddd54ae302c40f1110572b7e9908c289b2e