### PR TITLE
scene: fix compile error in release builds

### DIFF
--- a/types/wlr_scene.c
+++ b/types/wlr_scene.c
@@ -243,7 +243,7 @@ static void _scene_node_damage_whole(struct wlr_scene_node *node,
 			lx + child->state.x, ly + child->state.y);
 	}
 
-	int width, height;
+	int width = 0, height = 0;
 	switch (node->type) {
 	case WLR_SCENE_NODE_ROOT:
 		return;


### PR DESCRIPTION
On release builds, gcc detects a variable uninitialized error, and generates
a warning, which gets converted to an error due to -Werror:

```
cc -Ilibwlroots.so.10.p -I. -I.. -Iinclude -I../include -Iprotocol -I../protocol -I/usr/include/libdrm -I/usr/include/pixman-1 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -std=c11 -O3 -DWLR_USE_UNSTABLE -DWLR_LITTLE_ENDIAN=1 -DWLR_BIG_ENDIAN=0 -Wundef -Wlogical-op -Wmissing-include-dirs -Wold-style-definition -Wpointer-arith -Winit-self -Wstrict-prototypes -Wimplicit-fallthrough=2 -Wendif-labels -Wstrict-aliasing=2 -Woverflow -Wmissing-prototypes -Walloca -Wno-missing-braces -Wno-missing-field-initializers -Wno-unused-parameter -fmacro-prefix-map=../= -DHAS_GBM_BO_GET_FD_FOR_PLANE=0 '-DICONDIR="/usr/local/share/icons"' -DHAS_XCB_ERRORS=0 -fPIC -MD -MQ libwlroots.so.10.p/types_wlr_scene.c.o -MF libwlroots.so.10.p/types_wlr_scene.c.o.d -o libwlroots.so.10.p/types_wlr_scene.c.o -c ../types/wlr_scene.c
../types/wlr_scene.c: In function ‘_scene_node_damage_whole’:
../types/wlr_scene.c:246:13: error: ‘height’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  246 |  int width, height;
      |             ^~~~~~
../types/wlr_scene.c:246:6: error: ‘width’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  246 |  int width, height;
      |      ^~~~~
cc1: all warnings being treated as errors
```