### PR TITLE
buffer: drop resource arg from wlr_client_buffer_create

### DIFF
--- a/include/wlr/types/wlr_buffer.h
+++ b/include/wlr/types/wlr_buffer.h
@@ -150,7 +150,7 @@ struct wlr_client_buffer {
  * from it, and copying its wl_resource.
  */
 struct wlr_client_buffer *wlr_client_buffer_create(struct wlr_buffer *buffer,
-	struct wlr_renderer *renderer, struct wl_resource *resource);
+	struct wlr_renderer *renderer);
 
 /**
  * Get a client buffer from a generic buffer. If the buffer isn't a client

--- a/types/wlr_buffer.c
+++ b/types/wlr_buffer.c
@@ -190,11 +190,10 @@ struct wlr_buffer *wlr_buffer_from_resource(struct wlr_renderer *renderer,
 }
 
 struct wlr_client_buffer *wlr_client_buffer_create(struct wlr_buffer *buffer,
-		struct wlr_renderer *renderer, struct wl_resource *resource) {
+		struct wlr_renderer *renderer) {
 	struct wlr_texture *texture = wlr_texture_from_buffer(renderer, buffer);
 	if (texture == NULL) {
 		wlr_log(WLR_ERROR, "Failed to create texture");
-		wl_buffer_send_release(resource);
 		return NULL;
 	}
 
@@ -202,7 +201,6 @@ struct wlr_client_buffer *wlr_client_buffer_create(struct wlr_buffer *buffer,
 		calloc(1, sizeof(struct wlr_client_buffer));
 	if (client_buffer == NULL) {
 		wlr_texture_destroy(texture);
-		wl_resource_post_no_memory(resource);
 		return NULL;
 	}
 	wlr_buffer_init(&client_buffer->base, &client_buffer_impl,

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -383,7 +383,7 @@ static void surface_apply_damage(struct wlr_surface *surface) {
 	}
 
 	struct wlr_client_buffer *buffer = wlr_client_buffer_create(
-			surface->current.buffer, surface->renderer, resource);
+			surface->current.buffer, surface->renderer);
 
 	wlr_buffer_unlock(surface->current.buffer);
 	surface->current.buffer = NULL;


### PR DESCRIPTION
This function doesn't need the wl_resource anymore.

In the failure paths, wlr_buffer_unlock in surface_apply_damage
will take care of sending wl_buffer.release.