### PR TITLE
render: drop wlr_renderer_impl.texture_from_{pixels,dmabuf}

### DIFF
--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -121,8 +121,6 @@ struct wlr_gles2_texture *gles2_get_texture(
 
 struct wlr_texture *gles2_texture_from_wl_drm(struct wlr_renderer *wlr_renderer,
 	struct wl_resource *data);
-struct wlr_texture *gles2_texture_from_dmabuf(struct wlr_renderer *wlr_renderer,
-	struct wlr_dmabuf_attributes *attribs);
 struct wlr_texture *gles2_texture_from_buffer(struct wlr_renderer *wlr_renderer,
 	struct wlr_buffer *buffer);
 void gles2_texture_destroy(struct wlr_gles2_texture *texture);

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -119,9 +119,6 @@ struct wlr_gles2_renderer *gles2_get_renderer(
 struct wlr_gles2_texture *gles2_get_texture(
 	struct wlr_texture *wlr_texture);
 
-struct wlr_texture *gles2_texture_from_pixels(struct wlr_renderer *wlr_renderer,
-	uint32_t fmt, uint32_t stride, uint32_t width, uint32_t height,
-	const void *data);
 struct wlr_texture *gles2_texture_from_wl_drm(struct wlr_renderer *wlr_renderer,
 	struct wl_resource *data);
 struct wlr_texture *gles2_texture_from_dmabuf(struct wlr_renderer *wlr_renderer,

--- a/include/types/wlr_buffer.h
+++ b/include/types/wlr_buffer.h
@@ -53,6 +53,25 @@ struct wlr_readonly_data_buffer *readonly_data_buffer_create(uint32_t format,
  */
 bool readonly_data_buffer_drop(struct wlr_readonly_data_buffer *buffer);
 
+struct wlr_dmabuf_buffer {
+	struct wlr_buffer base;
+	struct wlr_dmabuf_attributes dmabuf;
+	bool saved;
+};
+
+/**
+ * Wraps a DMA-BUF into a wlr_buffer. The DMA-BUF may be accessed until
+ * dmabuf_buffer_drop() is called.
+ */
+struct wlr_dmabuf_buffer *dmabuf_buffer_create(
+	struct wlr_dmabuf_attributes *dmabuf);
+/**
+ * Drops ownership of the buffer (see wlr_buffer_drop() for more details) and
+ * takes a reference to the DMA-BUF (by dup'ing its file descriptors) if a
+ * consumer still has the buffer locked.
+ */
+bool dmabuf_buffer_drop(struct wlr_dmabuf_buffer *buffer);
+
 /**
  * Buffer capabilities.
  *

--- a/include/types/wlr_buffer.h
+++ b/include/types/wlr_buffer.h
@@ -26,6 +26,34 @@ struct wlr_shm_client_buffer *shm_client_buffer_create(
 	struct wl_resource *resource);
 
 /**
+ * A read-only buffer that holds a data pointer.
+ *
+ * This is suitable for passing raw pixel data to a function that accepts a
+ * wlr_buffer.
+ */
+struct wlr_readonly_data_buffer {
+	struct wlr_buffer base;
+
+	const void *data;
+	uint32_t format;
+	size_t stride;
+
+	void *saved_data;
+};
+
+/**
+ * Wraps a read-only data pointer into a wlr_buffer. The data pointer may be
+ * accessed until readonly_data_buffer_drop() is called.
+ */
+struct wlr_readonly_data_buffer *readonly_data_buffer_create(uint32_t format,
+		size_t stride, uint32_t width, uint32_t height, const void *data);
+/**
+ * Drops ownership of the buffer (see wlr_buffer_drop() for more details) and
+ * perform a copy of the data pointer if a consumer still has the buffer locked.
+ */
+bool readonly_data_buffer_drop(struct wlr_readonly_data_buffer *buffer);
+
+/**
  * Buffer capabilities.
  *
  * These bits indicate the features supported by a wlr_buffer. There is one bit

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -45,9 +45,6 @@ struct wlr_renderer_impl {
 		uint32_t *flags, uint32_t stride, uint32_t width, uint32_t height,
 		uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y,
 		void *data);
-	struct wlr_texture *(*texture_from_pixels)(struct wlr_renderer *renderer,
-		uint32_t fmt, uint32_t stride, uint32_t width, uint32_t height,
-		const void *data);
 	struct wlr_texture *(*texture_from_wl_drm)(struct wlr_renderer *renderer,
 		struct wl_resource *data);
 	struct wlr_texture *(*texture_from_dmabuf)(struct wlr_renderer *renderer,

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -47,8 +47,6 @@ struct wlr_renderer_impl {
 		void *data);
 	struct wlr_texture *(*texture_from_wl_drm)(struct wlr_renderer *renderer,
 		struct wl_resource *data);
-	struct wlr_texture *(*texture_from_dmabuf)(struct wlr_renderer *renderer,
-		struct wlr_dmabuf_attributes *attribs);
 	void (*destroy)(struct wlr_renderer *renderer);
 	bool (*init_wl_display)(struct wlr_renderer *renderer,
 		struct wl_display *wl_display);

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -592,7 +592,6 @@ static const struct wlr_renderer_impl renderer_impl = {
 	.get_render_formats = gles2_get_render_formats,
 	.preferred_read_format = gles2_preferred_read_format,
 	.read_pixels = gles2_read_pixels,
-	.texture_from_pixels = gles2_texture_from_pixels,
 	.texture_from_wl_drm = gles2_texture_from_wl_drm,
 	.texture_from_dmabuf = gles2_texture_from_dmabuf,
 	.init_wl_display = gles2_init_wl_display,

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -593,7 +593,6 @@ static const struct wlr_renderer_impl renderer_impl = {
 	.preferred_read_format = gles2_preferred_read_format,
 	.read_pixels = gles2_read_pixels,
 	.texture_from_wl_drm = gles2_texture_from_wl_drm,
-	.texture_from_dmabuf = gles2_texture_from_dmabuf,
 	.init_wl_display = gles2_init_wl_display,
 	.get_drm_fd = gles2_get_drm_fd,
 	.get_render_buffer_caps = gles2_get_render_buffer_caps,

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -309,7 +309,8 @@ error_ctx:
 	return NULL;
 }
 
-struct wlr_texture *gles2_texture_from_dmabuf(struct wlr_renderer *wlr_renderer,
+static struct wlr_texture *gles2_texture_from_dmabuf(
+		struct wlr_renderer *wlr_renderer,
 		struct wlr_dmabuf_attributes *attribs) {
 	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
 

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -179,7 +179,8 @@ static struct wlr_gles2_texture *gles2_texture_create(
 	return texture;
 }
 
-struct wlr_texture *gles2_texture_from_pixels(struct wlr_renderer *wlr_renderer,
+static struct wlr_texture *gles2_texture_from_pixels(
+		struct wlr_renderer *wlr_renderer,
 		uint32_t drm_format, uint32_t stride, uint32_t width,
 		uint32_t height, const void *data) {
 	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);

--- a/render/pixman/renderer.c
+++ b/render/pixman/renderer.c
@@ -368,40 +368,6 @@ static struct wlr_pixman_texture *pixman_texture_create(
 	return texture;
 }
 
-static struct wlr_texture *pixman_texture_from_pixels(
-		struct wlr_renderer *wlr_renderer, uint32_t drm_format,
-		uint32_t stride, uint32_t width, uint32_t height, const void *data) {
-	struct wlr_pixman_renderer *renderer = get_renderer(wlr_renderer);
-
-	struct wlr_pixman_texture *texture =
-		pixman_texture_create(renderer, drm_format, width, height);
-	if (texture == NULL) {
-		return NULL;
-	}
-
-	// TODO: avoid this copy
-	texture->data = malloc(stride * height);
-	if (texture->data == NULL) {
-		wlr_log_errno(WLR_ERROR, "Allocation failed");
-		wl_list_remove(&texture->link);
-		free(texture);
-		return NULL;
-	}
-	memcpy(texture->data, data, stride * height);
-
-	texture->image = pixman_image_create_bits_no_clear(texture->format,
-		width, height, texture->data, stride);
-	if (!texture->image) {
-		wlr_log(WLR_ERROR, "Failed to create pixman image");
-		wl_list_remove(&texture->link);
-		free(texture->data);
-		free(texture);
-		return NULL;
-	}
-
-	return &texture->wlr_texture;
-}
-
 static struct wlr_texture *pixman_texture_from_buffer(
 		struct wlr_renderer *wlr_renderer, struct wlr_buffer *buffer) {
 	struct wlr_pixman_renderer *renderer = get_renderer(wlr_renderer);
@@ -531,7 +497,6 @@ static const struct wlr_renderer_impl renderer_impl = {
 	.render_quad_with_matrix = pixman_render_quad_with_matrix,
 	.get_shm_texture_formats = pixman_get_shm_texture_formats,
 	.get_render_formats = pixman_get_render_formats,
-	.texture_from_pixels = pixman_texture_from_pixels,
 	.texture_from_buffer = pixman_texture_from_buffer,
 	.bind_buffer = pixman_bind_buffer,
 	.destroy = pixman_destroy,

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -26,7 +26,6 @@ void wlr_renderer_init(struct wlr_renderer *renderer,
 	assert(impl->render_subtexture_with_matrix);
 	assert(impl->render_quad_with_matrix);
 	assert(impl->get_shm_texture_formats);
-	assert(impl->texture_from_pixels);
 	assert(impl->get_render_buffer_caps);
 	renderer->impl = impl;
 

--- a/render/wlr_texture.c
+++ b/render/wlr_texture.c
@@ -55,10 +55,19 @@ struct wlr_texture *wlr_texture_from_wl_drm(struct wlr_renderer *renderer,
 
 struct wlr_texture *wlr_texture_from_dmabuf(struct wlr_renderer *renderer,
 		struct wlr_dmabuf_attributes *attribs) {
-	if (!renderer->impl->texture_from_dmabuf) {
+	struct wlr_dmabuf_buffer *buffer = dmabuf_buffer_create(attribs);
+	if (buffer == NULL) {
 		return NULL;
 	}
-	return renderer->impl->texture_from_dmabuf(renderer, attribs);
+
+	struct wlr_texture *texture =
+		wlr_texture_from_buffer(renderer, &buffer->base);
+
+	// By this point, the renderer should have locked the buffer if it still
+	// needs to access it in the future.
+	dmabuf_buffer_drop(buffer);
+
+	return texture;
 }
 
 struct wlr_texture *wlr_texture_from_buffer(struct wlr_renderer *renderer,

--- a/types/wlr_buffer.c
+++ b/types/wlr_buffer.c
@@ -451,3 +451,80 @@ struct wlr_shm_client_buffer *shm_client_buffer_create(
 
 	return buffer;
 }
+
+static const struct wlr_buffer_impl readonly_data_buffer_impl;
+
+static struct wlr_readonly_data_buffer *readonly_data_buffer_from_buffer(
+		struct wlr_buffer *buffer) {
+	assert(buffer->impl == &readonly_data_buffer_impl);
+	return (struct wlr_readonly_data_buffer *)buffer;
+}
+
+static void readonly_data_buffer_destroy(struct wlr_buffer *wlr_buffer) {
+	struct wlr_readonly_data_buffer *buffer =
+		readonly_data_buffer_from_buffer(wlr_buffer);
+	free(buffer->saved_data);
+	free(buffer);
+}
+
+static bool readonly_data_buffer_begin_data_ptr_access(struct wlr_buffer *wlr_buffer,
+		void **data, uint32_t *format, size_t *stride) {
+	struct wlr_readonly_data_buffer *buffer =
+		readonly_data_buffer_from_buffer(wlr_buffer);
+	if (buffer->data == NULL) {
+		return false;
+	}
+	*data = (void*)buffer->data;
+	*format = buffer->format;
+	*stride = buffer->stride;
+	return true;
+}
+
+static void readonly_data_buffer_end_data_ptr_access(struct wlr_buffer *wlr_buffer) {
+	// This space is intentionally left blank
+}
+
+static const struct wlr_buffer_impl readonly_data_buffer_impl = {
+	.destroy = readonly_data_buffer_destroy,
+	.begin_data_ptr_access = readonly_data_buffer_begin_data_ptr_access,
+	.end_data_ptr_access = readonly_data_buffer_end_data_ptr_access,
+};
+
+struct wlr_readonly_data_buffer *readonly_data_buffer_create(uint32_t format,
+		size_t stride, uint32_t width, uint32_t height, const void *data) {
+	struct wlr_readonly_data_buffer *buffer = calloc(1, sizeof(*buffer));
+	if (buffer == NULL) {
+		return NULL;
+	}
+	wlr_buffer_init(&buffer->base, &readonly_data_buffer_impl, width, height);
+
+	buffer->data = data;
+	buffer->format = format;
+	buffer->stride = stride;
+
+	return buffer;
+}
+
+bool readonly_data_buffer_drop(struct wlr_readonly_data_buffer *buffer) {
+	bool ok = true;
+
+	if (buffer->base.n_locks > 0) {
+		size_t size = buffer->stride * buffer->base.height;
+		buffer->saved_data = malloc(size);
+		if (buffer->saved_data == NULL) {
+			wlr_log_errno(WLR_ERROR, "Allocation failed");
+			ok = false;
+			buffer->data = NULL;
+			// We can't destroy the buffer, or we risk use-after-free in the
+			// consumers. We can't allow accesses to buffer->data anymore, so
+			// set it to NULL and make subsequent begin_data_ptr_access()
+			// calls fail.
+		} else {
+			memcpy(buffer->saved_data, buffer->data, size);
+			buffer->data = buffer->saved_data;
+		}
+	}
+
+	wlr_buffer_drop(&buffer->base);
+	return ok;
+}

--- a/types/wlr_buffer.c
+++ b/types/wlr_buffer.c
@@ -528,3 +528,67 @@ bool readonly_data_buffer_drop(struct wlr_readonly_data_buffer *buffer) {
 	wlr_buffer_drop(&buffer->base);
 	return ok;
 }
+
+static const struct wlr_buffer_impl dmabuf_buffer_impl;
+
+static struct wlr_dmabuf_buffer *dmabuf_buffer_from_buffer(
+		struct wlr_buffer *buffer) {
+	assert(buffer->impl == &dmabuf_buffer_impl);
+	return (struct wlr_dmabuf_buffer *)buffer;
+}
+
+static void dmabuf_buffer_destroy(struct wlr_buffer *wlr_buffer) {
+	struct wlr_dmabuf_buffer *buffer = dmabuf_buffer_from_buffer(wlr_buffer);
+	if (buffer->saved) {
+		wlr_dmabuf_attributes_finish(&buffer->dmabuf);
+	}
+	free(buffer);
+}
+
+static bool dmabuf_buffer_get_dmabuf(struct wlr_buffer *wlr_buffer,
+		struct wlr_dmabuf_attributes *dmabuf) {
+	struct wlr_dmabuf_buffer *buffer = dmabuf_buffer_from_buffer(wlr_buffer);
+	if (buffer->dmabuf.n_planes == 0) {
+		return false;
+	}
+	*dmabuf = buffer->dmabuf;
+	return true;
+}
+
+static const struct wlr_buffer_impl dmabuf_buffer_impl = {
+	.destroy = dmabuf_buffer_destroy,
+	.get_dmabuf = dmabuf_buffer_get_dmabuf,
+};
+
+struct wlr_dmabuf_buffer *dmabuf_buffer_create(
+		struct wlr_dmabuf_attributes *dmabuf) {
+	struct wlr_dmabuf_buffer *buffer = calloc(1, sizeof(*buffer));
+	if (buffer == NULL) {
+		return NULL;
+	}
+	wlr_buffer_init(&buffer->base, &dmabuf_buffer_impl,
+		dmabuf->width, dmabuf->height);
+
+	buffer->dmabuf = *dmabuf;
+
+	return buffer;
+}
+
+bool dmabuf_buffer_drop(struct wlr_dmabuf_buffer *buffer) {
+	bool ok = true;
+
+	if (buffer->base.n_locks > 0) {
+		struct wlr_dmabuf_attributes saved_dmabuf = {0};
+		if (!wlr_dmabuf_attributes_copy(&saved_dmabuf, &buffer->dmabuf)) {
+			wlr_log(WLR_ERROR, "Failed to save DMA-BUF");
+			ok = false;
+			memset(&buffer->dmabuf, 0, sizeof(buffer->dmabuf));
+		} else {
+			buffer->dmabuf = saved_dmabuf;
+			buffer->saved = true;
+		}
+	}
+
+	wlr_buffer_drop(&buffer->base);
+	return ok;
+}


### PR DESCRIPTION
Instead, unify all of the code-paths with `wlr_renderer_impl.texture_from_buffer`.