### PR TITLE
render/egl: allow creating an llvmpipe EGL context

### DIFF
--- a/include/render/egl.h
+++ b/include/render/egl.h
@@ -1,0 +1,15 @@
+#ifndef RENDER_EGL_H
+#define RENDER_EGL_H
+
+#include <wlr/render/egl.h>
+
+/**
+ * Creates and EGL context from a given drm fd. This function uses the
+ * following extensions:
+ * - EXT_device_enumeration to get the list of available EGLDeviceEXT
+ * - EXT_device_drm to get the name of the EGLDeviceEXT
+ * - EXT_platform_device to create an EGLDisplay from an EGLDeviceEXT
+ */
+struct wlr_egl *wlr_egl_create_from_drm_fd(int drm_fd);
+
+#endif

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -51,6 +51,9 @@ struct wlr_egl {
 
 		// Device extensions
 		bool device_drm_ext;
+
+		// Client extensions
+		bool device_query_ext;
 	} exts;
 
 	struct {
@@ -65,6 +68,7 @@ struct wlr_egl {
 		PFNEGLDEBUGMESSAGECONTROLKHRPROC eglDebugMessageControlKHR;
 		PFNEGLQUERYDISPLAYATTRIBEXTPROC eglQueryDisplayAttribEXT;
 		PFNEGLQUERYDEVICESTRINGEXTPROC eglQueryDeviceStringEXT;
+		PFNEGLQUERYDEVICESEXTPROC eglQueryDevicesEXT;
 	} procs;
 
 	struct wl_display *wl_display;

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -9,6 +9,7 @@
 #include <wlr/types/wlr_matrix.h>
 #include <wlr/util/log.h>
 #include "util/signal.h"
+#include "render/egl.h"
 #include "render/pixel_format.h"
 #include "render/wlr_renderer.h"
 
@@ -221,20 +222,11 @@ bool wlr_renderer_init_wl_display(struct wlr_renderer *r,
 }
 
 struct wlr_renderer *wlr_renderer_autocreate_with_drm_fd(int drm_fd) {
-	struct gbm_device *gbm_device = gbm_create_device(drm_fd);
-	if (!gbm_device) {
-		wlr_log(WLR_ERROR, "Failed to create GBM device");
-		return NULL;
-	}
-
-	struct wlr_egl *egl = wlr_egl_create(EGL_PLATFORM_GBM_KHR, gbm_device);
+	struct wlr_egl *egl = wlr_egl_create_from_drm_fd(drm_fd);
 	if (egl == NULL) {
 		wlr_log(WLR_ERROR, "Could not initialize EGL");
-		gbm_device_destroy(gbm_device);
 		return NULL;
 	}
-
-	egl->gbm_device = gbm_device;
 
 	struct wlr_renderer *renderer = wlr_gles2_renderer_create(egl);
 	if (!renderer) {


### PR DESCRIPTION
There are use-cases for forcing an llvmpipe EGL context, e.g. CI. Allow users to force it.

Depends on: https://github.com/swaywm/wlroots/pull/2671