### PR TITLE
output: add generic wlr_output_export_dmabuf implementation 

### DIFF
--- a/include/backend/headless.h
+++ b/include/backend/headless.h
@@ -25,8 +25,6 @@ struct wlr_headless_output {
 	struct wlr_headless_backend *backend;
 	struct wl_list link;
 
-	struct wlr_buffer *front_buffer;
-
 	struct wl_event_source *frame_timer;
 	int frame_delay; // ms
 };

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -84,11 +84,6 @@ struct wlr_output_impl {
 	 */
 	size_t (*get_gamma_size)(struct wlr_output *output);
 	/**
-	 * Export the output's current back-buffer as a DMA-BUF.
-	 */
-	bool (*export_dmabuf)(struct wlr_output *output,
-		struct wlr_dmabuf_attributes *attribs);
-	/**
 	 * Get the list of formats suitable for the cursor, assuming a buffer with
 	 * the specified capabilities.
 	 *

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -186,7 +186,7 @@ struct wlr_output {
 	int software_cursor_locks; // number of locks forcing software cursors
 
 	struct wlr_swapchain *swapchain;
-	struct wlr_buffer *back_buffer;
+	struct wlr_buffer *back_buffer, *front_buffer;
 
 	struct wl_listener display_destroy;
 

--- a/types/wlr_export_dmabuf_v1.c
+++ b/types/wlr_export_dmabuf_v1.c
@@ -135,7 +135,7 @@ static void manager_handle_capture_output(struct wl_client *client,
 
 	wl_list_insert(&manager->frames, &frame->link);
 
-	if (output == NULL || !output->enabled || !output->impl->export_dmabuf) {
+	if (output == NULL || !output->enabled) {
 		zwlr_export_dmabuf_frame_v1_send_cancel(frame->resource,
 			ZWLR_EXPORT_DMABUF_FRAME_V1_CANCEL_REASON_PERMANENT);
 		frame_destroy(frame);

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -926,10 +926,6 @@ size_t wlr_output_get_gamma_size(struct wlr_output *output) {
 
 bool wlr_output_export_dmabuf(struct wlr_output *output,
 		struct wlr_dmabuf_attributes *attribs) {
-	if (output->impl->export_dmabuf) {
-		return output->impl->export_dmabuf(output, attribs);
-	}
-
 	if (output->front_buffer == NULL) {
 		return false;
 	}


### PR DESCRIPTION
When wlr_output manages its own swap-chain, there's no need to
hook into the backend to grab DMA-BUFs. Instead, maintain a
`wlr_output.front_buffer` field with the latest committed buffer.