### PR TITLE
backend/drm: populate cursor plane's current_fb

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -920,7 +920,7 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 			local_buf = wlr_buffer_lock(buffer);
 		}
 
-		bool ok = drm_fb_import(&plane->pending_fb, drm, local_buf,
+		bool ok = drm_fb_import(&plane->current_fb, drm, local_buf,
 			&plane->formats);
 		wlr_buffer_unlock(local_buf);
 		if (!ok) {


### PR DESCRIPTION
The set_cursor() hook is a little bit special: it's not really
synchronized to commit() or test(). Once set_cursor() returns true,
the new cursor is part of the current state.

This fixes a state where wlr_drm_connector.cursor_enabled is true
but there is no FB available. This is triggered by set_cursor()
followed by a failed commit(), which resets pending_fb.

We should definitely fix the output interface to make the cursor part
of the pending state, but that's a more involved change.