### PR TITLE
surface: move frame callbacks out of state

### DIFF
--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -25,8 +25,7 @@ enum wlr_surface_state_field {
 	WLR_SURFACE_STATE_INPUT_REGION = 1 << 4,
 	WLR_SURFACE_STATE_TRANSFORM = 1 << 5,
 	WLR_SURFACE_STATE_SCALE = 1 << 6,
-	WLR_SURFACE_STATE_FRAME_CALLBACK_LIST = 1 << 7,
-	WLR_SURFACE_STATE_VIEWPORT = 1 << 8,
+	WLR_SURFACE_STATE_VIEWPORT = 1 << 7,
 };
 
 struct wlr_surface_state {
@@ -42,7 +41,6 @@ struct wlr_surface_state {
 	pixman_region32_t opaque, input;
 	enum wl_output_transform transform;
 	int32_t scale;
-	struct wl_list frame_callback_list; // wl_resource
 
 	int width, height; // in surface-local coordinates
 	int buffer_width, buffer_height;
@@ -148,6 +146,9 @@ struct wlr_surface {
 	struct wl_list subsurfaces_pending_above;
 
 	struct wl_list current_outputs; // wlr_surface_output::link
+
+	struct wl_list frame_callback_list; // wl_resource
+	struct wl_list pending_frame_callback_list; // wl_resource
 
 	void *data;
 


### PR DESCRIPTION
As frame callbacks aren't cached anyway, they can be handled separately
from the state logic.