### PR TITLE
output-damage: fix output swapchain handling

### DIFF
--- a/types/wlr_output_damage.c
+++ b/types/wlr_output_damage.c
@@ -52,7 +52,11 @@ static void output_handle_precommit(struct wl_listener *listener, void *data) {
 	if (output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
 		// TODO: find a better way to access this info without a precommit
 		// handler
-		output_damage->pending_buffer_type = output->pending.buffer_type;
+		if (output->back_buffer != NULL) {
+			output_damage->pending_buffer_type = WLR_OUTPUT_STATE_BUFFER_RENDER;
+		} else {
+			output_damage->pending_buffer_type = output->pending.buffer_type;
+		}
 	}
 }
 


### PR DESCRIPTION
When wlr_output.swapchain is used instead of the backend's, the
buffer_type will be set to SCANOUT even if wlr_output_attach_render
has been called. This tricks wlr_output_damage into thinking the
whole output needs to be repainted.

Workaround this issue by forcing buffer_type to RENDER when the
output has a back-buffer set.

Will clean all of that up when removing the precommit event handler
altogether.

This commit fixes damage tracking on the Wayland, X11 and headless
backends.