### PR TITLE
Enable xdg-activation for startup notifications in compositors

### DIFF
--- a/backend/wayland/meson.build
+++ b/backend/wayland/meson.build
@@ -12,6 +12,7 @@ client_protos = [
 	'presentation-time',
 	'relative-pointer-unstable-v1',
 	'tablet-unstable-v2',
+	'xdg-activation-v1',
 	'xdg-decoration-unstable-v1',
 	'xdg-shell',
 ]

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -23,6 +23,7 @@
 
 #include "linux-dmabuf-unstable-v1-client-protocol.h"
 #include "presentation-time-client-protocol.h"
+#include "xdg-activation-v1-client-protocol.h"
 #include "xdg-decoration-unstable-v1-client-protocol.h"
 #include "xdg-shell-client-protocol.h"
 
@@ -592,6 +593,12 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *wlr_backend) {
 		if (seat->pointer) {
 			create_wl_pointer(seat, output);
 		}
+	}
+
+	// TODO: let the compositor do this bit
+	if (backend->activation_v1 && backend->activation_token) {
+		xdg_activation_v1_activate(backend->activation_v1,
+				backend->activation_token, output->surface);
 	}
 
 	// Start the rendering loop by requesting the compositor to render a frame

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -24,6 +24,7 @@ struct wlr_wl_backend {
 	size_t requested_outputs;
 	size_t last_output_num;
 	struct wl_listener local_display_destroy;
+	char *activation_token;
 
 	/* remote state */
 	struct wl_display *remote_display;
@@ -42,6 +43,7 @@ struct wlr_wl_backend {
 	struct wlr_drm_format_set shm_formats;
 	struct wlr_drm_format_set linux_dmabuf_v1_formats;
 	struct wl_drm *legacy_drm;
+	struct xdg_activation_v1 *activation_v1;
 	char *drm_render_name;
 };
 

--- a/include/wlr/types/wlr_xdg_activation_v1.h
+++ b/include/wlr/types/wlr_xdg_activation_v1.h
@@ -44,6 +44,8 @@ struct wlr_xdg_activation_v1 {
 
 	// private state
 
+	struct wl_display *display;
+
 	struct wl_global *global;
 
 	struct wl_listener display_destroy;
@@ -59,5 +61,18 @@ struct wlr_xdg_activation_v1_request_activate_event {
 
 struct wlr_xdg_activation_v1 *wlr_xdg_activation_v1_create(
 	struct wl_display *display);
+
+struct wlr_xdg_activation_token_v1 *wlr_xdg_activation_token_v1_create(
+		struct wlr_xdg_activation_v1 *activation);
+
+void wlr_xdg_activation_token_v1_destroy(
+		struct wlr_xdg_activation_token_v1 *token);
+
+struct wlr_xdg_activation_token_v1 *wlr_xdg_activation_v1_find_token(
+		struct wlr_xdg_activation_v1 *activation, const char *token_str);
+
+// Get a string suitable for exporting to launched clients
+const char *wlr_xdg_activation_token_v1_get_name(
+		struct wlr_xdg_activation_token_v1 *token);
 
 #endif

--- a/include/wlr/types/wlr_xdg_activation_v1.h
+++ b/include/wlr/types/wlr_xdg_activation_v1.h
@@ -22,6 +22,12 @@ struct wlr_xdg_activation_token_v1 {
 	char *app_id; // can be NULL
 	struct wl_list link; // wlr_xdg_activation_v1.tokens
 
+	void *data;
+
+	struct {
+		struct wl_signal destroy;
+	} events;
+
 	// private state
 
 	char *token;

--- a/types/wlr_xdg_activation_v1.c
+++ b/types/wlr_xdg_activation_v1.c
@@ -32,6 +32,9 @@ void wlr_xdg_activation_token_v1_destroy(
 	if (token->timeout != NULL) {
 		wl_event_source_remove(token->timeout);
 	}
+
+	wlr_signal_emit_safe(&token->events.destroy, NULL);
+
 	wl_list_remove(&token->link);
 	wl_list_remove(&token->seat_destroy.link);
 	wl_list_remove(&token->surface_destroy.link);
@@ -258,6 +261,7 @@ static void activation_handle_get_activation_token(struct wl_client *client,
 	wl_list_init(&token->link);
 	wl_list_init(&token->seat_destroy.link);
 	wl_list_init(&token->surface_destroy.link);
+	wl_signal_init(&token->events.destroy);
 
 	token->activation = activation;
 
@@ -376,6 +380,7 @@ struct wlr_xdg_activation_token_v1 *wlr_xdg_activation_token_v1_create(
 	// Currently no way to set seat/surface
 	wl_list_init(&token->seat_destroy.link);
 	wl_list_init(&token->surface_destroy.link);
+	wl_signal_init(&token->events.destroy);
 
 	token->activation = activation;
 


### PR DESCRIPTION
Closes #3211 and implements the activation procedure as a client in the wayland backend, so sway is a test client as well.

See also: swaywm/sway#6639