### PR TITLE
render/gles2: remove unnecessary EGL import ext checks

### DIFF
--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -506,12 +506,8 @@ static bool gles2_init_wl_display(struct wlr_renderer *wlr_renderer,
 		wlr_log(WLR_INFO, "EGL_WL_bind_wayland_display is not supported");
 	}
 
-	if (renderer->egl->exts.image_dmabuf_import_ext) {
-		if (wlr_linux_dmabuf_v1_create(wl_display, wlr_renderer) == NULL) {
-			return false;
-		}
-	} else {
-		wlr_log(WLR_INFO, "EGL_EXT_image_dma_buf_import is not supported");
+	if (wlr_linux_dmabuf_v1_create(wl_display, wlr_renderer) == NULL) {
+		return false;
 	}
 
 	return true;

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -269,12 +269,6 @@ struct wlr_texture *gles2_texture_from_dmabuf(struct wlr_renderer *wlr_renderer,
 		return NULL;
 	}
 
-	if (!renderer->egl->exts.image_dmabuf_import_ext) {
-		wlr_log(WLR_ERROR, "Cannot create DMA-BUF texture: EGL extension "
-			"unavailable");
-		return NULL;
-	}
-
 	struct wlr_gles2_texture *texture =
 		calloc(1, sizeof(struct wlr_gles2_texture));
 	if (texture == NULL) {


### PR DESCRIPTION
We require the ext in the renderer init function.