### PR TITLE
render/gles2: add support for some 24 and 16-bit formats

### DIFF
--- a/render/gles2/pixel_format.c
+++ b/render/gles2/pixel_format.c
@@ -32,6 +32,45 @@ static const struct wlr_gles2_pixel_format formats[] = {
 		.gl_type = GL_UNSIGNED_BYTE,
 		.has_alpha = true,
 	},
+	{
+		.drm_format = DRM_FORMAT_BGR888,
+		.gl_format = GL_RGB,
+		.gl_type = GL_UNSIGNED_BYTE,
+		.has_alpha = false,
+	},
+#if WLR_LITTLE_ENDIAN
+	{
+		.drm_format = DRM_FORMAT_RGBX4444,
+		.gl_format = GL_RGBA,
+		.gl_type = GL_UNSIGNED_SHORT_4_4_4_4,
+		.has_alpha = false,
+	},
+	{
+		.drm_format = DRM_FORMAT_RGBA4444,
+		.gl_format = GL_RGBA,
+		.gl_type = GL_UNSIGNED_SHORT_4_4_4_4,
+		.has_alpha = true,
+	},
+	{
+		.drm_format = DRM_FORMAT_RGBX5551,
+		.gl_format = GL_RGBA,
+		.gl_type = GL_UNSIGNED_SHORT_5_5_5_1,
+		.has_alpha = false,
+	},
+	{
+		.drm_format = DRM_FORMAT_RGBA5551,
+		.gl_format = GL_RGBA,
+		.gl_type = GL_UNSIGNED_SHORT_5_5_5_1,
+		.has_alpha = true,
+	},
+	{
+		.drm_format = DRM_FORMAT_RGB565,
+		.gl_format = GL_RGB,
+		.gl_type = GL_UNSIGNED_SHORT_5_6_5,
+		.has_alpha = false,
+	},
+	// TODO: EXT_texture_type_2_10_10_10_REV support
+#endif
 };
 
 // TODO: more pixel formats

--- a/render/pixel_format.c
+++ b/render/pixel_format.c
@@ -26,6 +26,42 @@ static const struct wlr_pixel_format_info pixel_format_info[] = {
 		.bpp = 32,
 		.has_alpha = true,
 	},
+	{
+		.drm_format = DRM_FORMAT_BGR888,
+		.opaque_substitute = DRM_FORMAT_INVALID,
+		.bpp = 24,
+		.has_alpha = false,
+	},
+	{
+		.drm_format = DRM_FORMAT_RGBX4444,
+		.opaque_substitute = DRM_FORMAT_INVALID,
+		.bpp = 16,
+		.has_alpha = false,
+	},
+	{
+		.drm_format = DRM_FORMAT_RGBA4444,
+		.opaque_substitute = DRM_FORMAT_RGBX4444,
+		.bpp = 16,
+		.has_alpha = false,
+	},
+	{
+		.drm_format = DRM_FORMAT_RGBX5551,
+		.opaque_substitute = DRM_FORMAT_INVALID,
+		.bpp = 16,
+		.has_alpha = false,
+	},
+	{
+		.drm_format = DRM_FORMAT_RGBA5551,
+		.opaque_substitute = DRM_FORMAT_RGBX5551,
+		.bpp = 16,
+		.has_alpha = false,
+	},
+	{
+		.drm_format = DRM_FORMAT_RGB565,
+		.opaque_substitute = DRM_FORMAT_INVALID,
+		.bpp = 16,
+		.has_alpha = false,
+	},
 };
 
 static const size_t pixel_format_info_size =


### PR DESCRIPTION
On little-endian, we can enable pixel formats which don't use
gl_type = GL_UNSIGNED_BYTE. See [1].

[1]: https://afrantzis.com/pixel-format-guide/