### PR TITLE
backend/drm: drop attempt_enable_needs_modeset

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -726,7 +726,6 @@ static bool drm_connector_set_mode(struct wlr_drm_connector *conn,
 	}
 
 	conn->desired_enabled = wlr_mode != NULL;
-	conn->desired_mode = wlr_mode;
 
 	if (wlr_mode == NULL) {
 		if (conn->crtc != NULL) {
@@ -773,7 +772,6 @@ static bool drm_connector_set_mode(struct wlr_drm_connector *conn,
 	}
 
 	conn->status = WLR_DRM_CONN_CONNECTED;
-	conn->desired_mode = NULL;
 	wlr_output_update_mode(&conn->output, wlr_mode);
 	wlr_output_update_enabled(&conn->output, true);
 	conn->desired_enabled = true;
@@ -947,7 +945,6 @@ static void drm_connector_destroy_output(struct wlr_output *output) {
 
 	conn->status = WLR_DRM_CONN_DISCONNECTED;
 	conn->desired_enabled = false;
-	conn->desired_mode = NULL;
 	conn->possible_crtcs = 0;
 	conn->pending_page_flip_crtc = 0;
 
@@ -1157,7 +1154,6 @@ static void realloc_crtcs(struct wlr_drm_backend *drm) {
 				wlr_drm_conn_log(conn, WLR_DEBUG, "Output has lost its CRTC");
 				conn->status = WLR_DRM_CONN_NEEDS_MODESET;
 				wlr_output_update_enabled(&conn->output, false);
-				conn->desired_mode = conn->output.current_mode;
 				wlr_output_update_mode(&conn->output, NULL);
 			}
 			continue;

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -691,27 +691,6 @@ static bool drm_connector_init_renderer(struct wlr_drm_connector *conn,
 
 static void realloc_crtcs(struct wlr_drm_backend *drm);
 
-static void attempt_enable_needs_modeset(struct wlr_drm_backend *drm) {
-	// Try to modeset any output that has a desired mode and a CRTC (ie. was
-	// lacking a CRTC on last modeset)
-	struct wlr_drm_connector *conn;
-	wl_list_for_each(conn, &drm->outputs, link) {
-		if (conn->status == WLR_DRM_CONN_NEEDS_MODESET &&
-				conn->crtc != NULL && conn->desired_mode != NULL &&
-				conn->desired_enabled) {
-			wlr_drm_conn_log(conn, WLR_DEBUG,
-				"Output has a desired mode and a CRTC, attempting a modeset");
-			struct wlr_output_state state = {
-				.committed = WLR_OUTPUT_STATE_MODE | WLR_OUTPUT_STATE_ENABLED,
-				.enabled = true,
-				.mode_type = WLR_OUTPUT_STATE_MODE_FIXED,
-				.mode = conn->desired_mode,
-			};
-			drm_connector_commit_state(conn, &state);
-		}
-	}
-}
-
 static bool drm_connector_alloc_crtc(struct wlr_drm_connector *conn) {
 	if (conn->crtc != NULL) {
 		return true;
@@ -727,8 +706,6 @@ static bool drm_connector_alloc_crtc(struct wlr_drm_connector *conn) {
 
 static bool drm_connector_set_mode(struct wlr_drm_connector *conn,
 		const struct wlr_drm_connector_state *state) {
-	struct wlr_drm_backend *drm = conn->backend;
-
 	struct wlr_output_mode *wlr_mode = NULL;
 	if (state->active) {
 		if (state->base->committed & WLR_OUTPUT_STATE_MODE) {
@@ -756,8 +733,6 @@ static bool drm_connector_set_mode(struct wlr_drm_connector *conn,
 			if (!drm_crtc_commit(conn, state, 0, false)) {
 				return false;
 			}
-			realloc_crtcs(drm);
-			attempt_enable_needs_modeset(drm);
 		}
 		wlr_output_update_enabled(&conn->output, false);
 		return true;
@@ -1451,8 +1426,6 @@ void scan_drm_connectors(struct wlr_drm_backend *drm) {
 		wlr_signal_emit_safe(&drm->backend.events.new_output,
 			&conn->output);
 	}
-
-	attempt_enable_needs_modeset(drm);
 }
 
 static int mhz_to_nsec(int mhz) {

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -117,7 +117,6 @@ struct wlr_drm_connector {
 	struct wlr_drm_backend *backend;
 	char name[24];
 	enum wlr_drm_connector_status status;
-	struct wlr_output_mode *desired_mode;
 	bool desired_enabled;
 	uint32_t id;
 


### PR DESCRIPTION
Modesets require a buffer. The DRM backend tried to auto-enable
outputs when a CRTC becomes available in the past, but now that
fails because no buffer is available.

Instead of having this magic inside the DRM backend, a better
approach is to do it in the compositor or in an optional helper.