### PR TITLE
backend: add common renderer and allocator creation

### DIFF
--- a/backend/backend.c
+++ b/backend/backend.c
@@ -18,6 +18,7 @@
 #include <wlr/util/log.h>
 #include "backend/backend.h"
 #include "backend/multi.h"
+#include "util/signal.h"
 
 #if WLR_HAS_X11_BACKEND
 #include <wlr/backend/x11.h>
@@ -30,6 +31,10 @@ void wlr_backend_init(struct wlr_backend *backend,
 	wl_signal_init(&backend->events.destroy);
 	wl_signal_init(&backend->events.new_input);
 	wl_signal_init(&backend->events.new_output);
+}
+
+void wlr_backend_finish(struct wlr_backend *backend) {
+	wlr_signal_emit_safe(&backend->events.destroy, backend);
 }
 
 bool wlr_backend_start(struct wlr_backend *backend) {

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -41,7 +41,7 @@ static void backend_destroy(struct wlr_backend *backend) {
 		destroy_drm_connector(conn);
 	}
 
-	wlr_signal_emit_safe(&backend->events.destroy, backend);
+	wlr_backend_finish(backend);
 
 	struct wlr_drm_fb *fb, *fb_tmp;
 	wl_list_for_each_safe(fb, fb_tmp, &drm->fbs, link) {

--- a/backend/headless/backend.c
+++ b/backend/headless/backend.c
@@ -67,7 +67,7 @@ static void backend_destroy(struct wlr_backend *wlr_backend) {
 		wlr_input_device_destroy(&input_device->wlr_input_device);
 	}
 
-	wlr_signal_emit_safe(&wlr_backend->events.destroy, backend);
+	wlr_backend_finish(wlr_backend);
 
 	free(backend->format);
 

--- a/backend/libinput/backend.c
+++ b/backend/libinput/backend.c
@@ -150,7 +150,7 @@ static void backend_destroy(struct wlr_backend *wlr_backend) {
 		free(wlr_devices);
 	}
 
-	wlr_signal_emit_safe(&wlr_backend->events.destroy, wlr_backend);
+	wlr_backend_finish(wlr_backend);
 
 	wl_list_remove(&backend->display_destroy.link);
 	wl_list_remove(&backend->session_destroy.link);

--- a/backend/multi/backend.c
+++ b/backend/multi/backend.c
@@ -58,7 +58,7 @@ static void multi_backend_destroy(struct wlr_backend *wlr_backend) {
 	}
 
 	// Destroy this backend only after removing all sub-backends
-	wlr_signal_emit_safe(&wlr_backend->events.destroy, backend);
+	wlr_backend_finish(wlr_backend);
 	free(backend);
 }
 

--- a/backend/noop/backend.c
+++ b/backend/noop/backend.c
@@ -37,7 +37,7 @@ static void backend_destroy(struct wlr_backend *wlr_backend) {
 		wlr_output_destroy(&output->wlr_output);
 	}
 
-	wlr_signal_emit_safe(&wlr_backend->events.destroy, backend);
+	wlr_backend_finish(wlr_backend);
 
 	wl_list_remove(&backend->display_destroy.link);
 

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -309,7 +309,7 @@ static void backend_destroy(struct wlr_backend *backend) {
 		wlr_input_device_destroy(input_device);
 	}
 
-	wlr_signal_emit_safe(&wl->backend.events.destroy, &wl->backend);
+	wlr_backend_finish(backend);
 
 	wl_list_remove(&wl->local_display_destroy.link);
 

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -191,7 +191,7 @@ static void backend_destroy(struct wlr_backend *backend) {
 
 	wlr_input_device_destroy(&x11->keyboard_dev);
 
-	wlr_signal_emit_safe(&backend->events.destroy, backend);
+	wlr_backend_finish(backend);
 
 	if (x11->event_source) {
 		wl_event_source_remove(x11->event_source);

--- a/include/backend/backend.h
+++ b/include/backend/backend.h
@@ -10,4 +10,10 @@
  */
 uint32_t backend_get_buffer_caps(struct wlr_backend *backend);
 
+/**
+ * Get the backend's allocator. Automatically creates the allocator if
+ * necessary.
+ */
+struct wlr_allocator *backend_get_allocator(struct wlr_backend *backend);
+
 #endif

--- a/include/backend/headless.h
+++ b/include/backend/headless.h
@@ -9,16 +9,14 @@
 struct wlr_headless_backend {
 	struct wlr_backend backend;
 	int drm_fd;
-	struct wlr_renderer *renderer;
-	struct wlr_allocator *allocator;
 	struct wlr_drm_format *format;
 	struct wl_display *display;
 	struct wl_list outputs;
 	size_t last_output_num;
 	struct wl_list input_devices;
 	struct wl_listener display_destroy;
-	struct wl_listener renderer_destroy;
-	bool has_parent_renderer;
+	struct wlr_renderer *parent_renderer;
+	struct wl_listener parent_renderer_destroy;
 	bool started;
 };
 

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -21,9 +21,7 @@ struct wlr_wl_backend {
 	struct wl_list devices;
 	struct wl_list outputs;
 	int drm_fd;
-	struct wlr_renderer *renderer;
 	struct wlr_drm_format *format;
-	struct wlr_allocator *allocator;
 	struct wl_list buffers; // wlr_wl_buffer.link
 	size_t requested_outputs;
 	size_t last_output_num;

--- a/include/backend/x11.h
+++ b/include/backend/x11.h
@@ -88,12 +88,10 @@ struct wlr_x11_backend {
 	struct wlr_input_device keyboard_dev;
 
 	int drm_fd;
-	struct wlr_renderer *renderer;
 	struct wlr_drm_format_set dri3_formats;
 	struct wlr_drm_format_set shm_formats;
 	const struct wlr_x11_format *x11_format;
 	struct wlr_drm_format *drm_format;
-	struct wlr_allocator *allocator;
 	struct wl_event_source *event_source;
 
 	struct {

--- a/include/wlr/backend.h
+++ b/include/wlr/backend.h
@@ -25,6 +25,10 @@ struct wlr_backend {
 		/** Raised when new outputs are added, passed the wlr_output */
 		struct wl_signal new_output;
 	} events;
+
+	// Private state
+
+	struct wlr_renderer *renderer;
 };
 
 /**

--- a/include/wlr/backend.h
+++ b/include/wlr/backend.h
@@ -29,6 +29,7 @@ struct wlr_backend {
 	// Private state
 
 	struct wlr_renderer *renderer;
+	struct wlr_allocator *allocator;
 };
 
 /**

--- a/include/wlr/backend/interface.h
+++ b/include/wlr/backend/interface.h
@@ -29,5 +29,9 @@ struct wlr_backend_impl {
  */
 void wlr_backend_init(struct wlr_backend *backend,
 		const struct wlr_backend_impl *impl);
+/**
+ * Emit the destroy event and clean up common backend state.
+ */
+void wlr_backend_finish(struct wlr_backend *backend);
 
 #endif


### PR DESCRIPTION
This is part of #2505 split out in a separate PR, and rebased on top of #2884.

Instead of explicitly creating the renderer and allocator inside the backends, do it in common code. The motivation is:

- Nothing of this is backend-specific. With #2505 backends won't need to care about renderers and allocators anymore (except for the edge case of DRM multi-GPU).
- Allow #2507 and #2505 to get access to a renderer and an allocator outside of the backend for creating swapchains and rendering.

With this PR, backends now get access to the renderer and allocator via `wlr_backend_get_renderer` and `backend_get_allocator`. This makes it pretty obvious that a lot of the backend logic no longer needs to live in the backend, and can be moved in common code as done in #2507 and #2505.

The DRM backend is left alone for now, because multi-GPU support complicates things: we can't easily get rid of the internal renderer/allocator on secondary DRM backends.