### PR TITLE
render/egl: replace wlr_egl_create with wlr_egl_create_with_drm_fd

### DIFF
--- a/include/render/egl.h
+++ b/include/render/egl.h
@@ -11,10 +11,11 @@ struct wlr_egl_context {
 };
 
 /**
- * Initializes an EGL context for the given platform and remote display.
- * Will attempt to load all possibly required api functions.
+ * Initializes an EGL context for the given DRM FD.
+ *
+ * Will attempt to load all possibly required API functions.
  */
-struct wlr_egl *wlr_egl_create(EGLenum platform, void *remote_display);
+struct wlr_egl *wlr_egl_create_with_drm_fd(int drm_fd);
 
 /**
  * Frees all related EGL resources, makes the context not-current and

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -733,20 +733,11 @@ extern const GLchar tex_fragment_src_rgbx[];
 extern const GLchar tex_fragment_src_external[];
 
 struct wlr_renderer *wlr_gles2_renderer_create_with_drm_fd(int drm_fd) {
-	struct gbm_device *gbm_device = gbm_create_device(drm_fd);
-	if (!gbm_device) {
-		wlr_log(WLR_ERROR, "Failed to create GBM device");
-		return NULL;
-	}
-
-	struct wlr_egl *egl = wlr_egl_create(EGL_PLATFORM_GBM_KHR, gbm_device);
+	struct wlr_egl *egl = wlr_egl_create_with_drm_fd(drm_fd);
 	if (egl == NULL) {
 		wlr_log(WLR_ERROR, "Could not initialize EGL");
-		gbm_device_destroy(gbm_device);
 		return NULL;
 	}
-
-	egl->gbm_device = gbm_device;
 
 	struct wlr_renderer *renderer = wlr_gles2_renderer_create(egl);
 	if (!renderer) {


### PR DESCRIPTION
We never create an EGL context with the platform set to something
other than EGL_PLATFORM_GBM_KHR. Let's simplify wlr_egl_create by
taking a DRM FD instead of a (platform, remote_display) tuple.

This hides the internal details of creating an EGL context for a
specific device. This will allow us to transparently use the device
platform (#2671) when the time comes.

~~Depends on: https://github.com/swaywm/wlroots/pull/2985~~

cc @bl4ckb0ne 