### PR TITLE
Add support for some 10-bit and FP16 formats

### DIFF
--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -43,6 +43,8 @@ struct wlr_gles2_renderer {
 		bool KHR_debug;
 		bool OES_egl_image_external;
 		bool OES_egl_image;
+		bool EXT_texture_type_2_10_10_10_REV;
+		bool OES_texture_half_float_linear;
 	} exts;
 
 	struct {

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -109,10 +109,14 @@ struct wlr_gles2_texture {
 	struct wl_listener buffer_destroy;
 };
 
+
+bool is_gles2_pixel_format_supported(const struct wlr_gles2_renderer *renderer,
+	const struct wlr_gles2_pixel_format *format);
 const struct wlr_gles2_pixel_format *get_gles2_format_from_drm(uint32_t fmt);
 const struct wlr_gles2_pixel_format *get_gles2_format_from_gl(
 	GLint gl_format, GLint gl_type, bool alpha);
-const uint32_t *get_gles2_shm_formats(size_t *len);
+const uint32_t *get_gles2_shm_formats(const struct wlr_gles2_renderer *renderer,
+	size_t *len);
 
 struct wlr_gles2_renderer *gles2_get_renderer(
 	struct wlr_renderer *wlr_renderer);

--- a/render/gles2/pixel_format.c
+++ b/render/gles2/pixel_format.c
@@ -69,7 +69,30 @@ static const struct wlr_gles2_pixel_format formats[] = {
 		.gl_type = GL_UNSIGNED_SHORT_5_6_5,
 		.has_alpha = false,
 	},
-	// TODO: EXT_texture_type_2_10_10_10_REV support
+	{
+		.drm_format = DRM_FORMAT_XBGR2101010,
+		.gl_format = GL_RGBA,
+		.gl_type = GL_UNSIGNED_INT_2_10_10_10_REV_EXT,
+		.has_alpha = false,
+	},
+	{
+		.drm_format = DRM_FORMAT_ABGR2101010,
+		.gl_format = GL_RGBA,
+		.gl_type = GL_UNSIGNED_INT_2_10_10_10_REV_EXT,
+		.has_alpha = true,
+	},
+	{
+		.drm_format = DRM_FORMAT_XBGR16161616F,
+		.gl_format = GL_RGBA,
+		.gl_type = GL_HALF_FLOAT_OES,
+		.has_alpha = false,
+	},
+	{
+		.drm_format = DRM_FORMAT_ABGR16161616F,
+		.gl_format = GL_RGBA,
+		.gl_type = GL_HALF_FLOAT_OES,
+		.has_alpha = true,
+	},
 #endif
 };
 
