### PR TITLE
render: add missing arg to wlr_renderer_impl.get_buffer_caps

### DIFF
--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -56,7 +56,7 @@ struct wlr_renderer_impl {
 	bool (*init_wl_display)(struct wlr_renderer *renderer,
 		struct wl_display *wl_display);
 	int (*get_drm_fd)(struct wlr_renderer *renderer);
-	uint32_t (*get_render_buffer_caps)(void);
+	uint32_t (*get_render_buffer_caps)(struct wlr_renderer *renderer);
 	struct wlr_texture *(*texture_from_buffer)(struct wlr_renderer *renderer,
 		struct wlr_buffer *buffer);
 };

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -524,7 +524,7 @@ static int gles2_get_drm_fd(struct wlr_renderer *wlr_renderer) {
 	return renderer->drm_fd;
 }
 
-static uint32_t gles2_get_render_buffer_caps(void) {
+static uint32_t gles2_get_render_buffer_caps(struct wlr_renderer *wlr_renderer) {
 	return WLR_BUFFER_CAP_DMABUF;
 }
 

--- a/render/pixman/renderer.c
+++ b/render/pixman/renderer.c
@@ -510,7 +510,7 @@ static bool pixman_read_pixels(struct wlr_renderer *wlr_renderer,
 	return true;
 }
 
-static uint32_t pixman_get_render_buffer_caps(void) {
+static uint32_t pixman_get_render_buffer_caps(struct wlr_renderer *renderer) {
 	return WLR_BUFFER_CAP_DATA_PTR;
 }
 

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -194,7 +194,7 @@ const struct wlr_drm_format_set *wlr_renderer_get_render_formats(
 }
 
 uint32_t renderer_get_render_buffer_caps(struct wlr_renderer *r) {
-	return r->impl->get_render_buffer_caps();
+	return r->impl->get_render_buffer_caps(r);
 }
 
 bool wlr_renderer_read_pixels(struct wlr_renderer *r, uint32_t fmt,


### PR DESCRIPTION
The types of buffers supported by the renderer might depend on the
renderer's instance. For instance, a renderer might only support
DMA-BUFs if the necessary EGL extensions are available.

Pass the wlr_renderer to get_buffer_caps so that the renderer can
perform such checks.

Fixes: 982498fab3c4 ("render: introduce renderer_get_render_buffer_caps")