### PR TITLE
ci: add smoke test

### DIFF
--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -31,3 +31,13 @@ tasks:
   - clang: |
       cd wlroots/build-clang
       ninja
+  - smoke-test: |
+      cd wlroots/tinywl
+      sudo modprobe vkms
+      sudo seatd -u "$USER" &
+      while ! [ -e /run/seatd.sock ]; do sleep 0.1; done
+      export WLR_BACKENDS=drm
+      export WLR_RENDERER=pixman
+      export WLR_DRM_DEVICES=/dev/dri/by-path/platform-vkms-card
+      sudo chmod ugo+rw /dev/dri/by-path/platform-vkms-card
+      ./tinywl -s 'kill $PPID' || [ $? = 143 ]


### PR DESCRIPTION
Add a very basic smoke test which uses VKMS to fire up the DRM
backend.

It's a bit hacky atm:

- `sleep` could be replaced with polling for the socket to be created
- `chmod` is necessary because the dumb buffer allocator needs to open the card directly

cc @kennylevinsen 