### PR TITLE
backend: create renderer and allocator in wlr_backend_autocreate

### DIFF
--- a/backend/backend.c
+++ b/backend/backend.c
@@ -209,6 +209,21 @@ static size_t parse_outputs_env(const char *name) {
 	return outputs;
 }
 
+static struct wlr_backend *ensure_backend_renderer_and_allocator(
+		struct wlr_backend *backend) {
+	struct wlr_renderer *renderer = wlr_backend_get_renderer(backend);
+	if (renderer == NULL) {
+		wlr_backend_destroy(backend);
+		return NULL;
+	}
+	struct wlr_allocator *allocator = backend_get_allocator(backend);
+	if (allocator == NULL) {
+		wlr_backend_destroy(backend);
+		return NULL;
+	}
+	return backend;
+}
+
 static struct wlr_backend *attempt_wl_backend(struct wl_display *display) {
 	struct wlr_backend *backend = wlr_wl_backend_create(display, NULL);
 	if (backend == NULL) {
@@ -220,7 +235,7 @@ static struct wlr_backend *attempt_wl_backend(struct wl_display *display) {
 		wlr_wl_output_create(backend);
 	}
 
-	return backend;
+	return ensure_backend_renderer_and_allocator(backend);
 }
 
 #if WLR_HAS_X11_BACKEND
@@ -236,7 +251,7 @@ static struct wlr_backend *attempt_x11_backend(struct wl_display *display,
 		wlr_x11_output_create(backend);
 	}
 
-	return backend;
+	return ensure_backend_renderer_and_allocator(backend);
 }
 #endif
 
@@ -252,7 +267,7 @@ static struct wlr_backend *attempt_headless_backend(
 		wlr_headless_add_output(backend, 1280, 720);
 	}
 
-	return backend;
+	return ensure_backend_renderer_and_allocator(backend);
 }
 
 static struct wlr_backend *attempt_noop_backend(struct wl_display *display) {
@@ -297,7 +312,7 @@ static struct wlr_backend *attempt_drm_backend(struct wl_display *display,
 		wlr_multi_backend_add(backend, drm);
 	}
 
-	return primary_drm;
+	return ensure_backend_renderer_and_allocator(primary_drm);
 }
 #endif
 

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -11,7 +11,6 @@
 #include <wlr/interfaces/wlr_output.h>
 #include <wlr/util/log.h>
 #include <xf86drm.h>
-#include "backend/backend.h"
 #include "backend/drm/drm.h"
 #include "util/signal.h"
 
@@ -256,12 +255,6 @@ struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
 			wlr_drm_format_set_add(&drm->mgpu_formats, fmt->format,
 				DRM_FORMAT_MOD_LINEAR);
 		}
-	}
-
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(&drm->backend);
-	struct wlr_allocator *allocator = backend_get_allocator(&drm->backend);
-	if (renderer == NULL || allocator == NULL) {
-		goto error_mgpu_renderer;
 	}
 
 	drm->session_destroy.notify = handle_session_destroy;

--- a/backend/headless/backend.c
+++ b/backend/headless/backend.c
@@ -9,10 +9,8 @@
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/util/log.h>
 #include <xf86drm.h>
-#include "backend/backend.h"
 #include "backend/headless.h"
 #include "render/drm_format_set.h"
-#include "render/wlr_renderer.h"
 #include "util/signal.h"
 
 struct wlr_headless_backend *headless_backend_from_backend(
@@ -135,11 +133,6 @@ static bool backend_init(struct wlr_headless_backend *backend,
 		backend->parent_renderer = renderer;
 		backend->parent_renderer_destroy.notify = handle_renderer_destroy;
 		wl_signal_add(&renderer->events.destroy, &backend->parent_renderer_destroy);
-	}
-
-	if (backend_get_allocator(&backend->backend) == NULL) {
-		wlr_log(WLR_ERROR, "Failed to create allocator");
-		return false;
 	}
 
 	backend->display_destroy.notify = handle_display_destroy;

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -15,11 +15,9 @@
 #include <wlr/interfaces/wlr_output.h>
 #include <wlr/util/log.h>
 
-#include "backend/backend.h"
 #include "backend/wayland.h"
 #include "render/drm_format_set.h"
 #include "render/pixel_format.h"
-#include "render/wlr_renderer.h"
 #include "util/signal.h"
 
 #include "drm-client-protocol.h"
@@ -444,19 +442,11 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display,
 		wl->drm_fd = -1;
 	}
 
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(&wl->backend);
-	struct wlr_allocator *allocator = backend_get_allocator(&wl->backend);
-	if (renderer == NULL || allocator == NULL) {
-		goto error_drm_fd;
-	}
-
 	wl->local_display_destroy.notify = handle_display_destroy;
 	wl_display_add_destroy_listener(display, &wl->local_display_destroy);
 
 	return &wl->backend;
 
-error_drm_fd:
-	close(wl->drm_fd);
 error_remote_display_src:
 	wl_event_source_remove(wl->remote_display_src);
 error_registry:

--- a/backend/x11/backend.c
+++ b/backend/x11/backend.c
@@ -29,7 +29,6 @@
 #include <wlr/interfaces/wlr_pointer.h>
 #include <wlr/util/log.h>
 
-#include "backend/backend.h"
 #include "backend/x11.h"
 #include "render/drm_format_set.h"
 #include "util/signal.h"
@@ -609,12 +608,6 @@ struct wlr_backend *wlr_x11_backend_create(struct wl_display *display,
 			wlr_log(WLR_ERROR, "Failed to query DRI3 DRM FD");
 			goto error_event;
 		}
-	}
-
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(&x11->backend);
-	struct wlr_allocator *allocator = backend_get_allocator(&x11->backend);
-	if (renderer == NULL || allocator == NULL) {
-		goto error_event;
 	}
 
 	// Windows can only display buffers with the depth they were created with


### PR DESCRIPTION
Instead of ensuring the renderer and allocator are initialized in each
backend, do it in wlr_backend_autocreate. This allows compositors to
create backends without any renderer/allocator if they side-step
wlr_backend_autocreate.

Since the wlr_backend_get_renderer and backend_get_allocator end up
calling wlr_renderer_autocreate and wlr_allocator_autocreate, it sounds
like a good idea to centralize all of the opimionated bits in one place.