### PR TITLE
render/pixman/pixel_format: add more formats

### DIFF
--- a/render/pixel_format.c
+++ b/render/pixel_format.c
@@ -27,6 +27,30 @@ static const struct wlr_pixel_format_info pixel_format_info[] = {
 		.has_alpha = true,
 	},
 	{
+		.drm_format = DRM_FORMAT_RGBX8888,
+		.opaque_substitute = DRM_FORMAT_INVALID,
+		.bpp = 32,
+		.has_alpha = false,
+	},
+	{
+		.drm_format = DRM_FORMAT_RGBA8888,
+		.opaque_substitute = DRM_FORMAT_RGBX8888,
+		.bpp = 32,
+		.has_alpha = true,
+	},
+	{
+		.drm_format = DRM_FORMAT_BGRX8888,
+		.opaque_substitute = DRM_FORMAT_INVALID,
+		.bpp = 32,
+		.has_alpha = false,
+	},
+	{
+		.drm_format = DRM_FORMAT_BGRA8888,
+		.opaque_substitute = DRM_FORMAT_BGRX8888,
+		.bpp = 32,
+		.has_alpha = true,
+	},
+	{
 		.drm_format = DRM_FORMAT_BGR888,
 		.opaque_substitute = DRM_FORMAT_INVALID,
 		.bpp = 24,
@@ -61,6 +85,24 @@ static const struct wlr_pixel_format_info pixel_format_info[] = {
 		.opaque_substitute = DRM_FORMAT_INVALID,
 		.bpp = 16,
 		.has_alpha = false,
+	},
+	{
+		.drm_format = DRM_FORMAT_BGR565,
+		.opaque_substitute = DRM_FORMAT_INVALID,
+		.bpp = 16,
+		.has_alpha = false,
+	},
+	{
+		.drm_format = DRM_FORMAT_XRGB2101010,
+		.opaque_substitute = DRM_FORMAT_INVALID,
+		.bpp = 32,
+		.has_alpha = false,
+	},
+	{
+		.drm_format = DRM_FORMAT_ARGB2101010,
+		.opaque_substitute = DRM_FORMAT_XRGB2101010,
+		.bpp = 32,
+		.has_alpha = true,
 	},
 	{
 		.drm_format = DRM_FORMAT_XBGR2101010,

--- a/render/pixman/pixel_format.c
+++ b/render/pixman/pixel_format.c
@@ -35,7 +35,68 @@ static const struct wlr_pixman_pixel_format formats[] = {
 #else
 		.pixman_format = PIXMAN_a8b8g8r8,
 #endif
-	}
+	},
+	{
+		.drm_format = DRM_FORMAT_RGBA8888,
+#if WLR_BIG_ENDIAN
+		.pixman_format = PIXMAN_a8b8g8r8,
+#else
+		.pixman_format = PIXMAN_r8g8b8a8,
+#endif
+	},
+	{
+		.drm_format = DRM_FORMAT_RGBX8888,
+#if WLR_BIG_ENDIAN
+		.pixman_format = PIXMAN_x8b8g8r8,
+#else
+		.pixman_format = PIXMAN_r8g8b8x8,
+#endif
+	},
+	{
+		.drm_format = DRM_FORMAT_BGRA8888,
+#if WLR_BIG_ENDIAN
+		.pixman_format = PIXMAN_a8r8g8b8,
+#else
+		.pixman_format = PIXMAN_b8g8r8a8,
+#endif
+	},
+	{
+		.drm_format = DRM_FORMAT_BGRX8888,
+#if WLR_BIG_ENDIAN
+		.pixman_format = PIXMAN_x8r8g8b8,
+#else
+		.pixman_format = PIXMAN_b8g8r8x8,
+#endif
+	},
+#if WLR_LITTLE_ENDIAN
+	// Since DRM formats are always little-endian, they don't have an
+	// equivalent on big-endian if their components are spanning across
+	// multiple bytes.
+	{
+		.drm_format = DRM_FORMAT_RGB565,
+		.pixman_format = PIXMAN_r5g6b5,
+	},
+	{
+		.drm_format = DRM_FORMAT_BGR565,
+		.pixman_format = PIXMAN_b5g6r5,
+	},
+	{
+		.drm_format = DRM_FORMAT_ARGB2101010,
+		.pixman_format = PIXMAN_a2r10g10b10,
+	},
+	{
+		.drm_format = DRM_FORMAT_XRGB2101010,
+		.pixman_format = PIXMAN_x2r10g10b10,
+	},
+	{
+		.drm_format = DRM_FORMAT_ABGR2101010,
+		.pixman_format = PIXMAN_a2b10g10r10,
+	},
+	{
+		.drm_format = DRM_FORMAT_XBGR2101010,
+		.pixman_format = PIXMAN_x2b10g10r10,
+	},
+#endif
 };
 
 pixman_format_code_t get_pixman_format_from_drm(uint32_t fmt) {


### PR DESCRIPTION
Add a bunch of new formats for Pixman: a few missing 32-bit ones,
some 16-bit and 32-bit formats as well.

Mostly based on a Weston patch [1].

[1]: https://gitlab.freedesktop.org/wayland/weston/-/merge_requests/664

cc @mstoeckl @bl4ckb0ne 