### PR TITLE
scene: add functions to place node on top/bottom

### DIFF
--- a/include/wlr/types/wlr_scene.h
+++ b/include/wlr/types/wlr_scene.h
@@ -140,6 +140,14 @@ void wlr_scene_node_place_above(struct wlr_scene_node *node,
 void wlr_scene_node_place_below(struct wlr_scene_node *node,
 	struct wlr_scene_node *sibling);
 /**
+ * Move the node above all of its sibling nodes.
+ */
+void wlr_scene_node_raise_to_top(struct wlr_scene_node *node);
+/**
+ * Move the node below all of its sibling nodes.
+ */
+void wlr_scene_node_lower_to_bottom(struct wlr_scene_node *node);
+/**
  * Move the node to another location in the tree.
  */
 void wlr_scene_node_reparent(struct wlr_scene_node *node,

--- a/types/scene/wlr_scene.c
+++ b/types/scene/wlr_scene.c
@@ -470,6 +470,24 @@ void wlr_scene_node_place_below(struct wlr_scene_node *node,
 	scene_node_damage_whole(sibling);
 }
 
+void wlr_scene_node_raise_to_top(struct wlr_scene_node *node) {
+	struct wlr_scene_node *current_top = wl_container_of(
+		node->parent->state.children.prev, current_top, state.link);
+	if (node == current_top) {
+		return;
+	}
+	wlr_scene_node_place_above(node, current_top);
+}
+
+void wlr_scene_node_lower_to_bottom(struct wlr_scene_node *node) {
+	struct wlr_scene_node *current_bottom = wl_container_of(
+		node->parent->state.children.prev, current_bottom, state.link);
+	if (node == current_bottom) {
+		return;
+	}
+	wlr_scene_node_place_below(node, current_bottom);
+}
+
 void wlr_scene_node_reparent(struct wlr_scene_node *node,
 		struct wlr_scene_node *new_parent) {
 	assert(node->type != WLR_SCENE_NODE_ROOT && new_parent != NULL);


### PR DESCRIPTION
Currently these functions remove the node from the scene if the sibling
argument is the same node as the node. Making this case a noop is much
more predictable behavior.