### PR TITLE
xdg-toplevel: refactor configure/state flow

### DIFF
--- a/include/types/wlr_xdg_shell.h
+++ b/include/types/wlr_xdg_shell.h
@@ -13,7 +13,6 @@ struct wlr_xdg_positioner_resource {
 extern const struct wlr_surface_role xdg_toplevel_surface_role;
 extern const struct wlr_surface_role xdg_popup_surface_role;
 
-uint32_t schedule_xdg_surface_configure(struct wlr_xdg_surface *surface);
 struct wlr_xdg_surface *create_xdg_surface(
 	struct wlr_xdg_client *client, struct wlr_surface *surface,
 	uint32_t id);
@@ -41,7 +40,6 @@ void send_xdg_toplevel_configure(struct wlr_xdg_surface *surface,
 	struct wlr_xdg_surface_configure *configure);
 void handle_xdg_toplevel_ack_configure(struct wlr_xdg_surface *surface,
 	struct wlr_xdg_surface_configure *configure);
-bool compare_xdg_surface_toplevel_state(struct wlr_xdg_toplevel *state);
 void destroy_xdg_toplevel(struct wlr_xdg_surface *surface);
 
 #endif

--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -105,10 +105,16 @@ struct wlr_xdg_toplevel_state {
 	uint32_t width, height;
 	uint32_t max_width, max_height;
 	uint32_t min_width, min_height;
+};
 
-	// Since the fullscreen request may be made before the toplevel's surface
-	// is mapped, this is used to store the requested fullscreen output (if
-	// any) for wlr_xdg_toplevel::client_pending.
+struct wlr_xdg_toplevel_configure {
+	bool maximized, fullscreen, resizing, activated;
+	uint32_t tiled; // enum wlr_edges
+	uint32_t width, height;
+};
+
+struct wlr_xdg_toplevel_requested {
+	bool maximized, minimized, fullscreen;
 	struct wlr_output *fullscreen_output;
 	struct wl_listener fullscreen_output_destroy;
 };
@@ -121,10 +127,15 @@ struct wlr_xdg_toplevel {
 	struct wlr_xdg_surface *parent;
 	struct wl_listener parent_unmap;
 
-	struct wlr_xdg_toplevel_state client_pending;
-	struct wlr_xdg_toplevel_state server_pending;
-	struct wlr_xdg_toplevel_state last_acked;
-	struct wlr_xdg_toplevel_state current;
+	struct wlr_xdg_toplevel_state current, pending;
+
+	// Properties to be sent to the client in the next configure event.
+	struct wlr_xdg_toplevel_configure scheduled;
+
+	// Properties that the client has requested. Intended to be checked
+	// by the compositor on surface map and handled accordingly
+	// (e.g. a client might want to start already in a fullscreen state).
+	struct wlr_xdg_toplevel_requested requested;
 
 	char *title;
 	char *app_id;
@@ -147,7 +158,7 @@ struct wlr_xdg_surface_configure {
 	struct wl_list link; // wlr_xdg_surface::configure_list
 	uint32_t serial;
 
-	struct wlr_xdg_toplevel_state *toplevel_state;
+	struct wlr_xdg_toplevel_configure *toplevel_configure;
 };
 
 /**

--- a/types/xdg_shell/wlr_xdg_popup.c
+++ b/types/xdg_shell/wlr_xdg_popup.c
@@ -207,7 +207,7 @@ void handle_xdg_surface_popup_committed(struct wlr_xdg_surface *surface) {
 	}
 
 	if (!surface->popup->committed) {
-		schedule_xdg_surface_configure(surface);
+		wlr_xdg_surface_schedule_configure(surface);
 		surface->popup->committed = true;
 	}
 }

--- a/types/xdg_shell/wlr_xdg_surface.c
+++ b/types/xdg_shell/wlr_xdg_surface.c
@@ -195,6 +195,9 @@ uint32_t wlr_xdg_surface_schedule_configure(struct wlr_xdg_surface *surface) {
 		surface->configure_next_serial = wl_display_next_serial(display);
 		surface->configure_idle = wl_event_loop_add_idle(loop,
 			surface_send_configure, surface);
+		if (surface->configure_idle == NULL) {
+			wl_client_post_no_memory(surface->client->client);
+		}
 	}
 	return surface->configure_next_serial;
 }

--- a/types/xdg_shell/wlr_xdg_surface.c
+++ b/types/xdg_shell/wlr_xdg_surface.c
@@ -23,7 +23,7 @@ static void xdg_surface_configure_destroy(
 		return;
 	}
 	wl_list_remove(&configure->link);
-	free(configure->toplevel_state);
+	free(configure->toplevel_configure);
 	free(configure);
 }
 
@@ -487,11 +487,10 @@ void reset_xdg_surface(struct wlr_xdg_surface *xdg_surface) {
 	case WLR_XDG_SURFACE_ROLE_TOPLEVEL:
 		wl_resource_set_user_data(xdg_surface->toplevel->resource, NULL);
 		xdg_surface->toplevel->resource = NULL;
-
-		if (xdg_surface->toplevel->client_pending.fullscreen_output) {
-			struct wlr_xdg_toplevel_state *client_pending =
-				&xdg_surface->toplevel->client_pending;
-			wl_list_remove(&client_pending->fullscreen_output_destroy.link);
+		struct wlr_xdg_toplevel_requested *req =
+			&xdg_surface->toplevel->requested;
+		if (req->fullscreen_output) {
+			wl_list_remove(&req->fullscreen_output_destroy.link);
 		}
 		free(xdg_surface->toplevel);
 		xdg_surface->toplevel = NULL;


### PR DESCRIPTION
*See individual commits.*

Fixes https://github.com/swaywm/wlroots/issues/2330

---

Preliminary work for https://github.com/swaywm/wlroots/pull/3151.
If this is fine, I'll make a similar PR for `wlr_layer_surface`.

This is a breaking change: compositors that used to check `wlr_xdg_toplevel.client_pending` will now have to check `wlr_xdg_toplevel.requested`.