### PR TITLE
render/egl: add support for EGL_EXT_device_drm_render_node

### DIFF
--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -43,6 +43,7 @@ struct wlr_egl {
 
 		// Device extensions
 		bool EXT_device_drm;
+		bool EXT_device_drm_render_node;
 	} exts;
 
 	struct {


### PR DESCRIPTION
This EGL extension has been added in [1]. The upsides are:

- We directly get a render node, instead of having to convert the
  primary node name to a render node name.
- If EGL_DRM_RENDER_NODE_FILE_EXT returns NULL, that means there is
  no render node being used by the driver.

[1]: https://github.com/KhronosGroup/EGL-Registry/pull/127

Mesa patch: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/11797
libglvnd patch: https://gitlab.freedesktop.org/glvnd/libglvnd/-/merge_requests/245