### PR TITLE
backend/drm: add support for FB_DAMAGE_CLIPS

### DIFF
--- a/backend/drm/properties.c
+++ b/backend/drm/properties.c
@@ -47,6 +47,7 @@ static const struct prop_info plane_info[] = {
 	{ "CRTC_W", INDEX(crtc_w) },
 	{ "CRTC_X", INDEX(crtc_x) },
 	{ "CRTC_Y", INDEX(crtc_y) },
+	{ "FB_DAMAGE_CLIPS", INDEX(fb_damage_clips) },
 	{ "FB_ID", INDEX(fb_id) },
 	{ "IN_FORMATS", INDEX(in_formats) },
 	{ "SRC_H", INDEX(src_h) },

--- a/include/backend/drm/properties.h
+++ b/include/backend/drm/properties.h
@@ -59,8 +59,9 @@ union wlr_drm_plane_props {
 		uint32_t crtc_h;
 		uint32_t fb_id;
 		uint32_t crtc_id;
+		uint32_t fb_damage_clips;
 	};
-	uint32_t props[13];
+	uint32_t props[14];
 };
 
 bool get_drm_connector_props(int fd, uint32_t id,


### PR DESCRIPTION
This allows the kernel to access our buffer damage. Some drivers
can take advantage of this, e.g. for PSR2 panels (Panel Self
Refresh) or for transfer over USB.

Closes: https://github.com/swaywm/wlroots/issues/1267