### PR TITLE
Revert "build: workaround for meson disabler object not working with if not"

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -18,8 +18,7 @@ else
 	libepoll = dependency('', required: false)
 endif
 
-# Check if libavutil is found because of https://github.com/mesonbuild/meson/issues/6010
-if libavutil.found() and not cc.has_header('libavutil/hwcontext_drm.h', dependencies: libavutil)
+if not cc.has_header('libavutil/hwcontext_drm.h', dependencies: libavutil)
 	libavutil = disabler()
 endif
 


### PR DESCRIPTION
This reverts commit 9796abccedef881e99d293a2658c4da9466acd88.

This Meson issue has been fixed upstream for a while. We require 0.56.0 so we should never hit an unpatched Meson.