### PR TITLE
xdg-activation: Pass on activation id when we don't find a token

### DIFF
--- a/include/wlr/types/wlr_xdg_activation_v1.h
+++ b/include/wlr/types/wlr_xdg_activation_v1.h
@@ -55,6 +55,8 @@ struct wlr_xdg_activation_v1_request_activate_event {
 	struct wlr_xdg_activation_token_v1 *token;
 	// The surface requesting for activation.
 	struct wlr_surface *surface;
+	// The startup-id
+	const char* id;
 };
 
 struct wlr_xdg_activation_v1 *wlr_xdg_activation_v1_create(

--- a/types/wlr_xdg_activation_v1.c
+++ b/types/wlr_xdg_activation_v1.c
@@ -275,18 +275,21 @@ static void activation_handle_activate(struct wl_client *client,
 		}
 	}
 	if (!found) {
-		wlr_log(WLR_DEBUG, "Rejecting activate request: unknown token");
-		return;
+		wlr_log(WLR_DEBUG, "Token '%s' wasn't set via xdg_activation_v1",
+			token_str);
 	}
 
 	struct wlr_xdg_activation_v1_request_activate_event event = {
 		.activation = activation,
 		.token = token,
+		.id = token_str,
 		.surface = surface,
 	};
 	wlr_signal_emit_safe(&activation->events.request_activate, &event);
 
-	token_destroy(token);
+	if (found) {
+		token_destroy(token);
+	}
 }
 
 static const struct xdg_activation_v1_interface activation_impl = {


### PR DESCRIPTION
If the activation happened via another protocol (such as startup
notification protocol,  gtk_shell1 or other compositor specific
mechanisms the compositor might know about the id but don't have a valid
token. Just pass on the id in this case so it can match up things against
it's token list.

See https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/main/staging/xdg-activation/x11-interoperation.rst