### PR TITLE
render/vulkan: check vulkan-headers dependency

### DIFF
--- a/render/vulkan/meson.build
+++ b/render/vulkan/meson.build
@@ -10,9 +10,18 @@ dep_vulkan = dependency('vulkan',
 	required: 'vulkan' in renderers,
 	not_found_message: '\n'.join(msg).format('vulkan')
 )
-
 if not dep_vulkan.found()
 	subdir_done()
+endif
+
+# Vulkan headers are installed separately from the loader (which ships the
+# pkg-config file)
+if not cc.check_header('vulkan/vulkan.h', dependencies: dep_vulkan)
+	if 'vulkan' in renderers
+		error('\n'.join(msg).format('vulkan-headers'))
+	else
+		subdir_done()
+	endif
 endif
 
 glslang = find_program('glslangValidator', native: true, required: false)


### PR DESCRIPTION
There's no pkg-config file we can check for sadly, so check
VK_HEADER_VERSION as a fallback.

Closes: https://github.com/swaywm/wlroots/issues/3272