### PR TITLE
subsurface: move parent link to state

### DIFF
--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -170,6 +170,7 @@ struct wlr_surface {
  */
 struct wlr_subsurface_parent_state {
 	int32_t x, y;
+	struct wl_list link;
 };
 
 struct wlr_subsurface {
@@ -185,9 +186,6 @@ struct wlr_subsurface {
 	bool synchronized;
 	bool reordered;
 	bool mapped;
-
-	struct wl_list parent_link;
-	struct wl_list parent_pending_link;
 
 	struct wl_listener surface_destroy;
 	struct wl_listener parent_destroy;

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -163,7 +163,12 @@ struct wlr_surface {
 	} previous;
 };
 
-struct wlr_subsurface_state {
+/**
+ * The sub-surface state describing the sub-surface's relationship with its
+ * parent. Contrary to other states, this one is not applied on surface commit.
+ * Instead, it's applied on parent surface commit.
+ */
+struct wlr_subsurface_parent_state {
 	int32_t x, y;
 };
 
@@ -172,7 +177,7 @@ struct wlr_subsurface {
 	struct wlr_surface *surface;
 	struct wlr_surface *parent;
 
-	struct wlr_subsurface_state current, pending;
+	struct wlr_subsurface_parent_state current, pending;
 
 	uint32_t cached_seq;
 	bool has_cache;

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -1348,7 +1348,7 @@ static void surface_for_each_surface(struct wlr_surface *surface, int x, int y,
 		wlr_surface_iterator_func_t iterator, void *user_data) {
 	struct wlr_subsurface *subsurface;
 	wl_list_for_each(subsurface, &surface->subsurfaces_below, parent_link) {
-		struct wlr_subsurface_state *state = &subsurface->current;
+		struct wlr_subsurface_parent_state *state = &subsurface->current;
 		int sx = state->x;
 		int sy = state->y;
 
@@ -1359,7 +1359,7 @@ static void surface_for_each_surface(struct wlr_surface *surface, int x, int y,
 	iterator(surface, x, y, user_data);
 
 	wl_list_for_each(subsurface, &surface->subsurfaces_above, parent_link) {
-		struct wlr_subsurface_state *state = &subsurface->current;
+		struct wlr_subsurface_parent_state *state = &subsurface->current;
 		int sx = state->x;
 		int sy = state->y;
 

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -336,10 +336,12 @@ static void surface_damage_subsurfaces(struct wlr_subsurface *subsurface) {
 	subsurface->reordered = false;
 
 	struct wlr_subsurface *child;
-	wl_list_for_each(child, &subsurface->surface->subsurfaces_below, parent_link) {
+	wl_list_for_each(child, &subsurface->surface->subsurfaces_below,
+			current.link) {
 		surface_damage_subsurfaces(child);
 	}
-	wl_list_for_each(child, &subsurface->surface->subsurfaces_above, parent_link) {
+	wl_list_for_each(child, &subsurface->surface->subsurfaces_above,
+			current.link) {
 		surface_damage_subsurfaces(child);
 	}
 }
@@ -453,9 +455,10 @@ static void surface_commit_state(struct wlr_surface *surface,
 	// commit subsurface order
 	struct wlr_subsurface *subsurface;
 	wl_list_for_each_reverse(subsurface, &surface->subsurfaces_pending_above,
-			parent_pending_link) {
-		wl_list_remove(&subsurface->parent_link);
-		wl_list_insert(&surface->subsurfaces_above, &subsurface->parent_link);
+			pending.link) {
+		wl_list_remove(&subsurface->current.link);
+		wl_list_insert(&surface->subsurfaces_above,
+			&subsurface->current.link);
 
 		if (subsurface->reordered) {
 			// TODO: damage all the subsurfaces
@@ -463,9 +466,10 @@ static void surface_commit_state(struct wlr_surface *surface,
 		}
 	}
 	wl_list_for_each_reverse(subsurface, &surface->subsurfaces_pending_below,
-			parent_pending_link) {
-		wl_list_remove(&subsurface->parent_link);
-		wl_list_insert(&surface->subsurfaces_below, &subsurface->parent_link);
+			pending.link) {
+		wl_list_remove(&subsurface->current.link);
+		wl_list_insert(&surface->subsurfaces_below,
+			&subsurface->current.link);
 
 		if (subsurface->reordered) {
 			// TODO: damage all the subsurfaces
@@ -541,10 +545,12 @@ static void subsurface_parent_commit(struct wlr_subsurface *subsurface,
 		}
 
 		struct wlr_subsurface *subsurface;
-		wl_list_for_each(subsurface, &surface->subsurfaces_below, parent_link) {
+		wl_list_for_each(subsurface, &surface->subsurfaces_below,
+				current.link) {
 			subsurface_parent_commit(subsurface, true);
 		}
-		wl_list_for_each(subsurface, &surface->subsurfaces_above, parent_link) {
+		wl_list_for_each(subsurface, &surface->subsurfaces_above,
+				current.link) {
 			subsurface_parent_commit(subsurface, true);
 		}
 	}
@@ -576,10 +582,10 @@ static void surface_commit(struct wl_client *client,
 
 	surface_commit_pending(surface);
 
-	wl_list_for_each(subsurface, &surface->subsurfaces_below, parent_link) {
+	wl_list_for_each(subsurface, &surface->subsurfaces_below, current.link) {
 		subsurface_parent_commit(subsurface, false);
 	}
-	wl_list_for_each(subsurface, &surface->subsurfaces_above, parent_link) {
+	wl_list_for_each(subsurface, &surface->subsurfaces_above, current.link) {
 		subsurface_parent_commit(subsurface, false);
 	}
 }
@@ -690,8 +696,8 @@ static void subsurface_destroy(struct wlr_subsurface *subsurface) {
 	wl_list_remove(&subsurface->surface_destroy.link);
 
 	if (subsurface->parent) {
-		wl_list_remove(&subsurface->parent_link);
-		wl_list_remove(&subsurface->parent_pending_link);
+		wl_list_remove(&subsurface->current.link);
+		wl_list_remove(&subsurface->pending.link);
 		wl_list_remove(&subsurface->parent_destroy.link);
 	}
 
@@ -903,12 +909,12 @@ static struct wlr_subsurface *subsurface_find_sibling(
 	struct wlr_surface *parent = subsurface->parent;
 
 	struct wlr_subsurface *sibling;
-	wl_list_for_each(sibling, &parent->subsurfaces_below, parent_link) {
+	wl_list_for_each(sibling, &parent->subsurfaces_below, current.link) {
 		if (sibling->surface == surface && sibling != subsurface) {
 			return sibling;
 		}
 	}
-	wl_list_for_each(sibling, &parent->subsurfaces_above, parent_link) {
+	wl_list_for_each(sibling, &parent->subsurfaces_above, current.link) {
 		if (sibling->surface == surface && sibling != subsurface) {
 			return sibling;
 		}
@@ -940,11 +946,11 @@ static void subsurface_handle_place_above(struct wl_client *client,
 				"place_above", wl_resource_get_id(sibling_resource));
 			return;
 		}
-		node = &sibling->parent_pending_link;
+		node = &sibling->pending.link;
 	}
 
-	wl_list_remove(&subsurface->parent_pending_link);
-	wl_list_insert(node, &subsurface->parent_pending_link);
+	wl_list_remove(&subsurface->pending.link);
+	wl_list_insert(node, &subsurface->pending.link);
 
 	subsurface->reordered = true;
 }
@@ -972,11 +978,11 @@ static void subsurface_handle_place_below(struct wl_client *client,
 				"place_below", wl_resource_get_id(sibling_resource));
 			return;
 		}
-		node = &sibling->parent_pending_link;
+		node = &sibling->pending.link;
 	}
 
-	wl_list_remove(&subsurface->parent_pending_link);
-	wl_list_insert(node->prev, &subsurface->parent_pending_link);
+	wl_list_remove(&subsurface->pending.link);
+	wl_list_insert(node->prev, &subsurface->pending.link);
 
 	subsurface->reordered = true;
 }
@@ -1053,10 +1059,12 @@ static void subsurface_consider_map(struct wlr_subsurface *subsurface,
 
 	// Try mapping all children too
 	struct wlr_subsurface *child;
-	wl_list_for_each(child, &subsurface->surface->subsurfaces_below, parent_link) {
+	wl_list_for_each(child, &subsurface->surface->subsurfaces_below,
+			current.link) {
 		subsurface_consider_map(child, false);
 	}
-	wl_list_for_each(child, &subsurface->surface->subsurfaces_above, parent_link) {
+	wl_list_for_each(child, &subsurface->surface->subsurfaces_above,
+			current.link) {
 		subsurface_consider_map(child, false);
 	}
 }
@@ -1071,10 +1079,12 @@ static void subsurface_unmap(struct wlr_subsurface *subsurface) {
 
 	// Unmap all children
 	struct wlr_subsurface *child;
-	wl_list_for_each(child, &subsurface->surface->subsurfaces_below, parent_link) {
+	wl_list_for_each(child, &subsurface->surface->subsurfaces_below,
+			current.link) {
 		subsurface_unmap(child);
 	}
-	wl_list_for_each(child, &subsurface->surface->subsurfaces_above, parent_link) {
+	wl_list_for_each(child, &subsurface->surface->subsurfaces_above,
+			current.link) {
 		subsurface_unmap(child);
 	}
 }
@@ -1138,8 +1148,8 @@ static void subsurface_handle_parent_destroy(struct wl_listener *listener,
 	struct wlr_subsurface *subsurface =
 		wl_container_of(listener, subsurface, parent_destroy);
 	subsurface_unmap(subsurface);
-	wl_list_remove(&subsurface->parent_link);
-	wl_list_remove(&subsurface->parent_pending_link);
+	wl_list_remove(&subsurface->current.link);
+	wl_list_remove(&subsurface->pending.link);
 	wl_list_remove(&subsurface->parent_destroy.link);
 	subsurface->parent = NULL;
 }
@@ -1184,9 +1194,9 @@ struct wlr_subsurface *subsurface_create(struct wlr_surface *surface,
 	subsurface->parent = parent;
 	wl_signal_add(&parent->events.destroy, &subsurface->parent_destroy);
 	subsurface->parent_destroy.notify = subsurface_handle_parent_destroy;
-	wl_list_insert(parent->subsurfaces_above.prev, &subsurface->parent_link);
+	wl_list_insert(parent->subsurfaces_above.prev, &subsurface->current.link);
 	wl_list_insert(parent->subsurfaces_pending_above.prev,
-		&subsurface->parent_pending_link);
+		&subsurface->pending.link);
 
 	surface->role_data = subsurface;
 
@@ -1221,7 +1231,8 @@ bool wlr_surface_point_accepts_input(struct wlr_surface *surface,
 struct wlr_surface *wlr_surface_surface_at(struct wlr_surface *surface,
 		double sx, double sy, double *sub_x, double *sub_y) {
 	struct wlr_subsurface *subsurface;
-	wl_list_for_each_reverse(subsurface, &surface->subsurfaces_above, parent_link) {
+	wl_list_for_each_reverse(subsurface, &surface->subsurfaces_above,
+			current.link) {
 		double _sub_x = subsurface->current.x;
 		double _sub_y = subsurface->current.y;
 		struct wlr_surface *sub = wlr_surface_surface_at(subsurface->surface,
@@ -1241,7 +1252,8 @@ struct wlr_surface *wlr_surface_surface_at(struct wlr_surface *surface,
 		return surface;
 	}
 
-	wl_list_for_each_reverse(subsurface, &surface->subsurfaces_below, parent_link) {
+	wl_list_for_each_reverse(subsurface, &surface->subsurfaces_below,
+			current.link) {
 		double _sub_x = subsurface->current.x;
 		double _sub_y = subsurface->current.y;
 		struct wlr_surface *sub = wlr_surface_surface_at(subsurface->surface,
@@ -1347,7 +1359,7 @@ void wlr_surface_send_frame_done(struct wlr_surface *surface,
 static void surface_for_each_surface(struct wlr_surface *surface, int x, int y,
 		wlr_surface_iterator_func_t iterator, void *user_data) {
 	struct wlr_subsurface *subsurface;
-	wl_list_for_each(subsurface, &surface->subsurfaces_below, parent_link) {
+	wl_list_for_each(subsurface, &surface->subsurfaces_below, current.link) {
 		struct wlr_subsurface_parent_state *state = &subsurface->current;
 		int sx = state->x;
 		int sy = state->y;
@@ -1358,7 +1370,7 @@ static void surface_for_each_surface(struct wlr_surface *surface, int x, int y,
 
 	iterator(surface, x, y, user_data);
 
-	wl_list_for_each(subsurface, &surface->subsurfaces_above, parent_link) {
+	wl_list_for_each(subsurface, &surface->subsurfaces_above, current.link) {
 		struct wlr_subsurface_parent_state *state = &subsurface->current;
 		int sx = state->x;
 		int sy = state->y;


### PR DESCRIPTION
Move the wlr_subsurface parent link to the subsurface state.

This is a dumb find/replace operation. This shouldn't result in
any behavior change.

* * *

We need to be a bit careful here, the `wlr_subsurface_state` is actually an "add-on" for the parent wl_surface's state. It's not applied on child commit, it's applied on parent commit.

```
      Sub-surfaces also have another kind of state, which is managed by
      wl_subsurface requests, as opposed to wl_surface requests. This
      state includes the sub-surface position relative to the parent
      surface (wl_subsurface.set_position), and the stacking order of
      the parent and its sub-surfaces (wl_subsurface.place_above and
      .place_below). This state is applied when the parent surface's
      wl_surface state is applied, regardless of the sub-surface's mode.
      As the exception, set_sync and set_desync are effective immediately.
```

cc @vyivel