### PR TITLE
render: disallow wlr_renderer_destroy while rendering

### DIFF
--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -37,6 +37,9 @@ void wlr_renderer_destroy(struct wlr_renderer *r) {
 	if (!r) {
 		return;
 	}
+
+	assert(!r->rendering);
+
 	wlr_signal_emit_safe(&r->events.destroy, r);
 
 	if (r->impl && r->impl->destroy) {


### PR DESCRIPTION
This probably already felt apart, but let's make it explicit that
this is not allowed.