### PR TITLE
render/egl: make most functions private

### DIFF
--- a/include/render/egl.h
+++ b/include/render/egl.h
@@ -1,0 +1,76 @@
+#ifndef RENDER_EGL_H
+#define RENDER_EGL_H
+
+#include <wlr/render/egl.h>
+
+struct wlr_egl_context {
+	EGLDisplay display;
+	EGLContext context;
+	EGLSurface draw_surface;
+	EGLSurface read_surface;
+};
+
+/**
+ * Initializes an EGL context for the given platform and remote display.
+ * Will attempt to load all possibly required api functions.
+ */
+struct wlr_egl *wlr_egl_create(EGLenum platform, void *remote_display);
+
+/**
+ * Frees all related EGL resources, makes the context not-current and
+ * unbinds a bound wayland display.
+ */
+void wlr_egl_destroy(struct wlr_egl *egl);
+
+/**
+ * Binds the given display to the EGL instance.
+ * This will allow clients to create EGL surfaces from wayland ones and render
+ * to it.
+ */
+bool wlr_egl_bind_display(struct wlr_egl *egl, struct wl_display *local_display);
+
+/**
+ * Creates an EGL image from the given wl_drm buffer resource.
+ */
+EGLImageKHR wlr_egl_create_image_from_wl_drm(struct wlr_egl *egl,
+	struct wl_resource *data, EGLint *fmt, int *width, int *height,
+	bool *inverted_y);
+
+/**
+ * Creates an EGL image from the given dmabuf attributes. Check usability
+ * of the dmabuf with wlr_egl_check_import_dmabuf once first.
+ */
+EGLImageKHR wlr_egl_create_image_from_dmabuf(struct wlr_egl *egl,
+	struct wlr_dmabuf_attributes *attributes, bool *external_only);
+
+/**
+ * Get DMA-BUF formats suitable for sampling usage.
+ */
+const struct wlr_drm_format_set *wlr_egl_get_dmabuf_texture_formats(
+	struct wlr_egl *egl);
+/**
+ * Get DMA-BUF formats suitable for rendering usage.
+ */
+const struct wlr_drm_format_set *wlr_egl_get_dmabuf_render_formats(
+	struct wlr_egl *egl);
+
+/**
+ * Destroys an EGL image created with the given wlr_egl.
+ */
+bool wlr_egl_destroy_image(struct wlr_egl *egl, EGLImageKHR image);
+
+int wlr_egl_dup_drm_fd(struct wlr_egl *egl);
+
+/**
+ * Save the current EGL context to the structure provided in the argument.
+ *
+ * This includes display, context, draw surface and read surface.
+ */
+void wlr_egl_save_context(struct wlr_egl_context *context);
+
+/**
+ * Restore EGL context that was previously saved using wlr_egl_save_current().
+ */
+bool wlr_egl_restore_context(struct wlr_egl_context *context);
+
+#endif

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -29,13 +29,6 @@
 #include <wlr/render/dmabuf.h>
 #include <wlr/render/drm_format_set.h>
 
-struct wlr_egl_context {
-	EGLDisplay display;
-	EGLContext context;
-	EGLSurface draw_surface;
-	EGLSurface read_surface;
-};
-
 struct wlr_egl {
 	EGLDisplay display;
 	EGLContext context;
@@ -74,55 +67,6 @@ struct wlr_egl {
 };
 
 /**
- * Initializes an EGL context for the given platform and remote display.
- * Will attempt to load all possibly required api functions.
- */
-struct wlr_egl *wlr_egl_create(EGLenum platform, void *remote_display);
-
-/**
- * Frees all related EGL resources, makes the context not-current and
- * unbinds a bound wayland display.
- */
-void wlr_egl_destroy(struct wlr_egl *egl);
-
-/**
- * Binds the given display to the EGL instance.
- * This will allow clients to create EGL surfaces from wayland ones and render
- * to it.
- */
-bool wlr_egl_bind_display(struct wlr_egl *egl, struct wl_display *local_display);
-
-/**
- * Creates an EGL image from the given wl_drm buffer resource.
- */
-EGLImageKHR wlr_egl_create_image_from_wl_drm(struct wlr_egl *egl,
-	struct wl_resource *data, EGLint *fmt, int *width, int *height,
-	bool *inverted_y);
-
-/**
- * Creates an EGL image from the given dmabuf attributes. Check usability
- * of the dmabuf with wlr_egl_check_import_dmabuf once first.
- */
-EGLImageKHR wlr_egl_create_image_from_dmabuf(struct wlr_egl *egl,
-	struct wlr_dmabuf_attributes *attributes, bool *external_only);
-
-/**
- * Get DMA-BUF formats suitable for sampling usage.
- */
-const struct wlr_drm_format_set *wlr_egl_get_dmabuf_texture_formats(
-	struct wlr_egl *egl);
-/**
- * Get DMA-BUF formats suitable for rendering usage.
- */
-const struct wlr_drm_format_set *wlr_egl_get_dmabuf_render_formats(
-	struct wlr_egl *egl);
-
-/**
- * Destroys an EGL image created with the given wlr_egl.
- */
-bool wlr_egl_destroy_image(struct wlr_egl *egl, EGLImageKHR image);
-
-/**
  * Make the EGL context current.
  *
  * Callers are expected to clear the current context when they are done by
@@ -133,19 +77,5 @@ bool wlr_egl_make_current(struct wlr_egl *egl);
 bool wlr_egl_unset_current(struct wlr_egl *egl);
 
 bool wlr_egl_is_current(struct wlr_egl *egl);
-
-/**
- * Save the current EGL context to the structure provided in the argument.
- *
- * This includes display, context, draw surface and read surface.
- */
-void wlr_egl_save_context(struct wlr_egl_context *context);
-
-/**
- * Restore EGL context that was previously saved using wlr_egl_save_current().
- */
-bool wlr_egl_restore_context(struct wlr_egl_context *context);
-
-int wlr_egl_dup_drm_fd(struct wlr_egl *egl);
 
 #endif

--- a/render/egl.c
+++ b/render/egl.c
@@ -10,6 +10,7 @@
 #include <wlr/util/log.h>
 #include <wlr/util/region.h>
 #include <xf86drm.h>
+#include "render/egl.h"
 
 static enum wlr_log_importance egl_log_importance_to_wlr(EGLint type) {
 	switch (type) {

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -15,6 +15,7 @@
 #include <wlr/types/wlr_matrix.h>
 #include <wlr/types/wlr_linux_dmabuf_v1.h>
 #include <wlr/util/log.h>
+#include "render/egl.h"
 #include "render/gles2.h"
 #include "render/pixel_format.h"
 #include "types/wlr_buffer.h"

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -11,6 +11,7 @@
 #include <wlr/render/wlr_texture.h>
 #include <wlr/types/wlr_matrix.h>
 #include <wlr/util/log.h>
+#include "render/egl.h"
 #include "render/gles2.h"
 #include "render/pixel_format.h"
 #include "types/wlr_buffer.h"


### PR DESCRIPTION
The wlr_egl functions are mostly used internally by the GLES2
renderer. Let's reduce our API surface a bit by hiding them. If
there are good use-cases for one of these, we can always make them
public again.

The functions mutating the current EGL context are not made private
because e.g. Wayfire uses them.

cc @ammen99 