### PR TITLE
Make wlr_output_enable idempotent

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -18,7 +18,7 @@ packages:
   - xwayland
   - libseat-dev
 sources:
-  - https://github.com/swaywm/wlroots
+  - https://gitlab.freedesktop.org/wlroots/wlroots.git
 tasks:
   - setup: |
       cd wlroots

--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -19,7 +19,7 @@ packages:
   - vulkan-headers
   - glslang
 sources:
-  - https://github.com/swaywm/wlroots
+  - https://gitlab.freedesktop.org/wlroots/wlroots.git
 tasks:
   - setup: |
       cd wlroots

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -26,7 +26,7 @@ packages:
   - sysutils/seatd
   - gmake
 sources:
-  - https://github.com/swaywm/wlroots
+  - https://gitlab.freedesktop.org/wlroots/wlroots.git
 tasks:
   - wlroots: |
       cd wlroots

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,7 @@
+include: https://git.sr.ht/~emersion/dalligi/blob/master/templates/multi.yml
+alpine:
+  extends: .dalligi
+archlinux:
+  extends: .dalligi
+freebsd:
+  extends: .dalligi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,13 @@ process is:
 4. **Merge** the merge request when all reviewers approve.
 5. **File** follow-up tickets if appropriate.
 
+## Code of Conduct
+
+Note that as a project hosted on freedesktop.org, wlroots follows its
+[Code of Conduct], based on the Contributor Covenant. Please conduct yourself
+in a respectful and civilized manner when communicating with community members
+on IRC and bug tracker.
+
 ## Style Reference
 
 wlroots is written in C with a style similar to the [kernel style], but with a
