### PR TITLE
Custom wlr_client_buffer from wl_resource

### DIFF
--- a/include/wlr/types/wlr_buffer.h
+++ b/include/wlr/types/wlr_buffer.h
@@ -100,11 +100,17 @@ bool wlr_buffer_get_dmabuf(struct wlr_buffer *buffer,
 bool wlr_buffer_get_shm(struct wlr_buffer *buffer,
 	struct wlr_shm_attributes *attribs);
 
+struct wlr_renderer;
+struct wlr_client_buffer;
+struct wlr_client_buffer_impl;
+
 /**
  * A client buffer.
  */
 struct wlr_client_buffer {
 	struct wlr_buffer base;
+
+	const struct wlr_client_buffer_impl *impl;
 
 	/**
 	 * The buffer resource, if any. Will be NULL if the client destroys it.
@@ -124,8 +130,20 @@ struct wlr_client_buffer {
 	struct wl_listener release;
 };
 
-struct wlr_renderer;
+struct wlr_client_buffer_impl {
+	bool (*is_instance)(struct wl_resource *resource);
+	bool (*get_buffer_size)(struct wl_resource *resource, int *width,
+			int *height);
+	struct wlr_client_buffer *(*create)(struct wl_resource *resource,
+			struct wlr_renderer *renderer);
+	void (*destroy)(struct wlr_client_buffer *buffer);
+};
 
+
+/**
+ * Allows a client to registered a custom implementation of a client buffer
+ */
+void wlr_client_buffer_register_impl(const struct wlr_client_buffer_impl *impl);
 /**
  * Get a client buffer from a generic buffer. If the buffer isn't a client
  * buffer, returns NULL.

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -4,6 +4,7 @@
 #include <wlr/render/interface.h>
 #include <wlr/render/pixman.h>
 #include <wlr/render/wlr_renderer.h>
+#include <wlr/types/wlr_buffer.h>
 #include <wlr/types/wlr_matrix.h>
 #include <wlr/util/log.h>
 
@@ -248,7 +249,12 @@ bool wlr_renderer_init_wl_display(struct wlr_renderer *r,
 	return true;
 }
 
+extern const struct wlr_client_buffer_impl shm_client_buffer_impl;
+
 struct wlr_renderer *renderer_autocreate_with_drm_fd(int drm_fd) {
+
+	wlr_client_buffer_register_impl(&shm_client_buffer_impl);
+
 	const char *name = getenv("WLR_RENDERER");
 	if (name) {
 		wlr_log(WLR_INFO, "Loading user-specified renderer due to WLR_RENDERER: %s",


### PR DESCRIPTION
This patch is a rewrite of the work done by ddevault in https://github.com/swaywm/wlroots/commit/c88abfbc23da485507add71534785b4d8141efdc

The patchset is currently used [here](https://git.sr.ht/~bl4ckb0ne/wxrc/commit/6e66418103cb2b866818adbdd99186408599fb48#src/xr-shell-protocol.c) in my own fork of wxrc.

I chose to not make the existing client buffer impl (shm, dma-buf and wl_drm) yet because of the pending status of [wl_drm in wlroots](https://github.com/swaywm/wlroots/pull/2708). 

