### PR TITLE
buffer: make enum wlr_buffer_cap public

### DIFF
--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -12,7 +12,6 @@
 #include <wlr/util/log.h>
 #include <xf86drm.h>
 #include "backend/drm/drm.h"
-#include "types/wlr_buffer.h"
 #include "util/signal.h"
 
 struct wlr_drm_backend *get_drm_backend_from_backend(

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -28,7 +28,6 @@
 #include "render/drm_format_set.h"
 #include "render/swapchain.h"
 #include "render/wlr_renderer.h"
-#include "types/wlr_buffer.h"
 #include "util/signal.h"
 
 static const uint32_t SUPPORTED_OUTPUT_STATE =

--- a/backend/headless/backend.c
+++ b/backend/headless/backend.c
@@ -14,7 +14,6 @@
 #include "render/drm_format_set.h"
 #include "render/gbm_allocator.h"
 #include "render/wlr_renderer.h"
-#include "types/wlr_buffer.h"
 #include "util/signal.h"
 
 struct wlr_headless_backend *headless_backend_from_backend(

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -21,7 +21,6 @@
 #include "render/drm_format_set.h"
 #include "render/pixel_format.h"
 #include "render/wlr_renderer.h"
-#include "types/wlr_buffer.h"
 #include "util/signal.h"
 
 #include "drm-client-protocol.h"

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -19,7 +19,6 @@
 #include "render/pixel_format.h"
 #include "render/swapchain.h"
 #include "render/wlr_renderer.h"
-#include "types/wlr_buffer.h"
 #include "util/signal.h"
 
 #include "linux-dmabuf-unstable-v1-client-protocol.h"

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -33,7 +33,6 @@
 #include "backend/x11.h"
 #include "render/allocator.h"
 #include "render/drm_format_set.h"
-#include "types/wlr_buffer.h"
 #include "util/signal.h"
 
 // See dri2_format_for_depth in mesa

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -21,7 +21,6 @@
 #include <wlr/util/log.h>
 
 #include "backend/x11.h"
-#include "types/wlr_buffer.h"
 #include "util/signal.h"
 #include "util/time.h"
 

--- a/include/types/wlr_buffer.h
+++ b/include/types/wlr_buffer.h
@@ -73,18 +73,6 @@ struct wlr_dmabuf_buffer *dmabuf_buffer_create(
 bool dmabuf_buffer_drop(struct wlr_dmabuf_buffer *buffer);
 
 /**
- * Buffer capabilities.
- *
- * These bits indicate the features supported by a wlr_buffer. There is one bit
- * per function in wlr_buffer_impl.
- */
-enum wlr_buffer_cap {
-	WLR_BUFFER_CAP_DATA_PTR = 1 << 0,
-	WLR_BUFFER_CAP_DMABUF = 1 << 1,
-	WLR_BUFFER_CAP_SHM = 1 << 2,
-};
-
-/**
  * Get a pointer to a region of memory referring to the buffer's underlying
  * storage. The format and stride can be used to interpret the memory region
  * contents.

--- a/include/wlr/types/wlr_buffer.h
+++ b/include/wlr/types/wlr_buffer.h
@@ -34,6 +34,18 @@ struct wlr_buffer_impl {
 };
 
 /**
+ * Buffer capabilities.
+ *
+ * These bits indicate the features supported by a wlr_buffer. There is one bit
+ * per function in wlr_buffer_impl.
+ */
+enum wlr_buffer_cap {
+	WLR_BUFFER_CAP_DATA_PTR = 1 << 0,
+	WLR_BUFFER_CAP_DMABUF = 1 << 1,
+	WLR_BUFFER_CAP_SHM = 1 << 2,
+};
+
+/**
  * A buffer containing pixel data.
  *
  * A buffer has a single producer (the party who created the buffer) and

--- a/render/allocator.c
+++ b/render/allocator.c
@@ -8,7 +8,6 @@
 #include "render/shm_allocator.h"
 #include "render/drm_dumb_allocator.h"
 #include "render/wlr_renderer.h"
-#include "types/wlr_buffer.h"
 
 void wlr_allocator_init(struct wlr_allocator *alloc,
 		const struct wlr_allocator_interface *impl, uint32_t buffer_caps) {

--- a/render/drm_dumb_allocator.c
+++ b/render/drm_dumb_allocator.c
@@ -15,7 +15,6 @@
 
 #include "render/drm_dumb_allocator.h"
 #include "render/pixel_format.h"
-#include "types/wlr_buffer.h"
 
 static const struct wlr_buffer_impl buffer_impl;
 

--- a/render/gbm_allocator.c
+++ b/render/gbm_allocator.c
@@ -7,7 +7,6 @@
 #include <wlr/util/log.h>
 #include <xf86drm.h>
 #include "render/gbm_allocator.h"
-#include "types/wlr_buffer.h"
 
 static const struct wlr_buffer_impl buffer_impl;
 

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -18,7 +18,6 @@
 #include "render/egl.h"
 #include "render/gles2.h"
 #include "render/pixel_format.h"
-#include "types/wlr_buffer.h"
 
 static const GLfloat verts[] = {
 	1, 0, // top right

--- a/render/shm_allocator.c
+++ b/render/shm_allocator.c
@@ -7,7 +7,6 @@
 #include "render/pixel_format.h"
 #include "render/shm_allocator.h"
 #include "util/shm.h"
-#include "types/wlr_buffer.h"
 
 static const struct wlr_buffer_impl buffer_impl;
 


### PR DESCRIPTION
Custom backends and renderers need to implement `wlr_backend_impl.get_buffer_caps` and `wlr_renderer_impl.get_render_buffer_caps`. They can't if `enum wlr_buffer_cap` isn't made public.

* * *

This was an oversight I made during the 0.14.0 release. I'd say it would make sense to backport to 0.14.1.

