### PR TITLE
output: fix stack variable lifetime in wlr_output_send_present

### DIFF
--- a/types/output/output.c
+++ b/types/output/output.c
@@ -751,8 +751,8 @@ void wlr_output_send_present(struct wlr_output *output,
 	assert(event);
 	event->output = output;
 
+	struct timespec now;
 	if (event->presented && event->when == NULL) {
-		struct timespec now;
 		clockid_t clock = wlr_backend_get_presentation_clock(output->backend);
 		errno = 0;
 		if (clock_gettime(clock, &now) != 0) {


### PR DESCRIPTION
Variables on the stack are released when the parent block is closed.
Here, `now` is used outside of the `if` block, causing the following
crash when starting Sway with the headless backend:

    ==49606==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7fff94645f90 at pc 0x5558aeae9e29 bp 0x7fff94645df0 sp 0x7fff94645de0
    READ of size 16 at 0x7fff94645f90 thread T0
        #0 0x5558aeae9e28 in handle_present ../sway/desktop/output.c:834
        #1 0x7fdc8d6792fb in wlr_signal_emit_safe ../subprojects/wlroots/util/signal.c:29
        #2 0x7fdc8d54f77f in wlr_output_send_present ../subprojects/wlroots/types/output/output.c:766
        #3 0x7fdc8d524a28 in output_commit ../subprojects/wlroots/backend/headless/output.c:71
        #4 0x7fdc8d54d2db in wlr_output_commit ../subprojects/wlroots/types/output/output.c:629
        #5 0x5558aeb013cb in output_render ../sway/desktop/render.c:1157
        #6 0x5558aeae549e in output_repaint_timer_handler ../sway/desktop/output.c:544
        #7 0x5558aeae5f8a in damage_handle_frame ../sway/desktop/output.c:606
        #8 0x7fdc8d6792fb in wlr_signal_emit_safe ../subprojects/wlroots/util/signal.c:29
        #9 0x7fdc8d6007d5 in output_handle_frame ../subprojects/wlroots/types/wlr_output_damage.c:44
        #10 0x7fdc8d6792fb in wlr_signal_emit_safe ../subprojects/wlroots/util/signal.c:29
        #11 0x7fdc8d54ee84 in wlr_output_send_frame ../subprojects/wlroots/types/output/output.c:720
        #12 0x7fdc8d54efc3 in schedule_frame_handle_idle_timer ../subprojects/wlroots/types/output/output.c:728
        #13 0x7fdc8c9dcf5a in wl_event_loop_dispatch_idle (/usr/lib/libwayland-server.so.0+0xaf5a)
        #14 0x7fdc8c9dcfb4 in wl_event_loop_dispatch (/usr/lib/libwayland-server.so.0+0xafb4)
        #15 0x7fdc8c9dabc6 in wl_display_run (/usr/lib/libwayland-server.so.0+0x8bc6)
        #16 0x5558aeac8e30 in server_run ../sway/server.c:285
        #17 0x5558aeac3c7d in main ../sway/main.c:396
        #18 0x7fdc8be35b24 in __libc_start_main (/usr/lib/libc.so.6+0x27b24)
        #19 0x5558aea8686d in _start (/home/simon/src/sway/build/sway/sway+0x33f86d)

cc @vyivel 