### PR TITLE
util/time: make NSEC_PER_SEC static

### DIFF
--- a/util/time.c
+++ b/util/time.c
@@ -4,7 +4,7 @@
 
 #include "util/time.h"
 
-const long NSEC_PER_SEC = 1000000000;
+static const long NSEC_PER_SEC = 1000000000;
 
 int64_t timespec_to_msec(const struct timespec *a) {
 	return (int64_t)a->tv_sec * 1000 + a->tv_nsec / 1000000;


### PR DESCRIPTION
This fixes static linking with libseat.

Closes #3072