### PR TITLE
scene: add RECT node type

### DIFF
--- a/include/wlr/types/wlr_scene.h
+++ b/include/wlr/types/wlr_scene.h
@@ -114,12 +114,13 @@ void wlr_scene_node_reparent(struct wlr_scene_node *node,
 void wlr_scene_node_for_each_surface(struct wlr_scene_node *node,
 	wlr_surface_iterator_func_t iterator, void *user_data);
 /**
- * Find a surface in this scene-graph that accepts input events at the given
- * layout-local coordinates. Returns the surface and coordinates relative to
- * the returned surface, or NULL if no surface is found at that location.
+ * Find the topmost node in this scene-graph that contains the point at the
+ * given layout-local coordinates. (For surface nodes, this means accepting
+ * input events at that point.) Returns the node and coordinates relative to the
+ * returned node, or NULL if no node is found at that location.
  */
-struct wlr_surface *wlr_scene_node_surface_at(struct wlr_scene_node *node,
-	double lx, double ly, double *sx, double *sy);
+struct wlr_scene_node *wlr_scene_node_at(struct wlr_scene_node *node,
+	double lx, double ly, double *nx, double *ny);
 
 /**
  * Create a new scene-graph.
@@ -141,6 +142,8 @@ void wlr_scene_render_output(struct wlr_scene *scene, struct wlr_output *output,
  */
 struct wlr_scene_surface *wlr_scene_surface_create(struct wlr_scene_node *parent,
 	struct wlr_surface *surface);
+
+struct wlr_scene_surface *wlr_scene_surface_from_node(struct wlr_scene_node *node);
 
 /**
  * Add a node displaying a solid-colored rectangle to the scene-graph.

--- a/include/wlr/types/wlr_scene.h
+++ b/include/wlr/types/wlr_scene.h
@@ -28,6 +28,7 @@ struct wlr_output;
 enum wlr_scene_node_type {
 	WLR_SCENE_NODE_ROOT,
 	WLR_SCENE_NODE_SURFACE,
+	WLR_SCENE_NODE_RECT,
 };
 
 struct wlr_scene_node_state {
@@ -65,6 +66,13 @@ struct wlr_scene_surface {
 	// private state
 
 	struct wl_listener surface_destroy;
+};
+
+/** A scene-graph node displaying a solid-colored rectangle */
+struct wlr_scene_rect {
+	struct wlr_scene_node node;
+	int width, height;
+	float color[4];
 };
 
 typedef void (*wlr_scene_node_iterator_func_t)(struct wlr_scene_node *node,
@@ -133,5 +141,21 @@ void wlr_scene_render_output(struct wlr_scene *scene, struct wlr_output *output,
  */
 struct wlr_scene_surface *wlr_scene_surface_create(struct wlr_scene_node *parent,
 	struct wlr_surface *surface);
+
+/**
+ * Add a node displaying a solid-colored rectangle to the scene-graph.
+ */
+struct wlr_scene_rect *wlr_scene_rect_create(struct wlr_scene_node *parent,
+		int width, int height, const float color[static 4]);
+
+/**
+ * Change the width and height of an existing rectangle node.
+ */
+void wlr_scene_rect_set_size(struct wlr_scene_rect *rect, int width, int height);
+
+/**
+ * Change the color of an existing rectangle node.
+ */
+void wlr_scene_rect_set_color(struct wlr_scene_rect *rect, const float color[static 4]);
 
 #endif

--- a/include/wlr/types/wlr_scene.h
+++ b/include/wlr/types/wlr_scene.h
@@ -67,6 +67,9 @@ struct wlr_scene_surface {
 	struct wl_listener surface_destroy;
 };
 
+typedef void (*wlr_scene_node_iterator_func_t)(struct wlr_scene_node *node,
+	int sx, int sy, void *data);
+
 /**
  * Immediately destroy the scene-graph node.
  */

--- a/types/wlr_scene.c
+++ b/types/wlr_scene.c
@@ -327,14 +327,14 @@ static void render_texture(struct wlr_output *output,
 	pixman_region32_init(&damage);
 	pixman_region32_init_rect(&damage, box->x, box->y, box->width, box->height);
 	pixman_region32_intersect(&damage, &damage, output_damage);
-	if (pixman_region32_not_empty(&damage)) {
-		int nrects;
-		pixman_box32_t *rects = pixman_region32_rectangles(&damage, &nrects);
-		for (int i = 0; i < nrects; ++i) {
-			scissor_output(output, &rects[i]);
-			wlr_render_texture_with_matrix(renderer, texture, matrix, 1.0);
-		}
+
+	int nrects;
+	pixman_box32_t *rects = pixman_region32_rectangles(&damage, &nrects);
+	for (int i = 0; i < nrects; ++i) {
+		scissor_output(output, &rects[i]);
+		wlr_render_texture_with_matrix(renderer, texture, matrix, 1.0);
 	}
+
 	pixman_region32_fini(&damage);
 }
 


### PR DESCRIPTION
Adds a new scene-graph node type for rendering solid-colored rectangles, which may be useful for simple window decorations. A little reworking was needed in the scene-graph implementation, since it would break the assumption that every rendered node has an associated surface.

Thoughts/questions:
1. Should there be a `wlr_scene_rect_set_size()` and/or `wlr_scene_rect_set_color()` function, or is it straghtforward enough to change the fields directly? (Maybe damage tracking considerations tip the scale toward functions?)
1. How should RECTs interact with `wlr_scene_node_surface_at()`?
1. Would it complicate the scene-graph example too much if I were to add a handler for wlr_surface.commit? It would allow us to get the surface dimensions and draw something less ugly than what I currently have.
1. Is there a point at which it makes more sense to implement additional node types with a `scene_node_impl` rather than switching on a type field?