### PR TITLE
meson: Make private static library symbols local

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -19,7 +19,7 @@ sources:
 tasks:
   - setup: |
       cd wlroots
-      meson build -Dauto_features=enabled -Dlibseat=disabled -Dxcb-errors=disabled
+      meson build --default-library=both -Dauto_features=enabled -Dlibseat=disabled -Dxcb-errors=disabled
   - build: |
       cd wlroots
       ninja -C build

--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -20,7 +20,7 @@ sources:
 tasks:
   - setup: |
       cd wlroots
-      CC=gcc meson build-gcc -Dauto_features=enabled --prefix /usr
+      CC=gcc meson build-gcc --default-library=both -Dauto_features=enabled --prefix /usr
       CC=clang meson build-clang -Dauto_features=enabled
   - gcc: |
       cd wlroots/build-gcc

--- a/meson.build
+++ b/meson.build
@@ -150,7 +150,29 @@ lib_wlr = library(
 	install: true,
 	link_args: symbols_flag,
 	link_depends: symbols_file,
+	prelink: true,
 )
+
+if get_option('default_library') != 'shared'
+	lib_target = lib_wlr
+	if get_option('default_library') == 'both'
+		lib_target = lib_wlr.get_static_lib()
+	endif
+	objcopy_prog = find_program('objcopy', native: true)
+	custom_target('libwlroots',
+		input: lib_target,
+		output: lib_target.name() + '.is-stripped',
+		capture: true,
+		command: [
+			objcopy_prog.full_path(), '-w',
+			'--localize-symbol=!wlr_*',
+			'--localize-symbol=!_wlr_*',
+			'--localize-symbol=*',
+			'@INPUT@',
+		],
+		build_by_default: true,
+	)
+endif
 
 wlr_vars = {}
 foreach name, have : features


### PR DESCRIPTION
Static libraries are not affected by our symbol file, so private symbols
are globally visible by default.

Use objcopy to make symbols that we do not want to expose local.

Closes: https://github.com/swaywm/wlroots/issues/1892
Closes: https://github.com/swaywm/wlroots/issues/2952