### PR TITLE
build: simplify get_variable calls

### DIFF
--- a/include/xwayland/meson.build
+++ b/include/xwayland/meson.build
@@ -1,7 +1,7 @@
 have_listenfd = false
 if xwayland.found()
-	xwayland_path = xwayland.get_variable(pkgconfig: 'xwayland')
-	have_listenfd = xwayland.get_variable(pkgconfig: 'have_listenfd') == 'true'
+	xwayland_path = xwayland.get_variable('xwayland')
+	have_listenfd = xwayland.get_variable('have_listenfd') == 'true'
 else
 	xwayland_path = xwayland_prog.full_path()
 endif

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -3,11 +3,11 @@ wayland_protos = dependency('wayland-protocols',
 	fallback: ['wayland-protocols', 'wayland_protocols'],
 	default_options: ['tests=false'],
 )
-wl_protocol_dir = wayland_protos.get_variable(pkgconfig: 'pkgdatadir', internal: 'pkgdatadir')
+wl_protocol_dir = wayland_protos.get_variable('pkgdatadir')
 
 wayland_scanner_dep = dependency('wayland-scanner', native: true)
 wayland_scanner = find_program(
-	wayland_scanner_dep.get_variable(pkgconfig: 'wayland_scanner'),
+	wayland_scanner_dep.get_variable('wayland_scanner'),
 	native: true,
 )
 


### PR DESCRIPTION
With recent-ish Meson we can stop repeating the variable name for
each provider.