### PR TITLE
render/vulkan: Refactor image usages for modifiers

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -18,7 +18,7 @@ packages:
   - xwayland
   - libseat-dev
 sources:
-  - https://github.com/swaywm/wlroots
+  - https://gitlab.freedesktop.org/wlroots/wlroots.git
 tasks:
   - setup: |
       cd wlroots

--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -19,7 +19,7 @@ packages:
   - vulkan-headers
   - glslang
 sources:
-  - https://github.com/swaywm/wlroots
+  - https://gitlab.freedesktop.org/wlroots/wlroots.git
 tasks:
   - setup: |
       cd wlroots

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -26,7 +26,7 @@ packages:
   - sysutils/seatd
   - gmake
 sources:
-  - https://github.com/swaywm/wlroots
+  - https://gitlab.freedesktop.org/wlroots/wlroots.git
 tasks:
   - wlroots: |
       cd wlroots

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,7 @@
+include: https://git.sr.ht/~emersion/dalligi/blob/master/templates/multi.yml
+alpine:
+  extends: .dalligi
+archlinux:
+  extends: .dalligi
+freebsd:
+  extends: .dalligi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,13 @@ process is:
 4. **Merge** the merge request when all reviewers approve.
 5. **File** follow-up tickets if appropriate.
 
+## Code of Conduct
+
+Note that as a project hosted on freedesktop.org, wlroots follows its
+[Code of Conduct], based on the Contributor Covenant. Please conduct yourself
+in a respectful and civilized manner when communicating with community members
+on IRC and bug tracker.
+
 ## Style Reference
 
 wlroots is written in C with a style similar to the [kernel style], but with a
