### PR TITLE
backend/drm: return true on test if no crtc

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -479,6 +479,12 @@ static bool drm_connector_test(struct wlr_output *output) {
 		return true;
 	}
 
+	if (!conn->crtc) {
+		// If the output is disabled, we don't have a crtc even after
+		// reallocation
+		return true;
+	}
+
 	if (output->pending.committed & WLR_OUTPUT_STATE_BUFFER) {
 		if (!drm_connector_set_pending_fb(conn, &output->pending)) {
 			return false;


### PR DESCRIPTION
This should fix the following backtrace, seen on my desktop with one
output disabled:
```
  #0  atomic_crtc_commit (conn=0x270f5c0, state=0x270f6d0, flags=0, test_only=<optimized out>) at ../backend/drm/atomic.c:178
          drm = 0x1ae9c10
          output = 0x270f5c0
          crtc = 0x0
          modeset = false
          active = false
          mode_id = 43989232
          gamma_lut = 0
          prev_vrr_enabled = <optimized out>
          vrr_enabled = <optimized out>
          atom = {req = 0x270f5c0, failed = 48}
          ok = <optimized out>
  #1  0x00007f1104f33128 in drm_crtc_commit (conn=conn@entry=0x270f5c0, state=state@entry=0x270f6d0, flags=flags@entry=0, test_only=test_only@entry=true) at ../backend/drm/drm.c:339
          __PRETTY_FUNCTION__ = "drm_crtc_commit"
          drm = <optimized out>
          crtc = 0x0
          ok = <optimized out>
  #2  0x00007f1104f34e6c in drm_connector_test (output=output@entry=0x270f5c0) at ../backend/drm/drm.c:488
          conn = 0x270f5c0
          unsupported = <optimized out>
  #3  0x00007f1104f35424 in drm_connector_commit (output=0x270f5c0) at ../backend/drm/drm.c:578
          conn = 0x270f5c0
  #4  0x00007f1104f600b7 in wlr_output_commit (output=output@entry=0x270f5c0) at ../types/wlr_output.c:837
          now = {tv_sec = 7732, tv_nsec = 623813006}
          pre_event = {output = 0x270f5c0, when = 0x7ffecc1be570}
          back_buffer = 0x0
          scale_updated = <optimized out>
          geometry_updated = <optimized out>
          committed = <optimized out>
          event = {output = 0x0, committed = 4401048, when = 0x29f38f0}
  #5  0x0000000000433047 in apply_output_config (oc=oc@entry=0x29f38f0, output=output@entry=0x2710720) at ../sway/config/output.c:431
          wlr_output = 0x270f5c0
          output_box = <optimized out>
  #6  0x0000000000433aaf in apply_output_config_to_outputs (oc=0x2308400) at ../sway/config/output.c:649
          current = 0x29f38f0
          name = <optimized out>
          wildcard = true
          id = "Dell Inc. DELL U2410 F525M9AK0MML\000\060\060\060ACD7\000\000\000\000\000\000\000\220\063\240\002\000\000\000\000L5C\000\000\000\000\000\377\377\377\377\000\000\000\000\377\377\377\377\000\000\000\000\377\377\377\377\000\000\000\000\377\377\377\377\000\000\000\000\355\240E\000\000\000\000\000\377\377\377\377\000\000\000\000@\206+\002\000\000\000\000`\260.\002\000\000\000"
          sway_output = 0x2710720
          tmp = 0x2242030
          seat = <optimized out>
  #7  0x000000000043df6b in cmd_output (argc=<optimized out>, argv=0x2a03390) at ../sway/commands/output.c:108
          error = <optimized out>
          output = <optimized out>
          background = false
  #8  0x0000000000410304 in execute_command (_exec=_exec@entry=0x2975d20 "output * dpms off", seat=0x22a3280, seat@entry=0x0, con=con@entry=0x0) at ../sway/commands.c:291
          res = <optimized out>
          argc = 4
          argv = 0x2a03370
          handler = 0x479230 <handlers+560>
          cmd = <optimized out>
          matched_delim = 0 '\000'
          containers = 0x0
          using_criteria = false
          __PRETTY_FUNCTION__ = "execute_command"
          exec = 0x28f63c0 "output * dpms off"
          head = 0x0
          res_list = 0x2a2e9d0
  #9  0x0000000000418b65 in ipc_client_handle_command (client=client@entry=0x2a6ac80, payload_length=<optimized out>, payload_type=IPC_COMMAND) at ../sway/ipc-server.c:645
          line = <optimized out>
          res_list = <optimized out>
          json = <optimized out>
          length = <optimized out>
          __PRETTY_FUNCTION__ = "ipc_client_handle_command"
          buf = 0x2975d20 "output * dpms off"
  #10 0x000000000041964c in ipc_client_handle_readable (client_fd=<optimized out>, mask=<optimized out>, data=0x2a6ac80) at ../sway/ipc-server.c:267
          pending_length = <optimized out>
          pending_type = <optimized out>
          client = 0x2a6ac80
          read_available = 31
          buf = "i3-ipc\021\000\000\000\000\000\000"
          received = 14
  #11 0x00007f1104fc3492 in wl_event_loop_dispatch () from /nix/store/ridk7k2ka6dbk4ly7qqjgmc523s4fj89-wayland-1.19.0/lib/libwayland-server.so.0
  No symbol table info available.
  #12 0x00007f1104fc1135 in wl_display_run () from /nix/store/ridk7k2ka6dbk4ly7qqjgmc523s4fj89-wayland-1.19.0/lib/libwayland-server.so.0
  No symbol table info available.
  #13 0x000000000041ac10 in server_run (server=server@entry=0x47b0c0 <server>) at ../sway/server.c:261
  No locals.
  #14 0x000000000041a3fc in main (argc=<optimized out>, argv=0x7ffecc1bec68) at ../sway/main.c:395
          verbose = 0
          debug = 0
          validate = 0
          allow_unsupported_gpu = 0
          long_options = {{name = 0x45b516 "help", has_arg = 0, flag = 0x0, val = 104}, {name = 0x45ee69 "config", has_arg = 1, flag = 0x0, val = 99}, {name = 0x45b51b "validate", has_arg = 0, flag = 0x0, val = 67}, {
              name = 0x45b524 "debug", has_arg = 0, flag = 0x0, val = 100}, {name = 0x45b3ac "version", has_arg = 0, flag = 0x0, val = 118}, {name = 0x45a55c "verbose", has_arg = 0, flag = 0x0, val = 86}, {name = 0x45b52a "get-socketpath",
              has_arg = 0, flag = 0x0, val = 112}, {name = 0x45b539 "unsupported-gpu", has_arg = 0, flag = 0x0, val = 117}, {name = 0x45b549 "my-next-gpu-wont-be-nvidia", has_arg = 0, flag = 0x0, val = 117}, {name = 0x0, has_arg = 0,
              flag = 0x0, val = 0}}
          config_path = 0x0
          usage = 0x45b830 "Usage: sway [options] [command]\n\n  -h, --help", ' ' <repeats 13 times>, "Show help message and quit.\n  -c, --config <config>  Specify a config file.\n  -C, --validate         Check the validity of the config file, th"...
          c = <optimized out>
```
where the second output is not enabled:
```
  (gdb) frame 4
  #4  0x00007f1104f600b7 in wlr_output_commit (output=output@entry=0x270f5c0) at ../types/wlr_output.c:837
  837	in ../types/wlr_output.c
  (gdb) p output->enabled
  $3 = false
  (gdb)
```
The culprit being that since 604674dc54a3b2cb4b73de267c8c2bcae259c4b6 we
always try to perform a commit, even on a disabled output.