### PR TITLE
xwayland: Allow to retrieve startup-id via _NET_STARTUP_INFO

### DIFF
--- a/include/wlr/xwayland.h
+++ b/include/wlr/xwayland.h
@@ -72,6 +72,7 @@ struct wlr_xwayland {
 	struct {
 		struct wl_signal ready;
 		struct wl_signal new_surface;
+		struct wl_signal remove_startup_info;
 	} events;
 
 	/**
@@ -230,6 +231,11 @@ struct wlr_xwayland_surface_configure_event {
 // TODO: maybe add a seat to these
 struct wlr_xwayland_move_event {
 	struct wlr_xwayland_surface *surface;
+};
+
+struct wlr_xwayland_remove_startup_info_event  {
+	const char *id;
+	xcb_window_t window;
 };
 
 struct wlr_xwayland_resize_event {

--- a/include/xwayland/xwm.h
+++ b/include/xwayland/xwm.h
@@ -56,6 +56,8 @@ enum atom_name {
 	TIMESTAMP,
 	DELETE,
 	NET_STARTUP_ID,
+	NET_STARTUP_INFO,
+	NET_STARTUP_INFO_BEGIN,
 	NET_WM_WINDOW_TYPE_NORMAL,
 	NET_WM_WINDOW_TYPE_UTILITY,
 	NET_WM_WINDOW_TYPE_TOOLTIP,
@@ -113,6 +115,7 @@ struct wlr_xwm {
 	// Surfaces in bottom-to-top stacking order, for _NET_CLIENT_LIST_STACKING
 	struct wl_list surfaces_in_stack_order; // wlr_xwayland_surface::stack_link
 	struct wl_list unpaired_surfaces; // wlr_xwayland_surface::unpaired_link
+	struct wl_list pending_startup_ids; // pending_startup_id
 
 	struct wlr_drag *drag;
 	struct wlr_xwayland_surface *drag_focus;

--- a/xwayland/xwayland.c
+++ b/xwayland/xwayland.c
@@ -81,6 +81,7 @@ struct wlr_xwayland *wlr_xwayland_create(struct wl_display *wl_display,
 
 	wl_signal_init(&xwayland->events.new_surface);
 	wl_signal_init(&xwayland->events.ready);
+	wl_signal_init(&xwayland->events.remove_startup_info);
 
 	struct wlr_xwayland_server_options options = {
 		.lazy = lazy,


### PR DESCRIPTION
A launchee notifies with a "remove"¹ message when done starting up.
Catch these and forward to the compositor. This allows the compositor to
end the startup sequence that might have been started by another
protocol like xdg-activation.

We don't handle other messages since we expect the launcher to use a
wayland protocol like xdg-activation.

While `_NET_STARTUP_ID` helps to associate toplevels with startup-ids
this signals the end of the startup sequence.

This would e.g. allow to remove tokens that we got via xdg-activation and where the launchee started an x11 application. 

1) https://specifications.freedesktop.org/startup-notification-spec/startup-notification-latest.txt

Related: #2968 , #3136