### PR TITLE
util/global: remove wl_display arg from wlr_global_destroy_safe

### DIFF
--- a/include/util/global.h
+++ b/include/util/global.h
@@ -9,7 +9,6 @@
  * Globals that are created and destroyed on the fly need special handling to
  * prevent race conditions with wl_registry. Use this function to destroy them.
  */
-void wlr_global_destroy_safe(struct wl_global *global,
-	struct wl_display *display);
+void wlr_global_destroy_safe(struct wl_global *global);
 
 #endif

--- a/meson.build
+++ b/meson.build
@@ -94,7 +94,7 @@ internal_features = {
 	'xcb-errors': false,
 }
 
-wayland_server = dependency('wayland-server', version: '>=1.19')
+wayland_server = dependency('wayland-server', version: '>=1.20')
 wayland_client = dependency('wayland-client')
 drm = dependency('libdrm', version: '>=2.4.105')
 gbm = dependency('gbm', version: '>=17.1.0')

--- a/types/seat/wlr_seat.c
+++ b/types/seat/wlr_seat.c
@@ -191,7 +191,7 @@ void wlr_seat_destroy(struct wlr_seat *seat) {
 		}
 	}
 
-	wlr_global_destroy_safe(seat->global, seat->display);
+	wlr_global_destroy_safe(seat->global);
 	free(seat->pointer_state.default_grab);
 	free(seat->keyboard_state.default_grab);
 	free(seat->touch_state.default_grab);

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -132,7 +132,7 @@ void wlr_output_destroy_global(struct wlr_output *output) {
 		wl_list_init(wl_resource_get_link(resource));
 	}
 
-	wlr_global_destroy_safe(output->global, output->display);
+	wlr_global_destroy_safe(output->global);
 	output->global = NULL;
 }
 

--- a/util/global.c
+++ b/util/global.c
@@ -14,8 +14,7 @@ static int destroy_global(void *_data) {
 	return 0;
 }
 
-void wlr_global_destroy_safe(struct wl_global *global,
-		struct wl_display *display) {
+void wlr_global_destroy_safe(struct wl_global *global) {
 	// Don't destroy the global immediately. If the global has been created
 	// recently, clients might try to bind to it after we've destroyed it.
 	// Instead, remove the global so that clients stop seeing it and wait an
@@ -25,6 +24,7 @@ void wlr_global_destroy_safe(struct wl_global *global,
 	wl_global_remove(global);
 	wl_global_set_user_data(global, NULL); // safety net
 
+	struct wl_display *display = wl_global_get_display(global);
 	struct wl_event_loop *event_loop = wl_display_get_event_loop(display);
 	struct destroy_global_data *data = calloc(1, sizeof(*data));
 	if (data == NULL) {


### PR DESCRIPTION
Since [1], we can get the wl_display directly from the wl_global.

[1]: https://gitlab.freedesktop.org/wayland/wayland/-/commit/2b22160fb690a76247aa9bd0be3069ff43e8239f