### PR TITLE
backend/drm: preserve mode order from kernel

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1385,7 +1385,7 @@ void scan_drm_connectors(struct wlr_drm_backend *drm) {
 					mode->wlr_mode.refresh,
 					mode->wlr_mode.preferred ? "(preferred)" : "");
 
-				wl_list_insert(&wlr_conn->output.modes, &mode->wlr_mode.link);
+				wl_list_insert(wlr_conn->output.modes.prev, &mode->wlr_mode.link);
 			}
 
 			wlr_conn->possible_crtcs = get_possible_crtcs(drm->fd, res, drm_conn);

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -457,8 +457,8 @@ struct wlr_output_mode *wlr_output_preferred_mode(struct wlr_output *output) {
 		}
 	}
 
-	// No preferred mode, choose the last one
-	return wl_container_of(output->modes.prev, mode, link);
+	// No preferred mode, choose the first one
+	return wl_container_of(output->modes.next, mode, link);
 }
 
 static void output_state_clear_buffer(struct wlr_output_state *state) {


### PR DESCRIPTION
The kernel orders the mode list from highest to lowest. Preserve
this ordering in the wlr_output.modes list.