### PR TITLE
surface: don't destroy surface while compositor has locks

### DIFF
--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -84,7 +84,7 @@ struct wlr_surface_output {
 };
 
 struct wlr_surface {
-	struct wl_resource *resource;
+	struct wl_resource *resource; // can be NULL if destroyed by the client
 	struct wlr_renderer *renderer;
 	/**
 	 * The surface's buffer, if any. A surface has an attached buffer when it


### PR DESCRIPTION
References: https://github.com/swaywm/wlroots/issues/2957

* * *

Breaking change: `wlr_surface.resource` may now be NULL if the client has destroyed it but the compositor still has locks.

TODO: check all `surface->resource` usage throughout wlroots, make sure we won't hit a NULL dereference.