### PR TITLE
surface: drop wlr_surface_state.buffer_resource

### DIFF
--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -36,7 +36,6 @@ struct wlr_surface_state {
 	uint32_t seq;
 
 	struct wlr_buffer *buffer;
-	struct wl_resource *buffer_resource;
 	int32_t dx, dy; // relative to previous position
 	pixman_region32_t surface_damage, buffer_damage; // clipped to bounds
 	pixman_region32_t opaque, input;
@@ -64,8 +63,6 @@ struct wlr_surface_state {
 		struct wlr_fbox src;
 		int dst_width, dst_height; // in surface-local coordinates
 	} viewport;
-
-	struct wl_listener buffer_destroy;
 
 	// Number of locks that prevent this surface state from being committed.
 	size_t cached_state_locks;

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -284,8 +284,9 @@ static void surface_state_move(struct wlr_surface_state *state,
 		surface_state_set_buffer(state, next->buffer_resource);
 		surface_state_reset_buffer(next);
 
+		wlr_buffer_unlock(state->buffer);
+		state->buffer = NULL;
 		if (next->buffer) {
-			wlr_buffer_unlock(state->buffer);
 			state->buffer = wlr_buffer_lock(next->buffer);
 		}
 		wlr_buffer_unlock(next->buffer);

--- a/types/wlr_viewporter.c
+++ b/types/wlr_viewporter.c
@@ -135,7 +135,7 @@ static void viewport_handle_surface_commit(struct wl_listener *listener,
 		return;
 	}
 
-	if (current->viewport.has_src && current->buffer_resource != NULL &&
+	if (current->viewport.has_src && current->buffer != NULL &&
 			(current->viewport.src.x + current->viewport.src.width >
 				current->buffer_width ||
 			current->viewport.src.y + current->viewport.src.height >

--- a/types/xdg_shell/wlr_xdg_surface.c
+++ b/types/xdg_shell/wlr_xdg_surface.c
@@ -398,7 +398,7 @@ void handle_xdg_surface_precommit(struct wlr_surface *wlr_surface) {
 	}
 
 	if (wlr_surface->pending.committed & WLR_SURFACE_STATE_BUFFER &&
-			wlr_surface->pending.buffer_resource == NULL) {
+			wlr_surface->pending.buffer == NULL) {
 		// This is a NULL commit
 		if (surface->configured && surface->mapped) {
 			unmap_xdg_surface(surface);

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -850,7 +850,7 @@ static void xwayland_surface_role_precommit(struct wlr_surface *wlr_surface) {
 	}
 
 	if (wlr_surface->pending.committed & WLR_SURFACE_STATE_BUFFER &&
-			wlr_surface->pending.buffer_resource == NULL) {
+			wlr_surface->pending.buffer == NULL) {
 		// This is a NULL commit
 		if (surface->mapped) {
 			wlr_signal_emit_safe(&surface->events.unmap, surface);


### PR DESCRIPTION
Instead, use wlr_surface_state.buffer only.

~~Depends on: https://github.com/swaywm/wlroots/pull/3104~~
~~Depends on: https://github.com/swaywm/wlroots/pull/3103~~