@@ -397,5 +404,6 @@ static void subsurface_handle_surface_destroy(struct wl_listener *listener,
 [linear, "recipe" style]: https://www.bitsnbites.eu/git-history-work-log-vs-recipe/
 [git-rebase.io]: https://git-rebase.io/
 [reference issues]: https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically
+[Code of Conduct]: https://www.freedesktop.org/wiki/CodeOfConduct/
 [How to Write a Git Commit Message]: https://chris.beams.io/posts/git-commit/
 [kernel style]: https://www.kernel.org/doc/Documentation/process/coding-style.rst

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,21 @@
 # Contributing to wlroots
 
-Contributing just involves sending a pull request. You will probably be more
+Contributing just involves sending a merge request. You will probably be more
 successful with your contribution if you visit [#sway-devel on Libera Chat]
 upfront and discuss your plans.
 
 Note: rules are made to be broken. Adjust or ignore any/all of these as you see
 fit, but be prepared to justify it to your peers.
 
-## Pull Requests
+## Merge Requests
 
-If you already have your own pull request habits, feel free to use them. If you
+If you already have your own merge request habits, feel free to use them. If you
 don't, however, allow me to make a suggestion: feature branches pulled from
 upstream. Try this:
 
 1. Fork wlroots
-2. `git clone git@github.com:<username>/wlroots.git && cd wlroots`
-3. `git remote add upstream https://github.com/swaywm/wlroots`
+2. `git clone git@gitlab.freedesktop.org:<username>/wlroots.git && cd wlroots`
+3. `git remote add upstream https://gitlab.freedesktop.org/wlroots/wlroots.git`
 
 You only need to do this once. You're never going to use your fork's master
 branch. Instead, when you start working on a feature, do this:
@@ -24,11 +24,11 @@ branch. Instead, when you start working on a feature, do this:
 2. `git checkout -b add-so-and-so-feature upstream/master`
 3. Add and commit your changes
 4. `git push -u origin add-so-and-so-feature`
-5. Make a pull request from your feature branch
+5. Make a merge request from your feature branch
 
-When you submit your pull request, your commit log should do most of the talking
+When you submit your merge request, your commit log should do most of the talking
 when it comes to describing your changes and their motivation. In addition to
-this, your pull request's comments will ideally include a test plan that the
+this, your merge request's comments will ideally include a test plan that the
 reviewers can use to (1) demonstrate the problem on master, if applicable and
 (2) verify that the problem no longer exists with your changes applied (or that
 your new features work correctly). Document all of the edge cases you're aware
@@ -80,15 +80,15 @@ cmd_move"* or *"Improve performance of arrange_windows on ARM"* or similar.
 
 The subsequent lines should be separated from the subject line by a single
 blank line, and include optional details. In this you can give justification
-for the change, [reference Github issues], or explain some of the subtler
+for the change, [reference issues], or explain some of the subtler
 details of your patch. This is important because when someone finds a line of
 code they don't understand later, they can use the `git blame` command to find
 out what the author was thinking when they wrote it. It's also easier to review
-your pull requests if they're separated into logical commits that have good
+your merge requests if they're separated into logical commits that have good
 commit messages and justify themselves in the extended commit description.
 
-As a good rule of thumb, anything you might put into the pull request
-description on Github is probably fair game for going into the extended commit
+As a good rule of thumb, anything you might put into the merge request
+description on GitLab is probably fair game for going into the extended commit
 message as well.
 
 See [How to Write a Git Commit Message] for more details.
@@ -101,16 +101,16 @@ changes will typically see review from several people. Be prepared to receive
 some feedback - you may be asked to make changes to your work. Our code review
 process is:
 
-1. **Triage** the pull request. Do the commit messages make sense? Is a test
+1. **Triage** the merge request. Do the commit messages make sense? Is a test
    plan necessary and/or present? Add anyone as reviewers that you think should
-   be there (using the relevant GitHub feature, if you have the permissions, or
+   be there (using the relevant GitLab feature, if you have the permissions, or
    with an @mention if necessary).
 2. **Review** the code. Look for code style violations, naming convention
    violations, buffer overflows, memory leaks, logic errors, non-portable code
    (including GNU-isms), etc. For significant changes to the public API, loop in
    a couple more people for discussion.
 3. **Execute** the test plan, if present.
-4. **Merge** the pull request when all reviewers approve.
+4. **Merge** the merge request when all reviewers approve.
 5. **File** follow-up tickets if appropriate.
 
 ## Style Reference
@@ -396,6 +396,6 @@ static void subsurface_handle_surface_destroy(struct wl_listener *listener,
 [#sway-devel on Libera Chat]: https://web.libera.chat/gamja/?channels=#sway-devel
 [linear, "recipe" style]: https://www.bitsnbites.eu/git-history-work-log-vs-recipe/
 [git-rebase.io]: https://git-rebase.io/
-[reference Github issues]: https://help.github.com/articles/closing-issues-via-commit-messages/
+[reference issues]: https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically
 [How to Write a Git Commit Message]: https://chris.beams.io/posts/git-commit/
 [kernel style]: https://www.kernel.org/doc/Documentation/process/coding-style.rst

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Install like so:
 See [CONTRIBUTING.md].
 
 [Wayland]: https://wayland.freedesktop.org/
-[wiki]: https://github.com/swaywm/wlroots/wiki/Getting-started
+[wiki]: https://gitlab.freedesktop.org/wlroots/wlroots/-/wikis/Getting-started
 [#sway-devel on Libera Chat]: https://web.libera.chat/gamja/?channels=#sway-devel
 [Sway]: https://github.com/swaywm/sway
 [wrapper libraries]: https://github.com/search?q=topic%3Abindings+org%3Aswaywm&type=Repositories
 [libseat]: https://git.sr.ht/~kennylevinsen/seatd
-[CONTRIBUTING.md]: https://github.com/swaywm/wlroots/blob/master/CONTRIBUTING.md
+[CONTRIBUTING.md]: https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/master/CONTRIBUTING.md

--- a/backend/backend.c
+++ b/backend/backend.c
@@ -208,21 +208,6 @@ static size_t parse_outputs_env(const char *name) {
 	return outputs;
 }
 
-static struct wlr_backend *ensure_backend_renderer_and_allocator(
-		struct wlr_backend *backend) {
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(backend);
-	if (renderer == NULL) {
-		wlr_backend_destroy(backend);
-		return NULL;
-	}
-	struct wlr_allocator *allocator = backend_get_allocator(backend);
-	if (allocator == NULL) {
-		wlr_backend_destroy(backend);
-		return NULL;
-	}
-	return backend;
-}
-
 static struct wlr_backend *attempt_wl_backend(struct wl_display *display) {
 	struct wlr_backend *backend = wlr_wl_backend_create(display, NULL);
 	if (backend == NULL) {
@@ -234,7 +219,7 @@ static struct wlr_backend *attempt_wl_backend(struct wl_display *display) {
 		wlr_wl_output_create(backend);
 	}
 
-	return ensure_backend_renderer_and_allocator(backend);
+	return backend;
 }
 
 #if WLR_HAS_X11_BACKEND
@@ -250,7 +235,7 @@ static struct wlr_backend *attempt_x11_backend(struct wl_display *display,
 		wlr_x11_output_create(backend);
 	}
 
-	return ensure_backend_renderer_and_allocator(backend);
+	return backend;
 }
 #endif
 
@@ -266,7 +251,7 @@ static struct wlr_backend *attempt_headless_backend(
 		wlr_headless_add_output(backend, 1280, 720);
 	}
 
-	return ensure_backend_renderer_and_allocator(backend);
+	return backend;
 }
 
 static struct wlr_backend *attempt_noop_backend(struct wl_display *display) {
@@ -320,7 +305,7 @@ static struct wlr_backend *attempt_drm_backend(struct wl_display *display,
 		return NULL;
 	}
 
-	return ensure_backend_renderer_and_allocator(primary_drm);
+	return backend;
 }
 #endif
 

--- a/backend/backend.c
+++ b/backend/backend.c
@@ -45,9 +45,6 @@ void wlr_backend_init(struct wlr_backend *backend,
 
 void wlr_backend_finish(struct wlr_backend *backend) {
 	wlr_signal_emit_safe(&backend->events.destroy, backend);
-	if (backend->has_own_renderer) {
-		wlr_renderer_destroy(backend->renderer);
-	}
 }
 
 bool wlr_backend_start(struct wlr_backend *backend) {
@@ -67,36 +64,6 @@ void wlr_backend_destroy(struct wlr_backend *backend) {
 	} else {
 		free(backend);
 	}
-}
-
-static bool backend_create_renderer(struct wlr_backend *backend) {
-	if (backend->renderer != NULL) {
-		return true;
-	}
-
-	backend->renderer = wlr_renderer_autocreate(backend);
-	if (backend->renderer == NULL) {
-		return false;
-	}
-
-	backend->has_own_renderer = true;
-	return true;
-}
-
-struct wlr_renderer *wlr_backend_get_renderer(struct wlr_backend *backend) {
-	if (backend->impl->get_renderer) {
-		return backend->impl->get_renderer(backend);
-	}
-	if (backend_get_buffer_caps(backend) != 0) {
-		// If the backend is capable of presenting buffers, automatically create
-		// the renderer if necessary.
-		if (!backend_create_renderer(backend)) {
-			wlr_log(WLR_ERROR, "Failed to create backend renderer");
-			return NULL;
-		}
-		return backend->renderer;
-	}
-	return NULL;
 }
 
 struct wlr_session *wlr_backend_get_session(struct wlr_backend *backend) {

--- a/backend/backend.c
+++ b/backend/backend.c
@@ -45,7 +45,6 @@ void wlr_backend_init(struct wlr_backend *backend,
 
 void wlr_backend_finish(struct wlr_backend *backend) {
 	wlr_signal_emit_safe(&backend->events.destroy, backend);
-	wlr_allocator_destroy(backend->allocator);
 	if (backend->has_own_renderer) {
 		wlr_renderer_destroy(backend->renderer);
 	}
@@ -173,23 +172,6 @@ uint32_t backend_get_buffer_caps(struct wlr_backend *backend) {
 	}
 
 	return backend->impl->get_buffer_caps(backend);
-}
-
-struct wlr_allocator *backend_get_allocator(struct wlr_backend *backend) {
-	if (backend->allocator != NULL) {
-		return backend->allocator;
-	}
-
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(backend);
-	if (renderer == NULL) {
-		return NULL;
-	}
-
-	backend->allocator = wlr_allocator_autocreate(backend, renderer);
-	if (backend->allocator == NULL) {
-		wlr_log(WLR_ERROR, "Failed to create backend allocator");
-	}
-	return backend->allocator;
 }
 
 static size_t parse_outputs_env(const char *name) {

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -232,10 +232,6 @@ struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
 	}
 
 	if (drm->parent) {
-		// Ensure we use the same renderer as the parent backend
-		drm->backend.renderer = wlr_backend_get_renderer(&drm->parent->backend);
-		assert(drm->backend.renderer != NULL);
-
 		if (!init_drm_renderer(drm, &drm->mgpu_renderer)) {
 			wlr_log(WLR_ERROR, "Failed to initialize renderer");
 			goto error_resources;

--- a/backend/drm/renderer.c
+++ b/backend/drm/renderer.c
@@ -282,12 +282,6 @@ static struct wlr_drm_fb *drm_fb_create(struct wlr_drm_backend *drm,
 		goto error_get_dmabuf;
 	}
 
-	if (attribs.flags != 0) {
-		wlr_log(WLR_DEBUG, "Buffer with DMA-BUF flags 0x%"PRIX32" cannot be "
-			"scanned out", attribs.flags);
-		goto error_get_dmabuf;
-	}
-
 	if (formats && !wlr_drm_format_set_has(formats, attribs.format,
 			attribs.modifier)) {
 		// The format isn't supported by the plane. Try stripping the alpha

--- a/backend/headless/input_device.c
+++ b/backend/headless/input_device.c
@@ -11,7 +11,14 @@
 #include "backend/headless.h"
 #include "util/signal.h"
 
-static const struct wlr_input_device_impl input_device_impl = { 0 };
+static void input_device_destroy(struct wlr_input_device *wlr_dev) {
+	wl_list_remove(&wlr_dev->link);
+	free(wlr_dev);
+}
+
+static const struct wlr_input_device_impl input_device_impl = {
+	.destroy = input_device_destroy,
+};
 
 bool wlr_input_device_is_headless(struct wlr_input_device *wlr_dev) {
 	return wlr_dev->impl == &input_device_impl;

--- a/backend/multi/backend.c
+++ b/backend/multi/backend.c
@@ -64,20 +64,6 @@ static void multi_backend_destroy(struct wlr_backend *wlr_backend) {
 	free(backend);
 }
 
-static struct wlr_renderer *multi_backend_get_renderer(
-		struct wlr_backend *backend) {
-	struct wlr_multi_backend *multi = multi_backend_from_backend(backend);
-
-	struct subbackend_state *sub;
-	wl_list_for_each(sub, &multi->backends, link) {
-		struct wlr_renderer *rend = wlr_backend_get_renderer(sub->backend);
-		if (rend != NULL) {
-			return rend;
-		}
-	}
-	return NULL;
-}
-
 static struct wlr_session *multi_backend_get_session(
 		struct wlr_backend *_backend) {
 	struct wlr_multi_backend *backend = multi_backend_from_backend(_backend);
@@ -136,7 +122,6 @@ static uint32_t multi_backend_get_buffer_caps(struct wlr_backend *backend) {
 static const struct wlr_backend_impl backend_impl = {
 	.start = multi_backend_start,
 	.destroy = multi_backend_destroy,
-	.get_renderer = multi_backend_get_renderer,
 	.get_session = multi_backend_get_session,
 	.get_presentation_clock = multi_backend_get_presentation_clock,
 	.get_drm_fd = multi_backend_get_drm_fd,
@@ -209,15 +194,6 @@ bool wlr_multi_backend_add(struct wlr_backend *_multi,
 	if (multi_backend_get_subbackend(multi, backend)) {
 		// already added
 		return true;
-	}
-
-	struct wlr_renderer *multi_renderer =
-		multi_backend_get_renderer(&multi->backend);
-	struct wlr_renderer *backend_renderer = wlr_backend_get_renderer(backend);
-	if (multi_renderer != NULL && backend_renderer != NULL && multi_renderer != backend_renderer) {
-		wlr_log(WLR_ERROR, "Could not add backend: multiple renderers at the "
-			"same time aren't supported");
-		return false;
 	}
 
 	struct subbackend_state *sub = calloc(1, sizeof(struct subbackend_state));

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -166,18 +166,8 @@ static struct wl_buffer *import_dmabuf(struct wlr_wl_backend *wl,
 			dmabuf->offset[i], dmabuf->stride[i], modifier_hi, modifier_lo);
 	}
 
-	uint32_t flags = 0;
-	if (dmabuf->flags & WLR_DMABUF_ATTRIBUTES_FLAGS_Y_INVERT) {
-		flags |= ZWP_LINUX_BUFFER_PARAMS_V1_FLAGS_Y_INVERT;
-	}
-	if (dmabuf->flags & WLR_DMABUF_ATTRIBUTES_FLAGS_INTERLACED) {
-		flags |= ZWP_LINUX_BUFFER_PARAMS_V1_FLAGS_INTERLACED;
-	}
-	if (dmabuf->flags & WLR_DMABUF_ATTRIBUTES_FLAGS_BOTTOM_FIRST) {
-		flags |= ZWP_LINUX_BUFFER_PARAMS_V1_FLAGS_BOTTOM_FIRST;
-	}
 	struct wl_buffer *wl_buffer = zwp_linux_buffer_params_v1_create_immed(
-		params, dmabuf->width, dmabuf->height, dmabuf->format, flags);
+		params, dmabuf->width, dmabuf->height, dmabuf->format, 0);
 	// TODO: handle create() errors
 	return wl_buffer;
 }

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -140,10 +140,6 @@ static xcb_pixmap_t import_dmabuf(struct wlr_x11_output *output,
 		return XCB_PIXMAP_NONE;
 	}
 
-	if (dmabuf->flags != 0) {
-		return XCB_PIXMAP_NONE;
-	}
-
 	// xcb closes the FDs after sending them, so we need to dup them here
 	struct wlr_dmabuf_attributes dup_attrs = {0};
 	if (!wlr_dmabuf_attributes_copy(&dup_attrs, dmabuf)) {

--- a/backend/x11/output.c
+++ b/backend/x11/output.c
@@ -376,7 +376,7 @@ static void update_x11_output_cursor(struct wlr_x11_output *output,
 static bool output_cursor_to_picture(struct wlr_x11_output *output,
 		struct wlr_buffer *buffer) {
 	struct wlr_x11_backend *x11 = output->x11;
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(&x11->backend);
+	struct wlr_renderer *renderer = output->wlr_output.renderer;
 
 	if (output->cursor.pic != XCB_NONE) {
 		xcb_render_free_picture(x11->xcb, output->cursor.pic);

--- a/examples/quads.c
+++ b/examples/quads.c
@@ -9,6 +9,7 @@
 #include <unistd.h>
 #include <wayland-server-core.h>
 #include <wlr/backend.h>
+#include <wlr/render/allocator.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_keyboard.h>
 #include <wlr/types/wlr_output.h>
@@ -24,6 +25,7 @@ struct sample_state {
 	struct wl_listener new_input;
 	struct timespec last_frame;
 	struct wlr_renderer *renderer;
+	struct wlr_allocator *allocator;
 	struct wl_list outputs;
 };
 
@@ -103,6 +105,9 @@ static void output_remove_notify(struct wl_listener *listener, void *data) {
 static void new_output_notify(struct wl_listener *listener, void *data) {
 	struct wlr_output *output = data;
 	struct sample_state *sample = wl_container_of(listener, sample, new_output);
+
+	wlr_output_init_render(output, sample->allocator, sample->renderer);
+
 	struct sample_output *sample_output = calloc(1, sizeof(struct sample_output));
 
 	struct wlr_output_mode *mode = wlr_output_preferred_mode(output);
@@ -195,12 +200,14 @@ int main(int argc, char *argv[]) {
 	state.new_input.notify = new_input_notify;
 	clock_gettime(CLOCK_MONOTONIC, &state.last_frame);
 
-	state.renderer = wlr_backend_get_renderer(wlr);
+	state.renderer = wlr_renderer_autocreate(wlr);
 	if (!state.renderer) {
 		wlr_log(WLR_ERROR, "Could not start compositor, OOM");
 		wlr_backend_destroy(wlr);
 		exit(EXIT_FAILURE);
 	}
+
+	state.allocator = wlr_allocator_autocreate(wlr, state.renderer);
 
 	if (!wlr_backend_start(wlr)) {
 		wlr_log(WLR_ERROR, "Failed to start backend");

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -10,6 +10,7 @@
 #include <unistd.h>
 #include <wayland-server-core.h>
 #include <wlr/backend.h>
+#include <wlr/render/allocator.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_keyboard.h>
 #include <wlr/types/wlr_output.h>
@@ -25,6 +26,7 @@ struct sample_state {
 	struct wl_listener new_input;
 	struct timespec last_frame;
 	struct wlr_renderer *renderer;
+	struct wlr_allocator *allocator;
 	struct wlr_texture *cat_texture;
 	struct wl_list outputs;
 	enum wl_output_transform transform;
@@ -105,6 +107,9 @@ static void output_remove_notify(struct wl_listener *listener, void *data) {
 static void new_output_notify(struct wl_listener *listener, void *data) {
 	struct wlr_output *output = data;
 	struct sample_state *sample = wl_container_of(listener, sample, new_output);
+
+	wlr_output_init_render(output, sample->allocator, sample->renderer);
+
 	struct sample_output *sample_output = calloc(1, sizeof(struct sample_output));
 	sample_output->x_offs = sample_output->y_offs = 0;
 	sample_output->x_vel = sample_output->y_vel = 128;
@@ -245,7 +250,7 @@ int main(int argc, char *argv[]) {
 	state.new_input.notify = new_input_notify;
 	clock_gettime(CLOCK_MONOTONIC, &state.last_frame);
 
-	state.renderer = wlr_backend_get_renderer(wlr);
+	state.renderer = wlr_renderer_autocreate(wlr);
 	if (!state.renderer) {
 		wlr_log(WLR_ERROR, "Could not start compositor, OOM");
 		wlr_backend_destroy(wlr);
@@ -258,6 +263,8 @@ int main(int argc, char *argv[]) {
 		wlr_log(WLR_ERROR, "Could not start compositor, OOM");
 		exit(EXIT_FAILURE);
 	}
+
+	state.allocator = wlr_allocator_autocreate(wlr, state.renderer);
 
 	if (!wlr_backend_start(wlr)) {
 		wlr_log(WLR_ERROR, "Failed to start backend");

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -7,6 +7,7 @@
 #include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
+#include <wlr/render/allocator.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_input_device.h>
@@ -18,6 +19,8 @@ struct sample_state {
 	struct wl_display *display;
 	struct wl_listener new_output;
 	struct wl_listener new_input;
+	struct wlr_renderer *renderer;
+	struct wlr_allocator *allocator;
 	struct timespec last_frame;
 	float color[4];
 	int dec;
@@ -61,8 +64,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 
 	wlr_output_attach_render(wlr_output, NULL);
 
-	struct wlr_renderer *renderer =
-		wlr_backend_get_renderer(wlr_output->backend);
+	struct wlr_renderer *renderer = sample->renderer;
 	wlr_renderer_begin(renderer, wlr_output->width, wlr_output->height);
 	wlr_renderer_clear(renderer, sample->color);
 	wlr_renderer_end(renderer);
@@ -84,6 +86,9 @@ static void new_output_notify(struct wl_listener *listener, void *data) {
 	struct wlr_output *output = data;
 	struct sample_state *sample =
 		wl_container_of(listener, sample, new_output);
+
+	wlr_output_init_render(output, sample->allocator, sample->renderer);
+
 	struct sample_output *sample_output =
 		calloc(1, sizeof(struct sample_output));
 	sample_output->output = output;
@@ -171,6 +176,10 @@ int main(void) {
 	if (!backend) {
 		exit(1);
 	}
+
+	state.renderer = wlr_renderer_autocreate(backend);
+	state.allocator = wlr_allocator_autocreate(backend, state.renderer);
+
 	wl_signal_add(&backend->events.new_output, &state.new_output);
 	state.new_output.notify = new_output_notify;
 	wl_signal_add(&backend->events.new_input, &state.new_input);

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -10,8 +10,9 @@
 #include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
-#include <wlr/types/wlr_output.h>
+#include <wlr/render/allocator.h>
 #include <wlr/render/wlr_renderer.h>
+#include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_keyboard.h>
 #include <wlr/types/wlr_matrix.h>
@@ -23,6 +24,7 @@
 struct sample_state {
 	struct wl_display *display;
 	struct wlr_renderer *renderer;
+	struct wlr_allocator *allocator;
 	struct wlr_texture *cat_texture;
 	struct wl_list touch_points;
 	struct timespec last_frame;
@@ -148,6 +150,9 @@ static void output_remove_notify(struct wl_listener *listener, void *data) {
 static void new_output_notify(struct wl_listener *listener, void *data) {
 	struct wlr_output *output = data;
 	struct sample_state *sample = wl_container_of(listener, sample, new_output);
+
+	wlr_output_init_render(output, sample->allocator, sample->renderer);
+
 	struct sample_output *sample_output = calloc(1, sizeof(struct sample_output));
 	sample_output->output = output;
 	sample_output->sample = sample;
@@ -254,8 +259,7 @@ int main(int argc, char *argv[]) {
 	state.new_input.notify = new_input_notify;
 	clock_gettime(CLOCK_MONOTONIC, &state.last_frame);
 
-
-	state.renderer = wlr_backend_get_renderer(wlr);
+	state.renderer = wlr_renderer_autocreate(wlr);
 	if (!state.renderer) {
 		wlr_log(WLR_ERROR, "Could not start compositor, OOM");
 		exit(EXIT_FAILURE);
@@ -267,6 +271,8 @@ int main(int argc, char *argv[]) {
 		wlr_log(WLR_ERROR, "Could not start compositor, OOM");
 		exit(EXIT_FAILURE);
 	}
+
+	state.allocator = wlr_allocator_autocreate(wlr, state.renderer);
 
 	if (!wlr_backend_start(wlr)) {
 		wlr_log(WLR_ERROR, "Failed to start backend");

--- a/include/backend/backend.h
+++ b/include/backend/backend.h
@@ -10,10 +10,4 @@
  */
 uint32_t backend_get_buffer_caps(struct wlr_backend *backend);
 
-/**
- * Get the backend's allocator. Automatically creates the allocator if
- * necessary.
- */
-struct wlr_allocator *backend_get_allocator(struct wlr_backend *backend);
-
 #endif

--- a/include/backend/drm/drm.h
+++ b/include/backend/drm/drm.h
@@ -147,7 +147,8 @@ struct wlr_drm_backend *get_drm_backend_from_backend(
 bool check_drm_features(struct wlr_drm_backend *drm);
 bool init_drm_resources(struct wlr_drm_backend *drm);
 void finish_drm_resources(struct wlr_drm_backend *drm);
-void scan_drm_connectors(struct wlr_drm_backend *state);
+void scan_drm_connectors(struct wlr_drm_backend *state,
+	struct wlr_device_hotplug_event *event);
 int handle_drm_event(int fd, uint32_t mask, void *data);
 void destroy_drm_connector(struct wlr_drm_connector *conn);
 bool drm_connector_commit_state(struct wlr_drm_connector *conn,

--- a/include/backend/headless.h
+++ b/include/backend/headless.h
@@ -14,8 +14,6 @@ struct wlr_headless_backend {
 	size_t last_output_num;
 	struct wl_list input_devices;
 	struct wl_listener display_destroy;
-	struct wlr_renderer *parent_renderer;
-	struct wl_listener parent_renderer_destroy;
 	bool started;
 };
 

--- a/include/render/allocator/allocator.h
+++ b/include/render/allocator/allocator.h
@@ -1,52 +1,7 @@
 #ifndef RENDER_ALLOCATOR_ALLOCATOR_H
 #define RENDER_ALLOCATOR_ALLOCATOR_H
 
-#include <stdbool.h>
-#include <wayland-server-core.h>
-#include <wlr/render/drm_format_set.h>
-
-struct wlr_allocator;
-struct wlr_backend;
-struct wlr_renderer;
-
-struct wlr_allocator_interface {
-	struct wlr_buffer *(*create_buffer)(struct wlr_allocator *alloc,
-		int width, int height, const struct wlr_drm_format *format);
-	void (*destroy)(struct wlr_allocator *alloc);
-};
-
-struct wlr_allocator {
-	const struct wlr_allocator_interface *impl;
-
-	// Capabilities of the buffers created with this allocator
-	uint32_t buffer_caps;
-
-	struct {
-		struct wl_signal destroy;
-	} events;
-};
-
-/**
- * Creates the adequate wlr_allocator given a backend and a renderer
- */
-struct wlr_allocator *wlr_allocator_autocreate(struct wlr_backend *backend,
-	struct wlr_renderer *renderer);
-/**
- * Destroy the allocator.
- */
-void wlr_allocator_destroy(struct wlr_allocator *alloc);
-/**
- * Allocate a new buffer.
- *
- * When the caller is done with it, they must unreference it by calling
- * wlr_buffer_drop.
- */
-struct wlr_buffer *wlr_allocator_create_buffer(struct wlr_allocator *alloc,
-	int width, int height, const struct wlr_drm_format *format);
-
-// For wlr_allocator implementors
-void wlr_allocator_init(struct wlr_allocator *alloc,
-	const struct wlr_allocator_interface *impl, uint32_t buffer_caps);
+#include <wlr/render/allocator.h>
 
 struct wlr_allocator *allocator_autocreate_with_drm_fd(
 	struct wlr_backend *backend, struct wlr_renderer *renderer, int drm_fd);

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -24,7 +24,6 @@ struct wlr_gles2_pixel_format {
 struct wlr_gles2_tex_shader {
 	GLuint program;
 	GLint proj;
-	GLint invert_y;
 	GLint tex;
 	GLint alpha;
 	GLint pos_attrib;
@@ -101,7 +100,6 @@ struct wlr_gles2_texture {
 
 	EGLImageKHR image;
 
-	bool inverted_y;
 	bool has_alpha;
 
 	// Only affects target == GL_TEXTURE_2D

--- a/include/render/vulkan.h
+++ b/include/render/vulkan.h
@@ -246,7 +246,6 @@ struct wlr_vk_texture {
 	bool dmabuf_imported;
 	bool owned; // if dmabuf_imported: whether we have ownership of the image
 	bool transitioned; // if dma_imported: whether we transitioned it away from preinit
-	bool invert_y; // if dma_imported: whether we must flip y
 	struct wl_list foreign_link;
 	struct wl_list destroy_link;
 	struct wl_list link; // wlr_gles2_renderer.textures

--- a/include/wlr/backend.h
+++ b/include/wlr/backend.h
@@ -30,7 +30,6 @@ struct wlr_backend {
 
 	bool has_own_renderer;
 	struct wlr_renderer *renderer;
-	struct wlr_allocator *allocator;
 };
 
 /**

--- a/include/wlr/backend.h
+++ b/include/wlr/backend.h
@@ -25,11 +25,6 @@ struct wlr_backend {
 		/** Raised when new outputs are added, passed the wlr_output */
 		struct wl_signal new_output;
 	} events;
-
-	// Private state
-
-	bool has_own_renderer;
-	struct wlr_renderer *renderer;
 };
 
 /**
@@ -49,10 +44,6 @@ bool wlr_backend_start(struct wlr_backend *backend);
  * automatically when the wl_display is destroyed.
  */
 void wlr_backend_destroy(struct wlr_backend *backend);
-/**
- * Obtains the wlr_renderer reference this backend is using.
- */
-struct wlr_renderer *wlr_backend_get_renderer(struct wlr_backend *backend);
 /**
  * Obtains the wlr_session reference from this backend if there is any.
  * Might return NULL for backends that don't use a session.

--- a/include/wlr/backend/interface.h
+++ b/include/wlr/backend/interface.h
@@ -16,7 +16,6 @@
 struct wlr_backend_impl {
 	bool (*start)(struct wlr_backend *backend);
 	void (*destroy)(struct wlr_backend *backend);
-	struct wlr_renderer *(*get_renderer)(struct wlr_backend *backend);
 	struct wlr_session *(*get_session)(struct wlr_backend *backend);
 	clockid_t (*get_presentation_clock)(struct wlr_backend *backend);
 	int (*get_drm_fd)(struct wlr_backend *backend);

--- a/include/wlr/backend/session.h
+++ b/include/wlr/backend/session.h
@@ -15,7 +15,7 @@ struct wlr_device {
 	struct wl_list link;
 
 	struct {
-		struct wl_signal change;
+		struct wl_signal change; // struct wlr_device_change_event
 		struct wl_signal remove;
 	} events;
 };
@@ -55,6 +55,22 @@ struct wlr_session {
 
 struct wlr_session_add_event {
 	const char *path;
+};
+
+enum wlr_device_change_type {
+	WLR_DEVICE_HOTPLUG = 1,
+};
+
+struct wlr_device_hotplug_event {
+	uint32_t connector_id;
+	uint32_t prop_id;
+};
+
+struct wlr_device_change_event {
+	enum wlr_device_change_type type;
+	union {
+		struct wlr_device_hotplug_event hotplug;
+	};
 };
 
 /*

--- a/include/wlr/render/allocator.h
+++ b/include/wlr/render/allocator.h
@@ -1,0 +1,58 @@
+/*
+ * This an unstable interface of wlroots. No guarantees are made regarding the
+ * future consistency of this API.
+ */
+#ifndef WLR_USE_UNSTABLE
+#error "Add -DWLR_USE_UNSTABLE to enable unstable wlroots features"
+#endif
+
+#ifndef WLR_ALLOCATOR_H
+#define WLR_ALLOCATOR_H
+
+#include <wayland-server-core.h>
+
+struct wlr_allocator;
+struct wlr_backend;
+struct wlr_drm_format;
+struct wlr_renderer;
+
+struct wlr_allocator_interface {
+	struct wlr_buffer *(*create_buffer)(struct wlr_allocator *alloc,
+		int width, int height, const struct wlr_drm_format *format);
+	void (*destroy)(struct wlr_allocator *alloc);
+};
+
+void wlr_allocator_init(struct wlr_allocator *alloc,
+	const struct wlr_allocator_interface *impl, uint32_t buffer_caps);
+
+struct wlr_allocator {
+	const struct wlr_allocator_interface *impl;
+
+	// Capabilities of the buffers created with this allocator
+	uint32_t buffer_caps;
+
+	struct {
+		struct wl_signal destroy;
+	} events;
+};
+
+/**
+ * Creates the adequate wlr_allocator given a backend and a renderer
+ */
+struct wlr_allocator *wlr_allocator_autocreate(struct wlr_backend *backend,
+	struct wlr_renderer *renderer);
+/**
+ * Destroy the allocator.
+ */
+void wlr_allocator_destroy(struct wlr_allocator *alloc);
+
+/**
+ * Allocate a new buffer.
+ *
+ * When the caller is done with it, they must unreference it by calling
+ * wlr_buffer_drop.
+ */
+struct wlr_buffer *wlr_allocator_create_buffer(struct wlr_allocator *alloc,
+	int width, int height, const struct wlr_drm_format *format);
+
+#endif

--- a/include/wlr/render/dmabuf.h
+++ b/include/wlr/render/dmabuf.h
@@ -14,16 +14,9 @@
 
 #define WLR_DMABUF_MAX_PLANES 4
 
-enum wlr_dmabuf_attributes_flags {
-	WLR_DMABUF_ATTRIBUTES_FLAGS_Y_INVERT = 1 << 0,
-	WLR_DMABUF_ATTRIBUTES_FLAGS_INTERLACED = 1 << 1,
-	WLR_DMABUF_ATTRIBUTES_FLAGS_BOTTOM_FIRST = 1 << 2,
-};
-
 struct wlr_dmabuf_attributes {
 	int32_t width, height;
 	uint32_t format;
-	uint32_t flags; // enum wlr_dmabuf_attributes_flags
 	uint64_t modifier;
 
 	int n_planes;

--- a/include/wlr/render/drm_format_set.h
+++ b/include/wlr/render/drm_format_set.h
@@ -5,19 +5,38 @@
 #include <stddef.h>
 #include <stdint.h>
 
+/** A single DRM format */
 struct wlr_drm_format {
+	// The actual DRM format, from `drm_fourcc.h`
 	uint32_t format;
-	size_t len, cap;
+	// The number of modifiers
+	size_t len;
+	// The capacity of the array; do not use.
+	size_t capacity;
+	// The actual modifiers
 	uint64_t modifiers[];
 };
 
+/** A set of DRM formats */
 struct wlr_drm_format_set {
-	size_t len, cap;
+	// The number of formats
+	size_t len;
+	// The capacity of the array; private to wlroots
+	size_t capacity;
+	// A pointer to an array of `struct wlr_drm_format *` of length `len`.
 	struct wlr_drm_format **formats;
 };
 
+/**
+ * Free all of the DRM formats in the set, making the set empty.  Does not
+ * free the set itself.
+ */
 void wlr_drm_format_set_finish(struct wlr_drm_format_set *set);
 
+/**
+ * Return a pointer to a member of this `wlr_drm_format_set` of format
+ * `format`, or NULL if none exists.
+ */
 const struct wlr_drm_format *wlr_drm_format_set_get(
 	const struct wlr_drm_format_set *set, uint32_t format);
 

--- a/include/wlr/render/gles2.h
+++ b/include/wlr/render/gles2.h
@@ -30,7 +30,6 @@ struct wlr_gles2_texture_attribs {
 	GLenum target; /* either GL_TEXTURE_2D or GL_TEXTURE_EXTERNAL_OES */
 	GLuint tex;
 
-	bool inverted_y;
 	bool has_alpha;
 };
 

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -14,7 +14,6 @@
 #include <time.h>
 #include <wayland-server-protocol.h>
 #include <wayland-util.h>
-#include <wlr/render/dmabuf.h>
 #include <wlr/types/wlr_buffer.h>
 #include <wlr/util/addon.h>
 
@@ -401,13 +400,6 @@ size_t wlr_output_get_gamma_size(struct wlr_output *output);
  */
 void wlr_output_set_gamma(struct wlr_output *output, size_t size,
 	const uint16_t *r, const uint16_t *g, const uint16_t *b);
-/**
- * Exports the last committed buffer as a DMA-BUF.
- *
- * The caller is responsible for cleaning up the DMA-BUF attributes.
- */
-bool wlr_output_export_dmabuf(struct wlr_output *output,
-	struct wlr_dmabuf_attributes *attribs);
 /**
  * Returns the wlr_output matching the provided wl_output resource. If the
  * resource isn't a wl_output, it aborts. If the resource is inert (because the

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -182,6 +182,8 @@ struct wlr_output {
 	struct wlr_buffer *cursor_front_buffer;
 	int software_cursor_locks; // number of locks forcing software cursors
 
+	struct wlr_allocator *allocator;
+	struct wlr_renderer *renderer;
 	struct wlr_swapchain *swapchain;
 	struct wlr_buffer *back_buffer, *front_buffer;
 
@@ -256,6 +258,18 @@ struct wlr_surface;
 void wlr_output_enable(struct wlr_output *output, bool enable);
 void wlr_output_create_global(struct wlr_output *output);
 void wlr_output_destroy_global(struct wlr_output *output);
+/**
+ * Initialize the output's rendering subsystem with the provided allocator and
+ * renderer. Can only be called once.
+ *
+ * Call this function prior to any call to wlr_output_attach_render,
+ * wlr_output_commit or wlr_output_cursor_create.
+ *
+ * The buffer capabilities of the provided must match the capabilities of the
+ * output's backend. Returns false otherwise.
+ */
+bool wlr_output_init_render(struct wlr_output *output,
+	struct wlr_allocator *allocator, struct wlr_renderer *renderer);
 /**
  * Returns the preferred mode for this output. If the output doesn't support
  * modes, returns NULL.

--- a/include/wlr/types/wlr_text_input_v3.h
+++ b/include/wlr/types/wlr_text_input_v3.h
@@ -87,7 +87,7 @@ void wlr_text_input_v3_send_enter(struct wlr_text_input_v3 *text_input,
 // Sends leave to the currently focused surface and clears it
 void wlr_text_input_v3_send_leave(struct wlr_text_input_v3 *text_input);
 void wlr_text_input_v3_send_preedit_string(struct wlr_text_input_v3 *text_input,
-	const char *text, uint32_t cursor_begin, uint32_t cursor_end);
+	const char *text, int32_t cursor_begin, int32_t cursor_end);
 void wlr_text_input_v3_send_commit_string(struct wlr_text_input_v3 *text_input,
 	const char *text);
 void wlr_text_input_v3_send_delete_surrounding_text(

--- a/include/wlr/xwayland.h
+++ b/include/wlr/xwayland.h
@@ -22,6 +22,7 @@ struct wlr_xwayland_cursor;
 struct wlr_xwayland_server_options {
 	bool lazy;
 	bool enable_wm;
+	bool no_touch_pointer_emulation;
 };
 
 struct wlr_xwayland_server {

--- a/include/xwayland/meson.build
+++ b/include/xwayland/meson.build
@@ -1,7 +1,11 @@
 have_listenfd = false
+have_no_touch_pointer_emulation = false
 if xwayland.found()
 	xwayland_path = xwayland.get_variable('xwayland')
-	have_listenfd = xwayland.get_variable('have_listenfd') == 'true'
+	have_listenfd = xwayland.get_variable('have_listenfd',
+		default_value: 'false') == 'true'
+	have_no_touch_pointer_emulation = xwayland.get_variable(
+		'have_no_touch_pointer_emulation', default_value: 'false') == 'true'
 else
 	xwayland_path = xwayland_prog.full_path()
 endif
@@ -9,6 +13,7 @@ endif
 xwayland_config_data = configuration_data()
 xwayland_config_data.set_quoted('XWAYLAND_PATH', xwayland_path)
 xwayland_config_data.set10('HAVE_XWAYLAND_LISTENFD', have_listenfd)
+xwayland_config_data.set10('HAVE_XWAYLAND_NO_TOUCH_POINTER_EMULATION', have_no_touch_pointer_emulation)
 configure_file(
 	output: 'config.h',
 	configuration: xwayland_config_data,

--- a/render/allocator/allocator.c
+++ b/render/allocator/allocator.c
@@ -3,6 +3,7 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <wlr/render/allocator.h>
 #include <wlr/util/log.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>

--- a/render/allocator/drm_dumb.c
+++ b/render/allocator/drm_dumb.c
@@ -7,11 +7,13 @@
 #include <string.h>
 #include <sys/mman.h>
 #include <unistd.h>
+#include <wlr/backend.h>
+#include <wlr/backend/session.h>
+#include <wlr/render/allocator.h>
+#include <wlr/render/drm_format_set.h>
 #include <wlr/util/log.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
-#include <wlr/backend.h>
-#include <wlr/backend/session.h>
 
 #include "render/allocator/drm_dumb.h"
 #include "render/pixel_format.h"

--- a/render/allocator/gbm.c
+++ b/render/allocator/gbm.c
@@ -4,8 +4,11 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <wlr/render/allocator.h>
+#include <wlr/render/drm_format_set.h>
 #include <wlr/util/log.h>
 #include <xf86drm.h>
+
 #include "render/allocator/gbm.h"
 
 static const struct wlr_buffer_impl buffer_impl;

--- a/render/allocator/shm.c
+++ b/render/allocator/shm.c
@@ -3,7 +3,10 @@
 #include <stdlib.h>
 #include <sys/mman.h>
 #include <unistd.h>
+#include <wlr/render/allocator.h>
+#include <wlr/render/drm_format_set.h>
 #include <wlr/util/log.h>
+
 #include "render/pixel_format.h"
 #include "render/allocator/shm.h"
 #include "util/shm.h"

--- a/render/drm_format_set.c
+++ b/render/drm_format_set.c
@@ -15,7 +15,7 @@ void wlr_drm_format_set_finish(struct wlr_drm_format_set *set) {
 	free(set->formats);
 
 	set->len = 0;
-	set->cap = 0;
+	set->capacity = 0;
 	set->formats = NULL;
 }
 
@@ -74,8 +74,8 @@ bool wlr_drm_format_set_add(struct wlr_drm_format_set *set, uint32_t format,
 		return false;
 	}
 
-	if (set->len == set->cap) {
-		size_t new = set->cap ? set->cap * 2 : 4;
+	if (set->len == set->capacity) {
+		size_t new = set->capacity ? set->capacity * 2 : 4;
 
 		struct wlr_drm_format **tmp = realloc(set->formats,
 			sizeof(*fmt) + sizeof(fmt->modifiers[0]) * new);
@@ -85,7 +85,7 @@ bool wlr_drm_format_set_add(struct wlr_drm_format_set *set, uint32_t format,
 			return false;
 		}
 
-		set->cap = new;
+		set->capacity = new;
 		set->formats = tmp;
 	}
 
@@ -94,15 +94,15 @@ bool wlr_drm_format_set_add(struct wlr_drm_format_set *set, uint32_t format,
 }
 
 struct wlr_drm_format *wlr_drm_format_create(uint32_t format) {
-	size_t cap = 4;
+	size_t capacity = 4;
 	struct wlr_drm_format *fmt =
-		calloc(1, sizeof(*fmt) + sizeof(fmt->modifiers[0]) * cap);
+		calloc(1, sizeof(*fmt) + sizeof(fmt->modifiers[0]) * capacity);
 	if (!fmt) {
 		wlr_log_errno(WLR_ERROR, "Allocation failed");
 		return NULL;
 	}
 	fmt->format = format;
-	fmt->cap = cap;
+	fmt->capacity = capacity;
 	return fmt;
 }
 
@@ -119,16 +119,16 @@ bool wlr_drm_format_add(struct wlr_drm_format **fmt_ptr, uint64_t modifier) {
 		}
 	}
 
-	if (fmt->len == fmt->cap) {
-		size_t cap = fmt->cap ? fmt->cap * 2 : 4;
+	if (fmt->len == fmt->capacity) {
+		size_t capacity = fmt->capacity ? fmt->capacity * 2 : 4;
 
-		fmt = realloc(fmt, sizeof(*fmt) + sizeof(fmt->modifiers[0]) * cap);
+		fmt = realloc(fmt, sizeof(*fmt) + sizeof(fmt->modifiers[0]) * capacity);
 		if (!fmt) {
 			wlr_log_errno(WLR_ERROR, "Allocation failed");
 			return false;
 		}
 
-		fmt->cap = cap;
+		fmt->capacity = capacity;
 		*fmt_ptr = fmt;
 	}
 
@@ -137,9 +137,9 @@ bool wlr_drm_format_add(struct wlr_drm_format **fmt_ptr, uint64_t modifier) {
 }
 
 struct wlr_drm_format *wlr_drm_format_dup(const struct wlr_drm_format *format) {
-	assert(format->len <= format->cap);
+	assert(format->len <= format->capacity);
 	size_t format_size = sizeof(struct wlr_drm_format) +
-		format->cap * sizeof(format->modifiers[0]);
+		format->capacity * sizeof(format->modifiers[0]);
 	struct wlr_drm_format *duped_format = malloc(format_size);
 	if (duped_format == NULL) {
 		return NULL;
@@ -171,12 +171,12 @@ struct wlr_drm_format *wlr_drm_format_intersect(
 		return NULL;
 	}
 	format->format = a->format;
-	format->cap = format_cap;
+	format->capacity = format_cap;
 
 	for (size_t i = 0; i < a->len; i++) {
 		for (size_t j = 0; j < b->len; j++) {
 			if (a->modifiers[i] == b->modifiers[j]) {
-				assert(format->len < format->cap);
+				assert(format->len < format->capacity);
 				format->modifiers[format->len] = a->modifiers[i];
 				format->len++;
 				break;

--- a/render/egl.c
+++ b/render/egl.c
@@ -189,11 +189,11 @@ static struct wlr_egl *egl_create(void) {
 	egl->exts.EXT_platform_device = check_egl_ext(client_exts_str,
 			"EGL_EXT_platform_device");
 
-	if (check_egl_ext(client_exts_str, "EGL_EXT_device_enumeration")) {
+	if (check_egl_ext(client_exts_str, "EGL_EXT_device_base") || check_egl_ext(client_exts_str, "EGL_EXT_device_enumeration")) {
 		load_egl_proc(&egl->procs.eglQueryDevicesEXT, "eglQueryDevicesEXT");
 	}
 
-	if (check_egl_ext(client_exts_str, "EGL_EXT_device_query")) {
+	if (check_egl_ext(client_exts_str, "EGL_EXT_device_base") || check_egl_ext(client_exts_str, "EGL_EXT_device_query")) {
 		egl->exts.EXT_device_query = true;
 		load_egl_proc(&egl->procs.eglQueryDeviceStringEXT,
 			"eglQueryDeviceStringEXT");

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -309,7 +309,6 @@ static bool gles2_render_subtexture_with_matrix(
 	glUseProgram(shader->program);
 
 	glUniformMatrix3fv(shader->proj, 1, GL_FALSE, gl_matrix);
-	glUniform1i(shader->invert_y, texture->inverted_y);
 	glUniform1i(shader->tex, 0);
 	glUniform1f(shader->alpha, alpha);
 
@@ -810,7 +809,6 @@ struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_egl *egl) {
 		goto error;
 	}
 	renderer->shaders.tex_rgba.proj = glGetUniformLocation(prog, "proj");
-	renderer->shaders.tex_rgba.invert_y = glGetUniformLocation(prog, "invert_y");
 	renderer->shaders.tex_rgba.tex = glGetUniformLocation(prog, "tex");
 	renderer->shaders.tex_rgba.alpha = glGetUniformLocation(prog, "alpha");
 	renderer->shaders.tex_rgba.pos_attrib = glGetAttribLocation(prog, "pos");
@@ -822,7 +820,6 @@ struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_egl *egl) {
 		goto error;
 	}
 	renderer->shaders.tex_rgbx.proj = glGetUniformLocation(prog, "proj");
-	renderer->shaders.tex_rgbx.invert_y = glGetUniformLocation(prog, "invert_y");
 	renderer->shaders.tex_rgbx.tex = glGetUniformLocation(prog, "tex");
 	renderer->shaders.tex_rgbx.alpha = glGetUniformLocation(prog, "alpha");
 	renderer->shaders.tex_rgbx.pos_attrib = glGetAttribLocation(prog, "pos");
@@ -835,7 +832,6 @@ struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_egl *egl) {
 			goto error;
 		}
 		renderer->shaders.tex_ext.proj = glGetUniformLocation(prog, "proj");
-		renderer->shaders.tex_ext.invert_y = glGetUniformLocation(prog, "invert_y");
 		renderer->shaders.tex_ext.tex = glGetUniformLocation(prog, "tex");
 		renderer->shaders.tex_ext.alpha = glGetUniformLocation(prog, "alpha");
 		renderer->shaders.tex_ext.pos_attrib = glGetAttribLocation(prog, "pos");

--- a/render/gles2/shaders.c
+++ b/render/gles2/shaders.c
@@ -28,18 +28,13 @@ const GLchar quad_fragment_src[] =
 // Textured quads
 const GLchar tex_vertex_src[] =
 "uniform mat3 proj;\n"
-"uniform bool invert_y;\n"
 "attribute vec2 pos;\n"
 "attribute vec2 texcoord;\n"
 "varying vec2 v_texcoord;\n"
 "\n"
 "void main() {\n"
 "	gl_Position = vec4(proj * vec3(pos, 1.0), 1.0);\n"
-"	if (invert_y) {\n"
-"		v_texcoord = vec2(texcoord.x, 1.0 - texcoord.y);\n"
-"	} else {\n"
-"		v_texcoord = texcoord;\n"
-"	}\n"
+"	v_texcoord = texcoord;\n"
 "}\n";
 
 const GLchar tex_fragment_src_rgba[] =

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -250,8 +250,6 @@ static struct wlr_texture *gles2_texture_from_dmabuf(
 		return NULL;
 	}
 	texture->drm_format = DRM_FORMAT_INVALID; // texture can't be written anyways
-	texture->inverted_y =
-		(attribs->flags & WLR_DMABUF_ATTRIBUTES_FLAGS_Y_INVERT) != 0;
 
 	const struct wlr_pixel_format_info *drm_fmt =
 		drm_get_pixel_format_info(attribs->format);
@@ -363,6 +361,5 @@ void wlr_gles2_texture_get_attribs(struct wlr_texture *wlr_texture,
 	memset(attribs, 0, sizeof(*attribs));
 	attribs->target = texture->target;
 	attribs->tex = texture->tex;
-	attribs->inverted_y = texture->inverted_y;
 	attribs->has_alpha = texture->has_alpha;
 }

--- a/render/meson.build
+++ b/render/meson.build
@@ -14,13 +14,12 @@ wlr_files += files(
 	'wlr_texture.c',
 )
 
-egl = dependency('egl', required: 'gles2' in renderers)
-if egl.found()
-	wlr_deps += egl
-	wlr_files += files('egl.c')
-endif
-
 if 'gles2' in renderers or 'auto' in renderers
+	egl = dependency('egl', required: 'gles2' in renderers)
+	if egl.found()
+		wlr_deps += egl
+		wlr_files += files('egl.c')
+	endif
 	subdir('gles2')
 endif
 

--- a/render/vulkan/renderer.c
+++ b/render/vulkan/renderer.c
@@ -433,15 +433,6 @@ static struct wlr_vk_render_buffer *create_render_buffer(
 	wlr_log(WLR_DEBUG, "vulkan create_render_buffer: %.4s, %dx%d",
 		(const char*) &dmabuf.format, dmabuf.width, dmabuf.height);
 
-	// NOTE: we could at least support WLR_DMABUF_ATTRIBUTES_FLAGS_Y_INVERT
-	// if it is needed by anyone. Can be implemented using negative viewport
-	// height or flipping matrix.
-	if (dmabuf.flags != 0) {
-		wlr_log(WLR_ERROR, "dmabuf flags %x not supported/implemented on vulkan",
-			dmabuf.flags);
-		goto error_buffer;
-	}
-
 	buffer->image = vulkan_import_dmabuf(renderer, &dmabuf,
 		buffer->memories, &buffer->mem_count, true);
 	if (!buffer->image) {
@@ -788,11 +779,6 @@ static bool vulkan_render_subtexture_with_matrix(struct wlr_renderer *wlr_render
 	vert_pcr_data.uv_off[1] = box->y / wlr_texture->height;
 	vert_pcr_data.uv_size[0] = box->width / wlr_texture->width;
 	vert_pcr_data.uv_size[1] = box->height / wlr_texture->height;
-
-	if (texture->invert_y) {
-		vert_pcr_data.uv_off[1] += vert_pcr_data.uv_size[1];
-		vert_pcr_data.uv_size[1] = -vert_pcr_data.uv_size[1];
-	}
 
 	vkCmdPushConstants(cb, renderer->pipe_layout,
 		VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(vert_pcr_data), &vert_pcr_data);

--- a/render/vulkan/texture.c
+++ b/render/vulkan/texture.c
@@ -605,19 +605,6 @@ static struct wlr_texture *vulkan_texture_from_dmabuf(struct wlr_renderer *wlr_r
 		goto error;
 	}
 
-	uint32_t flags = attribs->flags;
-	if (flags & WLR_DMABUF_ATTRIBUTES_FLAGS_Y_INVERT) {
-		texture->invert_y = true;
-		flags &= ~WLR_DMABUF_ATTRIBUTES_FLAGS_Y_INVERT;
-	}
-
-	if (flags != 0) {
-		wlr_log(WLR_ERROR, "dmabuf flags %x not supported/implemented on vulkan",
-			attribs->flags);
-		// NOTE: should probably make this a critical error in future
-		// return VK_NULL_HANDLE;
-	}
-
 	const struct wlr_pixel_format_info *format_info = drm_get_pixel_format_info(attribs->format);
 	assert(format_info);
 

--- a/types/output/cursor.c
+++ b/types/output/cursor.c
@@ -264,6 +264,7 @@ static struct wlr_buffer *render_cursor_buffer(struct wlr_output_cursor *cursor)
 		wlr_swapchain_destroy(output->cursor_swapchain);
 		output->cursor_swapchain = wlr_swapchain_create(allocator,
 			width, height, format);
+		free(format);
 		if (output->cursor_swapchain == NULL) {
 			wlr_log(WLR_ERROR, "Failed to create cursor swapchain");
 			return NULL;

--- a/types/output/output.c
+++ b/types/output/output.c
@@ -790,19 +790,6 @@ size_t wlr_output_get_gamma_size(struct wlr_output *output) {
 	return output->impl->get_gamma_size(output);
 }
 
-bool wlr_output_export_dmabuf(struct wlr_output *output,
-		struct wlr_dmabuf_attributes *attribs) {
-	if (output->front_buffer == NULL) {
-		return false;
-	}
-
-	struct wlr_dmabuf_attributes buf_attribs = {0};
-	if (!wlr_buffer_get_dmabuf(output->front_buffer, &buf_attribs)) {
-		return false;
-	}
-	return wlr_dmabuf_attributes_copy(attribs, &buf_attribs);
-}
-
 void wlr_output_update_needs_frame(struct wlr_output *output) {
 	if (output->needs_frame) {
 		return;

--- a/types/output/output.c
+++ b/types/output/output.c
@@ -175,13 +175,12 @@ static void output_update_matrix(struct wlr_output *output) {
 }
 
 void wlr_output_enable(struct wlr_output *output, bool enable) {
+	output->pending.enabled = enable;
 	if (output->enabled == enable) {
 		output->pending.committed &= ~WLR_OUTPUT_STATE_ENABLED;
-		return;
+	} else {
+		output->pending.committed |= WLR_OUTPUT_STATE_ENABLED;
 	}
-
-	output->pending.committed |= WLR_OUTPUT_STATE_ENABLED;
-	output->pending.enabled = enable;
 }
 
 static void output_state_clear_mode(struct wlr_output_state *state) {

--- a/types/scene/wlr_scene.c
+++ b/types/scene/wlr_scene.c
@@ -798,7 +798,7 @@ static const struct wlr_addon_interface output_addon_impl = {
 
 struct wlr_scene_output *wlr_scene_output_create(struct wlr_scene *scene,
 		struct wlr_output *output) {
-	struct wlr_scene_output *scene_output = calloc(1, sizeof(*output));
+	struct wlr_scene_output *scene_output = calloc(1, sizeof(*scene_output));
 	if (scene_output == NULL) {
 		return NULL;
 	}

--- a/types/scene/wlr_scene.c
+++ b/types/scene/wlr_scene.c
@@ -605,7 +605,7 @@ struct wlr_scene_node *wlr_scene_node_at(struct wlr_scene_node *node,
 }
 
 static void scissor_output(struct wlr_output *output, pixman_box32_t *rect) {
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(output->backend);
+	struct wlr_renderer *renderer = output->renderer;
 	assert(renderer);
 
 	struct wlr_box box = {
@@ -628,7 +628,7 @@ static void scissor_output(struct wlr_output *output, pixman_box32_t *rect) {
 static void render_rect(struct wlr_output *output,
 		pixman_region32_t *output_damage, const float color[static 4],
 		const struct wlr_box *box, const float matrix[static 9]) {
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(output->backend);
+	struct wlr_renderer *renderer = output->renderer;
 	assert(renderer);
 
 	pixman_region32_t damage;
@@ -650,7 +650,7 @@ static void render_texture(struct wlr_output *output,
 		pixman_region32_t *output_damage, struct wlr_texture *texture,
 		const struct wlr_fbox *src_box, const struct wlr_box *dst_box,
 		const float matrix[static 9]) {
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(output->backend);
+	struct wlr_renderer *renderer = output->renderer;
 	assert(renderer);
 
 	struct wlr_fbox default_src_box = {0};
@@ -726,7 +726,7 @@ static void render_node_iterator(struct wlr_scene_node *node,
 	case WLR_SCENE_NODE_BUFFER:;
 		struct wlr_scene_buffer *scene_buffer = scene_buffer_from_node(node);
 
-		struct wlr_renderer *renderer = wlr_backend_get_renderer(output->backend);
+		struct wlr_renderer *renderer = output->renderer;
 		texture = scene_buffer_get_texture(scene_buffer, renderer);
 		if (texture == NULL) {
 			return;
@@ -768,8 +768,7 @@ void wlr_scene_render_output(struct wlr_scene *scene, struct wlr_output *output,
 		damage = &full_region;
 	}
 
-	struct wlr_renderer *renderer =
-		wlr_backend_get_renderer(output->backend);
+	struct wlr_renderer *renderer = output->renderer;
 	assert(renderer);
 
 	if (output->enabled && pixman_region32_not_empty(damage)) {
@@ -919,7 +918,7 @@ static bool scene_output_scanout(struct wlr_scene_output *scene_output) {
 bool wlr_scene_output_commit(struct wlr_scene_output *scene_output) {
 	struct wlr_output *output = scene_output->output;
 
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(output->backend);
+	struct wlr_renderer *renderer = output->renderer;
 	assert(renderer != NULL);
 
 	bool scanout = scene_output_scanout(scene_output);

--- a/types/wlr_export_dmabuf_v1.c
+++ b/types/wlr_export_dmabuf_v1.c
@@ -66,7 +66,7 @@ static void frame_output_handle_commit(struct wl_listener *listener,
 	wl_list_init(&frame->output_commit.link);
 
 	struct wlr_dmabuf_attributes attribs = {0};
-	if (!wlr_output_export_dmabuf(frame->output, &attribs)) {
+	if (!wlr_buffer_get_dmabuf(frame->output->front_buffer, &attribs)) {
 		zwlr_export_dmabuf_frame_v1_send_cancel(frame->resource,
 			ZWLR_EXPORT_DMABUF_FRAME_V1_CANCEL_REASON_TEMPORARY);
 		frame_destroy(frame);
@@ -85,8 +85,6 @@ static void frame_output_handle_commit(struct wl_listener *listener,
 		zwlr_export_dmabuf_frame_v1_send_object(frame->resource, i,
 			attribs.fd[i], size, attribs.offset[i], attribs.stride[i], i);
 	}
-
-	wlr_dmabuf_attributes_finish(&attribs);
 
 	time_t tv_sec = event->when->tv_sec;
 	uint32_t tv_sec_hi = (sizeof(tv_sec) > 4) ? tv_sec >> 32 : 0;

--- a/types/wlr_export_dmabuf_v1.c
+++ b/types/wlr_export_dmabuf_v1.c
@@ -77,7 +77,7 @@ static void frame_output_handle_commit(struct wl_listener *listener,
 	uint32_t mod_high = attribs.modifier >> 32;
 	uint32_t mod_low = attribs.modifier & 0xFFFFFFFF;
 	zwlr_export_dmabuf_frame_v1_send_frame(frame->resource,
-		attribs.width, attribs.height, 0, 0, attribs.flags, frame_flags,
+		attribs.width, attribs.height, 0, 0, 0, frame_flags,
 		attribs.format, mod_high, mod_low, attribs.n_planes);
 
 	for (int i = 0; i < attribs.n_planes; ++i) {

--- a/types/wlr_input_method_v2.c
+++ b/types/wlr_input_method_v2.c
@@ -88,6 +88,10 @@ static void im_commit_string(struct wl_client *client,
 	}
 	free(input_method->pending.commit_text);
 	input_method->pending.commit_text = strdup(text);
+	if (input_method->pending.commit_text == NULL) {
+		wl_client_post_no_memory(client);
+		return;
+	}
 }
 
 static void im_set_preedit_string(struct wl_client *client,
@@ -102,6 +106,10 @@ static void im_set_preedit_string(struct wl_client *client,
 	input_method->pending.preedit.cursor_end = cursor_end;
 	free(input_method->pending.preedit.text);
 	input_method->pending.preedit.text = strdup(text);
+	if (input_method->pending.preedit.text == NULL) {
+		wl_client_post_no_memory(client);
+		return;
+	}
 }
 
 static void im_delete_surrounding_text(struct wl_client *client,

--- a/types/wlr_linux_dmabuf_v1.c
+++ b/types/wlr_linux_dmabuf_v1.c
@@ -215,10 +215,14 @@ static void params_create_common(struct wl_resource *params_resource,
 		goto err_out;
 	}
 
+	if (flags != 0) {
+		wlr_log(WLR_ERROR, "dmabuf flags aren't supported");
+		goto err_failed;
+	}
+
 	attribs.width = width;
 	attribs.height = height;
 	attribs.format = format;
-	attribs.flags = flags;
 
 	if (width < 1 || height < 1) {
 		wl_resource_post_error(params_resource,

--- a/types/wlr_linux_dmabuf_v1.c
+++ b/types/wlr_linux_dmabuf_v1.c
@@ -204,6 +204,17 @@ static void params_create_common(struct wl_resource *params_resource,
 		goto err_out;
 	}
 
+	/* reject unknown flags */
+	uint32_t all_flags = ZWP_LINUX_BUFFER_PARAMS_V1_FLAGS_Y_INVERT |
+		ZWP_LINUX_BUFFER_PARAMS_V1_FLAGS_INTERLACED |
+		ZWP_LINUX_BUFFER_PARAMS_V1_FLAGS_BOTTOM_FIRST;
+	if (flags & ~all_flags) {
+		wl_resource_post_error(params_resource,
+			ZWP_LINUX_BUFFER_PARAMS_V1_ERROR_INVALID_FORMAT,
+			"Unknown dmabuf flags %"PRIu32, flags);
+		goto err_out;
+	}
+
 	attribs.width = width;
 	attribs.height = height;
 	attribs.format = format;
@@ -263,14 +274,6 @@ static void params_create_common(struct wl_resource *params_resource,
 				"invalid buffer stride or height for plane %d", i);
 			goto err_out;
 		}
-	}
-
-	/* reject unknown flags */
-	if (attribs.flags & ~ZWP_LINUX_BUFFER_PARAMS_V1_FLAGS_Y_INVERT) {
-		wl_resource_post_error(params_resource,
-			ZWP_LINUX_BUFFER_PARAMS_V1_ERROR_INVALID_FORMAT,
-			"Unknown dmabuf flags %"PRIu32, attribs.flags);
-		goto err_out;
 	}
 
 	/* Check if dmabuf is usable */

--- a/types/wlr_screencopy_v1.c
+++ b/types/wlr_screencopy_v1.c
@@ -192,7 +192,7 @@ static bool frame_shm_copy(struct wlr_screencopy_frame_v1 *frame,
 		uint32_t *flags) {
 	struct wl_shm_buffer *shm_buffer = frame->shm_buffer;
 	struct wlr_output *output = frame->output;
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(output->backend);
+	struct wlr_renderer *renderer = output->renderer;
 	assert(renderer);
 
 	int x = frame->box.x;
@@ -257,7 +257,7 @@ error_src_tex:
 static bool frame_dma_copy(struct wlr_screencopy_frame_v1 *frame) {
 	struct wlr_dmabuf_v1_buffer *dma_buffer = frame->dma_buffer;
 	struct wlr_output *output = frame->output;
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(output->backend);
+	struct wlr_renderer *renderer = output->renderer;
 	assert(renderer);
 
 	// TODO: add support for copying regions with DMA-BUFs
@@ -276,7 +276,7 @@ static void frame_handle_output_commit(struct wl_listener *listener,
 		wl_container_of(listener, frame, output_commit);
 	struct wlr_output_event_commit *event = data;
 	struct wlr_output *output = frame->output;
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(output->backend);
+	struct wlr_renderer *renderer = output->renderer;
 	assert(renderer);
 
 	if (!(event->committed & WLR_OUTPUT_STATE_BUFFER)) {
@@ -538,7 +538,7 @@ static void capture_output(struct wl_client *wl_client,
 		goto error;
 	}
 
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(output->backend);
+	struct wlr_renderer *renderer = output->renderer;
 	assert(renderer);
 
 	uint32_t drm_format = wlr_output_preferred_read_format(frame->output);

--- a/types/wlr_screencopy_v1.c
+++ b/types/wlr_screencopy_v1.c
@@ -489,13 +489,12 @@ static struct wlr_screencopy_v1_client *client_from_resource(
 }
 
 static uint32_t get_output_fourcc(struct wlr_output *output) {
-	struct wlr_dmabuf_attributes attr = { 0 };
-	if (!wlr_output_export_dmabuf(output, &attr)) {
+	struct wlr_dmabuf_attributes attr = {0};
+	if (!output->front_buffer ||
+			!wlr_buffer_get_dmabuf(output->front_buffer, &attr)) {
 		return DRM_FORMAT_INVALID;
 	}
-	uint32_t format = attr.format;
-	wlr_dmabuf_attributes_finish(&attr);
-	return format;
+	return attr.format;
 }
 
 static void capture_output(struct wl_client *wl_client,

--- a/types/wlr_text_input_v3.c
+++ b/types/wlr_text_input_v3.c
@@ -171,6 +171,10 @@ static void text_input_commit(struct wl_client *client,
 	if (text_input->pending.surrounding.text) {
 		text_input->current.surrounding.text =
 			strdup(text_input->pending.surrounding.text);
+		if (text_input->current.surrounding.text == NULL) {
+			wl_client_post_no_memory(client);
+			return;
+		}
 	}
 
 	bool old_enabled = text_input->current_enabled;

--- a/types/wlr_text_input_v3.c
+++ b/types/wlr_text_input_v3.c
@@ -42,7 +42,7 @@ void wlr_text_input_v3_send_leave(struct wlr_text_input_v3 *text_input) {
 }
 
 void wlr_text_input_v3_send_preedit_string(struct wlr_text_input_v3 *text_input,
-		const char *text, uint32_t cursor_begin, uint32_t cursor_end) {
+		const char *text, int32_t cursor_begin, int32_t cursor_end) {
 	zwp_text_input_v3_send_preedit_string(text_input->resource, text,
 		cursor_begin, cursor_end);
 }

--- a/util/token.c
+++ b/util/token.c
@@ -1,18 +1,29 @@
+#define _POSIX_C_SOURCE 200809L
 #include "util/token.h"
 #include "wlr/util/log.h"
 
+#include <fcntl.h>
 #include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 bool generate_token(char out[static TOKEN_STRLEN]) {
 	static FILE *urandom = NULL;
 	uint64_t data[2];
 
 	if (!urandom) {
-		if (!(urandom = fopen("/dev/urandom", "r"))) {
+		int fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
+		if (fd < 0) {
 			wlr_log_errno(WLR_ERROR, "Failed to open random device");
+			return false;
+		}
+		if (!(urandom = fdopen(fd, "r"))) {
+			wlr_log_errno(WLR_ERROR, "fdopen failed");
+			close(fd);
 			return false;
 		}
 	}

--- a/xwayland/server.c
+++ b/xwayland/server.c
@@ -73,6 +73,14 @@ noreturn static void exec_xwayland(struct wlr_xwayland_server *server) {
 		argv[i++] = wmfd;
 	}
 
+#if HAVE_XWAYLAND_NO_TOUCH_POINTER_EMULATION
+	if (server->options.no_touch_pointer_emulation) {
+		argv[i++] = "-noTouchPointerEmulation";
+	}
+#else
+	server->options.no_touch_pointer_emulation = false;
+#endif
+
 	argv[i++] = NULL;
 
 	assert(i < sizeof(argv) / sizeof(argv[0]));


### PR DESCRIPTION
Enabling or disabling an output should be idempotent.  Previously, this
was not the case, causing bugs.