### PR TITLE
backend/drm: Do not require mode conmit on enable

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -729,9 +729,12 @@ static bool drm_connector_set_mode(struct wlr_drm_connector *conn,
 
 	struct wlr_output_mode *wlr_mode = NULL;
 	if (drm_connector_state_active(conn, state)) {
-		assert(state->committed & WLR_OUTPUT_STATE_MODE);
-		assert(state->mode_type == WLR_OUTPUT_STATE_MODE_FIXED);
-		wlr_mode = state->mode;
+		if (state->committed & WLR_OUTPUT_STATE_MODE) {
+			assert(state->mode_type == WLR_OUTPUT_STATE_MODE_FIXED);
+			wlr_mode = state->mode;
+		} else {
+			wlr_mode = conn->output.current_mode;
+		}
 	}
 
 	conn->desired_enabled = wlr_mode != NULL;


### PR DESCRIPTION
This was not required before, and the assert is tripped by simple
display disable/enable cycles.

Closes: https://github.com/swaywm/wlroots/issues/2904