### PR TITLE
Minor surface refactor

### DIFF
--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -170,6 +170,7 @@ struct wlr_surface {
  */
 struct wlr_subsurface_parent_state {
 	int32_t x, y;
+	struct wl_list link;
 };
 
 struct wlr_subsurface {
@@ -185,9 +186,6 @@ struct wlr_subsurface {
 	bool synchronized;
 	bool reordered;
 	bool mapped;
-
-	struct wl_list parent_link;
-	struct wl_list parent_pending_link;
 
 	struct wl_listener surface_destroy;
 	struct wl_listener parent_destroy;

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -163,7 +163,12 @@ struct wlr_surface {
 	} previous;
 };
 
-struct wlr_subsurface_state {
+/**
+ * The sub-surface state describing the sub-surface's relationship with its
+ * parent. Contrary to other states, this one is not applied on surface commit.
+ * Instead, it's applied on parent surface commit.
+ */
+struct wlr_subsurface_parent_state {
 	int32_t x, y;
 };
 
@@ -172,7 +177,7 @@ struct wlr_subsurface {
 	struct wlr_surface *surface;
 	struct wlr_surface *parent;
 
-	struct wlr_subsurface_state current, pending;
+	struct wlr_subsurface_parent_state current, pending;
 
 	uint32_t cached_seq;
 	bool has_cache;

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -47,6 +47,9 @@ struct wlr_surface_state {
 	int width, height; // in surface-local coordinates
 	int buffer_width, buffer_height;
 
+	struct wl_list subsurfaces_below;
+	struct wl_list subsurfaces_above;
+
 	/**
 	 * The viewport is applied after the surface transform and scale.
 	 *
@@ -138,14 +141,6 @@ struct wlr_surface {
 		struct wl_signal new_subsurface;
 		struct wl_signal destroy;
 	} events;
-
-	// wlr_subsurface.parent_link
-	struct wl_list subsurfaces_below;
-	struct wl_list subsurfaces_above;
-
-	// wlr_subsurface.parent_pending_link
-	struct wl_list subsurfaces_pending_below;
-	struct wl_list subsurfaces_pending_above;
 
 	struct wl_list current_outputs; // wlr_surface_output::link
 

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -313,6 +313,11 @@ static void surface_state_move(struct wlr_surface_state *state,
 	if (next->committed & WLR_SURFACE_STATE_VIEWPORT) {
 		memcpy(&state->viewport, &next->viewport, sizeof(state->viewport));
 	}
+	if (next->committed & WLR_SURFACE_STATE_FRAME_CALLBACK_LIST) {
+		wl_list_insert_list(&state->frame_callback_list,
+			&next->frame_callback_list);
+		wl_list_init(&next->frame_callback_list);
+	}
 
 	state->committed |= next->committed;
 	next->committed = 0;
@@ -491,14 +496,6 @@ static void surface_commit_pending(struct wlr_surface *surface) {
 
 	if (surface->role && surface->role->precommit) {
 		surface->role->precommit(surface);
-	}
-
-	// It doesn't to make sense to cache callback lists, so we always move
-	// them to the current state.
-	if (surface->pending.committed & WLR_SURFACE_STATE_FRAME_CALLBACK_LIST) {
-		wl_list_insert_list(&surface->current.frame_callback_list,
-			&surface->pending.frame_callback_list);
-		wl_list_init(&surface->pending.frame_callback_list);
 	}
 
 	if (surface->pending.cached_state_locks > 0 || !wl_list_empty(&surface->cached)) {

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -1350,7 +1350,7 @@ static void surface_for_each_surface(struct wlr_surface *surface, int x, int y,
 		wlr_surface_iterator_func_t iterator, void *user_data) {
 	struct wlr_subsurface *subsurface;
 	wl_list_for_each(subsurface, &surface->subsurfaces_below, parent_link) {
-		struct wlr_subsurface_state *state = &subsurface->current;
+		struct wlr_subsurface_parent_state *state = &subsurface->current;
 		int sx = state->x;
 		int sy = state->y;
 
@@ -1361,7 +1361,7 @@ static void surface_for_each_surface(struct wlr_surface *surface, int x, int y,
 	iterator(surface, x, y, user_data);
 
 	wl_list_for_each(subsurface, &surface->subsurfaces_above, parent_link) {
-		struct wlr_subsurface_state *state = &subsurface->current;
+		struct wlr_subsurface_parent_state *state = &subsurface->current;
 		int sx = state->x;
 		int sy = state->y;
 


### PR DESCRIPTION
A bunch of commits from #3143, including #3120 and #3122.

cc @emersion 

## Changes

- `wlr_subsurface.parent_link` is removed

Instead, use `wlr_subsurface.current.link`; same goes for `wlr_subsurface.parent_pending_link`.

- `wlr_surface.subsurfaces_{above,below}` is moved to `wlr_surface_state`

Use `wlr_surface.current.subsurfaces_{above,below}`.