### PR TITLE
render: relax stride check in wlr_texture_from_pixels

### DIFF
--- a/render/wlr_texture.c
+++ b/render/wlr_texture.c
@@ -24,7 +24,7 @@ struct wlr_texture *wlr_texture_from_pixels(struct wlr_renderer *renderer,
 		const void *data) {
 	assert(width > 0);
 	assert(height > 0);
-	assert(stride >= width);
+	assert(stride > 0);
 	assert(data);
 	return renderer->impl->texture_from_pixels(renderer, fmt, stride, width,
 		height, data);


### PR DESCRIPTION
Some formats have a byte-per-pixel lower than 1. Let's not encode
an arbitrary limitation into the wlr_renderer API.