### PR TITLE
viewporter: remove crop and scale state upon destruction

### DIFF
--- a/types/wlr_viewporter.c
+++ b/types/wlr_viewporter.c
@@ -95,6 +95,12 @@ static void viewport_destroy(struct wlr_viewport *viewport) {
 	if (viewport == NULL) {
 		return;
 	}
+
+	struct wlr_surface_state *pending = &viewport->surface->pending;
+	pending->viewport.has_src = false;
+	pending->viewport.has_dst = false;
+	pending->committed |= WLR_SURFACE_STATE_VIEWPORT;
+
 	wl_resource_set_user_data(viewport->resource, NULL);
 	wl_list_remove(&viewport->surface_destroy.link);
 	wl_list_remove(&viewport->surface_commit.link);


### PR DESCRIPTION
According to the viewport protocol, upon [`wp_viewport::destroy()`][1]:

> The associated `wl_surface`'s crop and scale state is removed.
> The change is applied on the next `wl_surface.commit`.

Therefore, `wp_viewport_destroy(viewport)` should remove all viewport state.

Currently, wlroots does not remove the crop and scale state. Instead, a client must do:

```c
wl_fixed_t clear = wl_fixed_from_int(-1);
wp_viewport_set_source(viewport, clear, clear, clear, clear);
wp_viewport_set_destination(viewport, -1, -1);
wp_viewport_destroy(viewport);
```

This commit adds the necessary logic into `viewport_destroy` and makes wlroots comply with the protocol.

  [1]: https://github.com/wayland-project/wayland-protocols/blob/main/stable/viewporter/viewporter.xml#L129-L134