### PR TITLE
surface: add WLR_SURFACE_STATE_SUBSURFACES

### DIFF
--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -27,6 +27,7 @@ enum wlr_surface_state_field {
 	WLR_SURFACE_STATE_SCALE = 1 << 6,
 	WLR_SURFACE_STATE_FRAME_CALLBACK_LIST = 1 << 7,
 	WLR_SURFACE_STATE_VIEWPORT = 1 << 8,
+	WLR_SURFACE_STATE_SUBSURFACES = 1 << 9,
 };
 
 struct wlr_surface_state {

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -698,6 +698,7 @@ static void subsurface_destroy(struct wlr_subsurface *subsurface) {
 	wl_list_remove(&subsurface->surface_destroy.link);
 
 	if (subsurface->parent) {
+		subsurface->parent->pending.committed |= WLR_SURFACE_STATE_SUBSURFACES;
 		wl_list_remove(&subsurface->current.link);
 		wl_list_remove(&subsurface->pending.link);
 		wl_list_remove(&subsurface->parent_destroy.link);
@@ -947,6 +948,7 @@ static void subsurface_handle_place_above(struct wl_client *client,
 		node = &sibling->pending.link;
 	}
 
+	subsurface->parent->pending.committed |= WLR_SURFACE_STATE_SUBSURFACES;
 	wl_list_remove(&subsurface->pending.link);
 	wl_list_insert(node, &subsurface->pending.link);
 
@@ -979,6 +981,7 @@ static void subsurface_handle_place_below(struct wl_client *client,
 		node = &sibling->pending.link;
 	}
 
+	subsurface->parent->pending.committed |= WLR_SURFACE_STATE_SUBSURFACES;
 	wl_list_remove(&subsurface->pending.link);
 	wl_list_insert(node->prev, &subsurface->pending.link);
 
@@ -1190,6 +1193,7 @@ struct wlr_subsurface *subsurface_create(struct wlr_surface *surface,
 
 	// link parent
 	subsurface->parent = parent;
+	subsurface->parent->pending.committed |= WLR_SURFACE_STATE_SUBSURFACES;
 	wl_signal_add(&parent->events.destroy, &subsurface->parent_destroy);
 	subsurface->parent_destroy.notify = subsurface_handle_parent_destroy;
 	wl_list_insert(parent->current.subsurfaces_above.prev, &subsurface->current.link);

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -458,28 +458,31 @@ static void surface_commit_state(struct wlr_surface *surface,
 	surface_update_opaque_region(surface);
 	surface_update_input_region(surface);
 
-	// commit subsurface order
-	struct wlr_subsurface *subsurface;
-	wl_list_for_each_reverse(subsurface, &surface->pending.subsurfaces_above,
-			pending.link) {
-		wl_list_remove(&subsurface->current.link);
-		wl_list_insert(&surface->current.subsurfaces_above,
-			&subsurface->current.link);
+	// TODO: use `next` instead of `surface->pending`
+	if (surface->pending.committed & WLR_SURFACE_STATE_SUBSURFACES) {
+		// commit subsurface order
+		struct wlr_subsurface *subsurface;
+		wl_list_for_each_reverse(subsurface, &surface->pending.subsurfaces_above,
+				pending.link) {
+			wl_list_remove(&subsurface->current.link);
+			wl_list_insert(&surface->current.subsurfaces_above,
+				&subsurface->current.link);
 
-		if (subsurface->reordered) {
-			// TODO: damage all the subsurfaces
-			surface_damage_subsurfaces(subsurface);
+			if (subsurface->reordered) {
+				// TODO: damage all the subsurfaces
+				surface_damage_subsurfaces(subsurface);
+			}
 		}
-	}
-	wl_list_for_each_reverse(subsurface, &surface->pending.subsurfaces_below,
-			pending.link) {
-		wl_list_remove(&subsurface->current.link);
-		wl_list_insert(&surface->current.subsurfaces_below,
-			&subsurface->current.link);
+		wl_list_for_each_reverse(subsurface, &surface->pending.subsurfaces_below,
+				pending.link) {
+			wl_list_remove(&subsurface->current.link);
+			wl_list_insert(&surface->current.subsurfaces_below,
+				&subsurface->current.link);
 
-		if (subsurface->reordered) {
-			// TODO: damage all the subsurfaces
-			surface_damage_subsurfaces(subsurface);
+			if (subsurface->reordered) {
+				// TODO: damage all the subsurfaces
+				surface_damage_subsurfaces(subsurface);
+			}
 		}
 	}
 


### PR DESCRIPTION
This allows to figure out when the subsurface list has changed:
subsurface added, removed, or re-ordered. In the case where
the subsurface list hasn't changed, some book-keeping operations
can be skipped.

Useful for https://github.com/swaywm/wlroots/pull/3128

cc @vyivel 