### PR TITLE
backend/drm: move primary wlr_swapchain handling out of backend

### DIFF
--- a/backend/backend.c
+++ b/backend/backend.c
@@ -45,7 +45,9 @@ void wlr_backend_init(struct wlr_backend *backend,
 void wlr_backend_finish(struct wlr_backend *backend) {
 	wlr_signal_emit_safe(&backend->events.destroy, backend);
 	wlr_allocator_destroy(backend->allocator);
-	wlr_renderer_destroy(backend->renderer);
+	if (backend->has_own_renderer) {
+		wlr_renderer_destroy(backend->renderer);
+	}
 }
 
 bool wlr_backend_start(struct wlr_backend *backend) {
@@ -77,6 +79,7 @@ static bool backend_create_renderer(struct wlr_backend *backend) {
 		return false;
 	}
 
+	backend->has_own_renderer = true;
 	return true;
 }
 

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -53,8 +53,13 @@ static void backend_destroy(struct wlr_backend *backend) {
 	wl_list_remove(&drm->dev_change.link);
 	wl_list_remove(&drm->dev_remove.link);
 
+	gbm_device_destroy(drm->gbm);
+
+	if (drm->parent) {
+		finish_drm_renderer(&drm->mgpu_renderer);
+	}
+
 	finish_drm_resources(drm);
-	finish_drm_renderer(&drm->renderer);
 
 	free(drm->name);
 	wlr_session_close_file(drm->session, drm->dev);
@@ -219,8 +224,9 @@ struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
 		goto error_event;
 	}
 
-	if (!init_drm_renderer(drm, &drm->renderer)) {
-		wlr_log(WLR_ERROR, "Failed to initialize renderer");
+	drm->gbm = gbm_create_device(drm->fd);
+	if (!drm->gbm) {
+		wlr_log(WLR_ERROR, "Failed to create GBM device");
 		goto error_event;
 	}
 
@@ -229,9 +235,14 @@ struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
 		drm->backend.renderer = wlr_backend_get_renderer(&drm->parent->backend);
 		assert(drm->backend.renderer != NULL);
 
+		if (!init_drm_renderer(drm, &drm->mgpu_renderer)) {
+			wlr_log(WLR_ERROR, "Failed to initialize renderer");
+			goto error_event;
+		}
+
 		// We'll perform a multi-GPU copy for all submitted buffers, we need
 		// to be able to texture from them
-		struct wlr_renderer *renderer = drm->renderer.wlr_rend;
+		struct wlr_renderer *renderer = drm->mgpu_renderer.wlr_rend;
 		const struct wlr_drm_format_set *texture_formats =
 			wlr_renderer_get_dmabuf_texture_formats(renderer);
 		if (texture_formats == NULL) {

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -401,14 +401,14 @@ static bool drm_connector_set_pending_fb(struct wlr_drm_connector *conn,
 	struct wlr_buffer *local_buf;
 	if (drm->parent) {
 		struct wlr_drm_format *format =
-			drm_plane_pick_render_format(plane, &drm->renderer);
+			drm_plane_pick_render_format(plane, &drm->mgpu_renderer);
 		if (format == NULL) {
 			wlr_log(WLR_ERROR, "Failed to pick primary plane format");
 			return false;
 		}
 
 		// TODO: fallback to modifier-less buffer allocation
-		bool ok = init_drm_surface(&plane->mgpu_surf, &drm->renderer,
+		bool ok = init_drm_surface(&plane->mgpu_surf, &drm->mgpu_renderer,
 			state->buffer->width, state->buffer->height, format);
 		free(format);
 		if (!ok) {
@@ -632,14 +632,14 @@ static bool drm_connector_init_renderer(struct wlr_drm_connector *conn,
 		int height = mode.vdisplay;
 
 		struct wlr_drm_format *format =
-			drm_plane_pick_render_format(plane, &drm->renderer);
+			drm_plane_pick_render_format(plane, &drm->mgpu_renderer);
 		if (format == NULL) {
 			wlr_log(WLR_ERROR, "Failed to pick primary plane format");
 			return false;
 		}
 
 		// TODO: fallback to modifier-less buffer allocation
-		bool ok = init_drm_surface(&plane->mgpu_surf, &drm->renderer,
+		bool ok = init_drm_surface(&plane->mgpu_surf, &drm->mgpu_renderer,
 			width, height, format);
 		free(format);
 		if (!ok) {
@@ -834,13 +834,13 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 		struct wlr_buffer *local_buf;
 		if (drm->parent) {
 			struct wlr_drm_format *format =
-				drm_plane_pick_render_format(plane, &drm->renderer);
+				drm_plane_pick_render_format(plane, &drm->mgpu_renderer);
 			if (format == NULL) {
 				wlr_log(WLR_ERROR, "Failed to pick cursor plane format");
 				return false;
 			}
 
-			bool ok = init_drm_surface(&plane->mgpu_surf, &drm->renderer,
+			bool ok = init_drm_surface(&plane->mgpu_surf, &drm->mgpu_renderer,
 				buffer->width, buffer->height, format);
 			free(format);
 			if (!ok) {

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -466,8 +466,7 @@ static bool drm_connector_test(struct wlr_output *output) {
 		}
 	}
 
-	if ((output->pending.committed & WLR_OUTPUT_STATE_BUFFER) &&
-			output->pending.buffer_type == WLR_OUTPUT_STATE_BUFFER_SCANOUT) {
+	if ((output->pending.committed & WLR_OUTPUT_STATE_BUFFER) && !conn->backend->parent) {
 		if (!drm_connector_set_pending_fb(conn, &output->pending)) {
 			return false;
 		}

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1004,6 +1004,21 @@ static void drm_connector_get_cursor_size(struct wlr_output *output,
 	*height = (int)drm->cursor_height;
 }
 
+static const struct wlr_drm_format_set *drm_connector_get_primary_formats(
+		struct wlr_output *output, uint32_t buffer_caps) {
+	if (!(buffer_caps & WLR_BUFFER_CAP_DMABUF)) {
+		return NULL;
+	}
+	struct wlr_drm_connector *conn = get_drm_connector_from_output(output);
+	if (!conn->crtc) {
+		return NULL;
+	}
+	if (conn->backend->parent) {
+		return &conn->backend->mgpu_formats;
+	}
+	return &conn->crtc->primary->formats;
+}
+
 static const struct wlr_output_impl output_impl = {
 	.set_cursor = drm_connector_set_cursor,
 	.move_cursor = drm_connector_move_cursor,
@@ -1015,6 +1030,7 @@ static const struct wlr_output_impl output_impl = {
 	.get_gamma_size = drm_connector_get_gamma_size,
 	.get_cursor_formats = drm_connector_get_cursor_formats,
 	.get_cursor_size = drm_connector_get_cursor_size,
+	.get_primary_formats = drm_connector_get_primary_formats,
 };
 
 bool wlr_output_is_drm(struct wlr_output *output) {

--- a/backend/drm/legacy.c
+++ b/backend/drm/legacy.c
@@ -36,7 +36,6 @@ static bool legacy_crtc_test(struct wlr_drm_connector *conn,
 	struct wlr_drm_crtc *crtc = conn->crtc;
 
 	if ((state->committed & WLR_OUTPUT_STATE_BUFFER) &&
-			state->buffer_type == WLR_OUTPUT_STATE_BUFFER_SCANOUT &&
 			!drm_connector_state_is_modeset(state)) {
 		struct wlr_drm_fb *pending_fb = crtc->primary->pending_fb;
 

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -72,8 +72,6 @@ bool init_drm_surface(struct wlr_drm_surface *surf,
 	surf->width = width;
 	surf->height = height;
 
-	wlr_buffer_unlock(surf->back_buffer);
-	surf->back_buffer = NULL;
 	wlr_swapchain_destroy(surf->swapchain);
 	surf->swapchain = NULL;
 
@@ -93,36 +91,9 @@ static void finish_drm_surface(struct wlr_drm_surface *surf) {
 		return;
 	}
 
-	wlr_buffer_unlock(surf->back_buffer);
 	wlr_swapchain_destroy(surf->swapchain);
 
 	memset(surf, 0, sizeof(*surf));
-}
-
-bool drm_surface_make_current(struct wlr_drm_surface *surf,
-		int *buffer_age) {
-	wlr_buffer_unlock(surf->back_buffer);
-	surf->back_buffer = wlr_swapchain_acquire(surf->swapchain, buffer_age);
-	if (surf->back_buffer == NULL) {
-		wlr_log(WLR_ERROR, "Failed to acquire swapchain buffer");
-		return false;
-	}
-
-	if (!renderer_bind_buffer(surf->renderer->wlr_rend, surf->back_buffer)) {
-		wlr_log(WLR_ERROR, "Failed to bind buffer to renderer");
-		return false;
-	}
-
-	return true;
-}
-
-void drm_surface_unset_current(struct wlr_drm_surface *surf) {
-	assert(surf->back_buffer != NULL);
-
-	renderer_bind_buffer(surf->renderer->wlr_rend, NULL);
-
-	wlr_buffer_unlock(surf->back_buffer);
-	surf->back_buffer = NULL;
 }
 
 struct wlr_buffer *drm_surface_blit(struct wlr_drm_surface *surf,

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -20,9 +20,7 @@ struct wlr_drm_plane {
 	uint32_t type;
 	uint32_t id;
 
-	/* Local if this isn't a multi-GPU setup, on the parent otherwise. */
-	struct wlr_drm_surface surf;
-	/* Local, only initialized on multi-GPU setups. */
+	/* Only initialized on multi-GPU setups */
 	struct wlr_drm_surface mgpu_surf;
 
 	/* Buffer to be submitted to the kernel on the next page-flip */

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -62,6 +62,7 @@ struct wlr_drm_backend {
 	int fd;
 	char *name;
 	struct wlr_device *dev;
+	struct gbm_device *gbm;
 
 	size_t num_crtcs;
 	struct wlr_drm_crtc *crtcs;
@@ -79,7 +80,9 @@ struct wlr_drm_backend {
 	struct wl_list fbs; // wlr_drm_fb.link
 	struct wl_list outputs;
 
-	struct wlr_drm_renderer renderer;
+	/* Only initialized on multi-GPU setups */
+	struct wlr_drm_renderer mgpu_renderer;
+
 	struct wlr_session *session;
 
 	uint64_t cursor_width, cursor_height;

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -58,15 +58,9 @@ void drm_fb_move(struct wlr_drm_fb **new, struct wlr_drm_fb **old);
 
 struct wlr_buffer *drm_surface_blit(struct wlr_drm_surface *surf,
 	struct wlr_buffer *buffer);
-bool drm_surface_render_black_frame(struct wlr_drm_surface *surf);
 
 struct wlr_drm_format *drm_plane_pick_render_format(
 		struct wlr_drm_plane *plane, struct wlr_drm_renderer *renderer);
-bool drm_plane_init_surface(struct wlr_drm_plane *plane,
-		struct wlr_drm_backend *drm, int32_t width, uint32_t height,
-		bool with_modifiers);
 void drm_plane_finish_surface(struct wlr_drm_plane *plane);
-bool drm_plane_lock_surface(struct wlr_drm_plane *plane,
-		struct wlr_drm_backend *drm);
 
 #endif

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -13,7 +13,6 @@ struct wlr_buffer;
 
 struct wlr_drm_renderer {
 	struct wlr_drm_backend *backend;
-	struct gbm_device *gbm;
 
 	struct wlr_renderer *wlr_rend;
 	struct wlr_allocator *allocator;

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -26,7 +26,6 @@ struct wlr_drm_surface {
 	uint32_t height;
 
 	struct wlr_swapchain *swapchain;
-	struct wlr_buffer *back_buffer;
 };
 
 struct wlr_drm_fb {
@@ -46,8 +45,6 @@ void finish_drm_renderer(struct wlr_drm_renderer *renderer);
 bool init_drm_surface(struct wlr_drm_surface *surf,
 	struct wlr_drm_renderer *renderer, uint32_t width, uint32_t height,
 	const struct wlr_drm_format *drm_format);
-bool drm_surface_make_current(struct wlr_drm_surface *surf, int *buffer_age);
-void drm_surface_unset_current(struct wlr_drm_surface *surf);
 
 bool drm_fb_import(struct wlr_drm_fb **fb, struct wlr_drm_backend *drm,
 		struct wlr_buffer *buf, const struct wlr_drm_format_set *formats);

--- a/include/wlr/backend.h
+++ b/include/wlr/backend.h
@@ -28,6 +28,7 @@ struct wlr_backend {
 
 	// Private state
 
+	bool has_own_renderer;
 	struct wlr_renderer *renderer;
 	struct wlr_allocator *allocator;
 };

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -480,12 +480,21 @@ static struct wlr_drm_format *output_pick_format(struct wlr_output *output,
 static void output_pending_resolution(struct wlr_output *output, int *width,
 		int *height);
 
-static bool output_create_swapchain(struct wlr_output *output) {
+/**
+ * Ensure the output has a suitable swapchain. The swapchain is re-created if
+ * necessary.
+ *
+ * If allow_modifiers is set to true, the swapchain's format may use modifiers.
+ * If set to false, the swapchain's format is guaranteed to not use modifiers.
+ */
+static bool output_create_swapchain(struct wlr_output *output,
+		bool allow_modifiers) {
 	int width, height;
 	output_pending_resolution(output, &width, &height);
 
 	if (output->swapchain != NULL && output->swapchain->width == width &&
-			output->swapchain->height == height) {
+			output->swapchain->height == height &&
+			(allow_modifiers || output->swapchain->format->len == 0)) {
 		return true;
 	}
 
@@ -514,6 +523,10 @@ static bool output_create_swapchain(struct wlr_output *output) {
 	wlr_log(WLR_DEBUG, "Choosing primary buffer format 0x%"PRIX32" for output '%s'",
 		format->format, output->name);
 
+	if (!allow_modifiers && (format->len != 1 || format->modifiers[0] != DRM_FORMAT_MOD_LINEAR)) {
+		format->len = 0;
+	}
+
 	struct wlr_swapchain *swapchain =
 		wlr_swapchain_create(allocator, width, height, format);
 	free(format);
@@ -532,7 +545,7 @@ static bool output_attach_back_buffer(struct wlr_output *output,
 		int *buffer_age) {
 	assert(output->back_buffer == NULL);
 
-	if (!output_create_swapchain(output)) {
+	if (!output_create_swapchain(output, true)) {
 		return false;
 	}
 
@@ -691,11 +704,38 @@ static bool output_ensure_buffer(struct wlr_output *output) {
 	wlr_log(WLR_DEBUG, "Attaching empty buffer to output for modeset");
 
 	if (!output_attach_empty_buffer(output)) {
-		output_clear_back_buffer(output);
+		goto error;
+	}
+	if (!output->impl->test || output->impl->test(output)) {
+		return true;
+	}
+
+	output_clear_back_buffer(output);
+	output->pending.committed &= ~WLR_OUTPUT_STATE_BUFFER;
+
+	if (output->swapchain->format->len == 0) {
 		return false;
 	}
 
+	// The test failed for a buffer which has modifiers, try disabling
+	// modifiers to see if that makes a difference.
+	wlr_log(WLR_DEBUG, "Output modeset test failed, retrying without modifiers");
+
+	if (!output_create_swapchain(output, false)) {
+		return false;
+	}
+	if (!output_attach_empty_buffer(output)) {
+		goto error;
+	}
+	if (!output->impl->test(output)) {
+		goto error;
+	}
 	return true;
+
+error:
+	output_clear_back_buffer(output);
+	output->pending.committed &= ~WLR_OUTPUT_STATE_BUFFER;
+	return false;
 }
 
 static bool output_basic_test(struct wlr_output *output) {

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -1178,32 +1178,41 @@ static struct wlr_drm_format *output_pick_format(struct wlr_output *output,
 		return NULL;
 	}
 
-	uint32_t fmt = DRM_FORMAT_ARGB8888;
+	struct wlr_drm_format *format = NULL;
+	const uint32_t candidates[] = { DRM_FORMAT_ARGB8888, DRM_FORMAT_XRGB8888 };
+	for (size_t i = 0; i < sizeof(candidates) / sizeof(candidates[0]); i++) {
+		uint32_t fmt = candidates[i];
 
-	const struct wlr_drm_format *render_format =
-		wlr_drm_format_set_get(render_formats, fmt);
-	if (render_format == NULL) {
-		wlr_log(WLR_DEBUG, "Renderer doesn't support format 0x%"PRIX32, fmt);
-		return NULL;
-	}
-
-	const struct wlr_drm_format *display_format;
-	if (display_formats != NULL) {
-		display_format = wlr_drm_format_set_get(display_formats, fmt);
-		if (display_format == NULL) {
-			wlr_log(WLR_DEBUG, "Output doesn't support format 0x%"PRIX32, fmt);
-			return NULL;
+		const struct wlr_drm_format *render_format =
+			wlr_drm_format_set_get(render_formats, fmt);
+		if (render_format == NULL) {
+			wlr_log(WLR_DEBUG, "Renderer doesn't support format 0x%"PRIX32, fmt);
+			continue;
 		}
-	} else {
-		// The output can display any format
-		display_format = render_format;
-	}
 
-	struct wlr_drm_format *format =
-		wlr_drm_format_intersect(display_format, render_format);
+		if (display_formats != NULL) {
+			const struct wlr_drm_format *display_format =
+				wlr_drm_format_set_get(display_formats, fmt);
+			if (display_format == NULL) {
+				wlr_log(WLR_DEBUG, "Output doesn't support format 0x%"PRIX32, fmt);
+				continue;
+			}
+			format = wlr_drm_format_intersect(display_format, render_format);
+		} else {
+			// The output can display any format
+			format = wlr_drm_format_dup(render_format);
+		}
+
+		if (format == NULL) {
+			wlr_log(WLR_DEBUG, "Failed to intersect display and render "
+				"modifiers for format 0x%"PRIX32, fmt);
+		} else {
+			break;
+		}
+	}
 	if (format == NULL) {
-		wlr_log(WLR_DEBUG, "Failed to intersect display and render "
-			"modifiers for format 0x%"PRIX32, fmt);
+		wlr_log(WLR_ERROR, "Failed to choose a format for output '%s'",
+			output->name);
 		return NULL;
 	}
 


### PR DESCRIPTION
This is https://github.com/swaywm/wlroots/pull/2505 but with the DRM backend changes too. This essentially completes the plan laid out in https://github.com/swaywm/wlroots/issues/1352, while keeping the existing compositor-facing `wlr_output` API intact.

- [x] Implement `get_primary_formats`
- [x] Allocate an empty buffer on modeset, if we don't have one
- [x] Allow direct scan-out with legacy KMS API as long as the format/modifier doesn't change
- [x] Perform a test-only commit with the buffer when mode-setting an output
- [x] Fallback to modifier-less buffers

~~Depends on: https://github.com/swaywm/wlroots/pull/2505~~
~~Depends on: https://github.com/swaywm/wlroots/pull/2829~~
~~Depends on: https://github.com/swaywm/wlroots/pull/3035~~