### PR TITLE
Drop legacy output APIs

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -396,7 +396,6 @@ static bool drm_connector_set_pending_fb(struct wlr_drm_connector *conn,
 	struct wlr_drm_plane *plane = crtc->primary;
 
 	assert(state->committed & WLR_OUTPUT_STATE_BUFFER);
-	assert(state->buffer_type == WLR_OUTPUT_STATE_BUFFER_SCANOUT);
 
 	struct wlr_buffer *local_buf;
 	if (drm->parent) {

--- a/backend/noop/output.c
+++ b/backend/noop/output.c
@@ -16,15 +16,6 @@ static struct wlr_noop_output *noop_output_from_output(
 	return (struct wlr_noop_output *)wlr_output;
 }
 
-static bool output_attach_render(struct wlr_output *wlr_output,
-		int *buffer_age) {
-	return false;
-}
-
-static void output_rollback_render(struct wlr_output *wlr_output) {
-	// This space is intentionally left blank
-}
-
 static bool output_commit(struct wlr_output *wlr_output) {
 	uint32_t unsupported =
 		wlr_output->pending.committed & ~SUPPORTED_OUTPUT_STATE;
@@ -60,8 +51,6 @@ static void output_destroy(struct wlr_output *wlr_output) {
 
 static const struct wlr_output_impl output_impl = {
 	.destroy = output_destroy,
-	.attach_render = output_attach_render,
-	.rollback_render = output_rollback_render,
 	.commit = output_commit,
 };
 

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -261,7 +261,6 @@ static bool output_test(struct wlr_output *wlr_output) {
 	}
 
 	if ((wlr_output->pending.committed & WLR_OUTPUT_STATE_BUFFER) &&
-			wlr_output->pending.buffer_type == WLR_OUTPUT_STATE_BUFFER_SCANOUT &&
 			!test_buffer(output->backend, wlr_output->pending.buffer)) {
 		return false;
 	}
@@ -287,9 +286,6 @@ static bool output_commit(struct wlr_output *wlr_output) {
 	}
 
 	if (wlr_output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
-		assert(wlr_output->pending.buffer_type ==
-			WLR_OUTPUT_STATE_BUFFER_SCANOUT);
-
 		struct wp_presentation_feedback *wp_feedback = NULL;
 		if (output->backend->presentation != NULL) {
 			wp_feedback = wp_presentation_feedback(output->backend->presentation,

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -257,9 +257,6 @@ static struct wlr_x11_buffer *get_or_create_x11_buffer(
 static bool output_commit_buffer(struct wlr_x11_output *output) {
 	struct wlr_x11_backend *x11 = output->x11;
 
-	assert(output->wlr_output.pending.buffer_type ==
-		WLR_OUTPUT_STATE_BUFFER_SCANOUT);
-
 	struct wlr_buffer *buffer = output->wlr_output.pending.buffer;
 	struct wlr_x11_buffer *x11_buffer =
 		get_or_create_x11_buffer(output, buffer);

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -52,19 +52,6 @@ struct wlr_output_impl {
 	 */
 	void (*destroy)(struct wlr_output *output);
 	/**
-	 * Make the output's back-buffer current for the renderer.
-	 *
-	 * buffer_age must be set to the buffer age in number of frames, or -1 if
-	 * unknown.
-	 */
-	bool (*attach_render)(struct wlr_output *output, int *buffer_age);
-	/**
-	 * Unset the current renderer's buffer.
-	 *
-	 * This is the opposite of attach_render.
-	 */
-	void (*rollback_render)(struct wlr_output *output);
-	/**
 	 * Check that the pending output state is a valid configuration.
 	 *
 	 * If this function returns true, commit can only fail due to a runtime

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -63,11 +63,6 @@ enum wlr_output_state_field {
 	WLR_OUTPUT_STATE_GAMMA_LUT = 1 << 7,
 };
 
-enum wlr_output_state_buffer_type {
-	WLR_OUTPUT_STATE_BUFFER_RENDER,
-	WLR_OUTPUT_STATE_BUFFER_SCANOUT,
-};
-
 enum wlr_output_state_mode_type {
 	WLR_OUTPUT_STATE_MODE_FIXED,
 	WLR_OUTPUT_STATE_MODE_CUSTOM,
@@ -85,8 +80,7 @@ struct wlr_output_state {
 	bool adaptive_sync_enabled;
 
 	// only valid if WLR_OUTPUT_STATE_BUFFER
-	enum wlr_output_state_buffer_type buffer_type;
-	struct wlr_buffer *buffer; // if WLR_OUTPUT_STATE_BUFFER_SCANOUT
+	struct wlr_buffer *buffer;
 
 	// only valid if WLR_OUTPUT_STATE_MODE
 	enum wlr_output_state_mode_type mode_type;

--- a/include/wlr/types/wlr_output_damage.h
+++ b/include/wlr/types/wlr_output_damage.h
@@ -43,7 +43,7 @@ struct wlr_output_damage {
 	pixman_region32_t previous[WLR_OUTPUT_DAMAGE_PREVIOUS_LEN];
 	size_t previous_idx;
 
-	enum wlr_output_state_buffer_type pending_buffer_type;
+	bool pending_attach_render;
 
 	struct {
 		struct wl_signal frame;

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -721,8 +721,7 @@ static bool output_basic_test(struct wlr_output *output) {
 			return false;
 		}
 
-		if (output->pending.buffer_type == WLR_OUTPUT_STATE_BUFFER_SCANOUT &&
-				output->back_buffer == NULL) {
+		if (output->back_buffer == NULL) {
 			if (output->attach_render_locks > 0) {
 				wlr_log(WLR_DEBUG, "Direct scan-out disabled by lock");
 				return false;
@@ -911,7 +910,6 @@ void wlr_output_attach_buffer(struct wlr_output *output,
 		struct wlr_buffer *buffer) {
 	output_state_clear_buffer(&output->pending);
 	output->pending.committed |= WLR_OUTPUT_STATE_BUFFER;
-	output->pending.buffer_type = WLR_OUTPUT_STATE_BUFFER_SCANOUT;
 	output->pending.buffer = wlr_buffer_lock(buffer);
 }
 

--- a/types/wlr_output_damage.c
+++ b/types/wlr_output_damage.c
@@ -52,8 +52,7 @@ static void output_handle_precommit(struct wl_listener *listener, void *data) {
 	if (output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
 		// TODO: find a better way to access this info without a precommit
 		// handler
-		output_damage->pending_attach_render = output->back_buffer != NULL ||
-			output->pending.buffer_type == WLR_OUTPUT_STATE_BUFFER_RENDER;
+		output_damage->pending_attach_render = output->back_buffer != NULL;
 	}
 }
 


### PR DESCRIPTION
- [x] ~~Nuke `wlr_backend_impl.get_renderer`~~ still used by the headless backend
- [x] Nuke `wlr_output_impl.{attach,rollback}_render`
- [x] Nuke `wlr_output_state.buffer_type`
- [x] ~~Nuke `wlr_output_impl.export_dmabuf`~~ done separately in https://github.com/swaywm/wlroots/pull/2955

~~Depends on: https://github.com/swaywm/wlroots/pull/2903~~