@@ -77,6 +100,14 @@ static const struct wlr_gles2_pixel_format formats[] = {
 
 bool is_gles2_pixel_format_supported(const struct wlr_gles2_renderer *renderer,
 		const struct wlr_gles2_pixel_format *format) {
+	if (format->gl_type == GL_UNSIGNED_INT_2_10_10_10_REV_EXT
+			&& !renderer->exts.EXT_texture_type_2_10_10_10_REV) {
+		return false;
+	}
+	if (format->gl_type == GL_HALF_FLOAT_OES
+			&& !renderer->exts.OES_texture_half_float_linear) {
+		return false;
+	}
 	if (format->gl_format == GL_BGRA_EXT
 			&& !renderer->exts.EXT_read_format_bgra) {
 		return false;

--- a/render/gles2/pixel_format.c
+++ b/render/gles2/pixel_format.c
@@ -75,6 +75,15 @@ static const struct wlr_gles2_pixel_format formats[] = {
 
 // TODO: more pixel formats
 
+bool is_gles2_pixel_format_supported(const struct wlr_gles2_renderer *renderer,
+		const struct wlr_gles2_pixel_format *format) {
+	if (format->gl_format == GL_BGRA_EXT
+			&& !renderer->exts.EXT_read_format_bgra) {
+		return false;
+	}
+	return true;
+}
+
 const struct wlr_gles2_pixel_format *get_gles2_format_from_drm(uint32_t fmt) {
 	for (size_t i = 0; i < sizeof(formats) / sizeof(*formats); ++i) {
 		if (formats[i].drm_format == fmt) {
@@ -96,11 +105,16 @@ const struct wlr_gles2_pixel_format *get_gles2_format_from_gl(
 	return NULL;
 }
 
-const uint32_t *get_gles2_shm_formats(size_t *len) {
+const uint32_t *get_gles2_shm_formats(const struct wlr_gles2_renderer *renderer,
+		size_t *len) {
 	static uint32_t shm_formats[sizeof(formats) / sizeof(formats[0])];
-	*len = sizeof(formats) / sizeof(formats[0]);
+	size_t j = 0;
 	for (size_t i = 0; i < sizeof(formats) / sizeof(formats[0]); i++) {
-		shm_formats[i] = formats[i].drm_format;
+		if (!is_gles2_pixel_format_supported(renderer, &formats[i])) {
+			continue;
+		}
+		shm_formats[j++] = formats[i].drm_format;
 	}
+	*len = j;
 	return shm_formats;
 }

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -376,7 +376,8 @@ static void gles2_render_quad_with_matrix(struct wlr_renderer *wlr_renderer,
 
 static const uint32_t *gles2_get_shm_texture_formats(
 		struct wlr_renderer *wlr_renderer, size_t *len) {
-	return get_gles2_shm_formats(len);
+	struct wlr_gles2_renderer *renderer = gles2_get_renderer(wlr_renderer);
+	return get_gles2_shm_formats(renderer, len);
 }
 
 static const struct wlr_drm_format_set *gles2_get_dmabuf_texture_formats(
@@ -431,14 +432,8 @@ static bool gles2_read_pixels(struct wlr_renderer *wlr_renderer,
 
 	const struct wlr_gles2_pixel_format *fmt =
 		get_gles2_format_from_drm(drm_format);
-	if (fmt == NULL) {
-		wlr_log(WLR_ERROR, "Cannot read pixels: unsupported pixel format");
-		return false;
-	}
-
-	if (fmt->gl_format == GL_BGRA_EXT && !renderer->exts.EXT_read_format_bgra) {
-		wlr_log(WLR_ERROR,
-			"Cannot read pixels: missing GL_EXT_read_format_bgra extension");
+	if (fmt == NULL || !is_gles2_pixel_format_supported(renderer, fmt)) {
+		wlr_log(WLR_ERROR, "Cannot read pixels: unsupported pixel format 0x%"PRIX32, drm_format);
 		return false;
 	}
 

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -749,6 +749,12 @@ struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_egl *egl) {
 	renderer->exts.EXT_read_format_bgra =
 		check_gl_ext(exts_str, "GL_EXT_read_format_bgra");
 
+	renderer->exts.EXT_texture_type_2_10_10_10_REV =
+		check_gl_ext(exts_str, "GL_EXT_texture_type_2_10_10_10_REV");
+
+	renderer->exts.OES_texture_half_float_linear =
+		check_gl_ext(exts_str, "GL_OES_texture_half_float_linear");
+
 	if (check_gl_ext(exts_str, "GL_KHR_debug")) {
 		renderer->exts.KHR_debug = true;
 		load_gl_proc(&renderer->procs.glDebugMessageCallbackKHR,

--- a/render/pixel_format.c
+++ b/render/pixel_format.c
@@ -62,6 +62,30 @@ static const struct wlr_pixel_format_info pixel_format_info[] = {
 		.bpp = 16,
 		.has_alpha = false,
 	},
+	{
+		.drm_format = DRM_FORMAT_XBGR2101010,
+		.opaque_substitute = DRM_FORMAT_INVALID,
+		.bpp = 32,
+		.has_alpha = false,
+	},
+	{
+		.drm_format = DRM_FORMAT_ABGR2101010,
+		.opaque_substitute = DRM_FORMAT_XBGR2101010,
+		.bpp = 32,
+		.has_alpha = true,
+	},
+	{
+		.drm_format = DRM_FORMAT_XBGR16161616F,
+		.opaque_substitute = DRM_FORMAT_INVALID,
+		.bpp = 64,
+		.has_alpha = false,
+	},
+	{
+		.drm_format = DRM_FORMAT_ABGR16161616F,
+		.opaque_substitute = DRM_FORMAT_XBGR16161616F,
+		.bpp = 64,
+		.has_alpha = true,
+	},
 };
 
 static const size_t pixel_format_info_size =


### PR DESCRIPTION
In addition to adding support for XBGR2101010, ABGR2101010, XBGR16161616F, and ABGR16161616F, this PR introduces a mechanism to filter the list of available shm formats based on the GL extensions that the renderer supports. See also commit messages.

I have a modified weston-simple-shm which supports these formats at https://gitlab.freedesktop.org/mstoeckl/weston/-/tree/simple-shm-10 ; there is also https://gitlab.freedesktop.org/jadahl/wayland-test-clients/blob/master/gradient-test.c .