### PR TITLE
backend/session: Run libseat callbacks on idle

### DIFF
--- a/backend/backend.c
+++ b/backend/backend.c
@@ -130,6 +130,8 @@ static struct wlr_session *session_create_and_wait(struct wl_display *disp) {
 		struct wl_event_loop *event_loop =
 			wl_display_get_event_loop(session->display);
 
+		// Session enable might already have been registered as idle callback
+		wl_event_loop_dispatch_idle(event_loop);
 		while (!session->active) {
 			int ret = wl_event_loop_dispatch(event_loop, (int)timeout);
 			if (ret < 0) {


### PR DESCRIPTION
libseat callbacks can be triggered from the stack of a libseat call if
they were read while waiting for a return value. This is necessary as
dispatch will not be called when the file descriptor has already
been drained.

This leads to issues if we're called by libinput to close a device, and
then handle a disable event that leads to libinput closing all its
devices.

As workaround, break the stack on libseat events by executing them as
idle events.

Fixes: https://github.com/swaywm/wlroots/issues/3200

TODO:
- [ ] queued idle events could fire after wlr_session_destroy (use-after-free)