### PR TITLE
Revert "meson: Make private static library symbols local"

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -150,29 +150,7 @@ lib_wlr = library(
 	install: true,
 	link_args: symbols_flag,
 	link_depends: symbols_file,
-	prelink: true,
 )
-
-if get_option('default_library') != 'shared'
-	lib_target = lib_wlr
-	if get_option('default_library') == 'both'
-		lib_target = lib_wlr.get_static_lib()
-	endif
-	objcopy_prog = find_program('objcopy', native: true)
-	custom_target('libwlroots',
-		input: lib_target,
-		output: lib_target.name() + '.is-stripped',
-		capture: true,
-		command: [
-			objcopy_prog.full_path(), '-w',
-			'--localize-symbol=!wlr_*',
-			'--localize-symbol=!_wlr_*',
-			'--localize-symbol=*',
-			'@INPUT@',
-		],
-		build_by_default: true,
-	)
-endif
 
 wlr_vars = {}
 foreach name, have : features


### PR DESCRIPTION
This reverts commit 28d23ba6bda4f799b8d6689555cd33a40adda17e.

The prelinking and symbol filtering pass breaks builds with link-time
optimization enabled.

Building static libs in CI should be fine, so I didn't revert that.

cc @emersion 