### PR TITLE
Remove redundant NULL buffer checks

### DIFF
--- a/types/wlr_layer_shell_v1.c
+++ b/types/wlr_layer_shell_v1.c
@@ -339,15 +339,28 @@ static void layer_surface_role_commit(struct wlr_surface *wlr_surface) {
 		surface->mapped = true;
 		wlr_signal_emit_safe(&surface->events.map, surface);
 	}
-	if (surface->configured && !wlr_surface_has_buffer(surface->surface) &&
-			surface->mapped) {
-		layer_surface_unmap(surface);
+}
+
+static void layer_surface_role_precommit(struct wlr_surface *wlr_surface) {
+	struct wlr_layer_surface_v1 *surface =
+		wlr_layer_surface_v1_from_wlr_surface(wlr_surface);
+	if (surface == NULL) {
+		return;
+	}
+
+	if (wlr_surface->pending.committed & WLR_SURFACE_STATE_BUFFER &&
+			wlr_surface->pending.buffer == NULL) {
+		// This is a NULL commit
+		if (surface->configured && surface->mapped) {
+			layer_surface_unmap(surface);
+		}
 	}
 }
 
 static const struct wlr_surface_role layer_surface_role = {
 	.name = "zwlr_layer_surface_v1",
 	.commit = layer_surface_role_commit,
+	.precommit = layer_surface_role_precommit,
 };
 
 static void handle_surface_destroyed(struct wl_listener *listener,

--- a/types/xdg_shell/wlr_xdg_surface.c
+++ b/types/xdg_shell/wlr_xdg_surface.c
@@ -336,10 +336,6 @@ void handle_xdg_surface_commit(struct wlr_surface *wlr_surface) {
 		surface->mapped = true;
 		wlr_signal_emit_safe(&surface->events.map, surface);
 	}
-	if (surface->configured && !wlr_surface_has_buffer(surface->surface) &&
-			surface->mapped) {
-		unmap_xdg_surface(surface);
-	}
 }
 
 void handle_xdg_surface_precommit(struct wlr_surface *wlr_surface) {


### PR DESCRIPTION
From what I understand, (confusingly named) `surface_apply_damage()` doesn't update `wlr_surface.buffer` if the upload has failed.