@@ -397,5 +404,6 @@ static void subsurface_handle_surface_destroy(struct wl_listener *listener,
 [linear, "recipe" style]: https://www.bitsnbites.eu/git-history-work-log-vs-recipe/
 [git-rebase.io]: https://git-rebase.io/
 [reference issues]: https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically
+[Code of Conduct]: https://www.freedesktop.org/wiki/CodeOfConduct/
 [How to Write a Git Commit Message]: https://chris.beams.io/posts/git-commit/
 [kernel style]: https://www.kernel.org/doc/Documentation/process/coding-style.rst

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,21 @@
 # Contributing to wlroots
 
-Contributing just involves sending a pull request. You will probably be more
+Contributing just involves sending a merge request. You will probably be more
 successful with your contribution if you visit [#sway-devel on Libera Chat]
 upfront and discuss your plans.
 
 Note: rules are made to be broken. Adjust or ignore any/all of these as you see
 fit, but be prepared to justify it to your peers.
 
-## Pull Requests
+## Merge Requests
 
-If you already have your own pull request habits, feel free to use them. If you
+If you already have your own merge request habits, feel free to use them. If you
 don't, however, allow me to make a suggestion: feature branches pulled from
 upstream. Try this:
 
 1. Fork wlroots
-2. `git clone git@github.com:<username>/wlroots.git && cd wlroots`
-3. `git remote add upstream https://github.com/swaywm/wlroots`
+2. `git clone git@gitlab.freedesktop.org:<username>/wlroots.git && cd wlroots`
+3. `git remote add upstream https://gitlab.freedesktop.org/wlroots/wlroots.git`
 
 You only need to do this once. You're never going to use your fork's master
 branch. Instead, when you start working on a feature, do this:
@@ -24,11 +24,11 @@ branch. Instead, when you start working on a feature, do this:
 2. `git checkout -b add-so-and-so-feature upstream/master`
 3. Add and commit your changes
 4. `git push -u origin add-so-and-so-feature`
-5. Make a pull request from your feature branch
+5. Make a merge request from your feature branch
 
-When you submit your pull request, your commit log should do most of the talking
+When you submit your merge request, your commit log should do most of the talking
 when it comes to describing your changes and their motivation. In addition to
-this, your pull request's comments will ideally include a test plan that the
+this, your merge request's comments will ideally include a test plan that the
 reviewers can use to (1) demonstrate the problem on master, if applicable and
 (2) verify that the problem no longer exists with your changes applied (or that
 your new features work correctly). Document all of the edge cases you're aware
@@ -80,15 +80,15 @@ cmd_move"* or *"Improve performance of arrange_windows on ARM"* or similar.
 
 The subsequent lines should be separated from the subject line by a single
 blank line, and include optional details. In this you can give justification
-for the change, [reference Github issues], or explain some of the subtler
+for the change, [reference issues], or explain some of the subtler
 details of your patch. This is important because when someone finds a line of
 code they don't understand later, they can use the `git blame` command to find
 out what the author was thinking when they wrote it. It's also easier to review
-your pull requests if they're separated into logical commits that have good
+your merge requests if they're separated into logical commits that have good
 commit messages and justify themselves in the extended commit description.
 
-As a good rule of thumb, anything you might put into the pull request
-description on Github is probably fair game for going into the extended commit
+As a good rule of thumb, anything you might put into the merge request
+description on GitLab is probably fair game for going into the extended commit
 message as well.
 
 See [How to Write a Git Commit Message] for more details.
@@ -101,16 +101,16 @@ changes will typically see review from several people. Be prepared to receive
 some feedback - you may be asked to make changes to your work. Our code review
 process is:
 
-1. **Triage** the pull request. Do the commit messages make sense? Is a test
+1. **Triage** the merge request. Do the commit messages make sense? Is a test
    plan necessary and/or present? Add anyone as reviewers that you think should
-   be there (using the relevant GitHub feature, if you have the permissions, or
+   be there (using the relevant GitLab feature, if you have the permissions, or
    with an @mention if necessary).
 2. **Review** the code. Look for code style violations, naming convention
    violations, buffer overflows, memory leaks, logic errors, non-portable code
    (including GNU-isms), etc. For significant changes to the public API, loop in
    a couple more people for discussion.
 3. **Execute** the test plan, if present.
-4. **Merge** the pull request when all reviewers approve.
+4. **Merge** the merge request when all reviewers approve.
 5. **File** follow-up tickets if appropriate.
 
 ## Style Reference
@@ -396,6 +396,6 @@ static void subsurface_handle_surface_destroy(struct wl_listener *listener,
 [#sway-devel on Libera Chat]: https://web.libera.chat/gamja/?channels=#sway-devel
 [linear, "recipe" style]: https://www.bitsnbites.eu/git-history-work-log-vs-recipe/
 [git-rebase.io]: https://git-rebase.io/
-[reference Github issues]: https://help.github.com/articles/closing-issues-via-commit-messages/
+[reference issues]: https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically
 [How to Write a Git Commit Message]: https://chris.beams.io/posts/git-commit/
 [kernel style]: https://www.kernel.org/doc/Documentation/process/coding-style.rst

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Install like so:
 See [CONTRIBUTING.md].
 
 [Wayland]: https://wayland.freedesktop.org/
-[wiki]: https://github.com/swaywm/wlroots/wiki/Getting-started
+[wiki]: https://gitlab.freedesktop.org/wlroots/wlroots/-/wikis/Getting-started
 [#sway-devel on Libera Chat]: https://web.libera.chat/gamja/?channels=#sway-devel
 [Sway]: https://github.com/swaywm/sway
 [wrapper libraries]: https://github.com/search?q=topic%3Abindings+org%3Aswaywm&type=Repositories
 [libseat]: https://git.sr.ht/~kennylevinsen/seatd
-[CONTRIBUTING.md]: https://github.com/swaywm/wlroots/blob/master/CONTRIBUTING.md
+[CONTRIBUTING.md]: https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/master/CONTRIBUTING.md

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -147,7 +147,8 @@ struct wlr_drm_backend *get_drm_backend_from_backend(
 bool check_drm_features(struct wlr_drm_backend *drm);
 bool init_drm_resources(struct wlr_drm_backend *drm);
 void finish_drm_resources(struct wlr_drm_backend *drm);
-void scan_drm_connectors(struct wlr_drm_backend *state);
+void scan_drm_connectors(struct wlr_drm_backend *state,
+	struct wlr_device_hotplug_event *event);
 int handle_drm_event(int fd, uint32_t mask, void *data);
 void destroy_drm_connector(struct wlr_drm_connector *conn);
 bool drm_connector_commit_state(struct wlr_drm_connector *conn,

--- a/include/render/allocator/allocator.h
+++ b/include/render/allocator/allocator.h
@@ -1,52 +1,7 @@
 #ifndef RENDER_ALLOCATOR_ALLOCATOR_H
 #define RENDER_ALLOCATOR_ALLOCATOR_H
 
-#include <stdbool.h>
-#include <wayland-server-core.h>
-#include <wlr/render/drm_format_set.h>
-
-struct wlr_allocator;
-struct wlr_backend;
-struct wlr_renderer;
-
-struct wlr_allocator_interface {
-	struct wlr_buffer *(*create_buffer)(struct wlr_allocator *alloc,
-		int width, int height, const struct wlr_drm_format *format);
-	void (*destroy)(struct wlr_allocator *alloc);
-};
-
-struct wlr_allocator {
-	const struct wlr_allocator_interface *impl;
-
-	// Capabilities of the buffers created with this allocator
-	uint32_t buffer_caps;
-
-	struct {
-		struct wl_signal destroy;
-	} events;
-};
-
-/**
- * Creates the adequate wlr_allocator given a backend and a renderer
- */
-struct wlr_allocator *wlr_allocator_autocreate(struct wlr_backend *backend,
-	struct wlr_renderer *renderer);
-/**
- * Destroy the allocator.
- */
-void wlr_allocator_destroy(struct wlr_allocator *alloc);
-/**
- * Allocate a new buffer.
- *
- * When the caller is done with it, they must unreference it by calling
- * wlr_buffer_drop.
- */
-struct wlr_buffer *wlr_allocator_create_buffer(struct wlr_allocator *alloc,
-	int width, int height, const struct wlr_drm_format *format);
-
-// For wlr_allocator implementors
-void wlr_allocator_init(struct wlr_allocator *alloc,
-	const struct wlr_allocator_interface *impl, uint32_t buffer_caps);
+#include <wlr/render/allocator.h>
 
 struct wlr_allocator *allocator_autocreate_with_drm_fd(
 	struct wlr_backend *backend, struct wlr_renderer *renderer, int drm_fd);

--- a/include/render/vulkan.h
+++ b/include/render/vulkan.h
@@ -106,22 +106,28 @@ struct wlr_vk_format_modifier_props {
 	bool export_imported;
 };
 
+enum wlr_vk_image_usage {
+	WLR_VK_IMAGE_USAGE_RENDER,
+	WLR_VK_IMAGE_USAGE_SAMPLED,
+
+	WLR_VK_IMAGE_USAGE_COUNT,
+};
+
+VkImageUsageFlags wlr_vk_image_usage_to_vk(enum wlr_vk_image_usage usage);
+
 struct wlr_vk_format_props {
 	struct wlr_vk_format format;
 	VkExtent2D max_extent; // relevant if not created as dma_buf
 	VkFormatFeatureFlags features; // relevant if not created as dma_buf
 
-	uint32_t render_mod_count;
-	struct wlr_vk_format_modifier_props *render_mods;
-
-	uint32_t texture_mod_count;
-	struct wlr_vk_format_modifier_props *texture_mods;
+	uint32_t mod_count[WLR_VK_IMAGE_USAGE_COUNT];
+	struct wlr_vk_format_modifier_props *mods[WLR_VK_IMAGE_USAGE_COUNT];
 };
 
 void vulkan_format_props_query(struct wlr_vk_device *dev,
 	const struct wlr_vk_format *format);
 struct wlr_vk_format_modifier_props *vulkan_format_props_find_modifier(
-	struct wlr_vk_format_props *props, uint64_t mod, bool render);
+	struct wlr_vk_format_props *props, uint64_t mod, enum wlr_vk_image_usage usage);
 void vulkan_format_props_finish(struct wlr_vk_format_props *props);
 
 // For each format we want to render, we need a separate renderpass
@@ -260,7 +266,7 @@ struct wlr_vk_texture *vulkan_get_texture(struct wlr_texture *wlr_texture);
 VkImage vulkan_import_dmabuf(struct wlr_vk_renderer *renderer,
 	const struct wlr_dmabuf_attributes *attribs,
 	VkDeviceMemory mems[static WLR_DMABUF_MAX_PLANES], uint32_t *n_mems,
-	bool for_render);
+	enum wlr_vk_image_usage usage);
 struct wlr_texture *vulkan_texture_from_buffer(
 	struct wlr_renderer *wlr_renderer, struct wlr_buffer *buffer);
 void vulkan_texture_destroy(struct wlr_vk_texture *texture);

--- a/include/wlr/backend/session.h
+++ b/include/wlr/backend/session.h
@@ -15,7 +15,7 @@ struct wlr_device {
 	struct wl_list link;
 
 	struct {
-		struct wl_signal change;
+		struct wl_signal change; // struct wlr_device_change_event
 		struct wl_signal remove;
 	} events;
 };
@@ -55,6 +55,22 @@ struct wlr_session {
 
 struct wlr_session_add_event {
 	const char *path;
+};
+
+enum wlr_device_change_type {
+	WLR_DEVICE_HOTPLUG = 1,
+};
+
+struct wlr_device_hotplug_event {
+	uint32_t connector_id;
+	uint32_t prop_id;
+};
+
+struct wlr_device_change_event {
+	enum wlr_device_change_type type;
+	union {
+		struct wlr_device_hotplug_event hotplug;
+	};
 };
 
 /*

--- a/include/wlr/render/allocator.h
+++ b/include/wlr/render/allocator.h
@@ -1,0 +1,58 @@
+/*
+ * This an unstable interface of wlroots. No guarantees are made regarding the
+ * future consistency of this API.
+ */
+#ifndef WLR_USE_UNSTABLE
+#error "Add -DWLR_USE_UNSTABLE to enable unstable wlroots features"
+#endif
+
+#ifndef WLR_ALLOCATOR_H
+#define WLR_ALLOCATOR_H
+
+#include <wayland-server-core.h>
+
+struct wlr_allocator;
+struct wlr_backend;
+struct wlr_drm_format;
+struct wlr_renderer;
+
+struct wlr_allocator_interface {
+	struct wlr_buffer *(*create_buffer)(struct wlr_allocator *alloc,
+		int width, int height, const struct wlr_drm_format *format);
+	void (*destroy)(struct wlr_allocator *alloc);
+};
+
+void wlr_allocator_init(struct wlr_allocator *alloc,
+	const struct wlr_allocator_interface *impl, uint32_t buffer_caps);
+
+struct wlr_allocator {
+	const struct wlr_allocator_interface *impl;
+
+	// Capabilities of the buffers created with this allocator
+	uint32_t buffer_caps;
+
+	struct {
+		struct wl_signal destroy;
+	} events;
+};
+
+/**
+ * Creates the adequate wlr_allocator given a backend and a renderer
+ */
+struct wlr_allocator *wlr_allocator_autocreate(struct wlr_backend *backend,
+	struct wlr_renderer *renderer);
+/**
+ * Destroy the allocator.
+ */
+void wlr_allocator_destroy(struct wlr_allocator *alloc);
+
+/**
+ * Allocate a new buffer.
+ *
+ * When the caller is done with it, they must unreference it by calling
+ * wlr_buffer_drop.
+ */
+struct wlr_buffer *wlr_allocator_create_buffer(struct wlr_allocator *alloc,
+	int width, int height, const struct wlr_drm_format *format);
+
+#endif

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -14,7 +14,6 @@
 #include <time.h>
 #include <wayland-server-protocol.h>
 #include <wayland-util.h>
-#include <wlr/render/dmabuf.h>
 #include <wlr/types/wlr_buffer.h>
 #include <wlr/util/addon.h>
 
@@ -401,13 +400,6 @@ size_t wlr_output_get_gamma_size(struct wlr_output *output);
  */
 void wlr_output_set_gamma(struct wlr_output *output, size_t size,
 	const uint16_t *r, const uint16_t *g, const uint16_t *b);
-/**
- * Exports the last committed buffer as a DMA-BUF.
- *
- * The caller is responsible for cleaning up the DMA-BUF attributes.
- */
-bool wlr_output_export_dmabuf(struct wlr_output *output,
-	struct wlr_dmabuf_attributes *attribs);
 /**
  * Returns the wlr_output matching the provided wl_output resource. If the
  * resource isn't a wl_output, it aborts. If the resource is inert (because the

--- a/include/wlr/types/wlr_text_input_v3.h
+++ b/include/wlr/types/wlr_text_input_v3.h
@@ -87,7 +87,7 @@ void wlr_text_input_v3_send_enter(struct wlr_text_input_v3 *text_input,
 // Sends leave to the currently focused surface and clears it
 void wlr_text_input_v3_send_leave(struct wlr_text_input_v3 *text_input);
 void wlr_text_input_v3_send_preedit_string(struct wlr_text_input_v3 *text_input,
-	const char *text, uint32_t cursor_begin, uint32_t cursor_end);
+	const char *text, int32_t cursor_begin, int32_t cursor_end);
 void wlr_text_input_v3_send_commit_string(struct wlr_text_input_v3 *text_input,
 	const char *text);
 void wlr_text_input_v3_send_delete_surrounding_text(

--- a/include/wlr/xwayland.h
+++ b/include/wlr/xwayland.h
@@ -22,6 +22,7 @@ struct wlr_xwayland_cursor;
 struct wlr_xwayland_server_options {
 	bool lazy;
 	bool enable_wm;
+	bool no_touch_pointer_emulation;
 };
 
 struct wlr_xwayland_server {

--- a/include/xwayland/meson.build
+++ b/include/xwayland/meson.build
@@ -1,7 +1,11 @@
 have_listenfd = false
+have_no_touch_pointer_emulation = false
 if xwayland.found()
 	xwayland_path = xwayland.get_variable('xwayland')
-	have_listenfd = xwayland.get_variable('have_listenfd') == 'true'
+	have_listenfd = xwayland.get_variable('have_listenfd',
+		default_value: 'false') == 'true'
+	have_no_touch_pointer_emulation = xwayland.get_variable(
+		'have_no_touch_pointer_emulation', default_value: 'false') == 'true'
 else
 	xwayland_path = xwayland_prog.full_path()
 endif
@@ -9,6 +13,7 @@ endif
 xwayland_config_data = configuration_data()
 xwayland_config_data.set_quoted('XWAYLAND_PATH', xwayland_path)
 xwayland_config_data.set10('HAVE_XWAYLAND_LISTENFD', have_listenfd)
+xwayland_config_data.set10('HAVE_XWAYLAND_NO_TOUCH_POINTER_EMULATION', have_no_touch_pointer_emulation)
 configure_file(
 	output: 'config.h',
 	configuration: xwayland_config_data,

--- a/render/allocator/allocator.c
+++ b/render/allocator/allocator.c
@@ -3,6 +3,7 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <wlr/render/allocator.h>
 #include <wlr/util/log.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>

--- a/render/allocator/drm_dumb.c
+++ b/render/allocator/drm_dumb.c
@@ -7,11 +7,13 @@
 #include <string.h>
 #include <sys/mman.h>
 #include <unistd.h>
+#include <wlr/backend.h>
+#include <wlr/backend/session.h>
+#include <wlr/render/allocator.h>
+#include <wlr/render/drm_format_set.h>
 #include <wlr/util/log.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
-#include <wlr/backend.h>
-#include <wlr/backend/session.h>
 
 #include "render/allocator/drm_dumb.h"
 #include "render/pixel_format.h"

--- a/render/allocator/gbm.c
+++ b/render/allocator/gbm.c
@@ -4,8 +4,11 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <wlr/render/allocator.h>
+#include <wlr/render/drm_format_set.h>
 #include <wlr/util/log.h>
 #include <xf86drm.h>
+
 #include "render/allocator/gbm.h"
 
 static const struct wlr_buffer_impl buffer_impl;

--- a/render/allocator/shm.c
+++ b/render/allocator/shm.c
@@ -3,7 +3,10 @@
 #include <stdlib.h>
 #include <sys/mman.h>
 #include <unistd.h>
+#include <wlr/render/allocator.h>
+#include <wlr/render/drm_format_set.h>
 #include <wlr/util/log.h>
+
 #include "render/pixel_format.h"
 #include "render/allocator/shm.h"
 #include "util/shm.h"

--- a/render/egl.c
+++ b/render/egl.c
@@ -189,11 +189,11 @@ static struct wlr_egl *egl_create(void) {
 	egl->exts.EXT_platform_device = check_egl_ext(client_exts_str,
 			"EGL_EXT_platform_device");
 
-	if (check_egl_ext(client_exts_str, "EGL_EXT_device_enumeration")) {
+	if (check_egl_ext(client_exts_str, "EGL_EXT_device_base") || check_egl_ext(client_exts_str, "EGL_EXT_device_enumeration")) {
 		load_egl_proc(&egl->procs.eglQueryDevicesEXT, "eglQueryDevicesEXT");
 	}
 
-	if (check_egl_ext(client_exts_str, "EGL_EXT_device_query")) {
+	if (check_egl_ext(client_exts_str, "EGL_EXT_device_base") || check_egl_ext(client_exts_str, "EGL_EXT_device_query")) {
 		egl->exts.EXT_device_query = true;
 		load_egl_proc(&egl->procs.eglQueryDeviceStringEXT,
 			"eglQueryDeviceStringEXT");

--- a/render/meson.build
+++ b/render/meson.build
@@ -14,13 +14,12 @@ wlr_files += files(
 	'wlr_texture.c',
 )
 
-egl = dependency('egl', required: 'gles2' in renderers)
-if egl.found()
-	wlr_deps += egl
-	wlr_files += files('egl.c')
-endif
-
 if 'gles2' in renderers or 'auto' in renderers
+	egl = dependency('egl', required: 'gles2' in renderers)
+	if egl.found()
+		wlr_deps += egl
+		wlr_files += files('egl.c')
+	endif
 	subdir('gles2')
 endif
 

--- a/render/vulkan/renderer.c
+++ b/render/vulkan/renderer.c
@@ -443,7 +443,7 @@ static struct wlr_vk_render_buffer *create_render_buffer(
 	}
 
 	buffer->image = vulkan_import_dmabuf(renderer, &dmabuf,
-		buffer->memories, &buffer->mem_count, true);
+		buffer->memories, &buffer->mem_count, WLR_VK_IMAGE_USAGE_RENDER);
 	if (!buffer->image) {
 		goto error_buffer;
 	}

--- a/types/output/cursor.c
+++ b/types/output/cursor.c
@@ -264,6 +264,7 @@ static struct wlr_buffer *render_cursor_buffer(struct wlr_output_cursor *cursor)
 		wlr_swapchain_destroy(output->cursor_swapchain);
 		output->cursor_swapchain = wlr_swapchain_create(allocator,
 			width, height, format);
+		free(format);
 		if (output->cursor_swapchain == NULL) {
 			wlr_log(WLR_ERROR, "Failed to create cursor swapchain");
 			return NULL;

--- a/types/output/output.c
+++ b/types/output/output.c
@@ -790,19 +790,6 @@ size_t wlr_output_get_gamma_size(struct wlr_output *output) {
 	return output->impl->get_gamma_size(output);
 }
 
-bool wlr_output_export_dmabuf(struct wlr_output *output,
-		struct wlr_dmabuf_attributes *attribs) {
-	if (output->front_buffer == NULL) {
-		return false;
-	}
-
-	struct wlr_dmabuf_attributes buf_attribs = {0};
-	if (!wlr_buffer_get_dmabuf(output->front_buffer, &buf_attribs)) {
-		return false;
-	}
-	return wlr_dmabuf_attributes_copy(attribs, &buf_attribs);
-}
-
 void wlr_output_update_needs_frame(struct wlr_output *output) {
 	if (output->needs_frame) {
 		return;

--- a/types/scene/wlr_scene.c
+++ b/types/scene/wlr_scene.c
@@ -798,7 +798,7 @@ static const struct wlr_addon_interface output_addon_impl = {
 
 struct wlr_scene_output *wlr_scene_output_create(struct wlr_scene *scene,
 		struct wlr_output *output) {
-	struct wlr_scene_output *scene_output = calloc(1, sizeof(*output));
+	struct wlr_scene_output *scene_output = calloc(1, sizeof(*scene_output));
 	if (scene_output == NULL) {
 		return NULL;
 	}

--- a/types/wlr_export_dmabuf_v1.c
+++ b/types/wlr_export_dmabuf_v1.c
@@ -66,7 +66,7 @@ static void frame_output_handle_commit(struct wl_listener *listener,
 	wl_list_init(&frame->output_commit.link);
 
 	struct wlr_dmabuf_attributes attribs = {0};
-	if (!wlr_output_export_dmabuf(frame->output, &attribs)) {
+	if (!wlr_buffer_get_dmabuf(frame->output->front_buffer, &attribs)) {
 		zwlr_export_dmabuf_frame_v1_send_cancel(frame->resource,
 			ZWLR_EXPORT_DMABUF_FRAME_V1_CANCEL_REASON_TEMPORARY);
 		frame_destroy(frame);
@@ -85,8 +85,6 @@ static void frame_output_handle_commit(struct wl_listener *listener,
 		zwlr_export_dmabuf_frame_v1_send_object(frame->resource, i,
 			attribs.fd[i], size, attribs.offset[i], attribs.stride[i], i);
 	}
-
-	wlr_dmabuf_attributes_finish(&attribs);
 
 	time_t tv_sec = event->when->tv_sec;
 	uint32_t tv_sec_hi = (sizeof(tv_sec) > 4) ? tv_sec >> 32 : 0;

--- a/types/wlr_input_method_v2.c
+++ b/types/wlr_input_method_v2.c
@@ -88,6 +88,10 @@ static void im_commit_string(struct wl_client *client,
 	}
 	free(input_method->pending.commit_text);
 	input_method->pending.commit_text = strdup(text);
+	if (input_method->pending.commit_text == NULL) {
+		wl_client_post_no_memory(client);
+		return;
+	}
 }
 
 static void im_set_preedit_string(struct wl_client *client,
@@ -102,6 +106,10 @@ static void im_set_preedit_string(struct wl_client *client,
 	input_method->pending.preedit.cursor_end = cursor_end;
 	free(input_method->pending.preedit.text);
 	input_method->pending.preedit.text = strdup(text);
+	if (input_method->pending.preedit.text == NULL) {
+		wl_client_post_no_memory(client);
+		return;
+	}
 }
 
 static void im_delete_surrounding_text(struct wl_client *client,

--- a/types/wlr_screencopy_v1.c
+++ b/types/wlr_screencopy_v1.c
@@ -489,13 +489,12 @@ static struct wlr_screencopy_v1_client *client_from_resource(
 }
 
 static uint32_t get_output_fourcc(struct wlr_output *output) {
-	struct wlr_dmabuf_attributes attr = { 0 };
-	if (!wlr_output_export_dmabuf(output, &attr)) {
+	struct wlr_dmabuf_attributes attr = {0};
+	if (!output->front_buffer ||
+			!wlr_buffer_get_dmabuf(output->front_buffer, &attr)) {
 		return DRM_FORMAT_INVALID;
 	}
-	uint32_t format = attr.format;
-	wlr_dmabuf_attributes_finish(&attr);
-	return format;
+	return attr.format;
 }
 
 static void capture_output(struct wl_client *wl_client,

--- a/types/wlr_text_input_v3.c
+++ b/types/wlr_text_input_v3.c
@@ -171,6 +171,10 @@ static void text_input_commit(struct wl_client *client,
 	if (text_input->pending.surrounding.text) {
 		text_input->current.surrounding.text =
 			strdup(text_input->pending.surrounding.text);
+		if (text_input->current.surrounding.text == NULL) {
+			wl_client_post_no_memory(client);
+			return;
+		}
 	}
 
 	bool old_enabled = text_input->current_enabled;

--- a/types/wlr_text_input_v3.c
+++ b/types/wlr_text_input_v3.c
@@ -42,7 +42,7 @@ void wlr_text_input_v3_send_leave(struct wlr_text_input_v3 *text_input) {
 }
 
 void wlr_text_input_v3_send_preedit_string(struct wlr_text_input_v3 *text_input,
-		const char *text, uint32_t cursor_begin, uint32_t cursor_end) {
+		const char *text, int32_t cursor_begin, int32_t cursor_end) {
 	zwp_text_input_v3_send_preedit_string(text_input->resource, text,
 		cursor_begin, cursor_end);
 }

--- a/xwayland/server.c
+++ b/xwayland/server.c
@@ -73,6 +73,14 @@ noreturn static void exec_xwayland(struct wlr_xwayland_server *server) {
 		argv[i++] = wmfd;
 	}
 
+#if HAVE_XWAYLAND_NO_TOUCH_POINTER_EMULATION
+	if (server->options.no_touch_pointer_emulation) {
+		argv[i++] = "-noTouchPointerEmulation";
+	}
+#else
+	server->options.no_touch_pointer_emulation = false;
+#endif
+
 	argv[i++] = NULL;
 
 	assert(i < sizeof(argv) / sizeof(argv[0]));


### PR DESCRIPTION
Makes this much more extensible so we could add a storage type in future for compute.

Signed-off-by: Joshua Ashton <joshua@froggi.es>