### PR TITLE
Screencopy clip regions

### DIFF
--- a/include/wlr/types/wlr_screencopy_v1.h
+++ b/include/wlr/types/wlr_screencopy_v1.h
@@ -12,6 +12,7 @@
 #include <stdbool.h>
 #include <wayland-server-core.h>
 #include <wlr/util/box.h>
+#include <pixman.h>
 
 struct wlr_screencopy_manager_v1 {
 	struct wl_global *global;
@@ -45,6 +46,8 @@ struct wlr_screencopy_frame_v1 {
 	bool overlay_cursor, cursor_locked;
 
 	bool with_damage;
+
+	struct pixman_region32 clip_region;
 
 	struct wl_shm_buffer *shm_buffer;
 	struct wlr_dmabuf_v1_buffer *dma_buffer;

--- a/protocol/wlr-screencopy-unstable-v1.xml
+++ b/protocol/wlr-screencopy-unstable-v1.xml
@@ -38,7 +38,7 @@
     interface version number is reset.
   </description>
 
-  <interface name="zwlr_screencopy_manager_v1" version="3">
+  <interface name="zwlr_screencopy_manager_v1" version="4">
     <description summary="manager to inform clients and begin capturing">
       This object is a manager which offers requests to start capturing from a
       source.
@@ -80,7 +80,7 @@
     </request>
   </interface>
 
-  <interface name="zwlr_screencopy_frame_v1" version="3">
+  <interface name="zwlr_screencopy_frame_v1" version="4">
     <description summary="a frame ready for copy">
       This object represents a single frame.
 
@@ -228,5 +228,29 @@
         types, and send a "copy" request.
       </description>
     </event>
+
+    <!-- Version 4 additions -->
+    <request name="set_clip_region" since="4">
+      <description summary="set clip region">
+        Sets the clip region for the subsequent copy request. This tells the
+        compositor that it needn't copy outside the given region. The default
+        clip region contains the whole frame.
+      </description>
+      <arg name="x" type="uint" summary="region x coordinates"/>
+      <arg name="y" type="uint" summary="region y coordinates"/>
+      <arg name="width" type="uint" summary="region width"/>
+      <arg name="height" type="uint" summary="region height"/>
+    </request>
+
+    <request name="add_clip_region" since="4">
+      <description summary="add box to clip region">
+        Adds the given box to the clip region. This can be used to compose a
+        more fine grained region.
+      </description>
+      <arg name="x" type="uint" summary="region x coordinates"/>
+      <arg name="y" type="uint" summary="region y coordinates"/>
+      <arg name="width" type="uint" summary="region width"/>
+      <arg name="height" type="uint" summary="region height"/>
+    </request>
   </interface>
 </protocol>


### PR DESCRIPTION
This introduces clip regions into the screencopy protocol. This reduces copying when only a small region on the screen is changing. The client can set a clip region on the frame object before calling `copy` or `copy_with_damage`, which limits the area that gets copied in the subsequent `copy` or `copy_with_damage` request.

Typically, the client would use this in combination with `copy_with_damage` and buffer damage tracking on the client's side. I've implemented such a mechanism here: https://github.com/any1/wayvnc/pull/109

Protocol PR is here: https://github.com/swaywm/wlr-protocols/pull/106

I've done some preliminary tests, which appear promising. The following screenshots show some performance figures for a headless sway session with output resolution of 1080p  running a floating instance of `weston-simple-egl` in the middle of the screen.
 * https://andri.yngvason.is/without-clip-regions.png
 * https://andri.yngvason.is/with-clip-regions.png

Without clip regions, wayvnc captures around 54 frames per second, sway's CPU load is circa 9.8% and the global GPU load circa 8.9%.

With clip regions, wayvnc captures around 57.5 frames per second, sway's CPU load is circa 7.2% and the global GPU load circa 4.9%.

I have not tested how this affects dmabuf copies yet.

Cc @cyanreg, @ammen99 
