### PR TITLE
backend: stop using renderer to get the buffer type

### DIFF
--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -17,6 +17,7 @@
 
 #include "backend/backend.h"
 #include "backend/wayland.h"
+#include "render/allocator.h"
 #include "render/drm_format_set.h"
 #include "render/pixel_format.h"
 #include "render/wlr_renderer.h"
@@ -451,11 +452,10 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display,
 		goto error_drm_fd;
 	}
 
-	uint32_t caps = renderer_get_render_buffer_caps(renderer);
 	const struct wlr_drm_format_set *remote_formats;
-	if ((caps & WLR_BUFFER_CAP_DMABUF) && wl->zwp_linux_dmabuf_v1) {
+	if ((allocator->buffer_caps & WLR_BUFFER_CAP_DMABUF) && wl->zwp_linux_dmabuf_v1) {
 		remote_formats = &wl->linux_dmabuf_v1_formats;
-	} else if ((caps & WLR_BUFFER_CAP_DATA_PTR) && wl->shm) {
+	} else if ((allocator->buffer_caps & WLR_BUFFER_CAP_SHM) && wl->shm) {
 		remote_formats = &wl->shm_formats;
 	}  else {
 		wlr_log(WLR_ERROR,

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -32,9 +32,8 @@
 
 #include "backend/backend.h"
 #include "backend/x11.h"
+#include "render/allocator.h"
 #include "render/drm_format_set.h"
-#include "render/gbm_allocator.h"
-#include "render/shm_allocator.h"
 #include "render/wlr_renderer.h"
 #include "types/wlr_buffer.h"
 #include "util/signal.h"
@@ -619,11 +618,10 @@ struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
 		goto error_event;
 	}
 
-	uint32_t caps = renderer_get_render_buffer_caps(renderer);
 	const struct wlr_drm_format_set *pixmap_formats;
-	if (x11->have_dri3 && (caps & WLR_BUFFER_CAP_DMABUF)) {
+	if (x11->have_dri3 && (allocator->buffer_caps & WLR_BUFFER_CAP_DMABUF)) {
 		pixmap_formats = &x11->dri3_formats;
-	} else if (x11->have_shm && (caps & WLR_BUFFER_CAP_DATA_PTR)) {
+	} else if (x11->have_shm && (allocator->buffer_caps & WLR_BUFFER_CAP_SHM)) {
 		pixmap_formats = &x11->shm_formats;
 	} else {
 		wlr_log(WLR_ERROR,

--- a/include/render/allocator.h
+++ b/include/render/allocator.h
@@ -19,6 +19,9 @@ struct wlr_allocator_interface {
 struct wlr_allocator {
 	const struct wlr_allocator_interface *impl;
 
+	// Capabilites of the buffers created with this allocator
+	uint32_t buffer_caps;
+
 	struct {
 		struct wl_signal destroy;
 	} events;
@@ -44,7 +47,7 @@ struct wlr_buffer *wlr_allocator_create_buffer(struct wlr_allocator *alloc,
 
 // For wlr_allocator implementors
 void wlr_allocator_init(struct wlr_allocator *alloc,
-	const struct wlr_allocator_interface *impl);
+	const struct wlr_allocator_interface *impl, uint32_t buffer_caps);
 
 struct wlr_allocator *allocator_autocreate_with_drm_fd(
 	struct wlr_backend *backend, struct wlr_renderer *renderer, int drm_fd);

--- a/render/drm_dumb_allocator.c
+++ b/render/drm_dumb_allocator.c
@@ -195,6 +195,11 @@ static const struct wlr_allocator_interface allocator_impl = {
 };
 
 struct wlr_allocator *wlr_drm_dumb_allocator_create(int fd) {
+	if (!drmIsMaster(fd)) {
+		wlr_log(WLR_ERROR, "Cannot use DRM dumb buffers with non-master DRM FD");
+		return NULL;
+	}
+
 	/* Re-open the DRM node to avoid GEM handle ref'counting issues. See:
 	 * https://gitlab.freedesktop.org/mesa/drm/-/merge_requests/110
 	 * TODO: don't assume we have the permission to just open the DRM node,

--- a/render/drm_dumb_allocator.c
+++ b/render/drm_dumb_allocator.c
@@ -15,6 +15,7 @@
 
 #include "render/drm_dumb_allocator.h"
 #include "render/pixel_format.h"
+#include "types/wlr_buffer.h"
 
 static const struct wlr_buffer_impl buffer_impl;
 
@@ -127,7 +128,7 @@ create_err:
 	return NULL;
 }
 
-static bool buffer_get_data_ptr(struct wlr_buffer *wlr_buffer, void **data,
+static bool drm_dumb_buffer_get_data_ptr(struct wlr_buffer *wlr_buffer, void **data,
 		uint32_t *format, size_t *stride) {
 	struct wlr_drm_dumb_buffer *buf = drm_dumb_buffer_from_buffer(wlr_buffer);
 	*data = buf->data;
@@ -152,7 +153,7 @@ static void buffer_destroy(struct wlr_buffer *wlr_buffer) {
 static const struct wlr_buffer_impl buffer_impl = {
 	.destroy = buffer_destroy,
 	.get_dmabuf = buffer_get_dmabuf,
-	.get_data_ptr = buffer_get_data_ptr,
+	.get_data_ptr = drm_dumb_buffer_get_data_ptr,
 };
 
 static const struct wlr_allocator_interface allocator_impl;
@@ -231,7 +232,8 @@ struct wlr_allocator *wlr_drm_dumb_allocator_create(int fd) {
 		free(path);
 		return NULL;
 	}
-	wlr_allocator_init(&alloc->base, &allocator_impl);
+	wlr_allocator_init(&alloc->base, &allocator_impl,
+		WLR_BUFFER_CAP_DATA_PTR | WLR_BUFFER_CAP_DMABUF);
 
 	alloc->drm_fd = drm_fd;
 	wl_list_init(&alloc->buffers);

--- a/render/gbm_allocator.c
+++ b/render/gbm_allocator.c
@@ -7,6 +7,7 @@
 #include <wlr/util/log.h>
 #include <xf86drm.h>
 #include "render/gbm_allocator.h"
+#include "types/wlr_buffer.h"
 
 static const struct wlr_buffer_impl buffer_impl;
 
@@ -181,7 +182,7 @@ struct wlr_allocator *wlr_gbm_allocator_create(int drm_fd) {
 	if (alloc == NULL) {
 		return NULL;
 	}
-	wlr_allocator_init(&alloc->base, &allocator_impl);
+	wlr_allocator_init(&alloc->base, &allocator_impl, WLR_BUFFER_CAP_DMABUF);
 
 	alloc->fd = fd;
 	wl_list_init(&alloc->buffers);

--- a/render/shm_allocator.c
+++ b/render/shm_allocator.c
@@ -7,6 +7,7 @@
 #include "render/pixel_format.h"
 #include "render/shm_allocator.h"
 #include "util/shm.h"
+#include "types/wlr_buffer.h"
 
 static const struct wlr_buffer_impl buffer_impl;
 
@@ -30,7 +31,7 @@ static bool buffer_get_shm(struct wlr_buffer *wlr_buffer,
 	return true;
 }
 
-static bool buffer_get_data_ptr(struct wlr_buffer *wlr_buffer, void **data,
+static bool shm_buffer_get_data_ptr(struct wlr_buffer *wlr_buffer, void **data,
 		uint32_t *format, size_t *stride) {
 	struct wlr_shm_buffer *buffer = shm_buffer_from_buffer(wlr_buffer);
 	*data = buffer->data;
@@ -42,7 +43,7 @@ static bool buffer_get_data_ptr(struct wlr_buffer *wlr_buffer, void **data,
 static const struct wlr_buffer_impl buffer_impl = {
 	.destroy = buffer_destroy,
 	.get_shm = buffer_get_shm,
-	.get_data_ptr = buffer_get_data_ptr,
+	.get_data_ptr = shm_buffer_get_data_ptr,
 };
 
 static struct wlr_buffer *allocator_create_buffer(
@@ -103,7 +104,8 @@ struct wlr_allocator *wlr_shm_allocator_create(void) {
 	if (allocator == NULL) {
 		return NULL;
 	}
-	wlr_allocator_init(&allocator->base, &allocator_impl);
+	wlr_allocator_init(&allocator->base, &allocator_impl,
+		WLR_BUFFER_CAP_DATA_PTR | WLR_BUFFER_CAP_SHM);
 
 	wlr_log(WLR_DEBUG, "Created shm allocator");
 	return &allocator->base;


### PR DESCRIPTION
When picking a format, the backend needs to know whether the
buffers allocated by the allocator will be DMA-BUFs or shared
memory. So far, the backend used the renderer's supported
buffer types to guess this information.

This is pretty fragile: renderers in general don't care about the
SHM cap (they only care about the DATA_PTR one). Additionally,
nothing stops a renderer from supporting both DMA-BUFs and shared
memory, but this would break the backend's guess.

Instead, use wlr_allocator.buffer_caps. This is more reliable since
the buffers created with the allocator are guaranteed to have these
caps.

cc @bl4ckb0ne 

* * *

Not a breaking change since `wlr_allocator` is still a private wlroots API.