### PR TITLE
Add wlr_backend_destroy for examples

### DIFF
--- a/examples/multi-pointer.c
+++ b/examples/multi-pointer.c
@@ -300,6 +300,7 @@ int main(int argc, char *argv[]) {
 		exit(1);
 	}
 	wl_display_run(display);
+	wlr_backend_destroy(wlr);
 	wl_display_destroy(display);
 
 	struct sample_cursor *cursor, *tmp_cursor;

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -286,6 +286,7 @@ int main(int argc, char *argv[]) {
 
 	wlr_texture_destroy(state.cat_texture);
 
+	wlr_backend_destroy(wlr);
 	wl_display_destroy(state.display);
 	wlr_output_layout_destroy(state.layout);
 }

--- a/examples/quads.c
+++ b/examples/quads.c
@@ -208,5 +208,6 @@ int main(int argc, char *argv[]) {
 	}
 	wl_display_run(display);
 
+	wlr_backend_destroy(wlr);
 	wl_display_destroy(display);
 }

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -267,5 +267,6 @@ int main(int argc, char *argv[]) {
 	wl_display_run(display);
 
 	wlr_texture_destroy(state.cat_texture);
+	wlr_backend_destroy(wlr);
 	wl_display_destroy(display);
 }

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -182,6 +182,7 @@ int main(void) {
 		wlr_backend_destroy(backend);
 		exit(1);
 	}
+	wlr_backend_destroy(backend);
 	wl_display_run(display);
 	wl_display_destroy(display);
 }

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -373,5 +373,6 @@ int main(int argc, char *argv[]) {
 	}
 	wl_display_run(display);
 
+	wlr_backend_destroy(wlr);
 	wl_display_destroy(display);
 }

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -277,5 +277,6 @@ int main(int argc, char *argv[]) {
 	wl_display_run(display);
 
 	wlr_texture_destroy(state.cat_texture);
+	wlr_backend_destroy(wlr);
 	wl_display_destroy(display);
 }

--- a/tinywl/tinywl.c
+++ b/tinywl/tinywl.c
@@ -966,6 +966,7 @@ int main(int argc, char *argv[]) {
 			socket);
 	wl_display_run(server.wl_display);
 
+	wlr_backend_destroy(server.backend);
 	/* Once wl_display_run returns, we shut down the server. */
 	wl_display_destroy_clients(server.wl_display);
 	wl_display_destroy(server.wl_display);


### PR DESCRIPTION
Destroy the wlr_backend on the application quit before, resources need
    released normally when the application exits.