### PR TITLE
Update loc count in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # wlroots
 
 Pluggable, composable, unopinionated modules for building a [Wayland]
-compositor; or about 50,000 lines of code you were going to write anyway.
+compositor; or about 60,000 lines of code you were going to write anyway.
 
 - wlroots provides backends that abstract the underlying display and input
   hardware, including KMS/DRM, libinput, Wayland, X11, and headless backends,


### PR DESCRIPTION
This improves on the work done in #1391.

Thanks for all the work!
```
wlroots cloc .
     366 text files.
     366 unique files.
      11 files ignored.

1 error:
Line count, exceeded timeout:  ./examples/cat.c

github.com/AlDanial/cloc v 1.90  T=2.29 s (155.7 files/s, 35608.6 lines/s)
-------------------------------------------------------------------------------
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
C                              171           9153           4595          49427
C/C++ Header                   139           2038           4174           7010
XML                             15            508             33           2794
Meson                           23             85             14            842
Markdown                         4            134              0            450
YAML                             3              0              0            111
make                             1              5              3             22
-------------------------------------------------------------------------------
SUM:                           356          11923           8819          60656
-------------------------------------------------------------------------------
```