### PR TITLE
xcursor: fix CVE-2013-2003

### DIFF
--- a/xcursor/xcursor.c
+++ b/xcursor/xcursor.c
@@ -301,7 +301,7 @@ _XcursorFileHeaderDestroy (XcursorFileHeader *fileHeader)
 }
 
 static XcursorFileHeader *
-_XcursorFileHeaderCreate (int ntoc)
+_XcursorFileHeaderCreate (XcursorUInt ntoc)
 {
     XcursorFileHeader	*fileHeader;
 


### PR DESCRIPTION
The libXcursor fix for CVE-2013-2003 has never been imported into
wlroots, leaving it vulnerable to it.

Changing the argument type to an unsigned type is an effective merge of
Ilja Van Sprundel's commit in libXcursor.

Proof of Concept (compile with address sanitizer):

$ mkdir -p ~/.local/share/icons/poc/cursors
$ base64 -d <<< WGN1chAAAAAAAAAA/////w== > \
    ~/.local/share/icons/poc/cursors/poc
$ echo "seat seat0 xcursor_theme poc 10" > ~/poc-config
$ sway -c ~/poc-config