### PR TITLE
backend/drm: move legacy-specific checks to legacy.c

### DIFF
--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -168,7 +168,7 @@ error:
 
 static bool atomic_crtc_commit(struct wlr_drm_backend *drm,
 		struct wlr_drm_connector *conn, const struct wlr_output_state *state,
-		uint32_t flags) {
+		uint32_t flags, bool test_only) {
 	struct wlr_output *output = &conn->output;
 	struct wlr_drm_crtc *crtc = conn->crtc;
 
@@ -209,9 +209,12 @@ static bool atomic_crtc_commit(struct wlr_drm_backend *drm,
 		vrr_enabled = state->adaptive_sync_enabled;
 	}
 
+	if (test_only) {
+		flags |= DRM_MODE_ATOMIC_TEST_ONLY;
+	}
 	if (modeset) {
 		flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
-	} else if (!(flags & DRM_MODE_ATOMIC_TEST_ONLY)) {
+	} else if (!test_only) {
 		flags |= DRM_MODE_ATOMIC_NONBLOCK;
 	}
 
@@ -250,7 +253,7 @@ static bool atomic_crtc_commit(struct wlr_drm_backend *drm,
 	bool ok = atomic_commit(&atom, conn, flags);
 	atomic_finish(&atom);
 
-	if (ok && !(flags & DRM_MODE_ATOMIC_TEST_ONLY)) {
+	if (ok && !test_only) {
 		commit_blob(drm, &crtc->mode_id, mode_id);
 		commit_blob(drm, &crtc->gamma_lut, gamma_lut);
 

--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -166,9 +166,9 @@ error:
 	atom->failed = true;
 }
 
-static bool atomic_crtc_commit(struct wlr_drm_backend *drm,
-		struct wlr_drm_connector *conn, const struct wlr_output_state *state,
-		uint32_t flags, bool test_only) {
+static bool atomic_crtc_commit(struct wlr_drm_connector *conn,
+		const struct wlr_output_state *state, uint32_t flags, bool test_only) {
+	struct wlr_drm_backend *drm = conn->backend;
 	struct wlr_output *output = &conn->output;
 	struct wlr_drm_crtc *crtc = conn->crtc;
 

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -419,14 +419,6 @@ static bool drm_connector_set_pending_fb(struct wlr_drm_connector *conn,
 		}
 		break;
 	case WLR_OUTPUT_STATE_BUFFER_SCANOUT:;
-		/* Legacy never gets to have nice things. But I doubt this would ever work,
-		 * and there is no reliable way to try, without risking messing up the
-		 * modesetting state. */
-		if (drm->iface == &legacy_iface) {
-			wlr_drm_conn_log(conn, WLR_DEBUG,
-				"Cannot use direct scan-out with legacy KMS API");
-			return false;
-		}
 		if (!drm_fb_import(&plane->pending_fb, drm, state->buffer,
 				&crtc->primary->formats)) {
 			wlr_drm_conn_log(conn, WLR_DEBUG,

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -351,7 +351,7 @@ static bool drm_crtc_commit(struct wlr_drm_connector *conn,
 
 	struct wlr_drm_backend *drm = conn->backend;
 	struct wlr_drm_crtc *crtc = conn->crtc;
-	bool ok = drm->iface->crtc_commit(drm, conn, state, flags, test_only);
+	bool ok = drm->iface->crtc_commit(conn, state, flags, test_only);
 	if (ok && !test_only) {
 		drm_plane_set_committed(crtc->primary);
 		if (crtc->cursor != NULL) {

--- a/backend/drm/legacy.c
+++ b/backend/drm/legacy.c
@@ -8,9 +8,24 @@
 #include "backend/drm/iface.h"
 #include "backend/drm/util.h"
 
+static bool legacy_crtc_test(struct wlr_drm_connector *conn,
+		const struct wlr_output_state *state) {
+	if ((state->committed & WLR_OUTPUT_STATE_BUFFER) &&
+			state->buffer_type == WLR_OUTPUT_STATE_BUFFER_SCANOUT) {
+		wlr_drm_conn_log(conn, WLR_DEBUG,
+			"Cannot use direct scan-out with legacy KMS API");
+		return false;
+	}
+
+	return true;
+}
+
 static bool legacy_crtc_commit(struct wlr_drm_backend *drm,
 		struct wlr_drm_connector *conn, const struct wlr_output_state *state,
 		uint32_t flags, bool test_only) {
+	if (!legacy_crtc_test(conn, state)) {
+		return false;
+	}
 	if (test_only) {
 		return true;
 	}

--- a/backend/drm/legacy.c
+++ b/backend/drm/legacy.c
@@ -20,9 +20,8 @@ static bool legacy_crtc_test(struct wlr_drm_connector *conn,
 	return true;
 }
 
-static bool legacy_crtc_commit(struct wlr_drm_backend *drm,
-		struct wlr_drm_connector *conn, const struct wlr_output_state *state,
-		uint32_t flags, bool test_only) {
+static bool legacy_crtc_commit(struct wlr_drm_connector *conn,
+		const struct wlr_output_state *state, uint32_t flags, bool test_only) {
 	if (!legacy_crtc_test(conn, state)) {
 		return false;
 	}
@@ -30,6 +29,7 @@ static bool legacy_crtc_commit(struct wlr_drm_backend *drm,
 		return true;
 	}
 
+	struct wlr_drm_backend *drm = conn->backend;
 	struct wlr_output *output = &conn->output;
 	struct wlr_drm_crtc *crtc = conn->crtc;
 	struct wlr_drm_plane *cursor = crtc->cursor;

--- a/backend/drm/legacy.c
+++ b/backend/drm/legacy.c
@@ -10,7 +10,11 @@
 
 static bool legacy_crtc_commit(struct wlr_drm_backend *drm,
 		struct wlr_drm_connector *conn, const struct wlr_output_state *state,
-		uint32_t flags) {
+		uint32_t flags, bool test_only) {
+	if (test_only) {
+		return true;
+	}
+
 	struct wlr_output *output = &conn->output;
 	struct wlr_drm_crtc *crtc = conn->crtc;
 	struct wlr_drm_plane *cursor = crtc->cursor;

--- a/include/backend/drm/iface.h
+++ b/include/backend/drm/iface.h
@@ -13,10 +13,9 @@ struct wlr_drm_crtc;
 
 // Used to provide atomic or legacy DRM functions
 struct wlr_drm_interface {
-	// Commit al pending changes on a CRTC.
-	bool (*crtc_commit)(struct wlr_drm_backend *drm,
-		struct wlr_drm_connector *conn, const struct wlr_output_state *state,
-		uint32_t flags, bool test_only);
+	// Commit all pending changes on a CRTC.
+	bool (*crtc_commit)(struct wlr_drm_connector *conn,
+		const struct wlr_output_state *state, uint32_t flags, bool test_only);
 };
 
 extern const struct wlr_drm_interface atomic_iface;

--- a/include/backend/drm/iface.h
+++ b/include/backend/drm/iface.h
@@ -16,7 +16,7 @@ struct wlr_drm_interface {
 	// Commit al pending changes on a CRTC.
 	bool (*crtc_commit)(struct wlr_drm_backend *drm,
 		struct wlr_drm_connector *conn, const struct wlr_output_state *state,
-		uint32_t flags);
+		uint32_t flags, bool test_only);
 };
 
 extern const struct wlr_drm_interface atomic_iface;


### PR DESCRIPTION
_See individual commits._

The legacy checks will get a bit more complicated with https://github.com/swaywm/wlroots/pull/2903.