### PR TITLE
output: reset back buffer on failed commit

### DIFF
--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -737,6 +737,7 @@ bool wlr_output_commit(struct wlr_output *output) {
 	wlr_signal_emit_safe(&output->events.precommit, &pre_event);
 
 	if (!output->impl->commit(output)) {
+		output_clear_back_buffer(output);
 		output_state_clear(&output->pending);
 		return false;
 	}


### PR DESCRIPTION
On commit failure, we need to unbind the back buffer from the
renderer.

This fixes assertions triggered on commits following a failed commit
where the compositor called wlr_output_attach_render.