### PR TITLE
buffer: re-use wlr_shm_client_buffer

### DIFF
--- a/include/types/wlr_buffer.h
+++ b/include/types/wlr_buffer.h
@@ -22,9 +22,6 @@ struct wlr_shm_client_buffer {
 	struct wl_listener release;
 };
 
-struct wlr_shm_client_buffer *shm_client_buffer_create(
-	struct wl_resource *resource);
-
 /**
  * A read-only buffer that holds a data pointer.
  *


### PR DESCRIPTION
The first time wlr_buffer_from_resource is called with a wl_buffer
resource that originates from wl_shm, create a new
wlr_shm_client_buffer as usual. If wlr_buffer_from_resource is called
multiple times, re-use the existing wlr_shm_client_buffer.

This commit changes how the wlr_shm_client_buffer lifetime is managed:
previously it was destroyed as soon as the wlr_buffer was released.
With this commit it's destroyed when the wl_buffer resource is.

Apart from de-duplicating wlr_shm_client_buffer creations, this allows
to easily track when a wlr_shm_client_buffer is re-used. This is useful
for the renderer and the backends, e.g. the Pixman renderer can keep
using the same Pixman image if the buffer is re-used. In the future,
this will also allow to re-use resources in the Wayland and X11 backends
(remote wl_buffer objects for Wayland, pixmaps for X11).