### PR TITLE
render/pixman: avoid copy when creating textures

### DIFF
--- a/include/render/pixman.h
+++ b/include/render/pixman.h
@@ -40,9 +40,12 @@ struct wlr_pixman_texture {
 	struct wlr_pixman_renderer *renderer;
 	struct wl_list link; // wlr_pixman_renderer.textures
 
-	void *data;
 	pixman_image_t *image;
-	const struct wlr_pixel_format_info *format;
+	pixman_format_code_t format;
+	const struct wlr_pixel_format_info *format_info;
+
+	void *data; // if created via texture_from_pixels
+	struct wlr_buffer *buffer; // if created via texture_from_buffer
 };
 
 pixman_format_code_t get_pixman_format_from_drm(uint32_t fmt);

--- a/include/types/wlr_buffer.h
+++ b/include/types/wlr_buffer.h
@@ -3,6 +3,28 @@
 
 #include <wlr/types/wlr_buffer.h>
 
+struct wlr_shm_client_buffer {
+	struct wlr_buffer base;
+
+	uint32_t format;
+	size_t stride;
+
+	// The following fields are NULL if the client has destroyed the wl_buffer
+	struct wl_resource *resource;
+	struct wl_shm_buffer *shm_buffer;
+
+	// This is used to keep the backing storage alive after the client has
+	// destroyed the wl_buffer
+	struct wl_shm_pool *saved_shm_pool;
+	void *saved_data;
+
+	struct wl_listener resource_destroy;
+	struct wl_listener release;
+};
+
+struct wlr_shm_client_buffer *shm_client_buffer_create(
+	struct wl_resource *resource);
+
 /**
  * Buffer capabilities.
  *

--- a/include/types/wlr_buffer.h
+++ b/include/types/wlr_buffer.h
@@ -16,13 +16,16 @@ enum wlr_buffer_cap {
 };
 
 /**
- * Access a pointer to the allocated data from the underlying implementation,
- * its format and its stride.
+ * Get a pointer to a region of memory referring to the buffer's underlying
+ * storage. The format and stride can be used to interpret the memory region
+ * contents.
  *
- * The returned pointer should be pointing to a valid memory location for read
- * and write operations.
+ * The returned pointer should be pointing to a valid memory region for read
+ * and write operations. The returned pointer is only valid up to the next
+ * buffer_end_data_ptr_access call.
  */
