### PR TITLE
Support DRM connector tiling [WIP]

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1369,6 +1369,12 @@ void scan_drm_connectors(struct wlr_drm_backend *drm) {
 			parse_edid(&wlr_conn->output, edid_len, edid);
 			free(edid);
 
+			size_t tile_len = 0;
+			uint8_t *tile = get_drm_prop_blob(drm->fd,
+				wlr_conn->id, wlr_conn->props.tile, &tile_len);
+			parse_tile(&wlr_conn->output, tile_len, tile);
+			free(tile);
+
 			char *subconnector = NULL;
 			if (wlr_conn->props.subconnector) {
 				subconnector = get_drm_prop_enum(drm->fd,

--- a/backend/drm/properties.c
+++ b/backend/drm/properties.c
@@ -24,6 +24,7 @@ static const struct prop_info connector_info[] = {
 	{ "DPMS", INDEX(dpms) },
 	{ "EDID", INDEX(edid) },
 	{ "PATH", INDEX(path) },
+	{ "TILE", INDEX(tile) },
 	{ "link-status", INDEX(link_status) },
 	{ "subconnector", INDEX(subconnector) },
 	{ "vrr_capable", INDEX(vrr_capable) },

--- a/backend/drm/util.c
+++ b/backend/drm/util.c
@@ -144,6 +144,41 @@ void parse_edid(struct wlr_output *restrict output, size_t len, const uint8_t *d
 	}
 }
 
+void parse_tile(struct wlr_output *restrict output, size_t len, const uint8_t *data) {
+	if (len > 0) {
+		int ret;
+		ret = sscanf((char*)data, "%d:%d:%d:%d:%d:%d:%d:%d",
+			&output->tile_info.group_id,
+			&output->tile_info.tile_is_single_monitor,
+			&output->tile_info.num_h_tile,
+			&output->tile_info.num_v_tile,
+			&output->tile_info.tile_h_loc,
+			&output->tile_info.tile_v_loc,
+			&output->tile_info.tile_h_size,
+			&output->tile_info.tile_v_size);
+		if(ret != 8)
+			wlr_log(WLR_ERROR, "Unable to understand tile information for "
+				"output %s", output->name);
+		else
+			wlr_log(WLR_INFO, "Output %s TILE information: "
+				"group ID %d, single monitor %d, total %d horizontal tiles, "
+				"total %d vertical tiles, horizontal tile %d, vertical tile "
+				"%d, width %d, height %d",
+				output->name,
+				output->tile_info.group_id,
+				output->tile_info.tile_is_single_monitor,
+				output->tile_info.num_h_tile,
+				output->tile_info.num_v_tile,
+				output->tile_info.tile_h_loc,
+				output->tile_info.tile_v_loc,
+				output->tile_info.tile_h_size,
+				output->tile_info.tile_v_size);
+	}
+	else
+		wlr_log(WLR_DEBUG, "No tile information available for output %s",
+			output->name);
+}
+
 const char *conn_get_name(uint32_t type_id) {
 	switch (type_id) {
 	case DRM_MODE_CONNECTOR_Unknown:     return "Unknown";

--- a/include/backend/drm/properties.h
+++ b/include/backend/drm/properties.h
@@ -18,12 +18,13 @@ union wlr_drm_connector_props {
 		uint32_t path;
 		uint32_t vrr_capable; // not guaranteed to exist
 		uint32_t subconnector; // not guaranteed to exist
+		uint32_t tile;
 
 		// atomic-modesetting only
 
 		uint32_t crtc_id;
 	};
-	uint32_t props[4];
+	uint32_t props[8];
 };
 
 union wlr_drm_crtc_props {

--- a/include/backend/drm/util.h
+++ b/include/backend/drm/util.h
@@ -11,6 +11,9 @@ int32_t calculate_refresh_rate(const drmModeModeInfo *mode);
 // Populates the make/model/phys_{width,height} of output from the edid data
 void parse_edid(struct wlr_output *restrict output, size_t len,
 	const uint8_t *data);
+// Parses the TILE property
+void parse_tile(struct wlr_output *restrict output, size_t len,
+	const uint8_t *data);
 // Returns the string representation of a DRM output type
 const char *conn_get_name(uint32_t type_id);
 // Returns the DRM framebuffer id for a gbm_bo

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -46,6 +46,17 @@ struct wlr_output_cursor {
 	} events;
 };
 
+struct wlr_output_tile_info {
+	uint32_t group_id;
+	uint32_t tile_is_single_monitor;
+	uint32_t num_h_tile;
+	uint32_t num_v_tile;
+	uint32_t tile_h_loc;
+	uint32_t tile_v_loc;
+	uint32_t tile_h_size;
+	uint32_t tile_v_size;
+};
+
 enum wlr_output_adaptive_sync_status {
 	WLR_OUTPUT_ADAPTIVE_SYNC_DISABLED,
 	WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED,
@@ -128,6 +139,7 @@ struct wlr_output {
 	char model[16];
 	char serial[16];
 	int32_t phys_width, phys_height; // mm
+	struct wlr_output_tile_info tile_info;
 
 	// Note: some backends may have zero modes
 	struct wl_list modes; // wlr_output_mode::link


### PR DESCRIPTION
This first part enables parsing of TILE info for the DRM backend and exposing the info into `wlr_output`. Addresses #1580, the remainder is still WIP:

- Add a way to crop a buffer with wlr_output. Probably something like wlr_output_set_src_box? This should translate to the KMS SRC_* props.
- Add wlr_output_group which forwards buffers to multiple child outputs on commit.