### PR TITLE
for_each_surface and surface_at: skip unmapped surfaces

### DIFF
--- a/include/wlr/types/wlr_layer_shell_v1.h
+++ b/include/wlr/types/wlr_layer_shell_v1.h
@@ -143,7 +143,10 @@ bool wlr_surface_is_layer_surface(struct wlr_surface *surface);
 struct wlr_layer_surface_v1 *wlr_layer_surface_v1_from_wlr_surface(
 		struct wlr_surface *surface);
 
-/* Calls the iterator function for each sub-surface and popup of this surface */
+/**
+ * Calls the iterator function for each mapped sub-surface and popup of this
+ * surface (whether or not this surface is mapped).
+ */
 void wlr_layer_surface_v1_for_each_surface(struct wlr_layer_surface_v1 *surface,
 		wlr_surface_iterator_func_t iterator, void *user_data);
 

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -264,9 +264,9 @@ void wlr_surface_get_extends(struct wlr_surface *surface, struct wlr_box *box);
 struct wlr_surface *wlr_surface_from_resource(struct wl_resource *resource);
 
 /**
- * Call `iterator` on each surface in the surface tree, with the surface's
- * position relative to the root surface. The function is called from root to
- * leaves (in rendering order).
+ * Call `iterator` on each mapped surface in the surface tree (whether or not
+ * this surface is mapped), with the surface's position relative to the root
+ * surface. The function is called from root to leaves (in rendering order).
  */
 void wlr_surface_for_each_surface(struct wlr_surface *surface,
 	wlr_surface_iterator_func_t iterator, void *user_data);

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -233,7 +233,8 @@ bool wlr_surface_point_accepts_input(struct wlr_surface *surface,
 		double sx, double sy);
 
 /**
- * Find a surface in this surface's tree that accepts input events at the given
+ * Find a surface in this surface's tree that accepts input events and has all
+ * parents mapped (except this surface, which can be unmapped) at the given
  * surface-local coordinates. Returns the surface and coordinates in the leaf
  * surface coordinate system or NULL if no surface is found at that location.
  */

--- a/include/wlr/types/wlr_xdg_shell.h
+++ b/include/wlr/types/wlr_xdg_shell.h
@@ -411,17 +411,19 @@ void wlr_xdg_surface_get_geometry(struct wlr_xdg_surface *surface,
 		struct wlr_box *box);
 
 /**
- * Call `iterator` on each surface and popup in the xdg-surface tree, with the
- * surface's position relative to the root xdg-surface. The function is called
- * from root to leaves (in rendering order).
+ * Call `iterator` on each mapped surface and popup in the xdg-surface tree
+ * (whether or not this xdg-surface is mapped), with the surface's position
+ * relative to the root xdg-surface. The function is called from root to leaves
+ * (in rendering order).
  */
 void wlr_xdg_surface_for_each_surface(struct wlr_xdg_surface *surface,
 		wlr_surface_iterator_func_t iterator, void *user_data);
 
 /**
- * Call `iterator` on each popup's surface and popup's subsurface in the
- * xdg-surface tree, with the surfaces's position relative to the root
- * xdg-surface. The function is called from root to leaves (in rendering order).
+ * Call `iterator` on each mapped popup's surface and popup's subsurface in the
+ * xdg-surface tree (whether or not this xdg-surface is mapped), with the
+ * surfaces's position relative to the root xdg-surface. The function is called
+ * from root to leaves (in rendering order).
  */
 void wlr_xdg_surface_for_each_popup_surface(struct wlr_xdg_surface *surface,
 		wlr_surface_iterator_func_t iterator, void *user_data);