-bool buffer_get_data_ptr(struct wlr_buffer *buffer, void **data,
+bool buffer_begin_data_ptr_access(struct wlr_buffer *buffer, void **data,
 	uint32_t *format, size_t *stride);
+void buffer_end_data_ptr_access(struct wlr_buffer *buffer);
 
 #endif

--- a/include/wlr/types/wlr_buffer.h
+++ b/include/wlr/types/wlr_buffer.h
@@ -26,10 +26,11 @@ struct wlr_buffer_impl {
 	void (*destroy)(struct wlr_buffer *buffer);
 	bool (*get_dmabuf)(struct wlr_buffer *buffer,
 		struct wlr_dmabuf_attributes *attribs);
-	bool (*get_data_ptr)(struct wlr_buffer *buffer, void **data,
-		uint32_t *format, size_t *stride);
 	bool (*get_shm)(struct wlr_buffer *buffer,
 		struct wlr_shm_attributes *attribs);
+	bool (*begin_data_ptr_access)(struct wlr_buffer *buffer, void **data,
+		uint32_t *format, size_t *stride);
+	void (*end_data_ptr_access)(struct wlr_buffer *buffer);
 };
 
 /**
@@ -47,6 +48,7 @@ struct wlr_buffer {
 
 	bool dropped;
 	size_t n_locks;
+	bool accessing_data_ptr;
 
 	struct {
 		struct wl_signal destroy;

--- a/render/allocator.c
+++ b/render/allocator.c
@@ -81,7 +81,8 @@ struct wlr_buffer *wlr_allocator_create_buffer(struct wlr_allocator *alloc,
 		return NULL;
 	}
 	if (alloc->buffer_caps & WLR_BUFFER_CAP_DATA_PTR) {
-		assert(buffer->impl->get_data_ptr);
+		assert(buffer->impl->begin_data_ptr_access &&
+			buffer->impl->end_data_ptr_access);
 	}
 	if (alloc->buffer_caps & WLR_BUFFER_CAP_DMABUF) {
 		assert(buffer->impl->get_dmabuf);

--- a/render/drm_dumb_allocator.c
+++ b/render/drm_dumb_allocator.c
@@ -128,13 +128,17 @@ create_err:
 	return NULL;
 }
 
-static bool drm_dumb_buffer_get_data_ptr(struct wlr_buffer *wlr_buffer, void **data,
-		uint32_t *format, size_t *stride) {
+static bool drm_dumb_buffer_begin_data_ptr_access(struct wlr_buffer *wlr_buffer,
+		void **data, uint32_t *format, size_t *stride) {
 	struct wlr_drm_dumb_buffer *buf = drm_dumb_buffer_from_buffer(wlr_buffer);
 	*data = buf->data;
 	*stride = buf->stride;
 	*format = buf->format;
 	return true;
+}
+
+static void drm_dumb_buffer_end_data_ptr_access(struct wlr_buffer *wlr_buffer) {
+	// This space is intentionally left blank
 }
 
 static bool buffer_get_dmabuf(struct wlr_buffer *wlr_buffer,
@@ -153,7 +157,8 @@ static void buffer_destroy(struct wlr_buffer *wlr_buffer) {
 static const struct wlr_buffer_impl buffer_impl = {
 	.destroy = buffer_destroy,
 	.get_dmabuf = buffer_get_dmabuf,
-	.get_data_ptr = drm_dumb_buffer_get_data_ptr,
+	.begin_data_ptr_access = drm_dumb_buffer_begin_data_ptr_access,
+	.end_data_ptr_access = drm_dumb_buffer_end_data_ptr_access,
 };
 
 static const struct wlr_allocator_interface allocator_impl;

--- a/render/shm_allocator.c
+++ b/render/shm_allocator.c
@@ -31,8 +31,8 @@ static bool buffer_get_shm(struct wlr_buffer *wlr_buffer,
 	return true;
 }
 
-static bool shm_buffer_get_data_ptr(struct wlr_buffer *wlr_buffer, void **data,
-		uint32_t *format, size_t *stride) {
+static bool shm_buffer_begin_data_ptr_access(struct wlr_buffer *wlr_buffer,
+		void **data, uint32_t *format, size_t *stride) {
 	struct wlr_shm_buffer *buffer = shm_buffer_from_buffer(wlr_buffer);
 	*data = buffer->data;
 	*format = buffer->shm.format;
@@ -40,10 +40,15 @@ static bool shm_buffer_get_data_ptr(struct wlr_buffer *wlr_buffer, void **data,
 	return true;
 }
 
+static void shm_buffer_end_data_ptr_access(struct wlr_buffer *wlr_buffer) {
+	// This space is intentionally left blank
+}
+
 static const struct wlr_buffer_impl buffer_impl = {
 	.destroy = buffer_destroy,
 	.get_shm = buffer_get_shm,
-	.get_data_ptr = shm_buffer_get_data_ptr,
+	.begin_data_ptr_access = shm_buffer_begin_data_ptr_access,
+	.end_data_ptr_access = shm_buffer_end_data_ptr_access,
 };
 
 static struct wlr_buffer *allocator_create_buffer(

--- a/types/wlr_buffer.c
+++ b/types/wlr_buffer.c
@@ -346,3 +346,106 @@ struct wlr_client_buffer *wlr_client_buffer_apply_damage(
 	buffer->resource_released = true;
 	return buffer;
 }
+
+static const struct wlr_buffer_impl shm_client_buffer_impl;
+
+static struct wlr_shm_client_buffer *shm_client_buffer_from_buffer(
+		struct wlr_buffer *buffer) {
+	assert(buffer->impl == &shm_client_buffer_impl);
+	return (struct wlr_shm_client_buffer *)buffer;
+}
+
+static void shm_client_buffer_destroy(struct wlr_buffer *wlr_buffer) {
+	struct wlr_shm_client_buffer *buffer =
+		shm_client_buffer_from_buffer(wlr_buffer);
+	wl_list_remove(&buffer->resource_destroy.link);
+	wl_list_remove(&buffer->release.link);
+	if (buffer->saved_shm_pool != NULL) {
+		wl_shm_pool_unref(buffer->saved_shm_pool);
+	}
+	free(buffer);
+}
+
+static bool shm_client_buffer_begin_data_ptr_access(struct wlr_buffer *wlr_buffer,
+		void **data, uint32_t *format, size_t *stride) {
+	struct wlr_shm_client_buffer *buffer =
+		shm_client_buffer_from_buffer(wlr_buffer);
+	*format = buffer->format;
+	*stride = buffer->stride;
+	if (buffer->shm_buffer != NULL) {
+		*data = wl_shm_buffer_get_data(buffer->shm_buffer);
+		wl_shm_buffer_begin_access(buffer->shm_buffer);
+	} else {
+		*data = buffer->saved_data;
+	}
+	return true;
+}
+
+static void shm_client_buffer_end_data_ptr_access(struct wlr_buffer *wlr_buffer) {
+	struct wlr_shm_client_buffer *buffer =
+		shm_client_buffer_from_buffer(wlr_buffer);
+	if (buffer->shm_buffer != NULL) {
+		wl_shm_buffer_end_access(buffer->shm_buffer);
+	}
+}
+
+static const struct wlr_buffer_impl shm_client_buffer_impl = {
+	.destroy = shm_client_buffer_destroy,
+	.begin_data_ptr_access = shm_client_buffer_begin_data_ptr_access,
+	.end_data_ptr_access = shm_client_buffer_end_data_ptr_access,
+};
+
+static void shm_client_buffer_resource_handle_destroy(
+		struct wl_listener *listener, void *data) {
+	struct wlr_shm_client_buffer *buffer =
+		wl_container_of(listener, buffer, resource_destroy);
+
+	// In order to still be able to access the shared memory region, we need to
+	// keep a reference to the wl_shm_pool
+	buffer->saved_shm_pool = wl_shm_buffer_ref_pool(buffer->shm_buffer);
+	buffer->saved_data = wl_shm_buffer_get_data(buffer->shm_buffer);
+
+	// The wl_shm_buffer destroys itself with the wl_resource
+	buffer->resource = NULL;
+	buffer->shm_buffer = NULL;
+	wl_list_remove(&buffer->resource_destroy.link);
+	wl_list_init(&buffer->resource_destroy.link);
+}
+
+static void shm_client_buffer_handle_release(struct wl_listener *listener,
+		void *data) {
+	struct wlr_shm_client_buffer *buffer =
+		wl_container_of(listener, buffer, release);
+	if (buffer->resource != NULL) {
+		wl_buffer_send_release(buffer->resource);
+	}
+}
+
+struct wlr_shm_client_buffer *shm_client_buffer_create(
+		struct wl_resource *resource) {
+	struct wl_shm_buffer *shm_buffer = wl_shm_buffer_get(resource);
+	assert(shm_buffer != NULL);
+
+	int32_t width = wl_shm_buffer_get_width(shm_buffer);
+	int32_t height = wl_shm_buffer_get_height(shm_buffer);
+
+	struct wlr_shm_client_buffer *buffer = calloc(1, sizeof(*buffer));
+	if (buffer == NULL) {
+		return NULL;
+	}
+	wlr_buffer_init(&buffer->base, &shm_client_buffer_impl, width, height);
+	buffer->resource = resource;
+	buffer->shm_buffer = shm_buffer;
+
+	enum wl_shm_format wl_shm_format = wl_shm_buffer_get_format(shm_buffer);
+	buffer->format = convert_wl_shm_format_to_drm(wl_shm_format);
+	buffer->stride = wl_shm_buffer_get_stride(shm_buffer);
+
+	buffer->resource_destroy.notify = shm_client_buffer_resource_handle_destroy;
+	wl_resource_add_destroy_listener(resource, &buffer->resource_destroy);
+
+	buffer->release.notify = shm_client_buffer_handle_release;
+	wl_signal_add(&buffer->base.events.release, &buffer->release);
+
+	return buffer;
+}


### PR DESCRIPTION
This allows the Pixman renderer to stop `memcpy`'ing textures.

- [x] Address the shm client buffer SIGBUS issue

Depends on: https://github.com/swaywm/wlroots/pull/2851

cc @bl4ckb0ne 