### PR TITLE
[obsolete] Subsurface caching

### DIFF
--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -146,11 +146,11 @@ struct wlr_surface {
 		struct wl_signal commit_addons; // struct wlr_surface_state *
 	} events;
 
-	// wlr_subsurface.parent_link
+	// wlr_subsurface.place.link
 	struct wl_list subsurfaces_below;
 	struct wl_list subsurfaces_above;
 
-	// wlr_subsurface.parent_pending_link
+	// wlr_subsurface.pending_place.link
 	struct wl_list subsurfaces_pending_below;
 	struct wl_list subsurfaces_pending_above;
 
@@ -170,6 +170,12 @@ struct wlr_surface {
 	} previous;
 };
 
+struct wlr_subsurface_place {
+	struct wlr_subsurface *subsurface;
+	struct wl_listener subsurface_destroy;
+	struct wl_list link;
+};
+
 struct wlr_subsurface_state {
 	int32_t x, y;
 };
@@ -181,15 +187,14 @@ struct wlr_subsurface {
 
 	struct wlr_subsurface_state current, pending;
 
+	struct wlr_subsurface_place place, pending_place;
+
 	uint32_t cached_seq;
 	bool has_cache;
 
 	bool synchronized;
 	bool reordered;
 	bool mapped;
-
-	struct wl_list parent_link;
-	struct wl_list parent_pending_link;
 
 	struct wl_listener surface_destroy;
 	struct wl_listener parent_destroy;

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -140,6 +140,9 @@ struct wlr_surface {
 		struct wl_signal commit;
 		struct wl_signal new_subsurface;
 		struct wl_signal destroy;
+
+		// For surface extensions
+		struct wl_signal prepare_addons; // struct wlr_surface_state *
 	} events;
 
 	// wlr_subsurface.parent_link

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -177,6 +177,8 @@ struct wlr_subsurface_place {
 // the parent surface commit and therefore is a part of the parent
 // surface state, hence the name.
 struct wlr_subsurface_parent_state {
+	struct wlr_addon addon;
+	bool has_position;
 	int32_t x, y;
 };
 
@@ -198,6 +200,8 @@ struct wlr_subsurface {
 
 	struct wl_listener surface_destroy;
 	struct wl_listener parent_destroy;
+	struct wl_listener parent_prepare_addons;
+	struct wl_listener parent_commit_addons;
 
 	struct {
 		struct wl_signal destroy;

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -143,6 +143,7 @@ struct wlr_surface {
 
 		// For surface extensions
 		struct wl_signal prepare_addons; // struct wlr_surface_state *
+		struct wl_signal commit_addons; // struct wlr_surface_state *
 	} events;
 
 	// wlr_subsurface.parent_link

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -28,6 +28,7 @@ enum wlr_surface_state_field {
 	WLR_SURFACE_STATE_SCALE = 1 << 6,
 	WLR_SURFACE_STATE_FRAME_CALLBACK_LIST = 1 << 7,
 	WLR_SURFACE_STATE_VIEWPORT = 1 << 8,
+	WLR_SURFACE_STATE_SUBSURFACE_ORDER = 1 << 9,
 };
 
 struct wlr_surface_state {

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -173,7 +173,10 @@ struct wlr_subsurface_place {
 	struct wl_list link;
 };
 
-struct wlr_subsurface_state {
+// Note: as per Wayland protocol, subsurface-specific state is applied on
+// the parent surface commit and therefore is a part of the parent
+// surface state, hence the name.
+struct wlr_subsurface_parent_state {
 	int32_t x, y;
 };
 
@@ -182,7 +185,7 @@ struct wlr_subsurface {
 	struct wlr_surface *surface;
 	struct wlr_surface *parent;
 
-	struct wlr_subsurface_state current, pending;
+	struct wlr_subsurface_parent_state current, pending;
 
 	struct wlr_subsurface_place place, pending_place;
 

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -15,6 +15,7 @@
 #include <time.h>
 #include <wayland-server-core.h>
 #include <wlr/types/wlr_output.h>
+#include <wlr/util/addon.h>
 #include <wlr/util/box.h>
 
 enum wlr_surface_state_field {
@@ -61,6 +62,8 @@ struct wlr_surface_state {
 		struct wlr_fbox src;
 		int dst_width, dst_height; // in surface-local coordinates
 	} viewport;
+
+	struct wlr_addon_set addons;
 
 	struct wl_listener buffer_destroy;
 

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -63,6 +63,10 @@ struct wlr_surface_state {
 		int dst_width, dst_height; // in surface-local coordinates
 	} viewport;
 
+	// wlr_subsurface_place.link
+	struct wl_list subsurfaces_below;
+	struct wl_list subsurfaces_above;
+
 	struct wlr_addon_set addons;
 
 	struct wl_listener buffer_destroy;
@@ -145,14 +149,6 @@ struct wlr_surface {
 		struct wl_signal prepare_addons; // struct wlr_surface_state *
 		struct wl_signal commit_addons; // struct wlr_surface_state *
 	} events;
-
-	// wlr_subsurface.place.link
-	struct wl_list subsurfaces_below;
-	struct wl_list subsurfaces_above;
-
-	// wlr_subsurface.pending_place.link
-	struct wl_list subsurfaces_pending_below;
-	struct wl_list subsurfaces_pending_above;
 
 	struct wl_list current_outputs; // wlr_surface_output::link
 

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -474,6 +474,11 @@ static void surface_commit_state(struct wlr_surface *surface,
 		}
 	}
 
+	wlr_signal_emit_safe(&surface->events.commit_addons, next);
+	// Reset the addon set
+	wlr_addon_set_finish(&next->addons);
+	wlr_addon_set_init(&next->addons);
+
 	// If we're committing the pending state, bump the pending sequence number
 	// here, to allow commit listeners to lock the new pending state.
 	if (next == &surface->pending) {
@@ -775,6 +780,7 @@ struct wlr_surface *surface_create(struct wl_client *client,
 	wl_signal_init(&surface->events.destroy);
 	wl_signal_init(&surface->events.new_subsurface);
 	wl_signal_init(&surface->events.prepare_addons);
+	wl_signal_init(&surface->events.commit_addons);
 	wl_list_init(&surface->subsurfaces_above);
 	wl_list_init(&surface->subsurfaces_below);
 	wl_list_init(&surface->subsurfaces_pending_above);

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -1471,7 +1471,7 @@ static void surface_for_each_surface(struct wlr_surface *surface, int x, int y,
 		wlr_surface_iterator_func_t iterator, void *user_data) {
 	struct wlr_subsurface *subsurface;
 	wl_list_for_each(subsurface, &surface->current.subsurfaces_below, place.link) {
-		struct wlr_subsurface_state *state = &subsurface->current;
+		struct wlr_subsurface_parent_state *state = &subsurface->current;
 		int sx = state->x;
 		int sy = state->y;
 
@@ -1482,7 +1482,7 @@ static void surface_for_each_surface(struct wlr_surface *surface, int x, int y,
 	iterator(surface, x, y, user_data);
 
 	wl_list_for_each(subsurface, &surface->current.subsurfaces_above, place.link) {
-		struct wlr_subsurface_state *state = &subsurface->current;
+		struct wlr_subsurface_parent_state *state = &subsurface->current;
 		int sx = state->x;
 		int sy = state->y;
 

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -419,6 +419,7 @@ static void surface_cache_pending(struct wlr_surface *surface) {
 
 	surface_state_init(cached);
 	surface_state_move(cached, &surface->pending);
+	wlr_signal_emit_safe(&surface->events.prepare_addons, cached);
 
 	wl_list_insert(surface->cached.prev, &cached->cached_state_link);
 
@@ -504,6 +505,8 @@ static void surface_commit_pending(struct wlr_surface *surface) {
 	if (surface->pending.cached_state_locks > 0 || !wl_list_empty(&surface->cached)) {
 		surface_cache_pending(surface);
 	} else {
+		wlr_signal_emit_safe(&surface->events.prepare_addons,
+			&surface->pending);
 		surface_commit_state(surface, &surface->pending);
 	}
 }
@@ -771,6 +774,7 @@ struct wlr_surface *surface_create(struct wl_client *client,
 	wl_signal_init(&surface->events.commit);
 	wl_signal_init(&surface->events.destroy);
 	wl_signal_init(&surface->events.new_subsurface);
+	wl_signal_init(&surface->events.prepare_addons);
 	wl_list_init(&surface->subsurfaces_above);
 	wl_list_init(&surface->subsurfaces_below);
 	wl_list_init(&surface->subsurfaces_pending_above);

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -648,6 +648,8 @@ static void surface_state_init(struct wlr_surface_state *state) {
 
 	wl_list_init(&state->frame_callback_list);
 
+	wlr_addon_set_init(&state->addons);
+
 	pixman_region32_init(&state->surface_damage);
 	pixman_region32_init(&state->buffer_damage);
 	pixman_region32_init(&state->opaque);
@@ -663,6 +665,8 @@ static void surface_state_finish(struct wlr_surface_state *state) {
 	wl_resource_for_each_safe(resource, tmp, &state->frame_callback_list) {
 		wl_resource_destroy(resource);
 	}
+
+	wlr_addon_set_finish(&state->addons);
 
 	pixman_region32_fini(&state->surface_damage);
 	pixman_region32_fini(&state->buffer_damage);

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -917,12 +917,14 @@ static struct wlr_subsurface *subsurface_find_sibling(
 	struct wlr_surface *parent = subsurface->parent;
 
 	struct wlr_subsurface *sibling;
-	wl_list_for_each(sibling, &parent->subsurfaces_below, parent_link) {
+	wl_list_for_each(sibling, &parent->subsurfaces_pending_below,
+			parent_pending_link) {
 		if (sibling->surface == surface && sibling != subsurface) {
 			return sibling;
 		}
 	}
-	wl_list_for_each(sibling, &parent->subsurfaces_above, parent_link) {
+	wl_list_for_each(sibling, &parent->subsurfaces_pending_above,
+			parent_pending_link) {
 		if (sibling->surface == surface && sibling != subsurface) {
 			return sibling;
 		}

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -285,10 +285,9 @@ static void surface_state_move(struct wlr_surface_state *state,
 
 		if (next->buffer) {
 			wlr_buffer_unlock(state->buffer);
-			state->buffer = wlr_buffer_lock(next->buffer);
+			state->buffer = next->buffer;
+			next->buffer = NULL;
 		}
-		wlr_buffer_unlock(next->buffer);
-		next->buffer = NULL;
 	} else {
 		state->dx = state->dy = 0;
 	}


### PR DESCRIPTION
Shares code with https://github.com/swaywm/wlroots/pull/3107

This PR implements proper* subsurface state handling and caching. The resulting behavior can be tested with [subsurface-client](https://codeberg.org/vyivel/subsurface-client) clients.

*probably

_See individual commits._

### Breaking changes

- `wlr_subsurface.parent_link` and `wlr_subsurface.parent_pending_link` are now `wlr_subsurface.place.link` and `wlr_subsurface.pending_place.link` respectively.