### PR TITLE
layer-shell: refactor configure/state flow

### DIFF
--- a/include/wlr/types/wlr_layer_shell_v1.h
+++ b/include/wlr/types/wlr_layer_shell_v1.h
@@ -53,12 +53,14 @@ struct wlr_layer_surface_v1_state {
 	uint32_t desired_width, desired_height;
 	uint32_t actual_width, actual_height;
 	enum zwlr_layer_shell_v1_layer layer;
+	uint32_t configure_serial;
 };
 
 struct wlr_layer_surface_v1_configure {
 	struct wl_list link; // wlr_layer_surface_v1::configure_list
 	uint32_t serial;
-	struct wlr_layer_surface_v1_state state;
+
+	uint32_t width, height;
 };
 
 struct wlr_layer_surface_v1 {
@@ -71,15 +73,9 @@ struct wlr_layer_surface_v1 {
 	char *namespace;
 
 	bool added, configured, mapped;
-	uint32_t configure_serial;
-	uint32_t configure_next_serial;
 	struct wl_list configure_list;
 
-	struct wlr_layer_surface_v1_configure *acked_configure;
-
-	struct wlr_layer_surface_v1_state client_pending;
-	struct wlr_layer_surface_v1_state server_pending;
-	struct wlr_layer_surface_v1_state current;
+	struct wlr_layer_surface_v1_state current, pending;
 
 	struct wl_listener surface_destroy;
 
@@ -119,9 +115,9 @@ struct wlr_layer_shell_v1 *wlr_layer_shell_v1_create(struct wl_display *display)
 /**
  * Notifies the layer surface to configure itself with this width/height. The
  * layer_surface will signal its map event when the surface is ready to assume
- * this size.
+ * this size. Returns the associated configure serial.
  */
-void wlr_layer_surface_v1_configure(struct wlr_layer_surface_v1 *surface,
+uint32_t wlr_layer_surface_v1_configure(struct wlr_layer_surface_v1 *surface,
 		uint32_t width, uint32_t height);
 
 /**


### PR DESCRIPTION
Same logic as xdg-toplevel.

---

Preliminary work for #3151.

This is a breaking change: compositors that used to check `wlr_layer_surface_v1.client_pending` will now have to check `wlr_layer_surface_v1.pending`