### PR TITLE
render: add wlr_renderer_begin_with_buffer

### DIFF
--- a/include/wlr/render/wlr_renderer.h
+++ b/include/wlr/render/wlr_renderer.h
@@ -27,6 +27,7 @@ struct wlr_renderer {
 	const struct wlr_renderer_impl *impl;
 
 	bool rendering;
+	bool rendering_with_buffer;
 
 	struct {
 		struct wl_signal destroy;
@@ -36,6 +37,8 @@ struct wlr_renderer {
 struct wlr_renderer *wlr_renderer_autocreate(struct wlr_backend *backend);
 
 void wlr_renderer_begin(struct wlr_renderer *r, uint32_t width, uint32_t height);
+bool wlr_renderer_begin_with_buffer(struct wlr_renderer *r,
+	struct wlr_buffer *buffer);
 void wlr_renderer_end(struct wlr_renderer *r);
 void wlr_renderer_clear(struct wlr_renderer *r, const float color[static 4]);
 /**

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -63,6 +63,16 @@ void wlr_renderer_begin(struct wlr_renderer *r, uint32_t width, uint32_t height)
 	r->rendering = true;
 }
 
+bool wlr_renderer_begin_with_buffer(struct wlr_renderer *r,
+		struct wlr_buffer *buffer) {
+	if (!wlr_renderer_bind_buffer(r, buffer)) {
+		return false;
+	}
+	wlr_renderer_begin(r, buffer->width, buffer->height);
+	r->rendering_with_buffer = true;
+	return true;
+}
+
 void wlr_renderer_end(struct wlr_renderer *r) {
 	assert(r->rendering);
 
@@ -71,6 +81,11 @@ void wlr_renderer_end(struct wlr_renderer *r) {
 	}
 
 	r->rendering = false;
+
+	if (r->rendering_with_buffer) {
+		wlr_renderer_bind_buffer(r, NULL);
+		r->rendering_with_buffer = false;
+	}
 }
 
 void wlr_renderer_clear(struct wlr_renderer *r, const float color[static 4]) {


### PR DESCRIPTION
This allows compositors to choose a wlr_buffer to render to. This
is a less awkward interface than having to call bind_buffer() before
and after begin() and end().

Closes: https://github.com/swaywm/wlroots/issues/2618

cc @dos1: would something like this be useful to phosh?