### PR TITLE
backend/drm: don't clear pending cursor FB on failed commit 

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -933,7 +933,7 @@ static bool drm_connector_set_cursor(struct wlr_output *output,
 			local_buf = wlr_buffer_lock(buffer);
 		}
 
-		bool ok = drm_fb_import(&plane->current_fb, drm, local_buf,
+		bool ok = drm_fb_import(&plane->pending_fb, drm, local_buf,
 			&plane->formats);
 		wlr_buffer_unlock(local_buf);
 		if (!ok) {

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -355,9 +355,12 @@ static bool drm_crtc_commit(struct wlr_drm_connector *conn,
 		}
 	} else {
 		drm_fb_clear(&crtc->primary->pending_fb);
-		if (crtc->cursor != NULL) {
-			drm_fb_clear(&crtc->cursor->pending_fb);
-		}
+		// The set_cursor() hook is a bit special: it's not really synchronized
+		// to commit() or test(). Once set_cursor() returns true, the new
+		// cursor is effectively committed. So don't roll it back here, or we
+		// risk ending up in a state where we don't have a cursor FB but
+		// wlr_drm_connector.cursor_enabled is true.
+		// TODO: fix our output interface to avoid this issue.
 	}
 	return ok;
 }


### PR DESCRIPTION
Populating wlr_drm_plane.current_fb messes up the buffer's locking.
The previous buffer is released while it's still being displayed
on-screen.

Instead, stop clearing the pending cursor FB on a failed commit. The
pending cursor FB will remain for the next commit.

Fixes: 6c3d080 ("backend/drm: populate cursor plane's current_fb")