### PR TITLE
seat: fix keyboard/pointer grab end

### DIFF
--- a/types/data_device/wlr_drag.c
+++ b/types/data_device/wlr_drag.c
@@ -513,7 +513,6 @@ void wlr_seat_start_pointer_drag(struct wlr_seat *seat, struct wlr_drag *drag,
 		uint32_t serial) {
 	drag->grab_type = WLR_DRAG_GRAB_KEYBOARD_POINTER;
 
-	wlr_seat_pointer_clear_focus(seat);
 	wlr_seat_pointer_start_grab(seat, &drag->pointer_grab);
 
 	wlr_seat_start_drag(seat, drag, serial);


### PR DESCRIPTION
- Call a grab's cancel() when another grab is started
- Clear focus on default grab cancel

This PR fixes the following issue (reproducible with Wayfire, not reproducible with Sway as it updates focus on every click):
1) Open a window with something to drag (tested with `weston-dnd`)
2) Create a layer surface with exclusive keyboard interactivity, so the focus won't switch on step 4 (tested with `bemenu` and `gtk-layer-demo`)
3) Press a key, typing it repeatedly to the layer surface
4) Holding the key, start a grab
6) Release the key
7) Observe that the layer surface didn't receive a key release event

Not sure if this is the right way to fix this though.