### PR TITLE
backend/drm: introduce wlr_drm_bo_handle_table

### DIFF
--- a/backend/drm/atomic.c
+++ b/backend/drm/atomic.c
@@ -1,4 +1,3 @@
-#include <gbm.h>
 #include <stdlib.h>
 #include <wlr/util/log.h>
 #include <xf86drm.h>
@@ -144,8 +143,8 @@ static void set_plane_props(struct atomic *atom, struct wlr_drm_backend *drm,
 		goto error;
 	}
 
-	uint32_t width = gbm_bo_get_width(fb->bo);
-	uint32_t height = gbm_bo_get_height(fb->bo);
+	uint32_t width = fb->wlr_buf->width;
+	uint32_t height = fb->wlr_buf->height;
 
 	// The src_* properties are in 16.16 fixed point
 	atomic_add(atom, id, props->src_x, 0);

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -53,7 +53,7 @@ static void backend_destroy(struct wlr_backend *backend) {
 	wl_list_remove(&drm->dev_change.link);
 	wl_list_remove(&drm->dev_remove.link);
 
-	gbm_device_destroy(drm->gbm);
+	drm_bo_handle_table_finish(&drm->bo_handles);
 
 	if (drm->parent) {
 		finish_drm_renderer(&drm->mgpu_renderer);
@@ -222,12 +222,6 @@ struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
 
 	if (!init_drm_resources(drm)) {
 		goto error_event;
-	}
-
-	drm->gbm = gbm_create_device(drm->fd);
-	if (!drm->gbm) {
-		wlr_log(WLR_ERROR, "Failed to create GBM device");
-		goto error_resources;
 	}
 
 	if (drm->parent) {

--- a/backend/drm/bo_handle_table.c
+++ b/backend/drm/bo_handle_table.c
@@ -1,0 +1,43 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <wlr/util/log.h>
+#include "backend/drm/bo_handle_table.h"
+
+static size_t align(size_t val, size_t align) {
+	size_t mask = align - 1;
+	return (val + mask) & ~mask;
+}
+
+void drm_bo_handle_table_finish(struct wlr_drm_bo_handle_table *table) {
+	free(table->nrefs);
+}
+
+bool drm_bo_handle_table_ref(struct wlr_drm_bo_handle_table *table,
+		uint32_t handle) {
+	assert(handle != 0);
+
+	if (handle > table->len) {
+		// Grow linearily, because we don't expect the number of BOs to explode
+		size_t len = align(handle + 1, 512);
+		size_t *nrefs = realloc(table->nrefs, len * sizeof(size_t));
+		if (nrefs == NULL) {
+			wlr_log_errno(WLR_ERROR, "realloc failed");
+			return false;
+		}
+		memset(&nrefs[table->len], 0, (len - table->len) * sizeof(size_t));
+		table->len = len;
+		table->nrefs = nrefs;
+	}
+
+	table->nrefs[handle]++;
+	return true;
+}
+
+size_t drm_bo_handle_table_unref(struct wlr_drm_bo_handle_table *table,
+		uint32_t handle) {
+	assert(handle < table->len);
+	assert(table->nrefs[handle] > 0);
+	table->nrefs[handle]--;
+	return table->nrefs[handle];
+}

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -3,7 +3,6 @@
 #include <drm_fourcc.h>
 #include <drm_mode.h>
 #include <errno.h>
-#include <gbm.h>
 #include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/backend/drm/meson.build
+++ b/backend/drm/meson.build
@@ -1,6 +1,7 @@
 wlr_files += files(
 	'atomic.c',
 	'backend.c',
+	'bo_handle_table.c',
 	'cvt.c',
 	'drm.c',
 	'legacy.c',

--- a/backend/drm/util.c
+++ b/backend/drm/util.c
@@ -2,7 +2,6 @@
 #include <drm_fourcc.h>
 #include <drm_mode.h>
 #include <drm.h>
-#include <gbm.h>
 #include <stdio.h>
 #include <string.h>
 #include <wlr/util/log.h>
@@ -173,56 +172,6 @@ const char *conn_get_name(uint32_t type_id) {
 #endif
 	default:                             return "Unknown";
 	}
-}
-
-uint32_t get_fb_for_bo(struct gbm_bo *bo, bool with_modifiers) {
-	struct gbm_device *gbm = gbm_bo_get_device(bo);
-
-	int fd = gbm_device_get_fd(gbm);
-	uint32_t width = gbm_bo_get_width(bo);
-	uint32_t height = gbm_bo_get_height(bo);
-	uint32_t format = gbm_bo_get_format(bo);
-
-	uint32_t handles[4] = {0};
-	uint32_t strides[4] = {0};
-	uint32_t offsets[4] = {0};
-	uint64_t modifiers[4] = {0};
-	for (int i = 0; i < gbm_bo_get_plane_count(bo); i++) {
-		handles[i] = gbm_bo_get_handle_for_plane(bo, i).u32;
-		strides[i] = gbm_bo_get_stride_for_plane(bo, i);
-		offsets[i] = gbm_bo_get_offset(bo, i);
-		// KMS requires all BO planes to have the same modifier
-		modifiers[i] = gbm_bo_get_modifier(bo);
-	}
-
-	uint32_t id = 0;
-	if (with_modifiers && gbm_bo_get_modifier(bo) != DRM_FORMAT_MOD_INVALID) {
-		if (drmModeAddFB2WithModifiers(fd, width, height, format, handles,
-				strides, offsets, modifiers, &id, DRM_MODE_FB_MODIFIERS)) {
-			wlr_log_errno(WLR_ERROR, "Unable to add DRM framebuffer");
-		}
-	} else {
-		int ret = drmModeAddFB2(fd, width, height, format, handles, strides,
-			offsets, &id, 0);
-		if (ret != 0 && gbm_bo_get_format(bo) == GBM_FORMAT_ARGB8888 &&
-				gbm_bo_get_plane_count(bo) == 1) {
-			// Some big-endian machines don't support drmModeAddFB2. Try a
-			// last-resort fallback for ARGB8888 buffers, like Xorg's
-			// modesetting driver does.
-			wlr_log(WLR_DEBUG, "drmModeAddFB2 failed (%s), falling back to "
-				"legacy drmModeAddFB", strerror(-ret));
-
-			uint32_t depth = 32;
-			uint32_t bpp = gbm_bo_get_bpp(bo);
-			ret = drmModeAddFB(fd, width, height, depth, bpp, strides[0],
-				handles[0], &id);
-		}
-		if (ret != 0) {
-			wlr_log(WLR_ERROR, "Unable to add DRM framebuffer: %s", strerror(-ret));
-		}
-	}
-
-	return id;
 }
 
 static bool is_taken(size_t n, const uint32_t arr[static n], uint32_t key) {

--- a/include/backend/drm/bo_handle_table.h
+++ b/include/backend/drm/bo_handle_table.h
@@ -1,0 +1,24 @@
+#ifndef BACKEND_DRM_BO_HANDLE_TABLE_H
+#define BACKEND_DRM_BO_HANDLE_TABLE_H
+
+/**
+ * Table performing reference counting for buffer object handles.
+ *
+ * The BO handles are allocated incrementally and are recycled by the kernel,
+ * so a simple array is used.
+ *
+ * This design is inspired from amdgpu's code in libdrm:
+ * https://gitlab.freedesktop.org/mesa/drm/-/blob/1a4c0ec9aea13211997f982715fe5ffcf19dd067/amdgpu/handle_table.c
+ */
+struct wlr_drm_bo_handle_table {
+	size_t *nrefs;
+	size_t len;
+};
+
+void drm_bo_handle_table_finish(struct wlr_drm_bo_handle_table *table);
+bool drm_bo_handle_table_ref(struct wlr_drm_bo_handle_table *table,
+	uint32_t handle);
+size_t drm_bo_handle_table_unref(struct wlr_drm_bo_handle_table *table,
+	uint32_t handle);
+
+#endif

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -1,7 +1,6 @@
 #ifndef BACKEND_DRM_DRM_H
 #define BACKEND_DRM_DRM_H
 
-#include <gbm.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -12,6 +11,7 @@
 #include <wlr/backend/session.h>
 #include <wlr/render/drm_format_set.h>
 #include <xf86drmMode.h>
+#include "backend/drm/bo_handle_table.h"
 #include "backend/drm/iface.h"
 #include "backend/drm/properties.h"
 #include "backend/drm/renderer.h"
@@ -62,7 +62,7 @@ struct wlr_drm_backend {
 	int fd;
 	char *name;
 	struct wlr_device *dev;
-	struct gbm_device *gbm;
+	struct wlr_drm_bo_handle_table bo_handles;
 
 	size_t num_crtcs;
 	struct wlr_drm_crtc *crtcs;

--- a/include/backend/drm/iface.h
+++ b/include/backend/drm/iface.h
@@ -1,7 +1,6 @@
 #ifndef BACKEND_DRM_IFACE_H
 #define BACKEND_DRM_IFACE_H
 
-#include <gbm.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <xf86drm.h>

--- a/include/backend/drm/renderer.h
+++ b/include/backend/drm/renderer.h
@@ -1,7 +1,6 @@
 #ifndef BACKEND_DRM_RENDERER_H
 #define BACKEND_DRM_RENDERER_H
 
-#include <gbm.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <wlr/backend.h>
@@ -30,9 +29,10 @@ struct wlr_drm_surface {
 struct wlr_drm_fb {
 	struct wlr_buffer *wlr_buf;
 	struct wlr_addon addon;
+	struct wlr_drm_backend *backend;
 	struct wl_list link; // wlr_drm_backend.fbs
 
-	struct gbm_bo *bo;
+	uint32_t handles[WLR_DMABUF_MAX_PLANES];
 	uint32_t id;
 };
 

--- a/include/backend/drm/util.h
+++ b/include/backend/drm/util.h
@@ -13,8 +13,6 @@ void parse_edid(struct wlr_output *restrict output, size_t len,
 	const uint8_t *data);
 // Returns the string representation of a DRM output type
 const char *conn_get_name(uint32_t type_id);
-// Returns the DRM framebuffer id for a gbm_bo
-uint32_t get_fb_for_bo(struct gbm_bo *bo, bool with_modifiers);
 
 // Part of match_obj
 enum {


### PR DESCRIPTION
Using GBM to import DRM dumb buffers tends to not work well. By
using GBM we're calling some driver-specific functions in Mesa.
These functions check whether Mesa can work with the buffer.
Sometimes Mesa has requirements which differ from DRM dumb buffers
and the GBM import will fail (e.g. on amdgpu).

Instead, drop GBM and use drmPrimeFDToHandle directly. But there's
a twist: BO handles are not ref'counted by the kernel and need to
be ref'counted in user-space [1]. libdrm usually performs this
bookkeeping and is used under-the-hood by Mesa.

We can't re-use libdrm for this task without using driver-specific
APIs. So let's just re-implement the ref'counting logic in wlroots.
The wlroots implementation is inspired from amdgpu's in libdrm [2].

Closes: #2916

[1]: https://gitlab.freedesktop.org/mesa/drm/-/merge_requests/110
[2]: https://gitlab.freedesktop.org/mesa/drm/-/blob/1a4c0ec9aea13211997f982715fe5ffcf19dd067/amdgpu/handle_table.c