### PR TITLE
render: remove wlr_texture_get_size

### DIFF
--- a/include/wlr/render/wlr_texture.h
+++ b/include/wlr/render/wlr_texture.h
@@ -52,14 +52,6 @@ struct wlr_texture *wlr_texture_from_dmabuf(struct wlr_renderer *renderer,
 	struct wlr_dmabuf_attributes *attribs);
 
 /**
- * Get the texture width and height.
- *
- * This function is deprecated. Access wlr_texture's width and height fields
- * directly instead.
- */
-void wlr_texture_get_size(struct wlr_texture *texture, int *width, int *height);
-
-/**
  * Returns true if this texture is using a fully opaque format.
  */
 bool wlr_texture_is_opaque(struct wlr_texture *texture);

--- a/render/wlr_texture.c
+++ b/render/wlr_texture.c
@@ -46,12 +46,6 @@ struct wlr_texture *wlr_texture_from_dmabuf(struct wlr_renderer *renderer,
 	return renderer->impl->texture_from_dmabuf(renderer, attribs);
 }
 
-void wlr_texture_get_size(struct wlr_texture *texture, int *width,
-		int *height) {
-	*width = texture->width;
-	*height = texture->height;
-}
-
 bool wlr_texture_is_opaque(struct wlr_texture *texture) {
 	if (!texture->impl->is_opaque) {
 		return false;


### PR DESCRIPTION
Users can just access the width/height fields directly.