### PR TITLE
render: drop wlr_ prefix from wlr_renderer_bind_buffer

### DIFF
--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -109,7 +109,7 @@ bool drm_surface_make_current(struct wlr_drm_surface *surf,
 		return false;
 	}
 
-	if (!wlr_renderer_bind_buffer(surf->renderer->wlr_rend, surf->back_buffer)) {
+	if (!renderer_bind_buffer(surf->renderer->wlr_rend, surf->back_buffer)) {
 		wlr_log(WLR_ERROR, "Failed to bind buffer to renderer");
 		return false;
 	}
@@ -120,7 +120,7 @@ bool drm_surface_make_current(struct wlr_drm_surface *surf,
 void drm_surface_unset_current(struct wlr_drm_surface *surf) {
 	assert(surf->back_buffer != NULL);
 
-	wlr_renderer_bind_buffer(surf->renderer->wlr_rend, NULL);
+	renderer_bind_buffer(surf->renderer->wlr_rend, NULL);
 
 	wlr_buffer_unlock(surf->back_buffer);
 	surf->back_buffer = NULL;

--- a/include/render/wlr_renderer.h
+++ b/include/render/wlr_renderer.h
@@ -12,12 +12,12 @@ struct wlr_renderer *renderer_autocreate_with_drm_fd(int drm_fd);
  *
  * All subsequent rendering operations will operate on the supplied buffer.
  * After rendering operations are done, the caller must unbind a buffer by
- * calling wlr_renderer_bind_buffer with a NULL buffer.
+ * calling renderer_bind_buffer with a NULL buffer.
  */
-bool wlr_renderer_bind_buffer(struct wlr_renderer *r, struct wlr_buffer *buffer);
+bool renderer_bind_buffer(struct wlr_renderer *r, struct wlr_buffer *buffer);
 /**
  * Get the supported render formats. Buffers allocated with a format from this
- * list may be attached via wlr_renderer_bind_buffer.
+ * list may be attached via wlr_renderer_begin_with_buffer.
  */
 const struct wlr_drm_format_set *wlr_renderer_get_render_formats(
 	struct wlr_renderer *renderer);

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -49,8 +49,7 @@ void wlr_renderer_destroy(struct wlr_renderer *r) {
 	}
 }
 
-bool wlr_renderer_bind_buffer(struct wlr_renderer *r,
-		struct wlr_buffer *buffer) {
+bool renderer_bind_buffer(struct wlr_renderer *r, struct wlr_buffer *buffer) {
 	assert(!r->rendering);
 	if (!r->impl->bind_buffer) {
 		return false;
@@ -68,7 +67,7 @@ void wlr_renderer_begin(struct wlr_renderer *r, uint32_t width, uint32_t height)
 
 bool wlr_renderer_begin_with_buffer(struct wlr_renderer *r,
 		struct wlr_buffer *buffer) {
-	if (!wlr_renderer_bind_buffer(r, buffer)) {
+	if (!renderer_bind_buffer(r, buffer)) {
 		return false;
 	}
 	wlr_renderer_begin(r, buffer->width, buffer->height);
@@ -86,7 +85,7 @@ void wlr_renderer_end(struct wlr_renderer *r) {
 	r->rendering = false;
 
 	if (r->rendering_with_buffer) {
-		wlr_renderer_bind_buffer(r, NULL);
+		renderer_bind_buffer(r, NULL);
 		r->rendering_with_buffer = false;
 	}
 }

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -533,7 +533,7 @@ static bool output_attach_back_buffer(struct wlr_output *output,
 		return false;
 	}
 
-	if (!wlr_renderer_bind_buffer(renderer, buffer)) {
+	if (!renderer_bind_buffer(renderer, buffer)) {
 		wlr_buffer_unlock(buffer);
 		return false;
 	}
@@ -550,7 +550,7 @@ static void output_clear_back_buffer(struct wlr_output *output) {
 	struct wlr_renderer *renderer = wlr_backend_get_renderer(output->backend);
 	assert(renderer != NULL);
 
-	wlr_renderer_bind_buffer(renderer, NULL);
+	renderer_bind_buffer(renderer, NULL);
 
 	wlr_buffer_unlock(output->back_buffer);
 	output->back_buffer = NULL;

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -1263,11 +1263,6 @@ static struct wlr_buffer *render_cursor_buffer(struct wlr_output_cursor *cursor)
 		return NULL;
 	}
 
-	if (!wlr_renderer_bind_buffer(renderer, buffer)) {
-		wlr_buffer_unlock(buffer);
-		return NULL;
-	}
-
 	struct wlr_box cursor_box = {
 		.width = texture->width * output->scale / scale,
 		.height = texture->height * output->scale / scale,
@@ -1292,12 +1287,15 @@ static struct wlr_buffer *render_cursor_buffer(struct wlr_output_cursor *cursor)
 	float matrix[9];
 	wlr_matrix_project_box(matrix, &cursor_box, transform, 0, output_matrix);
 
-	wlr_renderer_begin(renderer, width, height);
+	if (!wlr_renderer_begin_with_buffer(renderer, buffer)) {
+		wlr_buffer_unlock(buffer);
+		return NULL;
+	}
+
 	wlr_renderer_clear(renderer, (float[]){ 0.0, 0.0, 0.0, 0.0 });
 	wlr_render_texture_with_matrix(renderer, texture, matrix, 1.0);
-	wlr_renderer_end(renderer);
 
-	wlr_renderer_bind_buffer(renderer, NULL);
+	wlr_renderer_end(renderer);
 
 	return buffer;
 }


### PR DESCRIPTION
Make it clear this function is a private wlroots API and will stay that way. The only reason why it exists is to allow `wlr_output_attach_render` to continue to be supported.

Convert all other call sites to `wlr_renderer_begin_with_buffer`, which is the future-proof public API.