### PR TITLE
surface: cache frame callback lists again

### DIFF
--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -313,6 +313,11 @@ static void surface_state_move(struct wlr_surface_state *state,
 	if (next->committed & WLR_SURFACE_STATE_VIEWPORT) {
 		memcpy(&state->viewport, &next->viewport, sizeof(state->viewport));
 	}
+	if (next->committed & WLR_SURFACE_STATE_FRAME_CALLBACK_LIST) {
+		wl_list_insert_list(&state->frame_callback_list,
+			&next->frame_callback_list);
+		wl_list_init(&next->frame_callback_list);
+	}
 
 	state->committed |= next->committed;
 	next->committed = 0;
@@ -491,14 +496,6 @@ static void surface_commit_pending(struct wlr_surface *surface) {
 
 	if (surface->role && surface->role->precommit) {
 		surface->role->precommit(surface);
-	}
-
-	// It doesn't to make sense to cache callback lists, so we always move
-	// them to the current state.
-	if (surface->pending.committed & WLR_SURFACE_STATE_FRAME_CALLBACK_LIST) {
-		wl_list_insert_list(&surface->current.frame_callback_list,
-			&surface->pending.frame_callback_list);
-		wl_list_init(&surface->pending.frame_callback_list);
 	}
 
 	if (surface->pending.cached_state_locks > 0 || !wl_list_empty(&surface->cached)) {


### PR DESCRIPTION
Caching frame callback lists is actually the correct behavior, because
if a surface is locked because of e.g. subsurface synchronization,
clients would expect to receive frame done events only after the
pending state is actually committed.

---

If surface locking is going to be used for atomic layout updates by compositors, we would probably need to distinguish between locks required by protocols and locks made by compositors.