### PR TITLE
backend/drm: generate CVT reduced modes

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -1042,7 +1042,7 @@ void drm_connector_state_mode(struct wlr_drm_connector *conn,
 			drmModeModeInfo mode = {0};
 			generate_cvt_mode(&mode, state->custom_mode.width,
 				state->custom_mode.height,
-				(float)state->custom_mode.refresh / 1000, false, false);
+				(float)state->custom_mode.refresh / 1000, true, false);
 			mode.type = DRM_MODE_TYPE_USERDEF;
 			memcpy(out, &mode, sizeof(drmModeModeInfo));
 			return;


### PR DESCRIPTION
The Coordinated Video Timings (CVT) spec [1] defines two types of
timings: the "CVT standard CRT" timings and the "CVT reduced blanking"
timings (see section 3.6).

The standard CRT timings include pauses in the video stream to allow
CRT displays to reposition their electron beam at the end of each
horizontal scan line [2]. While this was desirable a few decades ago,
nowadays we can just generate a CVT reduced blanking timing by default.
wlroots users can still set full custom DRM modes via
wlr_drm_connector_add_mode.

[1]: https://glenwing.github.io/docs/VESA-CVT-1.2.pdf
[2]: https://en.wikipedia.org/wiki/Coordinated_Video_Timings#Reduced_blanking