### PR TITLE
region: drop leftover reference to the mailing list

### DIFF
--- a/include/wlr/types/wlr_region.h
+++ b/include/wlr/types/wlr_region.h
@@ -9,9 +9,8 @@
  * the layout and size of structs used by wlroots may change, requiring code
  * depending on this header to be recompiled (but not edited).
  *
- * Breaking changes are announced by email and follow a 1-year deprecation
- * schedule. Send an email to ~sircmpwn/wlroots-announce+subscribe@lists.sr.ht
- * to receive these announcements.
+ * Breaking changes are announced in the release notes and follow a 1-year
+ * deprecation schedule.
  */
 
 #ifndef WLR_TYPES_WLR_REGION_H


### PR DESCRIPTION
As per [1], the mailing list isn't used anymore.

[1]: https://github.com/swaywm/wlroots/pull/3016

Fixes: 82af6e720870 ("region: stabilize interface")