--- a/types/wlr_layer_shell_v1.c
+++ b/types/wlr_layer_shell_v1.c
@@ -506,7 +506,7 @@ void wlr_layer_surface_v1_for_each_popup_surface(struct wlr_layer_surface_v1 *su
 	struct wlr_xdg_popup *popup_state;
 	wl_list_for_each(popup_state, &surface->popups, link) {
 		struct wlr_xdg_surface *popup = popup_state->base;
-		if (!popup->configured) {
+		if (!popup->configured || !popup->mapped) {
 			continue;
 		}
 

--- a/types/wlr_layer_shell_v1.c
+++ b/types/wlr_layer_shell_v1.c
@@ -541,6 +541,9 @@ struct wlr_surface *wlr_layer_surface_v1_popup_surface_at(
 	struct wlr_xdg_popup *popup_state;
 	wl_list_for_each(popup_state, &surface->popups, link) {
 		struct wlr_xdg_surface *popup = popup_state->base;
+		if (!popup->mapped) {
+			continue;
+		}
 
 		double popup_sx = popup_state->geometry.x - popup->geometry.x;
 		double popup_sy = popup_state->geometry.y - popup->geometry.y;

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -1204,6 +1204,10 @@ struct wlr_surface *wlr_surface_surface_at(struct wlr_surface *surface,
 	struct wlr_subsurface *subsurface;
 	wl_list_for_each_reverse(subsurface, &surface->current.subsurfaces_above,
 			current.link) {
+		if (!subsurface->mapped) {
+			continue;
+		}
+
 		double _sub_x = subsurface->current.x;
 		double _sub_y = subsurface->current.y;
 		struct wlr_surface *sub = wlr_surface_surface_at(subsurface->surface,
@@ -1225,6 +1229,10 @@ struct wlr_surface *wlr_surface_surface_at(struct wlr_surface *surface,
 
 	wl_list_for_each_reverse(subsurface, &surface->current.subsurfaces_below,
 			current.link) {
+		if (!subsurface->mapped) {
+			continue;
+		}
+
 		double _sub_x = subsurface->current.x;
 		double _sub_y = subsurface->current.y;
 		struct wlr_surface *sub = wlr_surface_surface_at(subsurface->surface,

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -1331,6 +1331,10 @@ static void surface_for_each_surface(struct wlr_surface *surface, int x, int y,
 		wlr_surface_iterator_func_t iterator, void *user_data) {
 	struct wlr_subsurface *subsurface;
 	wl_list_for_each(subsurface, &surface->current.subsurfaces_below, current.link) {
+		if (!subsurface->mapped) {
+			continue;
+		}
+
 		struct wlr_subsurface_parent_state *state = &subsurface->current;
 		int sx = state->x;
 		int sy = state->y;
@@ -1342,6 +1346,10 @@ static void surface_for_each_surface(struct wlr_surface *surface, int x, int y,
 	iterator(surface, x, y, user_data);
 
 	wl_list_for_each(subsurface, &surface->current.subsurfaces_above, current.link) {
+		if (!subsurface->mapped) {
+			continue;
+		}
+
 		struct wlr_subsurface_parent_state *state = &subsurface->current;
 		int sx = state->x;
 		int sy = state->y;

--- a/types/xdg_shell/wlr_xdg_surface.c
+++ b/types/xdg_shell/wlr_xdg_surface.c
@@ -597,7 +597,7 @@ static void xdg_surface_for_each_popup_surface(struct wlr_xdg_surface *surface,
 	struct wlr_xdg_popup *popup_state;
 	wl_list_for_each(popup_state, &surface->popups, link) {
 		struct wlr_xdg_surface *popup = popup_state->base;
-		if (!popup->configured) {
+		if (!popup->configured || !popup->mapped) {
 			continue;
 		}
 

--- a/types/xdg_shell/wlr_xdg_surface.c
+++ b/types/xdg_shell/wlr_xdg_surface.c
@@ -563,6 +563,9 @@ struct wlr_surface *wlr_xdg_surface_popup_surface_at(
 	struct wlr_xdg_popup *popup_state;
 	wl_list_for_each(popup_state, &surface->popups, link) {
 		struct wlr_xdg_surface *popup = popup_state->base;
+		if (!popup->mapped) {
+			continue;
+		}
 
 		double popup_sx, popup_sy;
 		wlr_xdg_popup_get_position(popup_state, &popup_sx, &popup_sy);


### PR DESCRIPTION
These functions are used mostly for rendering, where including unmapped surfaces is undesired.

This is a breaking change. However, few to no usages will have to be updated.

Tested in kiwmi (with https://github.com/buffet/kiwmi/commit/d69ccc7bdd6d2e6d2930bdbeadbc6c1d679e55a0 reverted) using [`tiosgz/wleird@subsubsurface:subsubsurface.c`](https://github.com/tiosgz/wleird/blob/subsubsurface/subsubsurface.c) (when the black surface hides, its subsurface \[the red one\] should also be hidden). Can also be tested in tinywl.