### PR TITLE
ci: make Meson warnings fatal

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -19,7 +19,7 @@ sources:
 tasks:
   - setup: |
       cd wlroots
-      meson build --default-library=both -Dauto_features=enabled -Dlibseat=disabled -Dxcb-errors=disabled
+      meson build --default-library=both -Dauto_features=enabled -Dxcb-errors=disabled
   - build: |
       cd wlroots
       ninja -C build

--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -19,7 +19,7 @@ sources:
 tasks:
   - setup: |
       cd wlroots
-      meson build --default-library=both -Dauto_features=enabled -Dxcb-errors=disabled
+      meson build --fatal-meson-warnings --default-library=both -Dauto_features=enabled -Dxcb-errors=disabled
   - build: |
       cd wlroots
       ninja -C build

--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -20,8 +20,8 @@ sources:
 tasks:
   - setup: |
       cd wlroots
-      CC=gcc meson build-gcc --default-library=both -Dauto_features=enabled --prefix /usr
-      CC=clang meson build-clang -Dauto_features=enabled
+      CC=gcc meson build-gcc --fatal-meson-warnings --default-library=both -Dauto_features=enabled --prefix /usr
+      CC=clang meson build-clang --fatal-meson-warnings -Dauto_features=enabled
   - gcc: |
       cd wlroots/build-gcc
       ninja

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -27,7 +27,7 @@ sources:
 tasks:
   - wlroots: |
       cd wlroots
-      meson build -Dauto_features=enabled
+      meson build --fatal-meson-warnings -Dauto_features=enabled
       ninja -C build
       sudo ninja -C build install
   - tinywl: |

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
 	'c',
 	version: '0.15.0',
 	license: 'MIT',
-	meson_version: '>=0.56.0',
+	meson_version: '>=0.58.1',
 	default_options: [
 		'c_std=c11',
 		'warning_level=2',
@@ -50,7 +50,7 @@ add_project_arguments(cc.get_supported_arguments([
 
 # Compute the relative path used by compiler invocations.
 source_root = meson.current_source_dir().split('/')
-build_root = meson.build_root().split('/')
+build_root = meson.global_build_root().split('/')
 relative_dir_parts = []
 i = 0
 in_prefix = true


### PR DESCRIPTION
New warnings can be hard to notice in CI, since CI will just pass in
that case. Meson sometimes uses warnings for important mistakes, e.g.
invalid option.

Let's turn warnings into errors so that we can spot these more easily.

* * *

Note, we need to bump the Meson version to get rid of the `meson.build_root()` warning.