### PR TITLE
Handle output enabled in wlr_output_send_frame

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1521,7 +1521,7 @@ static void handle_page_flip(int fd, unsigned seq,
 	};
 	wlr_output_send_present(&conn->output, &present_event);
 
-	if (drm->session->active && conn->output.enabled) {
+	if (drm->session->active) {
 		wlr_output_send_frame(&conn->output);
 	}
 }

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -924,7 +924,9 @@ void wlr_output_attach_buffer(struct wlr_output *output,
 
 void wlr_output_send_frame(struct wlr_output *output) {
 	output->frame_pending = false;
-	wlr_signal_emit_safe(&output->events.frame, output);
+	if (output->enabled) {
+		wlr_signal_emit_safe(&output->events.frame, output);
+	}
 }
 
 static void schedule_frame_handle_idle_timer(void *data) {


### PR DESCRIPTION
Alternative to #3118. We now check if the output is enabled before emitting the frame event in `wlr_output_send_frame` and revert the commit within the DRM backend which added a similar check but forgot to reset `frame_pending` to false.
 
Closes #3118