### PR TITLE
backend/drm: force linear layout for multi-GPU buffers

### DIFF
--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -248,21 +248,15 @@ struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
 			goto error_event;
 		}
 
+		// Force a linear layout. In case explicit modifiers aren't supported,
+		// the meaning of implicit modifiers changes from one GPU to the other.
+		// In case explicit modifiers are supported, we still have no guarantee
+		// that the buffer producer will support these, so they might fallback
+		// to implicit modifiers.
 		for (size_t i = 0; i < texture_formats->len; i++) {
 			const struct wlr_drm_format *fmt = texture_formats->formats[i];
-			if (fmt->len == 0) {
-				// Modifiers aren't supported. The implicit modifier changes
-				// from a GPU to the other, so we can only accept linear
-				// buffers
-				wlr_drm_format_set_add(&drm->mgpu_formats, fmt->format,
-					DRM_FORMAT_MOD_LINEAR);
-				continue;
-			}
-
-			for (size_t j = 0; j < fmt->len; j++) {
-				wlr_drm_format_set_add(&drm->mgpu_formats, fmt->format,
-					fmt->modifiers[j]);
-			}
+			wlr_drm_format_set_add(&drm->mgpu_formats, fmt->format,
+				DRM_FORMAT_MOD_LINEAR);
 		}
 	}
 


### PR DESCRIPTION
Some buffers need to be copied across GPUs. Such buffers need to be
allocated with a format and modifier suitable for both the source
and the destination.

When explicit modifiers aren't supported, we were forcing the buffers
to be allocated with a linear layout, because implicit modifiers
aren't portable across GPUs. All is well with this case.

When explicit modifiers are supported, we were advertising the whole
list of destination modifiers, in the hope that the source might
have some in common and might be able to allocate a buffer with a
more optimized layout. This works well if the source supports explicit
modifiers. However, if the source doesn't, then wlr_drm_format_intersect
will fallback to implicit modifiers, and everything goes boom: the
source uses a GPU-specific tiling and the destination interprets it
as linear.

To avoid this, just force linear unconditionally. We'll be able to
revert this once we have a good way to indicate that an implicit modifier
isn't supported in wlr_drm_format_set, see [1].

[1]: https://github.com/swaywm/wlroots/pull/2815

Closes: https://github.com/swaywm/wlroots/issues/3030