### PR TITLE
scene: add support for direct scan-out

### DIFF
--- a/include/wlr/types/wlr_scene.h
+++ b/include/wlr/types/wlr_scene.h
@@ -109,6 +109,10 @@ struct wlr_scene_output {
 	struct wlr_output_damage *damage;
 
 	int x, y;
+
+	// private state
+
+	bool prev_scanout;
 };
 
 typedef void (*wlr_scene_node_iterator_func_t)(struct wlr_scene_node *node,


### PR DESCRIPTION
Check if only a single node intersects with the output viewport
and all of its properties match. In this case, attempt direct
scan-out.