### PR TITLE
xdg-shell: add state caching support

### DIFF
--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -146,6 +146,7 @@ struct wlr_surface {
 	struct {
 		struct wl_signal commit;
 		struct wl_signal cache;
+		struct wl_signal precommit;
 		struct wl_signal new_subsurface;
 		struct wl_signal destroy;
 	} events;

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -29,6 +29,13 @@ enum wlr_surface_state_field {
 	WLR_SURFACE_STATE_VIEWPORT = 1 << 8,
 };
 
+struct wlr_surface_state_addon {
+	void *state;
+	void *owner;
+	struct wl_list link;
+	void (*finish_state)(void *state);
+};
+
 struct wlr_surface_state {
 	uint32_t committed; // enum wlr_surface_state_field
 	// Sequence number of the surface state. Incremented on each commit, may
@@ -67,6 +74,8 @@ struct wlr_surface_state {
 	// Number of locks that prevent this surface state from being committed.
 	size_t cached_state_locks;
 	struct wl_list cached_state_link; // wlr_surface.cached
+
+	struct wl_list addons;
 };
 
 struct wlr_surface_role {
@@ -136,6 +145,7 @@ struct wlr_surface {
 
 	struct {
 		struct wl_signal commit;
+		struct wl_signal cache;
 		struct wl_signal new_subsurface;
 		struct wl_signal destroy;
 	} events;

--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -192,6 +192,7 @@ struct wlr_xdg_surface {
 
 	struct wl_listener surface_destroy;
 	struct wl_listener surface_commit;
+	struct wl_listener surface_precommit;
 
 	struct {
 		struct wl_signal destroy;

--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -129,6 +129,8 @@ struct wlr_xdg_toplevel {
 	char *title;
 	char *app_id;
 
+	struct wl_listener surface_precommit;
+
 	struct {
 		struct wl_signal request_maximize;
 		struct wl_signal request_fullscreen;

--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -150,6 +150,12 @@ struct wlr_xdg_surface_configure {
 	struct wlr_xdg_toplevel_state *toplevel_state;
 };
 
+struct wlr_xdg_surface_state {
+	uint32_t configure_serial;
+	bool has_geometry;
+	struct wlr_box geometry;
+};
+
 /**
  * An xdg-surface is a user interface element requiring management by the
  * compositor. An xdg-surface alone isn't useful, a role should be assigned to
@@ -180,9 +186,9 @@ struct wlr_xdg_surface {
 	uint32_t configure_next_serial;
 	struct wl_list configure_list;
 
-	bool has_next_geometry;
-	struct wlr_box next_geometry;
 	struct wlr_box geometry;
+
+	struct wlr_xdg_surface_state pending;
 
 	struct wl_listener surface_destroy;
 	struct wl_listener surface_commit;

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -501,6 +501,8 @@ static void surface_commit_pending(struct wlr_surface *surface) {
 		surface->role->precommit(surface);
 	}
 
+	wlr_signal_emit_safe(&surface->events.precommit, &surface->pending);
+
 	// It doesn't to make sense to cache callback lists, so we always move
 	// them to the current state.
 	if (surface->pending.committed & WLR_SURFACE_STATE_FRAME_CALLBACK_LIST) {
@@ -787,6 +789,7 @@ struct wlr_surface *surface_create(struct wl_client *client,
 	surface->pending.seq = 1;
 
 	wl_signal_init(&surface->events.commit);
+	wl_signal_init(&surface->events.precommit);
 	wl_signal_init(&surface->events.cache);
 	wl_signal_init(&surface->events.destroy);
 	wl_signal_init(&surface->events.new_subsurface);

--- a/types/xdg_shell/wlr_xdg_surface.c
+++ b/types/xdg_shell/wlr_xdg_surface.c
@@ -358,7 +358,7 @@ static void xdg_surface_handle_surface_precommit(struct wl_listener *listener,
 		free(state);
 		return;
 	}
-	memcpy(state, &surface->pending, sizeof(*state));
+	*state = surface->pending;
 	surface->pending.has_geometry = false;
 
 	addon->owner = surface;
@@ -524,6 +524,9 @@ void reset_xdg_surface(struct wlr_xdg_surface *xdg_surface) {
 				&xdg_surface->toplevel->client_pending;
 			wl_list_remove(&client_pending->fullscreen_output_destroy.link);
 		}
+
+		wl_list_remove(&xdg_surface->toplevel->surface_precommit.link);
+
 		free(xdg_surface->toplevel);
 		xdg_surface->toplevel = NULL;
 		break;

--- a/types/xdg_shell/wlr_xdg_surface.c
+++ b/types/xdg_shell/wlr_xdg_surface.c
@@ -88,11 +88,9 @@ void unmap_xdg_surface(struct wlr_xdg_surface *surface) {
 	}
 	surface->configure_next_serial = 0;
 
-	surface->has_next_geometry = false;
+	surface->pending.has_geometry = false;
 	memset(&surface->geometry, 0, sizeof(struct wlr_box));
-	memset(&surface->next_geometry, 0, sizeof(struct wlr_box));
 }
-
 
 static void xdg_surface_handle_ack_configure(struct wl_client *client,
 		struct wl_resource *resource, uint32_t serial) {
@@ -144,7 +142,7 @@ static void xdg_surface_handle_ack_configure(struct wl_client *client,
 	}
 
 	surface->configured = true;
-	surface->configure_serial = serial;
+	surface->pending.configure_serial = serial;
 
 	wlr_signal_emit_safe(&surface->events.ack_configure, configure);
 	xdg_surface_configure_destroy(configure);
@@ -286,11 +284,11 @@ static void xdg_surface_handle_set_window_geometry(struct wl_client *client,
 		return;
 	}
 
-	surface->has_next_geometry = true;
-	surface->next_geometry.height = height;
-	surface->next_geometry.width = width;
-	surface->next_geometry.x = x;
-	surface->next_geometry.y = y;
+	surface->pending.has_geometry = true;
+	surface->pending.geometry.height = height;
+	surface->pending.geometry.width = width;
+	surface->pending.geometry.x = x;
+	surface->pending.geometry.y = y;
 }
 
 static void xdg_surface_handle_destroy(struct wl_client *client,
@@ -347,6 +345,14 @@ static void xdg_surface_handle_surface_commit(struct wl_listener *listener,
 	}
 }
 
+static void surface_commit_state(struct wlr_xdg_surface *surface,
+		struct wlr_xdg_surface_state *state) {
+	surface->configure_serial = state->configure_serial;
+	if (state->has_geometry) {
+		surface->geometry = state->geometry;
+	}
+}
+
 void handle_xdg_surface_commit(struct wlr_surface *wlr_surface) {
 	struct wlr_xdg_surface *surface =
 		wlr_xdg_surface_from_wlr_surface(wlr_surface);
@@ -354,13 +360,7 @@ void handle_xdg_surface_commit(struct wlr_surface *wlr_surface) {
 		return;
 	}
 
-	if (surface->has_next_geometry) {
-		surface->has_next_geometry = false;
-		surface->geometry.x = surface->next_geometry.x;
-		surface->geometry.y = surface->next_geometry.y;
-		surface->geometry.width = surface->next_geometry.width;
-		surface->geometry.height = surface->next_geometry.height;
-	}
+	surface_commit_state(surface, &surface->pending);
 
 	switch (surface->role) {
 	case WLR_XDG_SURFACE_ROLE_NONE:


### PR DESCRIPTION
>The wlr_surface API for cached state is not very ergonomic. Ideas welcome to improve it.

This is another approach to what https://github.com/swaywm/wlroots/pull/2977 tries to accomplish. Whether it's more ergonomic or not is up for debate.