### PR TITLE
backend/drm: fix allocator DRM FD on multi-GPU setups

### DIFF
--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -35,8 +35,8 @@ bool init_drm_renderer(struct wlr_drm_backend *drm,
 		goto error_gbm;
 	}
 
-	renderer->allocator = wlr_allocator_autocreate(&drm->backend,
-			renderer->wlr_rend);
+	renderer->allocator = allocator_autocreate_with_drm_fd(&drm->backend,
+		renderer->wlr_rend, drm->fd);
 	if (renderer->allocator == NULL) {
 		wlr_log(WLR_ERROR, "Failed to create allocator");
 		goto error_wlr_rend;

--- a/include/render/allocator.h
+++ b/include/render/allocator.h
@@ -46,4 +46,7 @@ struct wlr_buffer *wlr_allocator_create_buffer(struct wlr_allocator *alloc,
 void wlr_allocator_init(struct wlr_allocator *alloc,
 	const struct wlr_allocator_interface *impl);
 
+struct wlr_allocator *allocator_autocreate_with_drm_fd(
+	struct wlr_backend *backend, struct wlr_renderer *renderer, int drm_fd);
+
 #endif

--- a/render/allocator.c
+++ b/render/allocator.c
@@ -18,11 +18,11 @@ void wlr_allocator_init(struct wlr_allocator *alloc,
 	wl_signal_init(&alloc->events.destroy);
 }
 
-struct wlr_allocator *wlr_allocator_autocreate(struct wlr_backend *backend,
-		struct wlr_renderer *renderer) {
+struct wlr_allocator *allocator_autocreate_with_drm_fd(
+		struct wlr_backend *backend, struct wlr_renderer *renderer,
+		int drm_fd) {
 	uint32_t backend_caps = backend_get_buffer_caps(backend);
 	uint32_t renderer_caps = renderer_get_render_buffer_caps(renderer);
-	int drm_fd = wlr_backend_get_drm_fd(backend);
 
 	struct wlr_allocator *alloc = NULL;
 	uint32_t gbm_caps = WLR_BUFFER_CAP_DMABUF;
@@ -49,6 +49,13 @@ struct wlr_allocator *wlr_allocator_autocreate(struct wlr_backend *backend,
 
 	wlr_log(WLR_ERROR, "Failed to create allocator");
 	return NULL;
+}
+
+struct wlr_allocator *wlr_allocator_autocreate(struct wlr_backend *backend,
+		struct wlr_renderer *renderer) {
+	// Note, drm_fd may be negative if unavailable
+	int drm_fd = wlr_backend_get_drm_fd(backend);
+	return allocator_autocreate_with_drm_fd(backend, renderer, drm_fd);
 }
 
 void wlr_allocator_destroy(struct wlr_allocator *alloc) {


### PR DESCRIPTION
On multi-GPU setups, there is a primary DRM backend and secondary
DRM backends. wlr_backend_get_drm_fd will always return the parent
DRM FD even on secondary backends, so that users always use the
primary device for rendering.

However, for our internal rendering we want to use the secondary
device. Use allocator_autocreate_with_drm_fd to make sure the
allocator will create buffers on the secondary device.

We do something similar to ensure our internal rendering will
happen on the secondary device with renderer_autocreate_with_drm_fd.

Fixes: cc1b663 ("backend: use wlr_allocator_autocreate")

cc @bl4ckb0ne 