### PR TITLE
Remove reference to the announce mailing list

### DIFF
--- a/include/wlr/types/wlr_matrix.h
+++ b/include/wlr/types/wlr_matrix.h
@@ -9,9 +9,8 @@
  * the layout and size of structs used by wlroots may change, requiring code
  * depending on this header to be recompiled (but not edited).
  *
- * Breaking changes are announced by email and follow a 1-year deprecation
- * schedule. Send an email to ~sircmpwn/wlroots-announce+subscribe@lists.sr.ht
- * to receive these announcements.
+ * Breaking changes are announced in the release notes and follow a 1-year
+ * deprecation schedule.
  */
 
 #ifndef WLR_TYPES_WLR_MATRIX_H

--- a/include/wlr/util/edges.h
+++ b/include/wlr/util/edges.h
@@ -9,9 +9,8 @@
  * the layout and size of structs used by wlroots may change, requiring code
  * depending on this header to be recompiled (but not edited).
  *
- * Breaking changes are announced by email and follow a 1-year deprecation
- * schedule. Send an email to ~sircmpwn/wlroots-announce+subscribe@lists.sr.ht
- * to receive these announcements.
+ * Breaking changes are announced in the release notes and follow a 1-year
+ * deprecation schedule.
  */
 
 #ifndef WLR_UTIL_EDGES_H

--- a/include/wlr/util/log.h
+++ b/include/wlr/util/log.h
@@ -9,9 +9,8 @@
  * the layout and size of structs used by wlroots may change, requiring code
  * depending on this header to be recompiled (but not edited).
  *
- * Breaking changes are announced by email and follow a 1-year deprecation
- * schedule. Send an email to ~sircmpwn/wlroots-announce+subscribe@lists.sr.ht
- * to receive these announcements.
+ * Breaking changes are announced in the release notes and follow a 1-year
+ * deprecation schedule.
  */
 
 #ifndef WLR_UTIL_LOG_H

--- a/include/wlr/util/region.h
+++ b/include/wlr/util/region.h
@@ -9,9 +9,8 @@
  * the layout and size of structs used by wlroots may change, requiring code
  * depending on this header to be recompiled (but not edited).
  *
- * Breaking changes are announced by email and follow a 1-year deprecation
- * schedule. Send an email to ~sircmpwn/wlroots-announce+subscribe@lists.sr.ht
- * to receive these announcements.
+ * Breaking changes are announced in the release notes and follow a 1-year
+ * deprecation schedule.
  */
 
 #ifndef WLR_UTIL_REGION_H

--- a/include/wlr/xcursor.h
+++ b/include/wlr/xcursor.h
@@ -34,9 +34,8 @@
  * the layout and size of structs used by wlroots may change, requiring code
  * depending on this header to be recompiled (but not edited).
  *
- * Breaking changes are announced by email and follow a 1-year deprecation
- * schedule. Send an email to ~sircmpwn/wlroots-announce+subscribe@lists.sr.ht
- * to receive these announcements.
+ * Breaking changes are announced in the release notes and follow a 1-year
+ * deprecation schedule.
  */
 
 #ifndef WLR_XCURSOR_H


### PR DESCRIPTION
The mailing list has never been used.

I think listing the deprecated functions in the release notes is
enough. I'd rather not add the burden of maintaining a separate
communication medium.