### PR TITLE
render/egl: set EGL_IMAGE_PRESERVED_KHR

### DIFF
--- a/render/egl.c
+++ b/render/egl.c
@@ -525,6 +525,11 @@ EGLImageKHR wlr_egl_create_image_from_dmabuf(struct wlr_egl *egl,
 			attribs[atti++] = attributes->modifier >> 32;
 		}
 	}
+
+	// Our clients don't expect our usage to trash the buffer contents
+	attribs[atti++] = EGL_IMAGE_PRESERVED_KHR;
+	attribs[atti++] = EGL_TRUE;
+
 	attribs[atti++] = EGL_NONE;
 	assert(atti < sizeof(attribs)/sizeof(attribs[0]));
 


### PR DESCRIPTION
Without setting this the EGL implementation is allowed to perform
destructive actions on the buffer when imported: its contents
become undefined.

This is mostly a pedantic change, because Mesa processes the attrib
and does absolutely nothing with it.