### PR TITLE
xwayland: actually use Xwayland from pkg-config

### DIFF
--- a/xwayland/server.c
+++ b/xwayland/server.c
@@ -119,13 +119,13 @@ noreturn static void exec_xwayland(struct wlr_xwayland_server *server) {
 		wlr_log(WLR_INFO, "Using Xwayland binary '%s' due to WLR_XWAYLAND",
 			xwayland_path);
 	} else {
-		xwayland_path = "Xwayland";
+		xwayland_path = XWAYLAND_PATH;
 	}
 
 	// This returns if and only if the call fails
 	execvp(xwayland_path, argv);
 
-	wlr_log_errno(WLR_ERROR, "failed to exec Xwayland");
+	wlr_log_errno(WLR_ERROR, "failed to exec %s", xwayland_path);
 	close(devnull);
 	_exit(EXIT_FAILURE);
 }


### PR DESCRIPTION
eec2e1d3b16ba40c85483badcc7809277274ce5d introduced logic to use the Xwayland
binary discovered via pkg-config.
While the newly introduced checks correctly used the binary from pkg-config,
the actual execution still used the previous PATH-search logic.