### PR TITLE
Revert "backend/drm: fail instead of stripping a modifier"

### DIFF
--- a/backend/drm/util.c
+++ b/backend/drm/util.c
@@ -199,14 +199,6 @@ uint32_t get_fb_for_bo(struct gbm_bo *bo, bool with_modifiers) {
 			wlr_log_errno(WLR_ERROR, "Unable to add DRM framebuffer");
 		}
 	} else {
-		if (gbm_bo_get_modifier(bo) != DRM_FORMAT_MOD_INVALID &&
-				gbm_bo_get_modifier(bo) != DRM_FORMAT_MOD_LINEAR) {
-			wlr_log(WLR_ERROR, "Failed to add DRM frame-buffer: "
-				"BO has modifier 0x%"PRIX64" but KMS doesn't support modifiers",
-				gbm_bo_get_modifier(bo));
-			return 0;
-		}
-
 		int ret = drmModeAddFB2(fd, width, height, format, handles, strides,
 			offsets, &id, 0);
 		if (ret != 0 && gbm_bo_get_format(bo) == GBM_FORMAT_ARGB8888 &&


### PR DESCRIPTION
This reverts commit f9f90b417366581b58d806956c9b2099417ed4b3.

gbm_bo_get_modifier may return a modifier in these cases:

- The kernel doesn't support modifiers but Mesa does
- WLR_DRM_NO_MODIFIERS=1 is set

However, in both of these cases, the gbm_bo has been allocated
without modifiers.

There is already a check in drm_fb_create for modifiers:
wlr_drm_format_set_has will make sure buffers with an explicit
modifier will be rejected if the DRM backend doesn't support them.
So no need for an additional check in get_fb_for_bo.

Closes: https://github.com/swaywm/wlroots/issues/2896

cc @kennylevinsen 