### PR TITLE
build: simplify version script

### DIFF
--- a/wlroots.syms
+++ b/wlroots.syms
@@ -1,11 +1,7 @@
 {
 	global:
 		wlr_*;
-		_wlr_log;
-		_wlr_vlog;
-		_wlr_strip_path;
+		_wlr_*;
 	local:
-		wlr_signal_emit_safe;
-		wlr_global_destroy_safe;
 		*;
 };


### PR DESCRIPTION
Let's expose all of our prefixed symbols. Instead of trying to have
fine-grained rules and only expose our public API, let's just expose
all symbols that won't cause a conflict.

Users won't be able to use the symbols without a proper header
declaration anyways. If they go through the process of re-defining
wlr_ symbols manually, that's on them if their build breaks.

This aligns the rules with [1].

[1]: https://github.com/swaywm/wlroots/pull/2969

cc @kennylevinsen 