### PR TITLE
surface: accept commits with buffer size not divisible by scale

### DIFF
--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -168,7 +168,7 @@ static void surface_state_viewport_src_size(struct wlr_surface_state *state,
 	}
 }
 
-static bool surface_state_finalize(struct wlr_surface *surface,
+static void surface_state_finalize(struct wlr_surface *surface,
 		struct wlr_surface_state *state) {
 	if ((state->committed & WLR_SURFACE_STATE_BUFFER)) {
 		if (state->buffer_resource != NULL) {
@@ -188,7 +188,6 @@ static bool surface_state_finalize(struct wlr_surface *surface,
 		wlr_log(WLR_DEBUG, "Client bug: submitted a buffer whose size (%dx%d) "
 			"is not divisible by scale (%d)", state->buffer_width,
 			state->buffer_height, state->scale);
-		return false;
 	}
 
 	if (state->viewport.has_dst) {
@@ -208,8 +207,6 @@ static bool surface_state_finalize(struct wlr_surface *surface,
 	pixman_region32_intersect_rect(&state->buffer_damage,
 		&state->buffer_damage, 0, 0, state->buffer_width,
 		state->buffer_height);
-
-	return true;
 }
 
 static void surface_update_damage(pixman_region32_t *buffer_damage,
@@ -471,9 +468,7 @@ static void surface_commit_state(struct wlr_surface *surface,
 }
 
 static void surface_commit_pending(struct wlr_surface *surface) {
-	if (!surface_state_finalize(surface, &surface->pending)) {
-		return;
-	}
+	surface_state_finalize(surface, &surface->pending);
 
 	if (surface->role && surface->role->precommit) {
 		surface->role->precommit(surface);


### PR DESCRIPTION
There are still many situations where the buffer scale is not
divisible by scale. The fix will require a tad more work, so
let's just log the client error for now and continue handling
the surface commit as usual.

Closes: https://github.com/swaywm/sway/issues/6352