### PR TITLE
scene: add support for damage tracking

### DIFF
--- a/include/wlr/types/wlr_scene.h
+++ b/include/wlr/types/wlr_scene.h
@@ -56,6 +56,8 @@ struct wlr_scene_node {
 /** The root scene-graph node. */
 struct wlr_scene {
 	struct wlr_scene_node node;
+
+	struct wl_list outputs; // wlr_scene_output.link
 };
 
 /** A scene-graph node displaying a single surface. */
@@ -73,6 +75,16 @@ struct wlr_scene_rect {
 	struct wlr_scene_node node;
 	int width, height;
 	float color[4];
+};
+
+/** A viewport for an output in the scene-graph */
+struct wlr_scene_output {
+	struct wlr_output *output;
+	struct wl_list link; // wlr_scene.outputs
+	struct wlr_scene *scene;
+	struct wlr_addon addon;
+
+	int x, y;
 };
 
 typedef void (*wlr_scene_node_iterator_func_t)(struct wlr_scene_node *node,
@@ -160,5 +172,22 @@ void wlr_scene_rect_set_size(struct wlr_scene_rect *rect, int width, int height)
  * Change the color of an existing rectangle node.
  */
 void wlr_scene_rect_set_color(struct wlr_scene_rect *rect, const float color[static 4]);
+
+/**
+ * Add a viewport for the specified output to the scene-graph.
+ *
+ * An output can only be added once to the scene-graph.
+ */
+struct wlr_scene_output *wlr_scene_output_create(struct wlr_scene *scene,
+	struct wlr_output *output);
+/**
+ * Destroy a scene-graph output.
+ */
+void wlr_scene_output_destroy(struct wlr_scene_output *scene_output);
+/**
+ * Set the output's position in the scene-graph.
+ */
+void wlr_scene_output_set_position(struct wlr_scene_output *scene_output,
+	int lx, int ly);
 
 #endif

--- a/include/wlr/types/wlr_scene.h
+++ b/include/wlr/types/wlr_scene.h
@@ -119,6 +119,12 @@ void wlr_scene_node_place_below(struct wlr_scene_node *node,
 void wlr_scene_node_reparent(struct wlr_scene_node *node,
 	struct wlr_scene_node *new_parent);
 /**
+ * Get the node's layout-local coordinates.
+ *
+ * True is returned if the node and all of its ancestors are enabled.
+ */
+bool wlr_scene_node_coords(struct wlr_scene_node *node, int *lx, int *ly);
+/**
  * Call `iterator` on each surface in the scene-graph, with the surface's
  * position in layout coordinates. The function is called from root to leaves
  * (in rendering order).

--- a/include/wlr/types/wlr_scene.h
+++ b/include/wlr/types/wlr_scene.h
@@ -68,6 +68,7 @@ struct wlr_scene_surface {
 	// private state
 
 	struct wl_listener surface_destroy;
+	struct wl_listener surface_commit;
 };
 
 /** A scene-graph node displaying a solid-colored rectangle */
@@ -83,6 +84,8 @@ struct wlr_scene_output {
 	struct wl_list link; // wlr_scene.outputs
 	struct wlr_scene *scene;
 	struct wlr_addon addon;
+
+	struct wlr_output_damage *damage;
 
 	int x, y;
 };

--- a/include/wlr/types/wlr_scene.h
+++ b/include/wlr/types/wlr_scene.h
@@ -189,5 +189,9 @@ void wlr_scene_output_destroy(struct wlr_scene_output *scene_output);
  */
 void wlr_scene_output_set_position(struct wlr_scene_output *scene_output,
 	int lx, int ly);
+/**
+ * Render and commit an output.
+ */
+bool wlr_scene_output_commit(struct wlr_scene_output *scene_output);
 
 #endif

--- a/types/wlr_scene.c
+++ b/types/wlr_scene.c
@@ -426,7 +426,7 @@ void wlr_scene_render_output(struct wlr_scene *scene, struct wlr_output *output,
 			.output = output,
 			.damage = damage,
 		};
-		scene_node_for_each_node(&scene->node, lx, ly,
+		scene_node_for_each_node(&scene->node, -lx, -ly,
 			render_node_iterator, &data);
 		wlr_renderer_scissor(renderer, NULL);
 	}

--- a/types/wlr_scene.c
+++ b/types/wlr_scene.c
@@ -477,3 +477,27 @@ void wlr_scene_output_set_position(struct wlr_scene_output *scene_output,
 	scene_output->x = lx;
 	scene_output->y = ly;
 }
+
+bool wlr_scene_output_commit(struct wlr_scene_output *scene_output) {
+	struct wlr_output *output = scene_output->output;
+
+	if (!wlr_output_attach_render(output, NULL)) {
+		return false;
+	}
+
+	struct wlr_renderer *renderer = wlr_backend_get_renderer(output->backend);
+	assert(renderer != NULL);
+
+	int width, height;
+	wlr_output_effective_resolution(output, &width, &height);
+	wlr_renderer_begin(renderer, width, height);
+	wlr_renderer_clear(renderer, (float[4]){ 0.0, 0.0, 0.0, 0.0 });
+
+	wlr_scene_render_output(scene_output->scene, output,
+		scene_output->x, scene_output->y, NULL);
+	wlr_output_render_software_cursors(output, NULL);
+
+	wlr_renderer_end(renderer);
+
+	return wlr_output_commit(output);
+}

--- a/types/wlr_scene.c
+++ b/types/wlr_scene.c
@@ -193,6 +193,22 @@ void wlr_scene_node_reparent(struct wlr_scene_node *node,
 	wl_list_insert(new_parent->state.children.prev, &node->state.link);
 }
 
+bool wlr_scene_node_coords(struct wlr_scene_node *node,
+		int *lx_ptr, int *ly_ptr) {
+	int lx = 0, ly = 0;
+	bool enabled = true;
+	while (node != NULL) {
+		lx += node->state.x;
+		ly += node->state.y;
+		enabled = enabled && node->state.enabled;
+		node = node->parent;
+	}
+
+	*lx_ptr = lx;
+	*ly_ptr = ly;
+	return enabled;
+}
+
 static void scene_node_for_each_surface(struct wlr_scene_node *node,
 		int lx, int ly, wlr_surface_iterator_func_t user_iterator,
 		void *user_data) {


### PR DESCRIPTION
Introduce `wlr_scene_output` to have per-output state in the scene-graph.

I've decided to _not_ make `wlr_scene_output` a `wlr_scene_node` to make a clear cut between elements that are rendered on screen and viewports in the scene.

~~Depends on: https://github.com/swaywm/wlroots/pull/1966~~
Cage patch: https://github.com/Hjdskes/cage/pull/203