### PR TITLE
backend: unbreak build without libinput package

### DIFF
--- a/backend/backend.c
+++ b/backend/backend.c
@@ -1,7 +1,6 @@
 #define _POSIX_C_SOURCE 200809L
 #include <assert.h>
 #include <errno.h>
-#include <libinput.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>


### PR DESCRIPTION
See [error log](https://github.com/swaywm/wlroots/files/7282201/wlroots-0.14.0.288.log) (`-Dbackends= -Drenderers= -Dxwayland=disabled`).