### PR TITLE
Use the pending resolution when rendering

### DIFF
--- a/include/types/wlr_output.h
+++ b/include/types/wlr_output.h
@@ -4,9 +4,6 @@
 #include <wlr/render/drm_format_set.h>
 #include <wlr/types/wlr_output.h>
 
-void output_pending_resolution(struct wlr_output *output, int *width,
-	int *height);
-
 struct wlr_drm_format *output_pick_format(struct wlr_output *output,
 	const struct wlr_drm_format_set *display_formats);
 void output_clear_back_buffer(struct wlr_output *output);

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -465,4 +465,15 @@ enum wl_output_transform wlr_output_transform_invert(
 enum wl_output_transform wlr_output_transform_compose(
 	enum wl_output_transform tr_a, enum wl_output_transform tr_b);
 
+/**
+ * Obtains the pending resolution of the output. Parameters must be valid
+ * non-NULL pointers.
+ */
+void wlr_output_pending_resolution(struct wlr_output *output,
+	int *width, int *height);
+
+/**
+ * Returns the pending state of the enabled flag.
+ */
+bool wlr_output_pending_enabled(struct wlr_output *output);
 #endif

--- a/types/output/render.c
+++ b/types/output/render.c
@@ -21,7 +21,7 @@
 static bool output_create_swapchain(struct wlr_output *output,
 		bool allow_modifiers) {
 	int width, height;
-	output_pending_resolution(output, &width, &height);
+	wlr_output_pending_resolution(output, &width, &height);
 
 	if (output->swapchain != NULL && output->swapchain->width == width &&
 			output->swapchain->height == height &&
@@ -128,7 +128,7 @@ static bool output_attach_empty_buffer(struct wlr_output *output) {
 	}
 
 	int width, height;
-	output_pending_resolution(output, &width, &height);
+	wlr_output_pending_resolution(output, &width, &height);
 
 	struct wlr_renderer *renderer = wlr_backend_get_renderer(output->backend);
 	wlr_renderer_begin(renderer, width, height);

--- a/types/scene/wlr_scene.c
+++ b/types/scene/wlr_scene.c
@@ -763,7 +763,9 @@ static void scene_node_for_each_node(struct wlr_scene_node *node,
 void wlr_scene_render_output(struct wlr_scene *scene, struct wlr_output *output,
 		int lx, int ly, pixman_region32_t *damage) {
 	pixman_region32_t full_region;
-	pixman_region32_init_rect(&full_region, 0, 0, output->width, output->height);
+	int width, height;
+	wlr_output_pending_resolution(output, &width, &height);
+	pixman_region32_init_rect(&full_region, 0, 0, width, height);
 	if (damage == NULL) {
 		damage = &full_region;
 	}
@@ -772,7 +774,8 @@ void wlr_scene_render_output(struct wlr_scene *scene, struct wlr_output *output,
 		wlr_backend_get_renderer(output->backend);
 	assert(renderer);
 
-	if (output->enabled && pixman_region32_not_empty(damage)) {
+	if (wlr_output_pending_enabled(output) &&
+	    pixman_region32_not_empty(damage)) {
 		struct render_data data = {
 			.output = output,
 			.damage = damage,
@@ -949,7 +952,9 @@ bool wlr_scene_output_commit(struct wlr_scene_output *scene_output) {
 		return true;
 	}
 
-	wlr_renderer_begin(renderer, output->width, output->height);
+	int width, height;
+	wlr_output_pending_resolution(output, &width, &height);
+	wlr_renderer_begin(renderer, width, height);
 
 	int nrects;
 	pixman_box32_t *rects = pixman_region32_rectangles(&damage, &nrects);


### PR DESCRIPTION
This is necessary for rootless compositors, where the output resolution
can be changed by a client at any time.  This requires wlr_scene to have
access to `output_pending_resolution`, which other renderers will need
as well.  Make that function a public API.