### PR TITLE
backend/drm: require buffer on modeset in drm_connector_test

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -458,6 +458,14 @@ static bool drm_connector_test(struct wlr_output *output) {
 	}
 
 	if (drm_connector_state_active(conn, &output->pending)) {
+		if ((output->pending.committed &
+				(WLR_OUTPUT_STATE_ENABLED | WLR_OUTPUT_STATE_MODE)) &&
+				!(output->pending.committed & WLR_OUTPUT_STATE_BUFFER)) {
+			wlr_drm_conn_log(conn, WLR_DEBUG,
+				"Can't enable an output without a buffer");
+			return false;
+		}
+
 		if (!drm_connector_alloc_crtc(conn)) {
 			wlr_drm_conn_log(conn, WLR_DEBUG,
 				"No CRTC available for this connector");


### PR DESCRIPTION
When testing a modeset, make sure the caller has also provided a
buffer. This allows df0e75ba05e2 ("output: try skipping buffer
allocation if the backend allows it") to work as expected with the
DRM backend.

Closes: https://github.com/swaywm/wlroots/issues/3086