### PR TITLE
scene: add node reparent function

### DIFF
--- a/include/wlr/types/wlr_scene.h
+++ b/include/wlr/types/wlr_scene.h
@@ -91,6 +91,11 @@ void wlr_scene_node_place_above(struct wlr_scene_node *node,
 void wlr_scene_node_place_below(struct wlr_scene_node *node,
 	struct wlr_scene_node *sibling);
 /**
+ * Move the node to another location in the tree.
+ */
+void wlr_scene_node_reparent(struct wlr_scene_node *node,
+	struct wlr_scene_node *new_parent);
+/**
  * Call `iterator` on each surface in the scene-graph, with the surface's
  * position in layout coordinates. The function is called from root to leaves
  * (in rendering order).

--- a/types/wlr_scene.c
+++ b/types/wlr_scene.c
@@ -133,6 +133,20 @@ void wlr_scene_node_place_below(struct wlr_scene_node *node,
 	wl_list_insert(sibling->state.link.prev, &node->state.link);
 }
 
+void wlr_scene_node_reparent(struct wlr_scene_node *node,
+		struct wlr_scene_node *new_parent) {
+	if (node->parent == new_parent) {
+		return;
+	}
+
+	wl_list_remove(&node->state.link);
+
+	node->parent = new_parent;
+	if (new_parent != NULL) {
+		wl_list_insert(new_parent->state.children.prev, &node->state.link);
+	}
+}
+
 static void scene_node_for_each_surface(struct wlr_scene_node *node,
 		int lx, int ly, wlr_surface_iterator_func_t user_iterator,
 		void *user_data) {

--- a/types/wlr_scene.c
+++ b/types/wlr_scene.c
@@ -141,9 +141,7 @@ void wlr_scene_node_reparent(struct wlr_scene_node *node,
 	/* Ensure that a node cannot become its own ancestor */
 	for (struct wlr_scene_node *ancestor = new_parent; ancestor != NULL;
 			ancestor = ancestor->parent) {
-		if (ancestor == node) {
-			return;
-		}
+		assert(ancestor != node);
 	}
 
 	wl_list_remove(&node->state.link);

--- a/types/wlr_scene.c
+++ b/types/wlr_scene.c
@@ -135,6 +135,8 @@ void wlr_scene_node_place_below(struct wlr_scene_node *node,
 
 void wlr_scene_node_reparent(struct wlr_scene_node *node,
 		struct wlr_scene_node *new_parent) {
+	assert(node->type != WLR_SCENE_NODE_ROOT && new_parent != NULL);
+
 	if (node->parent == new_parent) {
 		return;
 	}
@@ -145,11 +147,8 @@ void wlr_scene_node_reparent(struct wlr_scene_node *node,
 	}
 
 	wl_list_remove(&node->state.link);
-
 	node->parent = new_parent;
-	if (new_parent != NULL) {
-		wl_list_insert(new_parent->state.children.prev, &node->state.link);
-	}
+	wl_list_insert(new_parent->state.children.prev, &node->state.link);
 }
 
 static void scene_node_for_each_surface(struct wlr_scene_node *node,

--- a/types/wlr_scene.c
+++ b/types/wlr_scene.c
@@ -138,6 +138,13 @@ void wlr_scene_node_reparent(struct wlr_scene_node *node,
 	if (node->parent == new_parent) {
 		return;
 	}
+	/* Ensure that a node cannot become its own ancestor */
+	for (struct wlr_scene_node *ancestor = new_parent; ancestor != NULL;
+			ancestor = ancestor->parent) {
+		if (ancestor == node) {
+			return;
+		}
+	}
 
 	wl_list_remove(&node->state.link);
 


### PR DESCRIPTION
If nodes are arranged in a tree rather than at a single level (e.g. if #3128 is merged), then it makes sense to have a way to move them to a completely different parent in addition to moving up or down among siblings.