### PR TITLE
Remove wlr_resource_get_buffer_size

### DIFF
--- a/include/wlr/types/wlr_buffer.h
+++ b/include/wlr/types/wlr_buffer.h
@@ -157,11 +157,6 @@ struct wlr_client_buffer *wlr_client_buffer_get(struct wlr_buffer *buffer);
  */
 bool wlr_resource_is_buffer(struct wl_resource *resource);
 /**
- * Get the size of a wl_buffer resource.
- */
-bool wlr_resource_get_buffer_size(struct wl_resource *resource,
-	int *width, int *height);
-/**
  * Try to update the buffer's content. On success, returns the updated buffer
  * and destroys the provided `buffer`. On error, `buffer` is intact and NULL is
  * returned.

--- a/include/wlr/types/wlr_buffer.h
+++ b/include/wlr/types/wlr_buffer.h
@@ -14,6 +14,7 @@
 #include <wlr/render/dmabuf.h>
 
 struct wlr_buffer;
+struct wlr_renderer;
 
 struct wlr_shm_attributes {
 	int fd;
@@ -111,6 +112,14 @@ bool wlr_buffer_get_dmabuf(struct wlr_buffer *buffer,
  */
 bool wlr_buffer_get_shm(struct wlr_buffer *buffer,
 	struct wlr_shm_attributes *attribs);
+/**
+ * Transforms a wl_resource into a wlr_buffer and locks it. Once the caller is
+ * done with the buffer, they must call wlr_buffer_unlock.
+ *
+ * The provided wl_resource must be a wl_buffer.
+ */
+struct wlr_buffer *wlr_buffer_from_resource(struct wlr_renderer *renderer,
+	struct wl_resource *resource);
 
 /**
  * A client buffer.
@@ -131,7 +140,12 @@ struct wlr_client_buffer {
 	struct wl_listener resource_destroy;
 };
 
-struct wlr_renderer;
+/**
+ * Creates a wlr_client_buffer from a given wlr_buffer by creating a texture
+ * from it, and copying its wl_resource.
+ */
+struct wlr_client_buffer *wlr_client_buffer_create(struct wlr_buffer *buffer,
+	struct wlr_renderer *renderer, struct wl_resource *resource);
 
 /**
  * Get a client buffer from a generic buffer. If the buffer isn't a client
@@ -147,13 +161,6 @@ bool wlr_resource_is_buffer(struct wl_resource *resource);
  */
 bool wlr_resource_get_buffer_size(struct wl_resource *resource,
 	int *width, int *height);
-/**
- * Import a client buffer and lock it.
- *
- * Once the caller is done with the buffer, they must call wlr_buffer_unlock.
- */
-struct wlr_client_buffer *wlr_client_buffer_import(
-	struct wlr_renderer *renderer, struct wl_resource *resource);
 /**
  * Try to update the buffer's content. On success, returns the updated buffer
  * and destroys the provided `buffer`. On error, `buffer` is intact and NULL is

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -35,6 +35,7 @@ struct wlr_surface_state {
 	// overflow.
 	uint32_t seq;
 
+	struct wlr_buffer *buffer;
 	struct wl_resource *buffer_resource;
 	int32_t dx, dy; // relative to previous position
 	pixman_region32_t surface_damage, buffer_damage; // clipped to bounds

--- a/types/wlr_buffer.c
+++ b/types/wlr_buffer.c
@@ -104,32 +104,6 @@ bool wlr_resource_is_buffer(struct wl_resource *resource) {
 	return strcmp(wl_resource_get_class(resource), wl_buffer_interface.name) == 0;
 }
 
-bool wlr_resource_get_buffer_size(struct wl_resource *resource,
-		int *width, int *height) {
-	assert(wlr_resource_is_buffer(resource));
-
-	struct wl_shm_buffer *shm_buf = wl_shm_buffer_get(resource);
-	if (shm_buf != NULL) {
-		*width = wl_shm_buffer_get_width(shm_buf);
-		*height = wl_shm_buffer_get_height(shm_buf);
-	} else if (wlr_dmabuf_v1_resource_is_buffer(resource)) {
-		struct wlr_dmabuf_v1_buffer *dmabuf =
-			wlr_dmabuf_v1_buffer_from_buffer_resource(resource);
-		*width = dmabuf->attributes.width;
-		*height = dmabuf->attributes.height;
-	} else if (wlr_drm_buffer_is_resource(resource)) {
-		struct wlr_drm_buffer *drm_buffer =
-			wlr_drm_buffer_from_resource(resource);
-		*width = drm_buffer->base.width;
-		*height = drm_buffer->base.height;
-	} else {
-		*width = *height = 0;
-		return false;
-	}
-
-	return true;
-}
-
 static const struct wlr_buffer_impl client_buffer_impl;
 
 struct wlr_client_buffer *wlr_client_buffer_get(struct wlr_buffer *buffer) {

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -365,12 +365,13 @@ static void surface_apply_damage(struct wlr_surface *surface) {
 		}
 	}
 
-	struct wlr_client_buffer *buffer =
-		wlr_client_buffer_import(surface->renderer, resource);
+	struct wlr_client_buffer *buffer = wlr_client_buffer_create(
+			surface->current.buffer, surface->renderer, resource);
 	if (buffer == NULL) {
 		wlr_log(WLR_ERROR, "Failed to upload buffer");
 		return;
 	}
+	wlr_buffer_unlock(surface->current.buffer);
 
 	if (surface->buffer != NULL) {
 		wlr_buffer_unlock(&surface->buffer->base);


### PR DESCRIPTION
Fixes #3015 

~~Turns out `wlr_surface_state` buffer member can be avoided, I'm fairly sure there's a way to make it hold only a `wlr_buffer` and get the `buffer_resource`, `buffer_width` and `buffer_height` from it without having to duplicate them. Let me know if you want that in this patch or in another one.~~

cc @emersion 

* * *

Breaking change:

- `wlr_resource_get_buffer_size` has been removed.
- `wlr_client_buffer_import` has been split into two functions: `wlr_buffer_from_resource` and `wlr_client_buffer_create`.