### PR TITLE
backend/drm: reset frame_pending on last commit

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1521,8 +1521,12 @@ static void handle_page_flip(int fd, unsigned seq,
 	};
 	wlr_output_send_present(&conn->output, &present_event);
 
-	if (drm->session->active && conn->output.enabled) {
-		wlr_output_send_frame(&conn->output);
+	if (drm->session->active) {
+		if (conn->output.enabled) {
+			wlr_output_send_frame(&conn->output);
+		} else {
+			conn->output.frame_pending = false;
+		}
 	}
 }
 


### PR DESCRIPTION
Since commit 85757665e6e1 ("backend/drm: Check if output is enabled
before sending frame event"), we don't send a frame event if the output
has been disabled in the meantime. This however introduces a race: if we
schedule the flip and disable and commit the output before the flip
happens output.frame_pending will not be reset to false.
We than always fail to enable the output subsequently:
```
  00:07:13.276 [INFO] [sway/commands.c:257] Handling command 'output DP-2 enable'
  00:07:13.276 [DEBUG] [sway/commands.c:428] Subcommand: enable
  00:07:13.276 [DEBUG] [sway/config/output.c:204] Merging on top of existing output config
  00:07:13.276 [DEBUG] [sway/config/output.c:227] Config stored for output DP-2 (enabled: 1) (-1x-1@-1.000000Hz position 0,0 scale -1.000000 subpixel unknown transform -1) (bg /home/phoenix/Pictures/Wallpapers/mine/oper.jpg fill) (dpms 1) (max render time: -1)
  00:07:13.276 [DEBUG] [sway/config/output.c:351] Turning on output DP-2
  00:07:13.276 [DEBUG] [sway/config/output.c:360] Set preferred mode
  00:07:13.276 [DEBUG] [wlr] [backend/drm/drm.c:465] connector DP-2: Can't enable an output without a buffer
  00:07:13.276 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  00:07:13.277 [DEBUG] [sway/config/output.c:329] Output DPI: 162.560000x161.364706
  00:07:13.277 [DEBUG] [sway/config/output.c:400] Auto-detected output scale: 1.000000
  00:07:13.277 [DEBUG] [sway/config/output.c:430] Committing output DP-2
  00:07:13.277 [DEBUG] [wlr] [types/wlr_output.c:729] Tried to commit a buffer while a frame is pending
```
since the basic_output_test will always fail.
Reset frame_pending to false even if the output has been disabled in the
meantime.

Fixes https://github.com/swaywm/wlroots/issues/3109