### PR TITLE
tablet-v2: fix pad and tool object versions

### DIFF
--- a/types/tablet_v2/wlr_tablet_v2_pad.c
+++ b/types/tablet_v2/wlr_tablet_v2_pad.c
@@ -306,8 +306,9 @@ void add_tablet_pad_client(struct wlr_tablet_seat_client_v2 *seat,
 		return;
 	}
 
-	client->resource =
-		wl_resource_create(seat->wl_client, &zwp_tablet_pad_v2_interface, 1, 0);
+	uint32_t version = wl_resource_get_version(seat->resource);
+	client->resource = wl_resource_create(seat->wl_client,
+		&zwp_tablet_pad_v2_interface, version, 0);
 	if (!client->resource) {
 		wl_client_post_no_memory(seat->wl_client);
 		free(client->groups);

--- a/types/tablet_v2/wlr_tablet_v2_tool.c
+++ b/types/tablet_v2/wlr_tablet_v2_tool.c
@@ -115,8 +115,9 @@ void add_tablet_tool_client(struct wlr_tablet_seat_client_v2 *seat,
 	client->tool = tool;
 	client->seat = seat;
 
-	client->resource =
-		wl_resource_create(seat->wl_client, &zwp_tablet_tool_v2_interface, 1, 0);
+	uint32_t version = wl_resource_get_version(seat->resource);
+	client->resource = wl_resource_create(seat->wl_client,
+		&zwp_tablet_tool_v2_interface, version, 0);
 	if (!client->resource) {
 		free(client);
 		return;


### PR DESCRIPTION
These were hardcoded to 1. Instead, create the resource with the
version of the parent object.