### PR TITLE
drag: clear keyboard focus on start

### DIFF
--- a/types/data_device/wlr_drag.c
+++ b/types/data_device/wlr_drag.c
@@ -492,6 +492,7 @@ void wlr_seat_start_drag(struct wlr_seat *seat, struct wlr_drag *drag,
 	assert(!drag->started);
 	drag->started = true;
 
+	wlr_seat_keyboard_clear_focus(seat);
 	wlr_seat_keyboard_start_grab(seat, &drag->keyboard_grab);
 
 	seat->drag = drag;


### PR DESCRIPTION
Fixes the issue described in https://github.com/swaywm/wlroots/pull/3056.