### PR TITLE
backend/session: use drmIsKMS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -96,7 +96,7 @@ internal_features = {
 
 wayland_server = dependency('wayland-server', version: '>=1.19')
 wayland_client = dependency('wayland-client')
-drm = dependency('libdrm', version: '>=2.4.95')
+drm = dependency('libdrm', version: '>=2.4.105')
 gbm = dependency('gbm', version: '>=17.1.0')
 libinput = dependency('libinput', version: '>=1.14.0')
 xkbcommon = dependency('xkbcommon')


### PR DESCRIPTION
This moves the magic incantation into libdrm and is clearer. See
[1] for details.

While at it, fixup the doc comment and improve logging.

[1]: https://gitlab.freedesktop.org/mesa/drm/-/commit/523b3658aa8efa746417e916c987de23740ce313