### PR TITLE
xwayland: add support for -noTouchPointerEmulation

### DIFF
--- a/include/wlr/xwayland.h
+++ b/include/wlr/xwayland.h
@@ -22,6 +22,7 @@ struct wlr_xwayland_cursor;
 struct wlr_xwayland_server_options {
 	bool lazy;
 	bool enable_wm;
+	bool no_touch_pointer_emulation;
 };
 
 struct wlr_xwayland_server {

--- a/include/xwayland/meson.build
+++ b/include/xwayland/meson.build
@@ -1,7 +1,10 @@
 have_listenfd = false
+have_no_touch_pointer_emulation = false
 if xwayland.found()
 	xwayland_path = xwayland.get_variable('xwayland')
 	have_listenfd = xwayland.get_variable('have_listenfd') == 'true'
+	have_no_touch_pointer_emulation = xwayland.get_variable(
+		'have_no_touch_pointer_emulation') == 'true'
 else
 	xwayland_path = xwayland_prog.full_path()
 endif
@@ -9,6 +12,7 @@ endif
 xwayland_config_data = configuration_data()
 xwayland_config_data.set_quoted('XWAYLAND_PATH', xwayland_path)
 xwayland_config_data.set10('HAVE_XWAYLAND_LISTENFD', have_listenfd)
+xwayland_config_data.set10('HAVE_XWAYLAND_NO_TOUCH_POINTER_EMULATION', have_no_touch_pointer_emulation)
 configure_file(
 	output: 'config.h',
 	configuration: xwayland_config_data,

--- a/xwayland/server.c
+++ b/xwayland/server.c
@@ -73,6 +73,14 @@ noreturn static void exec_xwayland(struct wlr_xwayland_server *server) {
 		argv[i++] = wmfd;
 	}
 
+#if HAVE_XWAYLAND_NO_TOUCH_POINTER_EMULATION
+	if (server->options.no_touch_pointer_emulation) {
+		argv[i++] = "-noTouchPointerEmulation";
+	}
+#else
+	server->options.no_touch_pointer_emulation = false;
+#endif
+
 	argv[i++] = NULL;
 
 	assert(i < sizeof(argv) / sizeof(argv[0]));


### PR DESCRIPTION
This allows compositors to handle touch pointer emulation manually,
instead of having Xwayland do it [1].

[1]: https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/691