### PR TITLE
render/{egl,gles2}: rename wlr_egl.exts to better match Khronos

### DIFF
--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -39,10 +39,10 @@ struct wlr_gles2_renderer {
 
 	const char *exts_str;
 	struct {
-		bool read_format_bgra_ext;
-		bool debug_khr;
-		bool egl_image_external_oes;
-		bool egl_image_oes;
+		bool EXT_read_format_bgra;
+		bool KHR_debug;
+		bool OES_egl_image_external;
+		bool OES_egl_image;
 	} exts;
 
 	struct {

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -37,12 +37,12 @@ struct wlr_egl {
 
 	struct {
 		// Display extensions
-		bool image_base_khr;
-		bool image_dmabuf_import_ext;
-		bool image_dmabuf_import_modifiers_ext;
+		bool KHR_image_base;
+		bool EXT_image_dma_buf_import;
+		bool EXT_image_dma_buf_import_modifiers;
 
 		// Device extensions
-		bool device_drm_ext;
+		bool EXT_device_drm;
 	} exts;
 
 	struct {

--- a/render/egl.c
+++ b/render/egl.c
@@ -230,16 +230,16 @@ struct wlr_egl *wlr_egl_create_with_drm_fd(int drm_fd) {
 	}
 
 	if (check_egl_ext(display_exts_str, "EGL_KHR_image_base")) {
-		egl->exts.image_base_khr = true;
+		egl->exts.KHR_image_base = true;
 		load_egl_proc(&egl->procs.eglCreateImageKHR, "eglCreateImageKHR");
 		load_egl_proc(&egl->procs.eglDestroyImageKHR, "eglDestroyImageKHR");
 	}
 
-	egl->exts.image_dmabuf_import_ext =
+	egl->exts.EXT_image_dma_buf_import =
 		check_egl_ext(display_exts_str, "EGL_EXT_image_dma_buf_import");
 	if (check_egl_ext(display_exts_str,
 			"EGL_EXT_image_dma_buf_import_modifiers")) {
-		egl->exts.image_dmabuf_import_modifiers_ext = true;
+		egl->exts.EXT_image_dma_buf_import_modifiers = true;
 		load_egl_proc(&egl->procs.eglQueryDmaBufFormatsEXT,
 			"eglQueryDmaBufFormatsEXT");
 		load_egl_proc(&egl->procs.eglQueryDmaBufModifiersEXT,
@@ -287,7 +287,7 @@ struct wlr_egl *wlr_egl_create_with_drm_fd(int drm_fd) {
 		}
 #endif
 
-		egl->exts.device_drm_ext =
+		egl->exts.EXT_device_drm =
 			check_egl_ext(device_exts_str, "EGL_EXT_device_drm");
 	}
 
@@ -390,7 +390,7 @@ void wlr_egl_destroy(struct wlr_egl *egl) {
 }
 
 bool wlr_egl_destroy_image(struct wlr_egl *egl, EGLImage image) {
-	if (!egl->exts.image_base_khr) {
+	if (!egl->exts.KHR_image_base) {
 		return false;
 	}
 	if (!image) {
@@ -448,7 +448,7 @@ bool wlr_egl_restore_context(struct wlr_egl_context *context) {
 
 EGLImageKHR wlr_egl_create_image_from_dmabuf(struct wlr_egl *egl,
 		struct wlr_dmabuf_attributes *attributes, bool *external_only) {
-	if (!egl->exts.image_base_khr || !egl->exts.image_dmabuf_import_ext) {
+	if (!egl->exts.KHR_image_base || !egl->exts.EXT_image_dma_buf_import) {
 		wlr_log(WLR_ERROR, "dmabuf import extension not present");
 		return NULL;
 	}
@@ -461,7 +461,7 @@ EGLImageKHR wlr_egl_create_image_from_dmabuf(struct wlr_egl *egl,
 	// have here
 	if (attributes->modifier != DRM_FORMAT_MOD_INVALID &&
 			attributes->modifier != DRM_FORMAT_MOD_LINEAR) {
-		if (!egl->exts.image_dmabuf_import_modifiers_ext) {
+		if (!egl->exts.EXT_image_dma_buf_import_modifiers) {
 			wlr_log(WLR_ERROR, "dmabuf modifiers extension not present");
 			return NULL;
 		}
@@ -541,7 +541,7 @@ EGLImageKHR wlr_egl_create_image_from_dmabuf(struct wlr_egl *egl,
 }
 
 static int get_egl_dmabuf_formats(struct wlr_egl *egl, int **formats) {
-	if (!egl->exts.image_dmabuf_import_ext) {
+	if (!egl->exts.EXT_image_dma_buf_import) {
 		wlr_log(WLR_DEBUG, "DMA-BUF import extension not present");
 		return -1;
 	}
@@ -551,7 +551,7 @@ static int get_egl_dmabuf_formats(struct wlr_egl *egl, int **formats) {
 	// supported; it's the intended way to just try to create buffers.
 	// Just a guess but better than not supporting dmabufs at all,
 	// given that the modifiers extension isn't supported everywhere.
-	if (!egl->exts.image_dmabuf_import_modifiers_ext) {
+	if (!egl->exts.EXT_image_dma_buf_import_modifiers) {
 		static const int fallback_formats[] = {
 			DRM_FORMAT_ARGB8888,
 			DRM_FORMAT_XRGB8888,
@@ -594,11 +594,11 @@ static int get_egl_dmabuf_modifiers(struct wlr_egl *egl, int format,
 	*modifiers = NULL;
 	*external_only = NULL;
 
-	if (!egl->exts.image_dmabuf_import_ext) {
+	if (!egl->exts.EXT_image_dma_buf_import) {
 		wlr_log(WLR_DEBUG, "DMA-BUF extension not present");
 		return -1;
 	}
-	if (!egl->exts.image_dmabuf_import_modifiers_ext) {
+	if (!egl->exts.EXT_image_dma_buf_import_modifiers) {
 		return 0;
 	}
 
@@ -707,7 +707,7 @@ static char *get_render_name(const char *name) {
 }
 
 int wlr_egl_dup_drm_fd(struct wlr_egl *egl) {
-	if (egl->device == EGL_NO_DEVICE_EXT || !egl->exts.device_drm_ext) {
+	if (egl->device == EGL_NO_DEVICE_EXT || !egl->exts.EXT_device_drm) {
 		return -1;
 	}
 

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -744,7 +744,7 @@ struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_egl *egl) {
 	wlr_log(WLR_INFO, "GL renderer: %s", glGetString(GL_RENDERER));
 	wlr_log(WLR_INFO, "Supported GLES2 extensions: %s", exts_str);
 
-	if (!renderer->egl->exts.image_dmabuf_import_ext) {
+	if (!renderer->egl->exts.EXT_image_dma_buf_import) {
 		wlr_log(WLR_ERROR, "EGL_EXT_image_dma_buf_import not supported");
 		free(renderer);
 		return NULL;

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -274,7 +274,7 @@ static bool gles2_render_subtexture_with_matrix(
 	case GL_TEXTURE_EXTERNAL_OES:
 		shader = &renderer->shaders.tex_ext;
 
-		if (!renderer->exts.egl_image_external_oes) {
+		if (!renderer->exts.OES_egl_image_external) {
 			wlr_log(WLR_ERROR, "Failed to render texture: "
 				"GL_TEXTURE_EXTERNAL_OES not supported");
 			return false;
@@ -407,7 +407,7 @@ static uint32_t gles2_preferred_read_format(
 		return fmt->drm_format;
 	}
 
-	if (renderer->exts.read_format_bgra_ext) {
+	if (renderer->exts.EXT_read_format_bgra) {
 		return DRM_FORMAT_XRGB8888;
 	}
 	return DRM_FORMAT_XBGR8888;
@@ -427,7 +427,7 @@ static bool gles2_read_pixels(struct wlr_renderer *wlr_renderer,
 		return false;
 	}
 
-	if (fmt->gl_format == GL_BGRA_EXT && !renderer->exts.read_format_bgra_ext) {
+	if (fmt->gl_format == GL_BGRA_EXT && !renderer->exts.EXT_read_format_bgra) {
 		wlr_log(WLR_ERROR,
 			"Cannot read pixels: missing GL_EXT_read_format_bgra extension");
 		return false;
@@ -530,7 +530,7 @@ static void gles2_destroy(struct wlr_renderer *wlr_renderer) {
 	glDeleteProgram(renderer->shaders.tex_ext.program);
 	pop_gles2_debug(renderer);
 
-	if (renderer->exts.debug_khr) {
+	if (renderer->exts.KHR_debug) {
 		glDisable(GL_DEBUG_OUTPUT_KHR);
 		renderer->procs.glDebugMessageCallbackKHR(NULL, NULL);
 	}
@@ -760,11 +760,11 @@ struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_egl *egl) {
 		return NULL;
 	}
 
-	renderer->exts.read_format_bgra_ext =
+	renderer->exts.EXT_read_format_bgra =
 		check_gl_ext(exts_str, "GL_EXT_read_format_bgra");
 
 	if (check_gl_ext(exts_str, "GL_KHR_debug")) {
-		renderer->exts.debug_khr = true;
+		renderer->exts.KHR_debug = true;
 		load_gl_proc(&renderer->procs.glDebugMessageCallbackKHR,
 			"glDebugMessageCallbackKHR");
 		load_gl_proc(&renderer->procs.glDebugMessageControlKHR,
@@ -772,18 +772,18 @@ struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_egl *egl) {
 	}
 
 	if (check_gl_ext(exts_str, "GL_OES_EGL_image_external")) {
-		renderer->exts.egl_image_external_oes = true;
+		renderer->exts.OES_egl_image_external = true;
 		load_gl_proc(&renderer->procs.glEGLImageTargetTexture2DOES,
 			"glEGLImageTargetTexture2DOES");
 	}
 
 	if (check_gl_ext(exts_str, "GL_OES_EGL_image")) {
-		renderer->exts.egl_image_oes = true;
+		renderer->exts.OES_egl_image = true;
 		load_gl_proc(&renderer->procs.glEGLImageTargetRenderbufferStorageOES,
 			"glEGLImageTargetRenderbufferStorageOES");
 	}
 
-	if (renderer->exts.debug_khr) {
+	if (renderer->exts.KHR_debug) {
 		glEnable(GL_DEBUG_OUTPUT_KHR);
 		glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS_KHR);
 		renderer->procs.glDebugMessageCallbackKHR(gles2_log, NULL);
@@ -831,7 +831,7 @@ struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_egl *egl) {
 	renderer->shaders.tex_rgbx.pos_attrib = glGetAttribLocation(prog, "pos");
 	renderer->shaders.tex_rgbx.tex_attrib = glGetAttribLocation(prog, "texcoord");
 
-	if (renderer->exts.egl_image_external_oes) {
+	if (renderer->exts.OES_egl_image_external) {
 		renderer->shaders.tex_ext.program = prog =
 			link_program(renderer, tex_vertex_src, tex_fragment_src_external);
 		if (!renderer->shaders.tex_ext.program) {
@@ -859,7 +859,7 @@ error:
 
 	pop_gles2_debug(renderer);
 
-	if (renderer->exts.debug_khr) {
+	if (renderer->exts.KHR_debug) {
 		glDisable(GL_DEBUG_OUTPUT_KHR);
 		renderer->procs.glDebugMessageCallbackKHR(NULL, NULL);
 	}


### PR DESCRIPTION
Khronos refers to extensions with their namespace as a prefix in
uppercase. Change our naming to align with Khronos conventions.
This also makes grepping easier.