### PR TITLE
backend/drm: handle drm_surface_blit errors

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -414,6 +414,9 @@ static bool drm_connector_set_pending_fb(struct wlr_drm_connector *conn,
 		}
 
 		local_buf = drm_surface_blit(&plane->mgpu_surf, state->buffer);
+		if (local_buf == NULL) {
+			return false;
+		}
 	} else {
 		local_buf = wlr_buffer_lock(state->buffer);
 	}


### PR DESCRIPTION
drm_surface_blit returns NULL on error. This can happen e.g. when
the source buffer cannot be imported into EGL.

Closes: https://github.com/swaywm/wlroots/issues/3154