### PR TITLE
backend/drm: stop restoring CRTCs on exit

### DIFF
--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -33,8 +33,6 @@ static void backend_destroy(struct wlr_backend *backend) {
 
 	struct wlr_drm_backend *drm = get_drm_backend_from_backend(backend);
 
-	restore_drm_outputs(drm);
-
 	struct wlr_drm_connector *conn, *next;
 	wl_list_for_each_safe(conn, next, &drm->outputs, link) {
 		destroy_drm_connector(conn);

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -123,8 +123,6 @@ struct wlr_drm_connector {
 	int cursor_width, cursor_height;
 	int cursor_hotspot_x, cursor_hotspot_y;
 
-	drmModeCrtc *old_crtc;
-
 	struct wl_list link;
 
 	/* CRTC ID if a page-flip is pending, zero otherwise.
@@ -142,7 +140,6 @@ struct wlr_drm_backend *get_drm_backend_from_backend(
 bool check_drm_features(struct wlr_drm_backend *drm);
 bool init_drm_resources(struct wlr_drm_backend *drm);
 void finish_drm_resources(struct wlr_drm_backend *drm);
-void restore_drm_outputs(struct wlr_drm_backend *drm);
 void scan_drm_connectors(struct wlr_drm_backend *state);
 int handle_drm_event(int fd, uint32_t mask, void *data);
 void destroy_drm_connector(struct wlr_drm_connector *conn);


### PR DESCRIPTION
This is the cause of the spurious "drmHandleEvent failed" messages
at exit. restore_drm_outputs calls handle_drm_event in a loop without
checking whether the FD is readable, so drmHandleEvent ends up with a
short read (0 bytes) and returns an error.

The loop's goal is to wait for all queued page-flip events to complete,
to allow drmModeSetCrtc calls to succeed without EBUSY. The
drmModeSetCrtc calls are supposed to restore whatever KMS state we were
started with. But it's not clear from my PoV that restoring the KMS
state on exit is desirable.

KMS clients are supposed to save and restore the (full) KMS state on VT
switch, but not on exit. Leaving our KMS state on exit avoids unnecessary
modesets and allows flicker-free transitions between clients. See [1]
for more details, and note that with Pekka we've concluded that a new
flag to reset some KMS props to their default value on compositor
start-up is the best way forward. As a side note, Weston doesn't restore
the CRTC by does disable the cursor plane on exit (see
drm_output_deinit_planes, I still think disabling the cursor plane
shouldn't be necessary on exit).

Additionally, restore_drm_outputs only a subset of the KMS state.
Gamma and other atomic properties aren't accounted for. If the previous
KMS client had some outputs disabled, restore_drm_outputs would restore
a garbage mode.