### PR TITLE
buffer: add data_ptr access flags

### DIFF
--- a/include/types/wlr_buffer.h
+++ b/include/types/wlr_buffer.h
@@ -70,16 +70,30 @@ struct wlr_dmabuf_buffer *dmabuf_buffer_create(
 bool dmabuf_buffer_drop(struct wlr_dmabuf_buffer *buffer);
 
 /**
+ * Buffer data pointer access flags.
+ */
+enum wlr_buffer_data_ptr_access_flag {
+	/**
+	 * The buffer contents can be read back.
+	 */
+	WLR_BUFFER_DATA_PTR_ACCESS_READ = 1 << 0,
+	/**
+	 * The buffer contents can be written to.
+	 */
+	WLR_BUFFER_DATA_PTR_ACCESS_WRITE = 1 << 1,
+};
+
+/**
  * Get a pointer to a region of memory referring to the buffer's underlying
  * storage. The format and stride can be used to interpret the memory region
  * contents.
  *
- * The returned pointer should be pointing to a valid memory region for read
- * and write operations. The returned pointer is only valid up to the next
- * buffer_end_data_ptr_access call.
+ * The returned pointer should be pointing to a valid memory region for the
+ * operations specified in the flags. The returned pointer is only valid up to
+ * the next buffer_end_data_ptr_access call.
  */
-bool buffer_begin_data_ptr_access(struct wlr_buffer *buffer, void **data,
-	uint32_t *format, size_t *stride);
+bool buffer_begin_data_ptr_access(struct wlr_buffer *buffer, uint32_t flags,
+	void **data, uint32_t *format, size_t *stride);
 void buffer_end_data_ptr_access(struct wlr_buffer *buffer);
 
 #endif

--- a/include/wlr/types/wlr_buffer.h
+++ b/include/wlr/types/wlr_buffer.h
@@ -30,8 +30,8 @@ struct wlr_buffer_impl {
 		struct wlr_dmabuf_attributes *attribs);
 	bool (*get_shm)(struct wlr_buffer *buffer,
 		struct wlr_shm_attributes *attribs);
-	bool (*begin_data_ptr_access)(struct wlr_buffer *buffer, void **data,
-		uint32_t *format, size_t *stride);
+	bool (*begin_data_ptr_access)(struct wlr_buffer *buffer, uint32_t flags,
+		void **data, uint32_t *format, size_t *stride);
 	void (*end_data_ptr_access)(struct wlr_buffer *buffer);
 };
 

--- a/render/allocator/drm_dumb.c
+++ b/render/allocator/drm_dumb.c
@@ -128,7 +128,7 @@ create_err:
 }
 
 static bool drm_dumb_buffer_begin_data_ptr_access(struct wlr_buffer *wlr_buffer,
-		void **data, uint32_t *format, size_t *stride) {
+		uint32_t flags, void **data, uint32_t *format, size_t *stride) {
 	struct wlr_drm_dumb_buffer *buf = drm_dumb_buffer_from_buffer(wlr_buffer);
 	*data = buf->data;
 	*stride = buf->stride;

--- a/render/allocator/shm.c
+++ b/render/allocator/shm.c
@@ -31,7 +31,7 @@ static bool buffer_get_shm(struct wlr_buffer *wlr_buffer,
 }
 
 static bool shm_buffer_begin_data_ptr_access(struct wlr_buffer *wlr_buffer,
-		void **data, uint32_t *format, size_t *stride) {
+		uint32_t flags, void **data, uint32_t *format, size_t *stride) {
 	struct wlr_shm_buffer *buffer = shm_buffer_from_buffer(wlr_buffer);
 	*data = buffer->data;
 	*format = buffer->shm.format;

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -346,7 +346,8 @@ struct wlr_texture *gles2_texture_from_buffer(struct wlr_renderer *wlr_renderer,
 	struct wlr_dmabuf_attributes dmabuf;
 	if (wlr_buffer_get_dmabuf(buffer, &dmabuf)) {
 		return gles2_texture_from_dmabuf_buffer(renderer, buffer, &dmabuf);
-	} else if (buffer_begin_data_ptr_access(buffer, &data, &format, &stride)) {
+	} else if (buffer_begin_data_ptr_access(buffer,
+			WLR_BUFFER_DATA_PTR_ACCESS_READ, &data, &format, &stride)) {
 		struct wlr_texture *tex = gles2_texture_from_pixels(wlr_renderer,
 			format, stride, buffer->width, buffer->height, data);
 		buffer_end_data_ptr_access(buffer);

--- a/render/pixman/renderer.c
+++ b/render/pixman/renderer.c
@@ -96,7 +96,9 @@ static struct wlr_pixman_buffer *create_buffer(
 	void *data = NULL;
 	uint32_t drm_format;
 	size_t stride;
-	if (!buffer_begin_data_ptr_access(wlr_buffer, &data, &drm_format, &stride)) {
+	if (!buffer_begin_data_ptr_access(wlr_buffer,
+			WLR_BUFFER_DATA_PTR_ACCESS_READ | WLR_BUFFER_DATA_PTR_ACCESS_WRITE,
+			&data, &drm_format, &stride)) {
 		wlr_log(WLR_ERROR, "Failed to get buffer data");
 		goto error_buffer;
 	}
@@ -143,7 +145,9 @@ static void pixman_begin(struct wlr_renderer *wlr_renderer, uint32_t width,
 	void *data = NULL;
 	uint32_t drm_format;
 	size_t stride;
-	buffer_begin_data_ptr_access(buffer->buffer, &data, &drm_format, &stride);
+	buffer_begin_data_ptr_access(buffer->buffer,
+		WLR_BUFFER_DATA_PTR_ACCESS_READ | WLR_BUFFER_DATA_PTR_ACCESS_WRITE,
+		&data, &drm_format, &stride);
 
 	// If the data pointer has changed, re-create the Pixman image. This can
 	// happen if it's a client buffer and the wl_shm_pool has been resized.
@@ -229,8 +233,8 @@ static bool pixman_render_subtexture_with_matrix(
 		void *data;
 		uint32_t drm_format;
 		size_t stride;
-		if (!buffer_begin_data_ptr_access(texture->buffer, &data, &drm_format,
-				&stride)) {
+		if (!buffer_begin_data_ptr_access(texture->buffer,
+				WLR_BUFFER_DATA_PTR_ACCESS_READ, &data, &drm_format, &stride)) {
 			return false;
 		}
 
@@ -376,7 +380,8 @@ static struct wlr_texture *pixman_texture_from_buffer(
 	void *data = NULL;
 	uint32_t drm_format;
 	size_t stride;
-	if (!buffer_begin_data_ptr_access(buffer, &data, &drm_format, &stride)) {
+	if (!buffer_begin_data_ptr_access(buffer, WLR_BUFFER_DATA_PTR_ACCESS_READ,
+			&data, &drm_format, &stride)) {
 		return NULL;
 	}
 	buffer_end_data_ptr_access(buffer);


### PR DESCRIPTION
This allows callers to specify the operations they'll perform on
the returned data pointer. The motivations for this are:

- The upcoming Linux MAP_NOSIGBUS flag may only be usable on
  read-only mappings.
- gbm_bo_map with GBM_BO_TRANSFER_READ hurts performance.

References: https://github.com/swaywm/wlroots/issues/2864