### PR TITLE
backend/drm: fix NULL data in handle_drm_event

### DIFF
--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -215,7 +215,7 @@ struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
 
 	struct wl_event_loop *event_loop = wl_display_get_event_loop(display);
 	drm->drm_event = wl_event_loop_add_fd(event_loop, drm->fd,
-		WL_EVENT_READABLE, handle_drm_event, NULL);
+		WL_EVENT_READABLE, handle_drm_event, drm);
 	if (!drm->drm_event) {
 		wlr_log(WLR_ERROR, "Failed to create DRM event source");
 		goto error_fd;


### PR DESCRIPTION
wl_event_loop_add_fd was called with a NULL data argument, but the
function expects the data argument to be set to the wlr_drm_backend.

Fixes: 053ebe7c278b ("backend/drm: terminate display on drmHandleEvent failure")