### PR TITLE
xwm: do not restack surfaces on activation 

### DIFF
--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -320,7 +320,6 @@ static void xwm_set_focus_window(struct wlr_xwm *xwm,
 		xwm->last_focus_seq = cookie.sequence;
 	}
 
-	wlr_xwayland_surface_restack(xsurface, NULL, XCB_STACK_MODE_ABOVE);
 	xsurface_set_net_wm_state(xsurface);
 }
 


### PR DESCRIPTION
Currently, upon activating a surface, wlroots restacks it on top of all
others.

This may not necessarily be correct from the calling compositor's point
of view, where having focus may not imply being top-of-stack (e.g.,
focusing a window under an always-on-top window).

In Sway's case, this means that focused tiling windows will always be on
top of floating windows, at least in the order communicated to X11 apps.
This breaks drag-and-drop from a focused tiling X11 window to a floating
X11 window which partially obscures the former.

This is a breaking change; to retain the previous behavior, users that
were calling

    wlr_xwayland_surface_activate(xsurface, true);

should now be calling

    wlr_xwayland_surface_activate(xsurface, true);
    wlr_xwayland_surface_restack(xsurface, NULL, XCB_STACK_MODE_ABOVE);

---

This is currently based off of #2909. I will send in a patch making Sway do
the "right thing" (i.e. not unconditionally restack tiling windows on top of
floating ones) soon.

I've tested this change with this patch to Sway:

```diff
diff --git a/sway/desktop/xwayland.c b/sway/desktop/xwayland.c
index 66cb3b02..1af8d248 100644
--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -254,6 +254,7 @@ static void set_activated(struct sway_view *view, bool activated) {
 	}
 
 	wlr_xwayland_surface_activate(surface, activated);
+	wlr_xwayland_surface_restack(surface, NULL, XCB_STACK_MODE_ABOVE);
 }
 
 static void set_tiled(struct sway_view *view, bool tiled) {
```

and running `watch -n.1 -d xwininfo -root -tree` while doing focusing
operations with JetBrains, Slack, and Chromium, with the results
appearing correct.