### PR TITLE
render/gles2: disable blending opportunistically

### DIFF
--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -204,8 +204,6 @@ static void gles2_begin(struct wlr_renderer *wlr_renderer, uint32_t width,
 	wlr_matrix_projection(renderer->projection, width, height,
 			WL_OUTPUT_TRANSFORM_NORMAL);
 
-	// enable transparency
-	glEnable(GL_BLEND);
 	glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 
 	// XXX: maybe we should save output projection and remove some of the need
@@ -294,6 +292,12 @@ static bool gles2_render_subtexture_with_matrix(
 
 	push_gles2_debug(renderer);
 
+	if (!texture->has_alpha && alpha == 1.0) {
+		glDisable(GL_BLEND);
+	} else {
+		glEnable(GL_BLEND);
+	}
+
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(texture->target, texture->tex);
 
@@ -348,6 +352,13 @@ static void gles2_render_quad_with_matrix(struct wlr_renderer *wlr_renderer,
 	wlr_matrix_transpose(gl_matrix, gl_matrix);
 
 	push_gles2_debug(renderer);
+
+	if (color[3] == 1.0) {
+		glDisable(GL_BLEND);
+	} else {
+		glEnable(GL_BLEND);
+	}
+
 	glUseProgram(renderer->shaders.quad.program);
 
 	glUniformMatrix3fv(renderer->shaders.quad.proj, 1, GL_FALSE, gl_matrix);

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -248,10 +248,18 @@ static struct wlr_texture *gles2_texture_from_dmabuf(
 	if (texture == NULL) {
 		return NULL;
 	}
-	texture->has_alpha = true;
 	texture->drm_format = DRM_FORMAT_INVALID; // texture can't be written anyways
 	texture->inverted_y =
 		(attribs->flags & WLR_DMABUF_ATTRIBUTES_FLAGS_Y_INVERT) != 0;
+
+	const struct wlr_pixel_format_info *drm_fmt =
+		drm_get_pixel_format_info(attribs->format);
+	if (drm_fmt != NULL) {
+		texture->has_alpha = drm_fmt->has_alpha;
+	} else {
+		// We don't know, assume the texture has an alpha channel
+		texture->has_alpha = true;
+	}
 
 	struct wlr_egl_context prev_ctx;
 	wlr_egl_save_context(&prev_ctx);


### PR DESCRIPTION
We don't always need to enable blending: when the texture doesn't
have alpha or when the color is opaque, we can disable it.