### PR TITLE
seat: allow compositors to not load a keymap

### DIFF
--- a/types/seat/wlr_seat_keyboard.c
+++ b/types/seat/wlr_seat_keyboard.c
@@ -370,6 +370,13 @@ static void seat_client_send_keymap(struct wlr_seat_client *client,
 			continue;
 		}
 
+		if (keyboard->keymap == NULL) {
+			wl_keyboard_send_keymap(resource,
+				WL_KEYBOARD_KEYMAP_FORMAT_NO_KEYMAP, keymap_fd, 0);
+			close(keymap_fd);
+			continue;
+		}
+
 		void *ptr = mmap(NULL, keyboard->keymap_size, PROT_READ | PROT_WRITE,
 				MAP_SHARED, keymap_fd, 0);
 		if (ptr == MAP_FAILED) {


### PR DESCRIPTION
The protocol allows compositors to not send any keymap to Wayland
clients. Handle a keymap-less keyboard correctly by sending
WL_KEYBOARD_KEYMAP_FORMAT_NO_KEYMAP instead of erroring out in the
mmap call.