### PR TITLE
seat: avoid copying the keymap for each client 

### DIFF
--- a/include/util/shm.h
+++ b/include/util/shm.h
@@ -1,7 +1,10 @@
 #ifndef UTIL_SHM_H
 #define UTIL_SHM_H
 
+#include <stdbool.h>
+
 int create_shm_file(void);
 int allocate_shm_file(size_t size);
+bool allocate_shm_file_pair(size_t size, int *rw_fd, int *ro_fd);
 
 #endif

--- a/include/wlr/types/wlr_keyboard.h
+++ b/include/wlr/types/wlr_keyboard.h
@@ -53,6 +53,7 @@ struct wlr_keyboard {
 
 	char *keymap_string;
 	size_t keymap_size;
+	int keymap_fd;
 	struct xkb_keymap *keymap;
 	struct xkb_state *xkb_state;
 	xkb_led_index_t led_indexes[WLR_LED_COUNT];

--- a/types/seat/wlr_seat_keyboard.c
+++ b/types/seat/wlr_seat_keyboard.c
@@ -1,17 +1,13 @@
 #define _POSIX_C_SOURCE 200809L
 #include <assert.h>
 #include <stdlib.h>
-#include <string.h>
-#include <sys/mman.h>
 #include <time.h>
-#include <unistd.h>
 #include <wayland-server-core.h>
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/util/log.h>
 #include "types/wlr_data_device.h"
 #include "types/wlr_seat.h"
-#include "util/shm.h"
 #include "util/signal.h"
 
 static void default_keyboard_enter(struct wlr_seat_keyboard_grab *grab,
@@ -364,35 +360,8 @@ static void seat_client_send_keymap(struct wlr_seat_client *client,
 			continue;
 		}
 
-		int keymap_fd = allocate_shm_file(keyboard->keymap_size);
-		if (keymap_fd < 0) {
-			wlr_log(WLR_ERROR, "creating a keymap file for %zu bytes failed", keyboard->keymap_size);
-			continue;
-		}
-
-		if (keyboard->keymap == NULL) {
-			wl_keyboard_send_keymap(resource,
-				WL_KEYBOARD_KEYMAP_FORMAT_NO_KEYMAP, keymap_fd, 0);
-			close(keymap_fd);
-			continue;
-		}
-
-		void *ptr = mmap(NULL, keyboard->keymap_size, PROT_READ | PROT_WRITE,
-				MAP_SHARED, keymap_fd, 0);
-		if (ptr == MAP_FAILED) {
-			wlr_log(WLR_ERROR, "failed to mmap() %zu bytes", keyboard->keymap_size);
-			close(keymap_fd);
-			continue;
-		}
-
-		strcpy(ptr, keyboard->keymap_string);
-		munmap(ptr, keyboard->keymap_size);
-
-		wl_keyboard_send_keymap(resource,
-			WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1, keymap_fd,
-			keyboard->keymap_size);
-
-		close(keymap_fd);
+		wl_keyboard_send_keymap(resource, WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1,
+			keyboard->keymap_fd, keyboard->keymap_size);
 	}
 }
 

--- a/util/shm.c
+++ b/util/shm.c
@@ -8,6 +8,8 @@
 #include <wlr/config.h>
 #include "util/shm.h"
 
+#define RANDNAME_PATTERN "/wlroots-XXXXXX"
+
 static void randname(char *buf) {
 	struct timespec ts;
 	clock_gettime(CLOCK_REALTIME, &ts);
@@ -18,17 +20,15 @@ static void randname(char *buf) {
 	}
 }
 
-int create_shm_file(void) {
+static int excl_shm_open(char *name) {
 	int retries = 100;
 	do {
-		char name[] = "/wlroots-XXXXXX";
-		randname(name + strlen(name) - 6);
+		randname(name + strlen(RANDNAME_PATTERN) - 6);
 
 		--retries;
 		// CLOEXEC is guaranteed to be set by shm_open
 		int fd = shm_open(name, O_RDWR | O_CREAT | O_EXCL, 0600);
 		if (fd >= 0) {
-			shm_unlink(name);
 			return fd;
 		}
 	} while (retries > 0 && errno == EEXIST);
@@ -37,10 +37,12 @@ int create_shm_file(void) {
 }
 
 int allocate_shm_file(size_t size) {
-	int fd = create_shm_file();
+	char name[] = RANDNAME_PATTERN;
+	int fd = excl_shm_open(name);
 	if (fd < 0) {
 		return -1;
 	}
+	shm_unlink(name);
 
 	int ret;
 	do {
@@ -52,4 +54,36 @@ int allocate_shm_file(size_t size) {
 	}
 
 	return fd;
+}
+
+bool allocate_shm_file_pair(size_t size, int *rw_fd_ptr, int *ro_fd_ptr) {
+	char name[] = RANDNAME_PATTERN;
+	int rw_fd = excl_shm_open(name);
+	if (rw_fd < 0) {
+		return false;
+	}
+
+	// CLOEXEC is guaranteed to be set by shm_open
+	int ro_fd = shm_open(name, O_RDONLY, 0);
+	if (ro_fd < 0) {
+		shm_unlink(name);
+		close(rw_fd);
+		return false;
+	}
+
+	shm_unlink(name);
+
+	int ret;
+	do {
+		ret = ftruncate(rw_fd, size);
+	} while (ret < 0 && errno == EINTR);
+	if (ret < 0) {
+		close(rw_fd);
+		close(ro_fd);
+		return false;
+	}
+
+	*rw_fd_ptr = rw_fd;
+	*ro_fd_ptr = ro_fd;
+	return true;
 }


### PR DESCRIPTION
If a client supports wl_keyboard version 7, no need to allocate
and copy a new keymap file. We can use a read-only file instead.