### PR TITLE
render/pixman: fix texture_is_opaque()

### DIFF
--- a/render/pixman/renderer.c
+++ b/render/pixman/renderer.c
@@ -48,7 +48,7 @@ static struct wlr_pixman_texture *get_texture(
 
 static bool texture_is_opaque(struct wlr_texture *wlr_texture) {
 	struct wlr_pixman_texture *texture = get_texture(wlr_texture);
-	return texture->format_info->has_alpha;
+	return !texture->format_info->has_alpha;
 }
 
 static void texture_destroy(struct wlr_texture *wlr_texture) {


### PR DESCRIPTION
A texture is opaque when it does *not* have alpha.

Fixes https://github.com/swaywm/wlroots/issues/2907