### PR TITLE
backend/drm: try to allocate crtc for formats

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -959,7 +959,7 @@ static const struct wlr_drm_format_set *drm_connector_get_cursor_formats(
 		return NULL;
 	}
 	struct wlr_drm_connector *conn = get_drm_connector_from_output(output);
-	if (!conn->crtc) {
+	if (!conn->crtc && !drm_connector_alloc_crtc(conn)) {
 		return NULL;
 	}
 	struct wlr_drm_plane *plane = conn->crtc->cursor;
@@ -985,7 +985,7 @@ static const struct wlr_drm_format_set *drm_connector_get_primary_formats(
 		return NULL;
 	}
 	struct wlr_drm_connector *conn = get_drm_connector_from_output(output);
-	if (!conn->crtc) {
+	if (!conn->crtc && !drm_connector_alloc_crtc(conn)) {
 		return NULL;
 	}
 	if (conn->backend->parent) {


### PR DESCRIPTION
To retrieve the formats, an allocated crtc is required. If there is no
currently no crtc available, try to allocate it. This reproducable by
having a disabled output and going through a suspend cycle with amdgpu.
On start CRTCs look like this:
```
  00:00:00.588 [DEBUG] [wlr] [backend/drm/drm.c:1099] Reallocating CRTCs
  00:00:00.588 [DEBUG] [wlr] [backend/drm/drm.c:1110] State before reallocation:
  00:00:00.588 [DEBUG] [wlr] [backend/drm/drm.c:1116]   'DP-1' crtc=0 state=1 desired_enabled=1
  00:00:00.588 [DEBUG] [wlr] [backend/drm/drm.c:1116]   'DP-2' crtc=1 state=1 desired_enabled=1
  00:00:00.588 [DEBUG] [wlr] [backend/drm/drm.c:1116]   'HDMI-A-1' crtc=-1 state=0 desired_enabled=0
  00:00:00.588 [DEBUG] [wlr] [backend/drm/drm.c:1116]   'HDMI-A-2' crtc=-1 state=0 desired_enabled=0
  00:00:00.588 [DEBUG] [wlr] [backend/drm/drm.c:1116]   'DVI-D-1' crtc=-1 state=0 desired_enabled=0
  00:00:00.588 [DEBUG] [wlr] [backend/drm/drm.c:1167] State after reallocation:
  00:00:00.588 [DEBUG] [wlr] [backend/drm/drm.c:1174]   'DP-1' crtc=0 state=1 desired_enabled=1
  00:00:00.588 [DEBUG] [wlr] [backend/drm/drm.c:1174]   'DP-2' crtc=1 state=1 desired_enabled=1
  00:00:00.588 [DEBUG] [wlr] [backend/drm/drm.c:1174]   'HDMI-A-1' crtc=-1 state=0 desired_enabled=0
  00:00:00.588 [DEBUG] [wlr] [backend/drm/drm.c:1174]   'HDMI-A-2' crtc=-1 state=0 desired_enabled=0
  00:00:00.588 [DEBUG] [wlr] [backend/drm/drm.c:1174]   'DVI-D-1' crtc=-1 state=0 desired_enabled=0
```
where DP-1 is than disabled. After suspend/resume, allocation turns into:
```
  00:30:22.680 [DEBUG] [wlr] [backend/drm/drm.c:1099] Reallocating CRTCs
  00:30:22.680 [DEBUG] [wlr] [backend/drm/drm.c:1110] State before reallocation:
  00:30:22.680 [DEBUG] [wlr] [backend/drm/drm.c:1116]   'DP-1' crtc=-1 state=1 desired_enabled=0
  00:30:22.680 [DEBUG] [wlr] [backend/drm/drm.c:1116]   'DP-2' crtc=1 state=3 desired_enabled=1
  00:30:22.680 [DEBUG] [wlr] [backend/drm/drm.c:1116]   'HDMI-A-1' crtc=-1 state=0 desired_enabled=0
  00:30:22.680 [DEBUG] [wlr] [backend/drm/drm.c:1116]   'HDMI-A-2' crtc=-1 state=0 desired_enabled=0
  00:30:22.680 [DEBUG] [wlr] [backend/drm/drm.c:1116]   'DVI-D-1' crtc=-1 state=0 desired_enabled=0
  00:30:22.680 [DEBUG] [wlr] [backend/drm/drm.c:1167] State after reallocation:
  00:30:22.680 [DEBUG] [wlr] [backend/drm/drm.c:1174]   'DP-1' crtc=-1 state=1 desired_enabled=0
  00:30:22.680 [DEBUG] [wlr] [backend/drm/drm.c:1174]   'DP-2' crtc=1 state=3 desired_enabled=1
  00:30:22.680 [DEBUG] [wlr] [backend/drm/drm.c:1174]   'HDMI-A-1' crtc=-1 state=0 desired_enabled=0
  00:30:22.680 [DEBUG] [wlr] [backend/drm/drm.c:1174]   'HDMI-A-2' crtc=-1 state=0 desired_enabled=0
  00:30:22.680 [DEBUG] [wlr] [backend/drm/drm.c:1174]   'DVI-D-1' crtc=-1 state=0 desired_enabled=0
```
where the crtc for DP-1 is now NULL. Trying to enable the output results
in:
```
  10:43:36.906 [DEBUG] [sway/config/output.c:351] Turning on output DP-1
  10:43:36.906 [DEBUG] [sway/config/output.c:360] Set preferred mode
  10:43:36.906 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.906 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.906 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.906 [DEBUG] [sway/config/output.c:366] Preferred mode rejected, falling back to another mode
  10:43:36.906 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.906 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.906 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.906 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.906 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.906 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.906 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.906 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.906 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.906 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.906 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.906 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.906 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.906 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.906 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.906 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.906 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.906 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.906 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.906 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.906 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.906 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.906 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.906 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.906 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.906 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.906 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.906 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.906 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.906 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.906 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.906 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.906 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.906 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.906 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.906 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.906 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.906 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.906 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.906 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.906 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.906 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.906 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.906 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.906 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.906 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.907 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.907 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.907 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.907 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.907 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.907 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.907 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.907 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.907 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.907 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.907 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.907 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.907 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.907 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.907 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.907 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.907 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.907 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.907 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.907 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.907 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.907 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.907 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.907 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.907 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.907 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.907 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.907 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.907 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.907 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.907 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.907 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.907 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.907 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.907 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.907 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.907 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.907 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.907 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.907 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.907 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.907 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.907 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.907 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.907 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.907 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.907 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.907 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.907 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.907 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.907 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.907 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.907 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.907 [DEBUG] [sway/config/output.c:400] Auto-detected output scale: 1.000000
  10:43:36.907 [DEBUG] [sway/config/output.c:430] Committing output DP-1
  10:43:36.907 [DEBUG] [wlr] [backend/drm/drm.c:464] connector DP-1: Can't enable an output without a buffer
  10:43:36.907 [DEBUG] [wlr] [types/wlr_output.c:689] Attaching empty buffer to output for modeset
  10:43:36.907 [ERROR] [wlr] [types/wlr_output.c:512] Failed to get primary display formats
  10:43:36.907 [ERROR] [sway/config/output.c:435] Failed to commit output DP-1
```
where the primary format can't be queried since there is no crtc
allocated for the connector. Allocating the connector inside
drm_connector_get_primary_formats() fixes this issue. This is possible
since the only user of get_primary_formats() is the swapchain allocation
function, which is only called on output enable.