### PR TITLE
Add support for touch frame events

### DIFF
--- a/backend/libinput/events.c
+++ b/backend/libinput/events.c
@@ -261,7 +261,7 @@ void handle_libinput_event(struct wlr_libinput_backend *backend,
 		handle_touch_cancel(event, libinput_dev);
 		break;
 	case LIBINPUT_EVENT_TOUCH_FRAME:
-		// no-op (at least for now)
+		handle_touch_frame(event, libinput_dev);
 		break;
 	case LIBINPUT_EVENT_TABLET_TOOL_AXIS:
 		handle_tablet_tool_axis(event, libinput_dev);

--- a/backend/libinput/touch.c
+++ b/backend/libinput/touch.c
@@ -95,3 +95,14 @@ void handle_touch_cancel(struct libinput_event *event,
 	wlr_event.touch_id = libinput_event_touch_get_seat_slot(tevent);
 	wlr_signal_emit_safe(&wlr_dev->touch->events.cancel, &wlr_event);
 }
+
+void handle_touch_frame(struct libinput_event *event,
+		struct libinput_device *libinput_dev) {
+	struct wlr_input_device *wlr_dev =
+		get_appropriate_device(WLR_INPUT_DEVICE_TOUCH, libinput_dev);
+	if (!wlr_dev) {
+		wlr_log(WLR_DEBUG, "Got a touch event for a device with no touch?");
+		return;
+	}
+	wlr_signal_emit_safe(&wlr_dev->touch->events.frame, NULL);
+}

--- a/backend/wayland/seat.c
+++ b/backend/wayland/seat.c
@@ -352,7 +352,10 @@ static void touch_handle_motion(void *data, struct wl_touch *wl_touch,
 }
 
 static void touch_handle_frame(void *data, struct wl_touch *wl_touch) {
-	// no-op
+	struct wlr_wl_input_device *device = data;
+	assert(device && device->wlr_input_device.touch);
+
+	wlr_signal_emit_safe(&device->wlr_input_device.touch->events.frame, NULL);
 }
 
 static void touch_handle_cancel(void *data, struct wl_touch *wl_touch) {

--- a/backend/x11/input_device.c
+++ b/backend/x11/input_device.c
@@ -79,6 +79,7 @@ static void send_touch_down_event(struct wlr_x11_output *output,
 		.touch_id = touch_id,
 	};
 	wlr_signal_emit_safe(&output->touch.events.down, &ev);
+	wlr_signal_emit_safe(&output->touch.events.frame, NULL);
 }
 
 static void send_touch_motion_event(struct wlr_x11_output *output,
@@ -91,6 +92,7 @@ static void send_touch_motion_event(struct wlr_x11_output *output,
 		.touch_id = touch_id,
 	};
 	wlr_signal_emit_safe(&output->touch.events.motion, &ev);
+	wlr_signal_emit_safe(&output->touch.events.frame, NULL);
 }
 
 static void send_touch_up_event(struct wlr_x11_output *output,
@@ -101,6 +103,7 @@ static void send_touch_up_event(struct wlr_x11_output *output,
 		.touch_id = touch_id,
 	};
 	wlr_signal_emit_safe(&output->touch.events.up, &ev);
+	wlr_signal_emit_safe(&output->touch.events.frame, NULL);
 }
 
 static struct wlr_x11_touchpoint* get_touchpoint_from_x11_touch_id(struct wlr_x11_output *output,

--- a/include/backend/libinput.h
+++ b/include/backend/libinput.h
@@ -83,6 +83,8 @@ void handle_touch_motion(struct libinput_event *event,
 		struct libinput_device *device);
 void handle_touch_cancel(struct libinput_event *event,
 		struct libinput_device *device);
+void handle_touch_frame(struct libinput_event *event,
+		struct libinput_device *device);
 
 struct wlr_tablet *create_libinput_tablet(
 		struct libinput_device *device);

--- a/include/wlr/types/wlr_cursor.h
+++ b/include/wlr/types/wlr_cursor.h
@@ -63,6 +63,7 @@ struct wlr_cursor {
 		struct wl_signal touch_down;
 		struct wl_signal touch_motion;
 		struct wl_signal touch_cancel;
+		struct wl_signal touch_frame;
 
 		struct wl_signal tablet_tool_axis;
 		struct wl_signal tablet_tool_proximity;

--- a/include/wlr/types/wlr_seat.h
+++ b/include/wlr/types/wlr_seat.h
@@ -52,11 +52,12 @@ struct wlr_seat_client {
 	// set of serials which were sent to the client on this seat
 	// for use by wlr_seat_client_{next_serial,validate_event_serial}
 	struct wlr_serial_ringset serials;
+	bool needs_touch_frame;
 };
 
 struct wlr_touch_point {
 	int32_t touch_id;
-	struct wlr_surface *surface;
+	struct wlr_surface *surface; // may be NULL if destroyed
 	struct wlr_seat_client *client;
 
 	struct wlr_surface *focus_surface;
@@ -116,6 +117,7 @@ struct wlr_touch_grab_interface {
 			struct wlr_touch_point *point);
 	void (*enter)(struct wlr_seat_touch_grab *grab, uint32_t time_msec,
 			struct wlr_touch_point *point);
+	void (*frame)(struct wlr_seat_touch_grab *grab);
 	// XXX this will conflict with the actual touch cancel which is different so
 	// we need to rename this
 	void (*cancel)(struct wlr_seat_touch_grab *grab);
@@ -607,6 +609,8 @@ void wlr_seat_touch_send_up(struct wlr_seat *seat, uint32_t time_msec,
 void wlr_seat_touch_send_motion(struct wlr_seat *seat, uint32_t time_msec,
 		int32_t touch_id, double sx, double sy);
 
+void wlr_seat_touch_send_frame(struct wlr_seat *seat);
+
 /**
  * Notify the seat of a touch down on the given surface. Defers to any grab of
  * the touch device.
@@ -630,6 +634,8 @@ void wlr_seat_touch_notify_up(struct wlr_seat *seat, uint32_t time_msec,
  */
 void wlr_seat_touch_notify_motion(struct wlr_seat *seat, uint32_t time_msec,
 		int32_t touch_id, double sx, double sy);
+
+void wlr_seat_touch_notify_frame(struct wlr_seat *seat);
 
 /**
  * How many touch points are currently down for the seat.

--- a/include/wlr/types/wlr_touch.h
+++ b/include/wlr/types/wlr_touch.h
@@ -22,6 +22,7 @@ struct wlr_touch {
 		struct wl_signal up; // struct wlr_event_touch_up
 		struct wl_signal motion; // struct wlr_event_touch_motion
 		struct wl_signal cancel; // struct wlr_event_touch_cancel
+		struct wl_signal frame;
 	} events;
 
 	void *data;

--- a/types/wlr_touch.c
+++ b/types/wlr_touch.c
@@ -11,6 +11,7 @@ void wlr_touch_init(struct wlr_touch *touch,
 	wl_signal_init(&touch->events.up);
 	wl_signal_init(&touch->events.motion);
 	wl_signal_init(&touch->events.cancel);
+	wl_signal_init(&touch->events.frame);
 }
 
 void wlr_touch_destroy(struct wlr_touch *touch) {

--- a/types/xdg_shell/wlr_xdg_popup.c
+++ b/types/xdg_shell/wlr_xdg_popup.c
@@ -131,6 +131,10 @@ static void xdg_touch_grab_enter(struct wlr_seat_touch_grab *grab,
 		uint32_t time, struct wlr_touch_point *point) {
 }
 
+static void xdg_touch_grab_frame(struct wlr_seat_touch_grab *grab) {
+	wlr_seat_touch_send_frame(grab->seat);
+}
+
 static void xdg_touch_grab_cancel(struct wlr_seat_touch_grab *grab) {
 	wlr_seat_touch_end_grab(grab->seat);
 }
@@ -140,6 +144,7 @@ static const struct wlr_touch_grab_interface xdg_touch_grab_impl = {
 	.up = xdg_touch_grab_up,
 	.motion = xdg_touch_grab_motion,
 	.enter = xdg_touch_grab_enter,
+	.frame = xdg_touch_grab_frame,
 	.cancel = xdg_touch_grab_cancel
 };
 


### PR DESCRIPTION
Up until now, we were (wrongly) sending `wl_touch.frame` events after every touch event. This prevents clients from being able to group multiple touch events together and recognize touch gestures.

Fix this by allowing backends to send touch frame events.

* * *

Breaking change: compositors now need to listen to touch frame events and call `wlr_seat_touch_notify_frame`.

Sway patch: https://github.com/swaywm/sway/pull/6353