### PR TITLE
buffer: add format param to get_data_ptr

### DIFF
--- a/include/types/wlr_buffer.h
+++ b/include/types/wlr_buffer.h
@@ -2,14 +2,15 @@
 #define TYPES_WLR_BUFFER
 
 #include <wlr/types/wlr_buffer.h>
+
 /**
  * Access a pointer to the allocated data from the underlying implementation,
- * and its stride.
+ * its format and its stride.
  *
  * The returned pointer should be pointing to a valid memory location for read
  * and write operations.
  */
 bool buffer_get_data_ptr(struct wlr_buffer *buffer, void **data,
-	size_t *stride);
+	uint32_t *format, size_t *stride);
 
 #endif

--- a/include/wlr/types/wlr_buffer.h
+++ b/include/wlr/types/wlr_buffer.h
@@ -27,7 +27,7 @@ struct wlr_buffer_impl {
 	bool (*get_dmabuf)(struct wlr_buffer *buffer,
 		struct wlr_dmabuf_attributes *attribs);
 	bool (*get_data_ptr)(struct wlr_buffer *buffer, void **data,
-		size_t *stride);
+		uint32_t *format, size_t *stride);
 	bool (*get_shm)(struct wlr_buffer *buffer,
 		struct wlr_shm_attributes *attribs);
 };

--- a/render/pixman/renderer.c
+++ b/render/pixman/renderer.c
@@ -91,7 +91,12 @@ static struct wlr_pixman_buffer *create_buffer(
 		goto error_buffer;
 	}
 
-	uint32_t format = get_pixman_format_from_drm(drm_format);
+	pixman_format_code_t format = get_pixman_format_from_drm(drm_format);
+	if (format == 0) {
+		wlr_log(WLR_ERROR, "Unsupported pixman drm format 0x%"PRIX32,
+				drm_format);
+		return NULL;
+	}
 
 	buffer->image = pixman_image_create_bits(format, wlr_buffer->width,
 			wlr_buffer->height, data, stride);

--- a/render/pixman/renderer.c
+++ b/render/pixman/renderer.c
@@ -83,25 +83,15 @@ static struct wlr_pixman_buffer *create_buffer(
 	buffer->buffer = wlr_buffer;
 	buffer->renderer = renderer;
 
+	void *data = NULL;
 	uint32_t drm_format;
-	struct wlr_dmabuf_attributes dmabuf = {0};
-	struct wlr_shm_attributes shm = {0};
-	if (wlr_buffer_get_dmabuf(wlr_buffer, &dmabuf)) {
-		drm_format = dmabuf.format;
-	} else if (wlr_buffer_get_shm(wlr_buffer, &shm)) {
-		drm_format = shm.format;
-	} else {
+	size_t stride;
+	if (!buffer_get_data_ptr(wlr_buffer, &data, &drm_format, &stride)) {
+		wlr_log(WLR_ERROR, "Failed to get buffer data");
 		goto error_buffer;
 	}
 
 	uint32_t format = get_pixman_format_from_drm(drm_format);
-
-	void *data = NULL;
-	size_t stride;
-	if (!buffer_get_data_ptr(wlr_buffer, &data, &stride)) {
-		wlr_log(WLR_ERROR, "Failed to get buffer data");
-		goto error_buffer;
-	}
 
 	buffer->image = pixman_image_create_bits(format, wlr_buffer->width,
 			wlr_buffer->height, data, stride);

--- a/render/shm_allocator.c
+++ b/render/shm_allocator.c
@@ -31,9 +31,10 @@ static bool buffer_get_shm(struct wlr_buffer *wlr_buffer,
 }
 
 static bool buffer_get_data_ptr(struct wlr_buffer *wlr_buffer, void **data,
-		size_t *stride) {
+		uint32_t *format, size_t *stride) {
 	struct wlr_shm_buffer *buffer = shm_buffer_from_buffer(wlr_buffer);
 	*data = buffer->data;
+	*format = buffer->shm.format;
 	*stride = buffer->shm.stride;
 	return true;
 }

--- a/types/wlr_buffer.c
+++ b/types/wlr_buffer.c
@@ -67,11 +67,11 @@ bool wlr_buffer_get_dmabuf(struct wlr_buffer *buffer,
 }
 
 bool buffer_get_data_ptr(struct wlr_buffer *buffer, void **data,
-		size_t *size) {
+		uint32_t *format, size_t *stride) {
 	if (!buffer->impl->get_data_ptr) {
 		return false;
 	}
-	return buffer->impl->get_data_ptr(buffer, data, size);
+	return buffer->impl->get_data_ptr(buffer, data, format, stride);
 }
 
 bool wlr_buffer_get_shm(struct wlr_buffer *buffer,


### PR DESCRIPTION
Allow wlr_buffer_impl.get_data_ptr to return a format.

This allows the Pixman renderer to not care about get_dmabuf/get_shm,
and only care about get_data_ptr. This will also help with [1], because
client wl_shm buffers can't implement get_shm.

[1]: https://github.com/swaywm/wlroots/pull/2892

References: https://github.com/swaywm/wlroots/issues/2864

cc @bl4ckb0ne 