### PR TITLE
Hold gestures

### DIFF
--- a/backend/libinput/events.c
+++ b/backend/libinput/events.c
@@ -316,6 +316,14 @@ void handle_libinput_event(struct wlr_libinput_backend *backend,
 	case LIBINPUT_EVENT_GESTURE_PINCH_END:
 		handle_pointer_pinch_end(event, libinput_dev);
 		break;
+#if LIBINPUT_HAS_HOLD_GESTURES
+	case LIBINPUT_EVENT_GESTURE_HOLD_BEGIN:
+		handle_pointer_hold_begin(event, libinput_dev);
+		break;
+	case LIBINPUT_EVENT_GESTURE_HOLD_END:
+		handle_pointer_hold_end(event, libinput_dev);
+		break;
+#endif
 	default:
 		wlr_log(WLR_DEBUG, "Unknown libinput event %d", event_type);
 		break;

--- a/backend/libinput/meson.build
+++ b/backend/libinput/meson.build
@@ -27,3 +27,9 @@ wlr_files += files(
 
 features += { 'libinput-backend': true }
 wlr_deps += libinput
+
+# libinput hold gestures are available since 1.19.0
+add_project_arguments(
+	'-DLIBINPUT_HAS_HOLD_GESTURES=@0@'.format(libinput.version().version_compare('>=1.19.0').to_int()),
+	language: 'c',
+)

--- a/backend/libinput/pointer.c
+++ b/backend/libinput/pointer.c
@@ -260,3 +260,41 @@ void handle_pointer_pinch_end(struct libinput_event *event,
 	};
 	wlr_signal_emit_safe(&wlr_dev->pointer->events.pinch_end, &wlr_event);
 }
+
+void handle_pointer_hold_begin(struct libinput_event *event,
+		struct libinput_device *libinput_dev) {
+	struct wlr_input_device *wlr_dev =
+		get_appropriate_device(WLR_INPUT_DEVICE_POINTER, libinput_dev);
+	if (!wlr_dev) {
+		wlr_log(WLR_DEBUG, "Got a pointer gesture event for a device with no pointers?");
+		return;
+	}
+	struct libinput_event_gesture *gevent =
+		libinput_event_get_gesture_event(event);
+	struct wlr_event_pointer_hold_begin wlr_event = {
+		.device = wlr_dev,
+		.time_msec =
+			usec_to_msec(libinput_event_gesture_get_time_usec(gevent)),
+		.fingers = libinput_event_gesture_get_finger_count(gevent),
+	};
+	wlr_signal_emit_safe(&wlr_dev->pointer->events.hold_begin, &wlr_event);
+}
+
+void handle_pointer_hold_end(struct libinput_event *event,
+		struct libinput_device *libinput_dev) {
+	struct wlr_input_device *wlr_dev =
+		get_appropriate_device(WLR_INPUT_DEVICE_POINTER, libinput_dev);
+	if (!wlr_dev) {
+		wlr_log(WLR_DEBUG, "Got a pointer gesture event for a device with no pointers?");
+		return;
+	}
+	struct libinput_event_gesture *gevent =
+		libinput_event_get_gesture_event(event);
+	struct wlr_event_pointer_hold_end wlr_event = {
+		.device = wlr_dev,
+		.time_msec =
+			usec_to_msec(libinput_event_gesture_get_time_usec(gevent)),
+		.cancelled = libinput_event_gesture_get_cancelled(gevent),
+	};
+	wlr_signal_emit_safe(&wlr_dev->pointer->events.hold_end, &wlr_event);
+}

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -224,7 +224,7 @@ static void registry_global(void *data, struct wl_registry *registry,
 			&zxdg_decoration_manager_v1_interface, 1);
 	} else if (strcmp(iface, zwp_pointer_gestures_v1_interface.name) == 0) {
 		wl->zwp_pointer_gestures_v1 = wl_registry_bind(registry, name,
-			&zwp_pointer_gestures_v1_interface, 1);
+			&zwp_pointer_gestures_v1_interface, version < 3 ? version : 3);
 	} else if (strcmp(iface, wp_presentation_interface.name) == 0) {
 		wl->presentation = wl_registry_bind(registry, name,
 			&wp_presentation_interface, 1);

--- a/include/backend/libinput.h
+++ b/include/backend/libinput.h
@@ -66,6 +66,10 @@ void handle_pointer_pinch_update(struct libinput_event *event,
 		struct libinput_device *device);
 void handle_pointer_pinch_end(struct libinput_event *event,
 		struct libinput_device *device);
+void handle_pointer_hold_begin(struct libinput_event *event,
+		struct libinput_device *device);
+void handle_pointer_hold_end(struct libinput_event *event,
+		struct libinput_device *device);
 
 struct wlr_switch *create_libinput_switch(
 		struct libinput_device *device);

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -98,6 +98,7 @@ struct wlr_wl_pointer {
 	struct wl_pointer *wl_pointer;
 	struct zwp_pointer_gesture_swipe_v1 *gesture_swipe;
 	struct zwp_pointer_gesture_pinch_v1 *gesture_pinch;
+	struct zwp_pointer_gesture_hold_v1 *gesture_hold;
 	struct zwp_relative_pointer_v1 *relative_pointer;
 	enum wlr_axis_source axis_source;
 	int32_t axis_discrete;

--- a/include/wlr/types/wlr_cursor.h
+++ b/include/wlr/types/wlr_cursor.h
@@ -58,6 +58,8 @@ struct wlr_cursor {
 		struct wl_signal pinch_begin;
 		struct wl_signal pinch_update;
 		struct wl_signal pinch_end;
+		struct wl_signal hold_begin;
+		struct wl_signal hold_end;
 
 		struct wl_signal touch_up;
 		struct wl_signal touch_down;

--- a/include/wlr/types/wlr_pointer.h
+++ b/include/wlr/types/wlr_pointer.h
@@ -33,6 +33,9 @@ struct wlr_pointer {
 		struct wl_signal pinch_begin; // struct wlr_event_pointer_pinch_begin
 		struct wl_signal pinch_update; // struct wlr_event_pointer_pinch_update
 		struct wl_signal pinch_end; // struct wlr_event_pointer_pinch_end
+
+		struct wl_signal hold_begin; // struct wlr_event_pointer_hold_begin
+		struct wl_signal hold_end; // struct wlr_event_pointer_hold_end
 	} events;
 
 	void *data;
@@ -121,6 +124,18 @@ struct wlr_event_pointer_pinch_update {
 };
 
 struct wlr_event_pointer_pinch_end {
+	struct wlr_input_device *device;
+	uint32_t time_msec;
+	bool cancelled;
+};
+
+struct wlr_event_pointer_hold_begin {
+	struct wlr_input_device *device;
+	uint32_t time_msec;
+	uint32_t fingers;
+};
+
+struct wlr_event_pointer_hold_end {
 	struct wlr_input_device *device;
 	uint32_t time_msec;
 	bool cancelled;

--- a/include/wlr/types/wlr_pointer_gestures_v1.h
+++ b/include/wlr/types/wlr_pointer_gestures_v1.h
@@ -17,6 +17,7 @@ struct wlr_pointer_gestures_v1 {
 	struct wl_global *global;
 	struct wl_list swipes; // wl_resource_get_link
 	struct wl_list pinches; // wl_resource_get_link
+	struct wl_list holds; // wl_resource_get_link
 
 	struct wl_listener display_destroy;
 
@@ -61,6 +62,17 @@ void wlr_pointer_gestures_v1_send_pinch_update(
 	double scale,
 	double rotation);
 void wlr_pointer_gestures_v1_send_pinch_end(
+	struct wlr_pointer_gestures_v1 *gestures,
+	struct wlr_seat *seat,
+	uint32_t time_msec,
+	bool cancelled);
+
+void wlr_pointer_gestures_v1_send_hold_begin(
+	struct wlr_pointer_gestures_v1 *gestures,
+	struct wlr_seat *seat,
+	uint32_t time_msec,
+	uint32_t fingers);
+void wlr_pointer_gestures_v1_send_hold_end(
 	struct wlr_pointer_gestures_v1 *gestures,
 	struct wlr_seat *seat,
 	uint32_t time_msec,

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -1,5 +1,5 @@
 wayland_protos = dependency('wayland-protocols',
-	version: '>=1.22',
+	version: '>=1.23',
 	fallback: ['wayland-protocols', 'wayland_protocols'],
 	default_options: ['tests=false'],
 )

--- a/types/wlr_pointer.c
+++ b/types/wlr_pointer.c
@@ -18,6 +18,8 @@ void wlr_pointer_init(struct wlr_pointer *pointer,
 	wl_signal_init(&pointer->events.pinch_begin);
 	wl_signal_init(&pointer->events.pinch_update);
 	wl_signal_init(&pointer->events.pinch_end);
+	wl_signal_init(&pointer->events.hold_begin);
+	wl_signal_init(&pointer->events.hold_end);
 }
 
 void wlr_pointer_destroy(struct wlr_pointer *pointer) {

--- a/types/wlr_pointer_gestures_v1.c
+++ b/types/wlr_pointer_gestures_v1.c
@@ -11,7 +11,7 @@
 #include "util/signal.h"
 #include "pointer-gestures-unstable-v1-protocol.h"
 
-#define POINTER_GESTURES_VERSION 1
+#define POINTER_GESTURES_VERSION 2
 
 static void resource_handle_destroy(struct wl_client *client,
 		struct wl_resource *resource) {
@@ -270,9 +270,15 @@ static void get_pinch_gesture(struct wl_client *client,
 	wl_list_insert(&gestures->pinches, wl_resource_get_link(gesture));
 }
 
+static void pointer_gestures_release(struct wl_client *client,
+		struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+
 static const struct zwp_pointer_gestures_v1_interface gestures_impl = {
 	.get_swipe_gesture = get_swipe_gesture,
 	.get_pinch_gesture = get_pinch_gesture,
+	.release = pointer_gestures_release,
 };
 
 static void pointer_gestures_v1_bind(struct wl_client *wl_client, void *data,


### PR DESCRIPTION
## Description:

As touchpad touches are generally fully abstracted, a client cannot currently know when a user is interacting with the touchpad without moving. This is solved by hold gestures.

Hold gestures are notifications about one or more fingers being held down on the touchpad without significant movement.

Hold gestures are primarily designed for two interactions:

 - Hold to interact: where a hold gesture is active for some time a menu could pop up, some object could be selected, etc.
 - Hold to cancel: where e.g. kinetic scrolling is currently active, the start of a hold gesture can be used to stop the scroll.

Unlike swipe and pinch, hold gestures, by definition, do not have movement, so there is no need for an "update" stage in the gesture.

## Status:

 - [libinput](https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/602): Merged and tagged as v1.18.900.
 - [Wayland protocol](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/81): As mentioned by @emersion : "The protocol itself looks fine to me. Would be nice to get feedback from Mutter/GTK maintainers, and a third implementation." Both Mutter and GTK are pending for review. This is the third implementation

## wlroots example:

To be able to test this feature, I modified `tinywl` so it sends gestures to clients. I didn't include the patch in this PR because it feels out of the scope of `tinywl`, but if you want to easily test, just apply this patch:

<details>
<summary>

0001-tinywl-add-gesture-support.patch (click to expand it)

</summary>

```diff
From 520ad9b383c1c4c57578e7a59a80db24c09eb6d4 Mon Sep 17 00:00:00 2001
From: =?UTF-8?q?Jos=C3=A9=20Exp=C3=B3sito?= <jose.exposito89@gmail.com>
Date: Mon, 12 Jul 2021 22:59:07 +0200
Subject: [PATCH] tinywl: add gesture support

---
 tinywl/tinywl.c | 131 ++++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 131 insertions(+)

diff --git a/tinywl/tinywl.c b/tinywl/tinywl.c
index 2f2257ec..c6b66a3d 100644
--- a/tinywl/tinywl.c
+++ b/tinywl/tinywl.c
@@ -17,6 +17,7 @@
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_pointer.h>
+#include <wlr/types/wlr_pointer_gestures_v1.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/types/wlr_xdg_shell.h>
@@ -46,8 +47,17 @@ struct tinywl_server {
 	struct wl_listener cursor_button;
 	struct wl_listener cursor_axis;
 	struct wl_listener cursor_frame;
+	struct wl_listener swipe_begin;
+	struct wl_listener swipe_update;
+	struct wl_listener swipe_end;
+	struct wl_listener pinch_begin;
+	struct wl_listener pinch_update;
+	struct wl_listener pinch_end;
+	struct wl_listener hold_begin;
+	struct wl_listener hold_end;
 
 	struct wlr_seat *seat;
+	struct wlr_pointer_gestures_v1 *gestures;
 	struct wl_listener new_input;
 	struct wl_listener request_cursor;
 	struct wl_listener request_set_selection;
@@ -530,6 +540,106 @@ static void server_cursor_frame(struct wl_listener *listener, void *data) {
 	wlr_seat_pointer_notify_frame(server->seat);
 }
 
+static void server_swipe_begin(struct wl_listener *listener, void *data) {
+	struct tinywl_server *server =
+		wl_container_of(listener, server, swipe_begin);
+	struct wlr_event_pointer_swipe_begin *event = data;
+
+	wlr_pointer_gestures_v1_send_swipe_begin(
+			server->gestures,
+			server->seat,
+			event->time_msec,
+			event->fingers);
+}
+
+static void server_swipe_update(struct wl_listener *listener, void *data) {
+	struct tinywl_server *server =
+		wl_container_of(listener, server, swipe_update);
+	struct wlr_event_pointer_swipe_update *event = data;
+
+	wlr_pointer_gestures_v1_send_swipe_update(
+			server->gestures,
+			server->seat,
+			event->time_msec,
+			event->dx,
+			event->dy);
+}
+
+static void server_swipe_end(struct wl_listener *listener, void *data) {
+		struct tinywl_server *server =
+		wl_container_of(listener, server, swipe_end);
+	struct wlr_event_pointer_swipe_end *event = data;
+
+	wlr_pointer_gestures_v1_send_swipe_end(
+			server->gestures,
+			server->seat,
+			event->time_msec,
+			event->cancelled);
+}
+
+static void server_pinch_begin(struct wl_listener *listener, void *data) {
+	struct tinywl_server *server =
+		wl_container_of(listener, server, pinch_begin);
+	struct wlr_event_pointer_pinch_begin *event = data;
+
+	wlr_pointer_gestures_v1_send_pinch_begin(
+			server->gestures,
+			server->seat,
+			event->time_msec,
+			event->fingers);
+}
+
+static void server_pinch_update(struct wl_listener *listener, void *data) {
+	struct tinywl_server *server =
+		wl_container_of(listener, server, pinch_update);
+	struct wlr_event_pointer_pinch_update *event = data;
+
+	wlr_pointer_gestures_v1_send_pinch_update(
+			server->gestures,
+			server->seat,
+			event->time_msec,
+			event->dx,
+			event->dy,
+			event->scale,
+			event->rotation);
+}
+
+static void server_pinch_end(struct wl_listener *listener, void *data) {
+	struct tinywl_server *server =
+		wl_container_of(listener, server, pinch_end);
+	struct wlr_event_pointer_pinch_end *event = data;
+
+	wlr_pointer_gestures_v1_send_pinch_end(
+			server->gestures,
+			server->seat,
+			event->time_msec,
+			event->cancelled);
+}
+
+static void server_hold_begin(struct wl_listener *listener, void *data) {
+	struct tinywl_server *server =
+		wl_container_of(listener, server, hold_begin);
+	struct wlr_event_pointer_hold_begin *event = data;
+
+	wlr_pointer_gestures_v1_send_hold_begin(
+			server->gestures,
+			server->seat,
+			event->time_msec,
+			event->fingers);
+}
+
+static void server_hold_end(struct wl_listener *listener, void *data) {
+	struct tinywl_server *server =
+		wl_container_of(listener, server, hold_end);
+	struct wlr_event_pointer_hold_end *event = data;
+
+	wlr_pointer_gestures_v1_send_hold_end(
+			server->gestures,
+			server->seat,
+			event->time_msec,
+			event->cancelled);
+}
+
 /* Used to move all of the data necessary to render a surface from the top-level
  * frame handler to the per-surface render function. */
 struct render_data {
@@ -918,6 +1028,25 @@ int main(int argc, char *argv[]) {
 	server.cursor_frame.notify = server_cursor_frame;
 	wl_signal_add(&server.cursor->events.frame, &server.cursor_frame);
 
+	server.swipe_begin.notify = server_swipe_begin;
+	wl_signal_add(&server.cursor->events.swipe_begin, &server.swipe_begin);
+	server.swipe_update.notify = server_swipe_update;
+	wl_signal_add(&server.cursor->events.swipe_update, &server.swipe_update);
+	server.swipe_end.notify = server_swipe_end;
+	wl_signal_add(&server.cursor->events.swipe_end, &server.swipe_end);
+
+	server.pinch_begin.notify = server_pinch_begin;
+	wl_signal_add(&server.cursor->events.pinch_begin, &server.pinch_begin);
+	server.pinch_update.notify = server_pinch_update;
+	wl_signal_add(&server.cursor->events.pinch_update, &server.pinch_update);
+	server.pinch_end.notify = server_pinch_end;
+	wl_signal_add(&server.cursor->events.pinch_end, &server.pinch_end);
+
+	server.hold_begin.notify = server_hold_begin;
+	wl_signal_add(&server.cursor->events.hold_begin, &server.hold_begin);
+	server.hold_end.notify = server_hold_end;
+	wl_signal_add(&server.cursor->events.hold_end, &server.hold_end);
+
 	/*
 	 * Configures a seat, which is a single "seat" at which a user sits and
 	 * operates the computer. This conceptually includes up to one keyboard,
@@ -935,6 +1064,8 @@ int main(int argc, char *argv[]) {
 	wl_signal_add(&server.seat->events.request_set_selection,
 			&server.request_set_selection);
 
+	server.gestures = wlr_pointer_gestures_v1_create(server.wl_display);
+
 	/* Add a Unix socket to the Wayland display. */
 	const char *socket = wl_display_add_socket_auto(server.wl_display);
 	if (!socket) {
-- 
2.31.1
```

</details>

Let me know if you are interested in the patch, I can create another PR.


## How to test it:

Clone and install the latest libinput:

```bash
$ git clone https://gitlab.freedesktop.org/libinput/libinput.git
$ cd libinput
$ meson build --prefix=/usr -Ddocumentation=false
$ ninja -C build && ninja -C build install
```

Update your `unstable/pointer-gestures/pointer-gestures-unstable-v1.xml` Wayland protocol:
https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/81

Reboot.

To test a real use case, clone my GTK branch:
https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/3454 (Also, this PR is waiting for code review, comments are welcome :smiley:)

Run my my patched version of `tinywl` in a TTY, `cd` into my GTK branch and:

```bash
$ meson build --prefix=`pwd`/build/install --buildtype=debug # Installing here to not replace your stable GTK
$ ninja -C build && \
   ninja -C build install && \
   GDK_BACKEND=wayland WAYLAND_DEBUG=1 XDG_DATA_DIRS=`pwd`/build/install/share:$XDG_DATA_DIRS LD_LIBRARY_PATH=`pwd`/build/install/lib64:$LD_LIBRARY_PATH ./build/install/bin/gtk4-demo
```

Scroll somewhere, for example in the code, and hold with 2 fingers to stop kinetic scrolling. The gestures demo should also work.