### PR TITLE
Decouple the backend and the renderer

### DIFF
--- a/examples/fullscreen-shell.c
+++ b/examples/fullscreen-shell.c
@@ -203,7 +203,7 @@ int main(int argc, char *argv[]) {
 	struct fullscreen_server server = {0};
 	server.wl_display = wl_display_create();
 	server.backend = wlr_backend_autocreate(server.wl_display);
-	server.renderer = wlr_backend_get_renderer(server.backend);
+	server.renderer = wlr_renderer_autocreate(server.backend);
 	wlr_renderer_init_wl_display(server.renderer, server.wl_display);
 
 	wlr_compositor_create(server.wl_display, server.renderer);

--- a/examples/multi-pointer.c
+++ b/examples/multi-pointer.c
@@ -22,6 +22,7 @@
 struct sample_state {
 	struct wl_display *display;
 	struct wlr_xcursor *xcursor;
+	struct wlr_renderer *renderer;
 	float default_color[4];
 	float clear_color[4];
 	struct wlr_output_layout *layout;
@@ -90,7 +91,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	struct sample_output *output = wl_container_of(listener, output, frame);
 	struct sample_state *sample = output->sample;
 	struct wlr_output *wlr_output = output->output;
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(wlr_output->backend);
+	struct wlr_renderer *renderer = sample->renderer;
 
 	wlr_output_attach_render(wlr_output, NULL);
 
@@ -269,6 +270,9 @@ int main(int argc, char *argv[]) {
 	if (!wlr) {
 		exit(1);
 	}
+
+	state.renderer = wlr_renderer_autocreate(wlr);
+
 	wl_list_init(&state.cursors);
 	wl_list_init(&state.pointers);
 	wl_list_init(&state.outputs);

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -273,7 +273,7 @@ int main(int argc, char *argv[]) {
 	wl_signal_add(&wlr->events.new_input, &state.new_input);
 	state.new_input.notify = new_input_notify;
 
-	state.renderer = wlr_backend_get_renderer(wlr);
+	state.renderer = wlr_renderer_autocreate(wlr);
 	state.cat_texture = wlr_texture_from_pixels(state.renderer,
 		DRM_FORMAT_ABGR8888, cat_tex.width * 4, cat_tex.width, cat_tex.height,
 		cat_tex.pixel_data);

--- a/examples/pointer.c
+++ b/examples/pointer.c
@@ -24,6 +24,7 @@
 struct sample_state {
 	struct wl_display *display;
 	struct compositor_state *compositor;
+	struct wlr_renderer *renderer;
 	struct wlr_xcursor_manager *xcursor_manager;
 	struct wlr_cursor *cursor;
 	double cur_x, cur_y;
@@ -95,7 +96,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	struct sample_output *sample_output = wl_container_of(listener, sample_output, frame);
 	struct sample_state *state = sample_output->state;
 	struct wlr_output *wlr_output = sample_output->output;
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(wlr_output->backend);
+	struct wlr_renderer *renderer = state->renderer;
 	assert(renderer);
 
 	wlr_output_attach_render(wlr_output, NULL);
@@ -331,6 +332,9 @@ int main(int argc, char *argv[]) {
 	if (!wlr) {
 		exit(1);
 	}
+
+	state.renderer = wlr_renderer_autocreate(wlr);
+
 	state.cursor = wlr_cursor_create();
 	state.layout = wlr_output_layout_create();
 	wlr_cursor_attach_output_layout(state.cursor, state.layout);

--- a/examples/quads.c
+++ b/examples/quads.c
@@ -195,7 +195,7 @@ int main(int argc, char *argv[]) {
 	state.new_input.notify = new_input_notify;
 	clock_gettime(CLOCK_MONOTONIC, &state.last_frame);
 
-	state.renderer = wlr_backend_get_renderer(wlr);
+	state.renderer = wlr_renderer_autocreate(wlr);
 	if (!state.renderer) {
 		wlr_log(WLR_ERROR, "Could not start compositor, OOM");
 		wlr_backend_destroy(wlr);

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -245,7 +245,7 @@ int main(int argc, char *argv[]) {
 	state.new_input.notify = new_input_notify;
 	clock_gettime(CLOCK_MONOTONIC, &state.last_frame);
 
-	state.renderer = wlr_backend_get_renderer(wlr);
+	state.renderer = wlr_renderer_autocreate(wlr);
 	if (!state.renderer) {
 		wlr_log(WLR_ERROR, "Could not start compositor, OOM");
 		wlr_backend_destroy(wlr);

--- a/examples/scene-graph.c
+++ b/examples/scene-graph.c
@@ -161,7 +161,7 @@ int main(int argc, char *argv[]) {
 	server.backend = wlr_backend_autocreate(server.display);
 	server.scene = wlr_scene_create();
 
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(server.backend);
+	struct wlr_renderer *renderer = wlr_renderer_autocreate(server.backend);
 	wlr_renderer_init_wl_display(renderer, server.display);
 
 	struct wlr_compositor *compositor =

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -18,6 +18,7 @@ struct sample_state {
 	struct wl_display *display;
 	struct wl_listener new_output;
 	struct wl_listener new_input;
+	struct wlr_renderer *renderer;
 	struct timespec last_frame;
 	float color[4];
 	int dec;
@@ -61,8 +62,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 
 	wlr_output_attach_render(wlr_output, NULL);
 
-	struct wlr_renderer *renderer =
-		wlr_backend_get_renderer(wlr_output->backend);
+	struct wlr_renderer *renderer = sample->renderer;
 	wlr_renderer_begin(renderer, wlr_output->width, wlr_output->height);
 	wlr_renderer_clear(renderer, sample->color);
 	wlr_renderer_end(renderer);
@@ -171,6 +171,9 @@ int main(void) {
 	if (!backend) {
 		exit(1);
 	}
+
+	state.renderer = wlr_renderer_autocreate(backend);
+
 	wl_signal_add(&backend->events.new_output, &state.new_output);
 	state.new_output.notify = new_output_notify;
 	wl_signal_add(&backend->events.new_input, &state.new_input);

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -361,7 +361,7 @@ int main(int argc, char *argv[]) {
 	state.new_input.notify = new_input_notify;
 	clock_gettime(CLOCK_MONOTONIC, &state.last_frame);
 
-	state.renderer = wlr_backend_get_renderer(wlr);
+	state.renderer = wlr_renderer_autocreate(wlr);
 	if (!state.renderer) {
 		wlr_log(WLR_ERROR, "Could not start compositor, OOM");
 		exit(EXIT_FAILURE);

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -254,8 +254,7 @@ int main(int argc, char *argv[]) {
 	state.new_input.notify = new_input_notify;
 	clock_gettime(CLOCK_MONOTONIC, &state.last_frame);
 
-
-	state.renderer = wlr_backend_get_renderer(wlr);
+	state.renderer = wlr_renderer_autocreate(wlr);
 	if (!state.renderer) {
 		wlr_log(WLR_ERROR, "Could not start compositor, OOM");
 		exit(EXIT_FAILURE);


### PR DESCRIPTION
Removes the hard coupling between the backend and the renderer to improve third party backends/renderers

Related to #3195 